### PR TITLE
fix: Pass wishlist prop to VehiclePanel in wishlist grid view

### DIFF
--- a/app/frontend/frontend/pages/hangar/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/wishlist.vue
@@ -302,6 +302,7 @@ const openDisplayOptionsModal = () => {
             :vehicle="record"
             :details="detailsVisible"
             :editable="true"
+            wishlist
           />
         </template>
       </Grid>


### PR DESCRIPTION
## Summary
- Fix wishlist grid view showing "add to wishlist" instead of "add to hangar" in the vehicle context menu
- The `wishlist` prop was missing on `VehiclePanel` in the grid view (table view already had it)

## Test plan
- [x] Open the wishlist page in grid view
- [x] Open the context menu on a wishlist item
- [x] Verify it shows "add to hangar" instead of "add to wishlist"

🤖 Generated with [Claude Code](https://claude.com/claude-code)