### PR TITLE
Replace Toggle switches with icon buttons in InlineEditableList

### DIFF
--- a/app/frontend/admin/pages/maintenance/features.vue
+++ b/app/frontend/admin/pages/maintenance/features.vue
@@ -10,7 +10,10 @@ import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
 import Toggle from "@/shared/components/base/Toggle/index.vue";
 import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
 import UserFilterGroup from "@/admin/components/base/UserFilterGroup/index.vue";
@@ -308,12 +311,19 @@ const hasSelectedActor = computed(() => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
-        :label="mobile ? t('labels.features.toggle') : undefined"
-        :active="item.state === 'on'"
+      <Btn
+        v-tooltip="t('labels.features.toggle')"
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
         data-test="toggle-feature"
-        @toggle="toggleFeature(item)"
-      />
+        @click="toggleFeature(item)"
+      >
+        <i
+          class="fa-duotone fa-power-off"
+          :class="item.state === 'on' ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.features.toggle") }}</span>
+      </Btn>
     </template>
 
     <template #edit="{ item }">

--- a/app/frontend/admin/pages/models/[id]/edit/images.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/images.vue
@@ -8,7 +8,6 @@ export default {
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
 import {
   BtnSizesEnum,
   BtnVariantsEnum,
@@ -250,12 +249,18 @@ const handleUploadDone = async (files: FileUpload[]) => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
-        v-tooltip="t('labels.image.enabled')"
-        :label="mobile ? t('labels.image.enabled') : undefined"
-        :active="item.enabled"
-        @toggle="toggleField(item, 'enabled')"
-      />
+      <Btn
+        v-tooltip="t('labels.image.active')"
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'enabled')"
+      >
+        <i
+          class="fa-duotone fa-circle-check"
+          :class="item.enabled ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.image.active") }}</span>
+      </Btn>
       <Btn
         v-tooltip="t('labels.image.global')"
         :size="BtnSizesEnum.SMALL"

--- a/app/frontend/admin/pages/models/[id]/edit/loaners.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/loaners.vue
@@ -8,7 +8,10 @@ export default {
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
 import {
   type ModelExtended,
   type ModelLoaner,
@@ -23,7 +26,6 @@ import { useQueryClient } from "@tanstack/vue-query";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import ModelFilterGroup from "@/admin/components/base/ModelFilterGroup/index.vue";
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 
 type Props = {
   model: ModelExtended;
@@ -164,12 +166,18 @@ const onSaveCreate = async () => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
+      <Btn
         v-tooltip="t('labels.modelLoaner.hidden')"
-        :label="mobile ? t('labels.modelLoaner.hidden') : undefined"
-        :active="!item.hidden"
-        @toggle="toggleField(item, 'hidden')"
-      />
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'hidden')"
+      >
+        <i
+          class="fa-duotone fa-eye"
+          :class="!item.hidden ? '' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelLoaner.hidden") }}</span>
+      </Btn>
     </template>
 
     <template #edit>

--- a/app/frontend/admin/pages/models/[id]/edit/modules.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/modules.vue
@@ -9,7 +9,6 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
@@ -233,18 +232,30 @@ const onUnlink = (record: ModelModule) => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
+      <Btn
         v-tooltip="t('labels.modelModule.hidden')"
-        :label="mobile ? t('labels.modelModule.hidden') : undefined"
-        :active="!item.hidden"
-        @toggle="toggleField(item, 'hidden')"
-      />
-      <Toggle
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'hidden')"
+      >
+        <i
+          class="fa-duotone fa-eye"
+          :class="!item.hidden ? '' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelModule.hidden") }}</span>
+      </Btn>
+      <Btn
         v-tooltip="t('labels.modelModule.active')"
-        :label="mobile ? t('labels.modelModule.active') : undefined"
-        :active="item.active"
-        @toggle="toggleField(item, 'active')"
-      />
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'active')"
+      >
+        <i
+          class="fa-duotone fa-circle-check"
+          :class="item.active ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelModule.active") }}</span>
+      </Btn>
       <Btn
         v-tooltip="t('actions.unlink')"
         :size="BtnSizesEnum.SMALL"

--- a/app/frontend/admin/pages/models/[id]/edit/packages.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/packages.vue
@@ -9,7 +9,6 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
@@ -34,7 +33,10 @@ import {
 import { useQueryClient } from "@tanstack/vue-query";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
 
 type Props = {
   model: ModelExtended;
@@ -238,18 +240,30 @@ const onSaveCreate = async () => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
+      <Btn
         v-tooltip="t('labels.modelModulePackage.hidden')"
-        :label="mobile ? t('labels.modelModulePackage.hidden') : undefined"
-        :active="!item.hidden"
-        @toggle="toggleField(item, 'hidden')"
-      />
-      <Toggle
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'hidden')"
+      >
+        <i
+          class="fa-duotone fa-eye"
+          :class="!item.hidden ? '' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelModulePackage.hidden") }}</span>
+      </Btn>
+      <Btn
         v-tooltip="t('labels.modelModulePackage.active')"
-        :label="mobile ? t('labels.modelModulePackage.active') : undefined"
-        :active="item.active"
-        @toggle="toggleField(item, 'active')"
-      />
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'active')"
+      >
+        <i
+          class="fa-duotone fa-circle-check"
+          :class="item.active ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelModulePackage.active") }}</span>
+      </Btn>
     </template>
 
     <template #edit="{ item }">

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -8,7 +8,10 @@ export default {
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
 import {
   type ModelExtended,
   type ModelPaint,
@@ -26,7 +29,6 @@ import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 
 type Props = {
   model: ModelExtended;
@@ -189,18 +191,30 @@ const onSaveCreate = async () => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
+      <Btn
         v-tooltip="t('labels.modelPaint.hidden')"
-        :label="mobile ? t('labels.modelPaint.hidden') : undefined"
-        :active="!item.hidden"
-        @toggle="toggleField(item, 'hidden')"
-      />
-      <Toggle
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'hidden')"
+      >
+        <i
+          class="fa-duotone fa-eye"
+          :class="!item.hidden ? '' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelPaint.hidden") }}</span>
+      </Btn>
+      <Btn
         v-tooltip="t('labels.modelPaint.active')"
-        :label="mobile ? t('labels.modelPaint.active') : undefined"
-        :active="item.active"
-        @toggle="toggleField(item, 'active')"
-      />
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'active')"
+      >
+        <i
+          class="fa-duotone fa-circle-check"
+          :class="item.active ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelPaint.active") }}</span>
+      </Btn>
       <Btn
         v-tooltip="!mobile && t('actions.copy')"
         :size="BtnSizesEnum.SMALL"

--- a/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
@@ -9,7 +9,6 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
@@ -228,18 +227,30 @@ const onUnlink = (record: ModelUpgrade) => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
+      <Btn
         v-tooltip="t('labels.modelUpgrade.hidden')"
-        :label="mobile ? t('labels.modelUpgrade.hidden') : undefined"
-        :active="!item.hidden"
-        @toggle="toggleField(item, 'hidden')"
-      />
-      <Toggle
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'hidden')"
+      >
+        <i
+          class="fa-duotone fa-eye"
+          :class="!item.hidden ? '' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelUpgrade.hidden") }}</span>
+      </Btn>
+      <Btn
         v-tooltip="t('labels.modelUpgrade.active')"
-        :label="mobile ? t('labels.modelUpgrade.active') : undefined"
-        :active="item.active"
-        @toggle="toggleField(item, 'active')"
-      />
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleField(item, 'active')"
+      >
+        <i
+          class="fa-duotone fa-circle-check"
+          :class="item.active ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.modelUpgrade.active") }}</span>
+      </Btn>
       <Btn
         v-tooltip="t('actions.unlink')"
         :size="BtnSizesEnum.SMALL"

--- a/app/frontend/frontend/pages/settings/features.vue
+++ b/app/frontend/frontend/pages/settings/features.vue
@@ -13,7 +13,10 @@ import InlineEditableList from "@/shared/components/InlineEditableList/index.vue
 import Empty from "@/shared/components/Empty/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
-import Toggle from "@/shared/components/base/Toggle/index.vue";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
 import {
   useUserFeatures,
   getUserFeaturesQueryKey,
@@ -105,11 +108,18 @@ const toggleFeature = async (feature: FeatureItem) => {
     </template>
 
     <template #actions="{ item, mobile }">
-      <Toggle
-        :label="mobile ? t('labels.features.toggle') : undefined"
-        :active="item.enabled"
-        @toggle="toggleFeature(item)"
-      />
+      <Btn
+        v-tooltip="t('labels.features.toggle')"
+        :size="BtnSizesEnum.SMALL"
+        :variant="BtnVariantsEnum.TRANSPARENT"
+        @click="toggleFeature(item)"
+      >
+        <i
+          class="fa-duotone fa-power-off"
+          :class="item.enabled ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.features.toggle") }}</span>
+      </Btn>
     </template>
   </InlineEditableList>
 </template>

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -424,6 +424,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Use as Background?",
         "enabled": "Enabled?",
         "global": "Global?",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -735,6 +735,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Use as Background?",
         "caption": "Caption",
         "enabled": "Enabled?",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -363,6 +363,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Use as Background?",
         "enabled": "Enabled?",
         "global": "Global?",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -363,6 +363,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Utiliser comme arrière-plan ?",
         "enabled": "Activé?",
         "global": "Global?",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -363,6 +363,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Utilizzare come background?",
         "enabled": "Abilitato?",
         "global": "Globale?",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -365,6 +365,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Use as Background?",
         "enabled": "Enabled?",
         "global": "Global?",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -365,6 +365,7 @@
         }
       },
       "image": {
+        "active": "Active?",
         "background": "Use as Background?",
         "enabled": "Enabled?",
         "global": "Global?",


### PR DESCRIPTION
## Summary
- Replaced sliding `Toggle` switches with simple icon `Btn` components in all InlineEditableList action slots
- Uses `fa-eye` for hidden toggles, `fa-circle-check` for active toggles, and `fa-power-off` for feature toggles
- Added `image.active` translation key across all 7 locales

## Test plan
- [x] Verify icon buttons render correctly in admin model edit pages (paints, images, modules, packages, upgrades, loaners)
- [x] Verify feature toggle buttons work on admin features page and user settings features page
- [x] Verify mobile dropdown still shows text labels alongside icons
- [x] Verify tooltips appear on hover for desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)