### PR TITLE
Add copy function for paints in admin model edit

### DIFF
--- a/app/api_components/admin/v1/schemas/models/paints/model_paint.rb
+++ b/app/api_components/admin/v1/schemas/models/paints/model_paint.rb
@@ -12,6 +12,10 @@ module Admin
               properties: {
                 hidden: {type: :boolean},
                 active: {type: :boolean},
+                onSale: {type: :boolean},
+                pledgePrice: {type: :number},
+                productionStatus: {type: :string},
+                productionNote: {type: :string},
                 model: {"$ref": "#/components/schemas/Model"},
                 media: {
                   type: :object,

--- a/app/api_components/shared/v1/schemas/media_file.rb
+++ b/app/api_components/shared/v1/schemas/media_file.rb
@@ -13,6 +13,7 @@ module Shared
             contentType: {type: :string},
             size: {type: :integer},
             url: {type: :string, format: :uri},
+            signedId: {type: :string},
             smallUrl: {type: :string, format: :uri},
             mediumUrl: {type: :string, format: :uri},
             largeUrl: {type: :string, format: :uri},

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -111,7 +111,7 @@ const onDestroy = async (record: ModelPaint) => {
   await destroyMutation.mutateAsync({ id: record.id });
 };
 
-// Create
+// Create / Copy
 const createForm = ref<ModelPaintInput>({
   modelId: props.model.id,
 });
@@ -119,6 +119,21 @@ const createForm = ref<ModelPaintInput>({
 const onStartCreate = () => {
   createForm.value = {
     modelId: props.model.id,
+  };
+};
+
+const copyPaint = (item: ModelPaint) => {
+  editableList.value?.startCreate();
+  createForm.value = {
+    name: item.name,
+    modelId: props.model.id,
+    active: item.active,
+    hidden: item.hidden,
+    onSale: item.onSale,
+    pledgePrice: item.pledgePrice,
+    productionStatus: item.productionStatus,
+    productionNote: item.productionNote,
+    storeImage: item.media?.storeImage?.signedId,
   };
 };
 
@@ -186,6 +201,14 @@ const onSaveCreate = async () => {
         :active="item.active"
         @toggle="toggleField(item, 'active')"
       />
+      <Btn
+        v-tooltip="!mobile && t('actions.copy')"
+        :size="BtnSizesEnum.SMALL"
+        @click="copyPaint(item)"
+      >
+        <i class="fa-duotone fa-copy" />
+        <span v-if="mobile">{{ t("actions.copy") }}</span>
+      </Btn>
     </template>
 
     <template #edit="{ item }">

--- a/app/frontend/admin/pages/models/paints/create.vue
+++ b/app/frontend/admin/pages/models/paints/create.vue
@@ -45,6 +45,10 @@ const initialValues = computed<Partial<ModelPaintInput>>(() => {
     modelId: sourcePaint.value.model?.id,
     active: sourcePaint.value.active,
     hidden: sourcePaint.value.hidden,
+    onSale: sourcePaint.value.onSale,
+    pledgePrice: sourcePaint.value.pledgePrice,
+    productionStatus: sourcePaint.value.productionStatus,
+    productionNote: sourcePaint.value.productionNote,
   };
 });
 

--- a/app/views/admin/api/v1/model_paints/_base.jbuilder
+++ b/app/views/admin/api/v1/model_paints/_base.jbuilder
@@ -5,6 +5,10 @@ json.name model_paint.name
 json.slug model_paint.slug
 json.hidden model_paint.hidden
 json.active model_paint.active
+json.on_sale model_paint.on_sale
+json.pledge_price model_paint.pledge_price
+json.production_status model_paint.production_status
+json.production_note model_paint.production_note
 
 json.availability do
   json.bought_at do

--- a/app/views/api/v1/shared/_file.jbuilder
+++ b/app/views/api/v1/shared/_file.jbuilder
@@ -8,6 +8,7 @@ if record.try(attr) && record.send(attr).attached?
   json.content_type file.content_type
   json.size file.byte_size
   json.url rails_blob_url(file)
+  json.signed_id file.blob.signed_id
   if file.representable?
     json.small_url rails_representation_url(file.representation(ActiveStorageVariants::REPRESENTATION_SIZES[:small]))
     json.medium_url rails_representation_url(file.representation(ActiveStorageVariants::REPRESENTATION_SIZES[:medium]))

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5670,6 +5670,8 @@ components:
         url:
           type: string
           format: uri
+        signedId:
+          type: string
         smallUrl:
           type: string
           format: uri
@@ -6780,6 +6782,8 @@ components:
         url:
           type: string
           format: uri
+        signedId:
+          type: string
         smallUrl:
           type: string
           format: uri
@@ -8630,6 +8634,14 @@ components:
           type: boolean
         active:
           type: boolean
+        onSale:
+          type: boolean
+        pledgePrice:
+          type: number
+        productionStatus:
+          type: string
+        productionNote:
+          type: string
         model:
           "$ref": "#/components/schemas/Model"
       additionalProperties: false

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -6130,6 +6130,8 @@ components:
         url:
           type: string
           format: uri
+        signedId:
+          type: string
         smallUrl:
           type: string
           format: uri
@@ -7891,6 +7893,8 @@ components:
         url:
           type: string
           format: uri
+        signedId:
+          type: string
         smallUrl:
           type: string
           format: uri


### PR DESCRIPTION
## Summary
- Add a copy button to the inline editable paints list in the model edit view
- Clicking copy opens the create form pre-filled with the source paint's data (name, flags, pricing, image)
- Expose `signedId` on `MediaFile` so ActiveStorage blobs can be reused when copying
- Add missing fields (`onSale`, `pledgePrice`, `productionStatus`, `productionNote`) to the admin model paint API response

## Test plan
- [x] Navigate to a model's edit page → Paints tab
- [x] Click the copy button on a paint with an image
- [x] Verify the create form opens with all fields pre-filled (name, image, toggles)
- [x] Change the name and submit — verify the new paint is created with the copied image
- [x] Verify editing and deleting existing paints still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)