### PR TITLE
fix(admin): add unsafe_eval to csp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,7 +22,8 @@ Rails.application.config.content_security_policy do |policy|
   if Rails.env.development?
     policy.script_src :self, :https, :unsafe_eval, :unsafe_inline
   else
-    policy.script_src :self, :https
+    policy.script_src :self, :https, :unsafe_eval
+    policy.report_uri ENV['SENTRY_CSP_URI']
   end
 end
 


### PR DESCRIPTION
This is temporary needed for the old Admin JS Tools

Once Admin is rewritten in VueJS and #245 is resolved this can be reverted.