### PR TITLE
Fix ATLS Sync to Hanger

### DIFF
--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -364,7 +364,7 @@ class HangarSync < HangarImporter
     name = name.tr("–", "-")
 
     mapping = {
-      "A.T.L.S" => "ATLS",
+      "A.T.L.S." => "ATLS",
       "GreyCat Estate Geotack Planetary Beacon" => "Geotack Planetary Beacon",
       "GreyCat Estate Geotack-X Planetary Beacon" => "Geotack-X Planetary Beacon",
       "X1 Base" => "X1",


### PR DESCRIPTION
Add missing dot in ATLS mapping to fix #3101 and correctly sync the vehicle from RSI API to Fleetyards Hanger