### PR TITLE
Add bulk enable/disable actions for admin images

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/image_update_bulk_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/image_update_bulk_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ImageUpdateBulkInput
+          include Rswag::SchemaComponents::Component
+
+          schema({
+            type: :object,
+            properties: {
+              ids: {type: :array, items: {type: :string, format: :uuid}},
+              enabled: {type: :boolean},
+              global: {type: :boolean},
+              background: {type: :boolean},
+              caption: {type: :string}
+            },
+            additionalProperties: false,
+            required: %w[ids]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/images_controller.rb
+++ b/app/controllers/admin/api/v1/images_controller.rb
@@ -5,6 +5,7 @@ module Admin
     module V1
       class ImagesController < ::Admin::Api::BaseController
         before_action :set_image, only: %i[update destroy]
+        before_action :set_images, only: %i[update_bulk]
 
         after_action -> { pagination_header(:images) }, only: [:index]
 
@@ -34,6 +35,20 @@ module Admin
           return if @image.update(image_params)
 
           render json: ValidationError.new("image.update", errors: @image.errors), status: :bad_request
+        end
+
+        def update_bulk
+          errors = []
+
+          Image.transaction do
+            @images.find_each do |image|
+              errors << image.errors unless image.update(image_params)
+            end
+          end
+
+          return head :ok if errors.blank?
+
+          render json: ValidationError.new("image.bulk_update", errors: errors.first), status: :bad_request
         end
 
         def destroy
@@ -68,6 +83,12 @@ module Admin
           @image = Image.find(params[:id])
 
           authorize! @image, with: ::Admin::ImagePolicy
+        end
+
+        private def set_images
+          authorize! with: ::Admin::ImagePolicy
+
+          @images = Image.where(id: params[:ids])
         end
       end
     end

--- a/app/frontend/admin/components/Images/List.vue
+++ b/app/frontend/admin/components/Images/List.vue
@@ -27,10 +27,12 @@ import {
   type ImageQuery,
   type Image,
   useCreateImage as useCreateImageMutation,
+  useUpdateBulkImage as useUpdateBulkImageMutation,
 } from "@/services/fyAdminApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import ImageActions from "@/admin/components/Images/Actions/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 
 type Props = {
   name?: string;
@@ -48,7 +50,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { isFilterSelected } = useImageFilters();
 
-const { l } = useI18n();
+const { l, t } = useI18n();
 
 const route = useRoute();
 
@@ -100,6 +102,54 @@ const handleUploadDone = async (files: FileUpload[]) => {
 
     await invalidateImages();
   }
+};
+
+const selected = ref<string[]>([]);
+
+const onSelectedChange = (ids: string[]) => {
+  selected.value = ids;
+};
+
+const updateBulkMutation = useUpdateBulkImageMutation();
+
+const updating = ref(false);
+
+const enableSelected = async () => {
+  updating.value = true;
+
+  await updateBulkMutation
+    .mutateAsync({
+      data: {
+        ids: selected.value,
+        enabled: true,
+      },
+    })
+    .then(async () => {
+      selected.value = [];
+      await invalidateImages();
+    })
+    .finally(() => {
+      updating.value = false;
+    });
+};
+
+const disableSelected = async () => {
+  updating.value = true;
+
+  await updateBulkMutation
+    .mutateAsync({
+      data: {
+        ids: selected.value,
+        enabled: false,
+      },
+    })
+    .then(async () => {
+      selected.value = [];
+      await invalidateImages();
+    })
+    .finally(() => {
+      updating.value = false;
+    });
 };
 
 const columns: BaseTableCol<Image>[] = [
@@ -160,7 +210,29 @@ const columns: BaseTableCol<Image>[] = [
         :empty-visible="emptyVisible"
         default-sort="name asc"
         selectable
+        :selected="selected"
+        @selected-change="onSelectedChange"
       >
+        <template #selected-actions>
+          <BtnGroup inline>
+            <Btn
+              v-tooltip="t('actions.enableSelected')"
+              :size="BtnSizesEnum.SMALL"
+              :disabled="updating"
+              @click="enableSelected"
+            >
+              <i class="fa-duotone fa-eye" />
+            </Btn>
+            <Btn
+              v-tooltip="t('actions.disableSelected')"
+              :size="BtnSizesEnum.SMALL"
+              :disabled="updating"
+              @click="disableSelected"
+            >
+              <i class="fa-duotone fa-eye-slash" />
+            </Btn>
+          </BtnGroup>
+        </template>
         <template #loader="{ loading }">
           <Loader :loading="loading" admin />
         </template>

--- a/app/frontend/admin/pages/models/[id]/edit/images.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/images.vue
@@ -21,6 +21,7 @@ import {
   useImages as useImagesQuery,
   useCreateImage as useCreateImageMutation,
   useUpdateImage as useUpdateImageMutation,
+  useUpdateBulkImage as useUpdateBulkImageMutation,
   useDestroyImage as useDestroyImageMutation,
   getImagesQueryKey,
 } from "@/services/fyAdminApi";
@@ -44,7 +45,9 @@ const queryClient = useQueryClient();
 
 const editableList = ref<{
   editingId: string | null;
+  selected: string[];
   finishEdit: () => void;
+  resetSelected: () => void;
 } | null>(null);
 
 const imagesQueryParams = computed(() => ({
@@ -117,6 +120,55 @@ const onDestroy = async (record: Image) => {
   await destroyMutation.mutateAsync({ id: record.id });
 };
 
+// Bulk update
+const updateBulkMutation = useUpdateBulkImageMutation();
+
+const bulkUpdating = ref(false);
+
+const enableSelected = async () => {
+  const selected = editableList.value?.selected;
+  if (!selected?.length) return;
+
+  bulkUpdating.value = true;
+
+  await updateBulkMutation
+    .mutateAsync({
+      data: {
+        ids: selected,
+        enabled: true,
+      },
+    })
+    .then(async () => {
+      editableList.value?.resetSelected();
+      await invalidateImages();
+    })
+    .finally(() => {
+      bulkUpdating.value = false;
+    });
+};
+
+const disableSelected = async () => {
+  const selected = editableList.value?.selected;
+  if (!selected?.length) return;
+
+  bulkUpdating.value = true;
+
+  await updateBulkMutation
+    .mutateAsync({
+      data: {
+        ids: selected,
+        enabled: false,
+      },
+    })
+    .then(async () => {
+      editableList.value?.resetSelected();
+      await invalidateImages();
+    })
+    .finally(() => {
+      bulkUpdating.value = false;
+    });
+};
+
 // Direct Upload
 const uploadMutation = useCreateImageMutation({
   mutation: {
@@ -160,10 +212,32 @@ const handleUploadDone = async (files: FileUpload[]) => {
     ref="editableList"
     :items="(data?.items as Image[]) || []"
     :confirm-destroy-text="t('messages.confirm.image.destroy')"
+    selectable
     @start-edit="onStartEdit"
     @save-edit="onSaveEdit"
     @destroy="onDestroy"
   >
+    <template #selected-actions>
+      <BtnGroup inline>
+        <Btn
+          v-tooltip="t('actions.enableSelected')"
+          :size="BtnSizesEnum.SMALL"
+          :disabled="bulkUpdating"
+          @click="enableSelected"
+        >
+          <i class="fa-duotone fa-eye" />
+        </Btn>
+        <Btn
+          v-tooltip="t('actions.disableSelected')"
+          :size="BtnSizesEnum.SMALL"
+          :disabled="bulkUpdating"
+          @click="disableSelected"
+        >
+          <i class="fa-duotone fa-eye-slash" />
+        </Btn>
+      </BtnGroup>
+    </template>
+
     <template #display="{ item }">
       <LazyImage
         v-if="item.smallUrl"

--- a/app/frontend/shared/components/InlineEditableList/index.vue
+++ b/app/frontend/shared/components/InlineEditableList/index.vue
@@ -9,10 +9,13 @@ import {
   BtnSizesEnum,
   BtnVariantsEnum,
 } from "@/shared/components/base/Btn/types";
+import Collapsed from "@/shared/components/Collapsed.vue";
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import ListGroup from "@/shared/components/ListGroup/index.vue";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useMobile } from "@/shared/composables/useMobile";
 import { useI18n } from "@/shared/composables/useI18n";
+import { uniq as uniqArray } from "@/shared/utils/Array";
 
 type Props = {
   items: T[];
@@ -21,6 +24,7 @@ type Props = {
   emptyName?: string;
   hideDestroy?: boolean;
   hideEdit?: boolean;
+  selectable?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -29,6 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
   emptyName: "entries",
   hideDestroy: false,
   hideEdit: false,
+  selectable: false,
 });
 
 const { displayConfirm } = useAppNotifications();
@@ -46,6 +51,40 @@ const emit = defineEmits<{
 
 const editingId = ref<string | null>(null);
 const creating = ref(false);
+
+const internalSelected = ref<string[]>([]);
+
+const allSelected = computed(() => {
+  if (!props.items.length) {
+    return false;
+  }
+
+  return props.items
+    .map((item) => item.id)
+    .every((id) => internalSelected.value.includes(id));
+});
+
+const partialSelected = computed(() => {
+  return internalSelected.value.length > 0 && !allSelected.value;
+});
+
+const onAllSelectedChange = (value?: boolean) => {
+  if (value) {
+    internalSelected.value = [
+      ...internalSelected.value,
+      ...props.items.map((item) => item.id),
+    ].filter(uniqArray);
+  } else {
+    const currentIds = props.items.map((item) => item.id);
+    internalSelected.value = internalSelected.value.filter(
+      (id) => !currentIds.includes(id),
+    );
+  }
+};
+
+const resetSelected = () => {
+  internalSelected.value = [];
+};
 
 const startEdit = (item: T) => {
   editingId.value = item.id;
@@ -99,13 +138,59 @@ const finishCreate = () => {
 defineExpose({
   editingId,
   creating,
+  selected: internalSelected,
   startCreate,
   finishEdit,
   finishCreate,
+  resetSelected,
 });
 </script>
 
 <template>
+  <div
+    v-if="props.selectable && items.length"
+    class="inline-editable-list__toolbar"
+  >
+    <div class="inline-editable-list__toolbar-left">
+      <FormCheckbox
+        :model-value="allSelected"
+        name="select-all"
+        no-label
+        inline
+        :partial="partialSelected"
+        @update:model-value="onAllSelectedChange"
+      />
+      <Collapsed
+        :visible="!!internalSelected.length"
+        as="span"
+        class="inline-editable-list__toolbar-info"
+      >
+        <span>
+          {{
+            t("filteredTable.labels.selected", {
+              count: internalSelected.length,
+            })
+          }}
+        </span>
+        <Btn
+          v-tooltip="t('filteredTable.actions.unselect')"
+          :size="BtnSizesEnum.SMALL"
+          :variant="BtnVariantsEnum.LINK"
+          inline
+          @click="resetSelected"
+        >
+          <i class="fa fa-times" />
+        </Btn>
+      </Collapsed>
+    </div>
+    <Collapsed
+      :visible="!!internalSelected.length"
+      class="inline-editable-list__actions"
+    >
+      <slot name="selected-actions" :selected="internalSelected" />
+    </Collapsed>
+  </div>
+
   <ListGroup :items="items" :loading="loading" :empty-name="emptyName">
     <template #prepend>
       <div v-if="creating" key="__create__" class="list-group__item">
@@ -136,6 +221,15 @@ defineExpose({
     </template>
 
     <template #display="{ item }">
+      <FormCheckbox
+        v-if="props.selectable"
+        v-model="internalSelected"
+        name="item"
+        no-label
+        inline
+        :checkbox-value="item.id"
+        class="inline-editable-list__checkbox"
+      />
       <template v-if="editingId === item.id">
         <div class="inline-editable-list__form">
           <slot name="edit" :item="item" />
@@ -232,5 +326,51 @@ defineExpose({
   & > * {
     flex: 1;
   }
+}
+
+.inline-editable-list__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px;
+  width: 100%;
+  min-height: 68px;
+}
+
+.inline-editable-list__toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: $primary;
+  white-space: nowrap;
+  font-size: 120%;
+
+  :deep(.panel-btn-inner) {
+    color: $primary;
+  }
+}
+
+.inline-editable-list__toolbar-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.inline-editable-list__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  :deep(.panel-btn),
+  :deep(.panel-btn-group) {
+    margin-bottom: 0;
+    margin-right: 0;
+  }
+}
+
+.inline-editable-list__checkbox {
+  flex-shrink: 0;
 }
 </style>

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -59,6 +59,8 @@
       "remove": "Entfernen",
       "delete": "Löschen",
       "deleteSelected": "Ausgewählte löschen",
+      "enableSelected": "Ausgewählte aktivieren",
+      "disableSelected": "Ausgewählte deaktivieren",
       "close": "Schließen",
       "filter": "Filter",
       "showStatusColor": "Status als Farbe anzeigen",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -69,6 +69,8 @@
       "remove": "Remove",
       "delete": "Delete",
       "deleteSelected": "Delete Selected",
+      "enableSelected": "Enable Selected",
+      "disableSelected": "Disable Selected",
       "close": "Close",
       "filter": "Filter",
       "showStatusColor": "Show Status as Color",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -53,6 +53,8 @@
       "remove": "Eliminar",
       "delete": "Borrar",
       "deleteSelected": "Borrar seleccionados",
+      "enableSelected": "Activar seleccionados",
+      "disableSelected": "Desactivar seleccionados",
       "close": "Cerrar",
       "filter": "Filtrar",
       "showStatusColor": "Mostrar estado como color",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -53,6 +53,8 @@
       "remove": "Retirer",
       "delete": "Supprimer",
       "deleteSelected": "Supprimer la sélection",
+      "enableSelected": "Activer la sélection",
+      "disableSelected": "Désactiver la sélection",
       "close": "Fermer",
       "filter": "Filtrer",
       "showStatusColor": "Afficher l'état en tant que couleur",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -53,6 +53,8 @@
       "remove": "Rimuovi",
       "delete": "Elimina",
       "deleteSelected": "Elimina selezionati",
+      "enableSelected": "Attiva selezionati",
+      "disableSelected": "Disattiva selezionati",
       "close": "Chiudi",
       "filter": "Filtra",
       "showStatusColor": "Mostra stato come colori",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -53,6 +53,8 @@
       "remove": "移除",
       "delete": "删除",
       "deleteSelected": "删除选中项",
+      "enableSelected": "启用选中项",
+      "disableSelected": "禁用选中项",
       "close": "关闭",
       "filter": "过滤",
       "showStatusColor": "显示状态颜色",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -53,6 +53,8 @@
       "remove": "移除",
       "delete": "刪除",
       "deleteSelected": "刪除選中項",
+      "enableSelected": "啟用選中項",
+      "disableSelected": "停用選中項",
       "close": "關閉",
       "filter": "篩選",
       "showStatusColor": "顯示狀態顏色",

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -76,7 +76,10 @@ v1_admin_api_routes = lambda do
   end
 
   resources :images, only: %i[index create destroy update] do
-    put :attach, on: :collection
+    collection do
+      put :attach
+      put "bulk", to: "images#update_bulk"
+    end
   end
 
   resources :imports, only: %i[index show]

--- a/spec/requests/admin/api/v1/images/update_bulk_spec.rb
+++ b/spec/requests/admin/api/v1/images/update_bulk_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:images]) }
+  let(:images) { create_list(:image, 3) }
+  let(:input) do
+    {
+      ids: images.pluck(:id),
+      enabled: true
+    }
+  end
+
+  before do
+    sign_in user if user.present?
+  end
+
+  path "/images/bulk" do
+    put("Bulk update images") do
+      operationId "updateBulkImage"
+      tags "Images"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :input, in: :body, schema: {"$ref": "#/components/schemas/ImageUpdateBulkInput"}, required: true
+
+      response(200, "successful") do
+        run_test!
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:user) { nil }
+
+        run_test!
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:user) { create(:admin_user, resource_access: []) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -1437,6 +1437,34 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/ImageInput"
+  "/images/bulk":
+    put:
+      summary: Bulk update images
+      operationId: updateBulkImage
+      tags:
+      - Images
+      parameters: []
+      responses:
+        '200':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ImageUpdateBulkInput"
+        required: true
   "/imports":
     get:
       summary: Imports list
@@ -6883,6 +6911,26 @@ components:
       additionalProperties: false
       example: {}
       title: ImageQuery
+    ImageUpdateBulkInput:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        enabled:
+          type: boolean
+        global:
+          type: boolean
+        background:
+          type: boolean
+        caption:
+          type: string
+      additionalProperties: false
+      required:
+      - ids
+      title: ImageUpdateBulkInput
     Images:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Add `PUT /images/bulk` admin API endpoint to update multiple images in a single request
- Add bulk enable/disable buttons to the admin images list page (`/admin/images`)
- Add selectable support to `InlineEditableList` component with select-all, partial selection, and animated transitions
- Wire up bulk enable/disable on the model images edit page (`/admin/models/[id]/edit/images`)

## Test plan
- [x] Navigate to `/admin/models/[id]/edit/images`, select images via checkboxes, verify enable/disable bulk actions work
- [x] Verify partial selection shows dash indicator on select-all checkbox
- [x] Verify select-all toggles all visible items
- [x] Navigate to `/admin/images`, select images, verify bulk actions work there too
- [x] Verify unauthorized users cannot access the bulk endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)