### PR TITLE
Fix hangar sync duplicates when RSI pledge ID changes

### DIFF
--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -157,6 +157,37 @@ class HangarSync < HangarImporter
       missing_models << item[:name]
     end
 
+    # Reconcile: match newly imported vehicles against unmatched existing vehicles
+    # This handles cases where pledge IDs changed and the normal matching failed
+    unmatched_vehicle_ids = vehicle_scope.where.not(id: vehicle_ids).pluck(:id, :model_id, :model_paint_id)
+    imported_vehicle_records = Vehicle.where(id: imported_vehicles).pluck(:id, :model_id, :model_paint_id)
+
+    imported_vehicle_records.each do |imported_id, imported_model_id, imported_paint_id|
+      match = unmatched_vehicle_ids.find { |_, model_id, paint_id| model_id == imported_model_id && paint_id == imported_paint_id }
+      next unless match
+
+      original_id = match[0]
+      original_vehicle = Vehicle.find(original_id)
+      imported_vehicle = Vehicle.find(imported_id)
+
+      # Transfer the new pledge data to the original vehicle
+      original_vehicle.update!(
+        rsi_pledge_id: imported_vehicle.rsi_pledge_id,
+        rsi_pledge_synced_at: imported_vehicle.rsi_pledge_synced_at,
+        wanted: false
+      )
+
+      # Remove the duplicate
+      imported_vehicle.destroy!
+
+      # Update tracking arrays
+      vehicle_ids << original_id
+      vehicle_ids.delete(imported_id)
+      imported_vehicles.delete(imported_id)
+      found_vehicles << original_id
+      unmatched_vehicle_ids.delete(match)
+    end
+
     vehicle_scope.where.not(id: vehicle_ids).find_each do |vehicle|
       initial_updated_at = vehicle.updated_at
       vehicle.update!(rsi_pledge_id: nil, rsi_pledge_synced_at: nil, wanted: true)

--- a/docs/exec-plans/3632-hangar-sync-pledge-id-change.md
+++ b/docs/exec-plans/3632-hangar-sync-pledge-id-change.md
@@ -1,0 +1,64 @@
+# Fix: Hangar sync creating duplicates when RSI pledge ID changes
+
+Issue: fleetyards/fleetyards#3632
+Branch: `fix/3632-hangar-sync-pledge-id-change`
+
+## Problem
+
+When RSI changes a pledge ID (package restructure, melt/rebuy), the hangar sync:
+1. Fails to match the existing vehicle by `model_id + rsi_pledge_id` (pledge ID changed)
+2. The model-only fallback at line 89 should catch it but fails in edge cases
+3. Creates a new duplicate vehicle
+4. Moves the original to wanted (wishlist)
+
+## Root Cause Analysis
+
+The sync processes RSI items one at a time. For each item:
+1. Try `model_id + rsi_pledge_id` match
+2. Fallback to `model_id` only match
+3. If neither matches, create new vehicle
+
+After all items processed, any unmatched vehicles are moved to wanted.
+
+The issue: if the fallback fails for any reason (race between shared pledge IDs, model resolution differences), there's no safety net before creating duplicates and moving originals to wanted.
+
+## Solution
+
+Add a reconciliation pass in `sync_vehicles` between the main loop and the "move to wanted" step:
+
+1. After the main loop, identify:
+   - **Unmatched RSI items**: items that resulted in a new vehicle creation where an existing vehicle of the same model already exists in the unmatched set
+   - **Unmatched vehicles**: vehicles not claimed by any RSI item (about to be moved to wanted)
+
+2. For each unmatched vehicle, check if a newly created vehicle exists with the same `model_id` (and optionally `model_paint_id`). If so, this is likely a duplicate caused by a pledge ID change — delete the new one and claim the original instead.
+
+This is simpler and more robust than trying to fix every possible edge case in the main loop.
+
+## Implementation Steps
+
+### Step 1: Add test for pledge ID change scenario
+File: `spec/loaders/hangar_sync_spec.rb`
+
+- Add a test case where an existing vehicle has an old `rsi_pledge_id` and the RSI data comes in with a new pledge ID for the same model
+- Verify: existing vehicle is updated (not moved to wanted), no duplicate created
+
+### Step 2: Add reconciliation logic to `HangarSync#sync_vehicles`
+File: `app/lib/hangar_sync.rb`
+
+After the main `@ships.each` loop and before the "move to wanted" loop:
+- Collect unmatched vehicle IDs (in scope but not in `vehicle_ids`)
+- Collect newly imported vehicle IDs (`imported_vehicles`)
+- For each imported vehicle, check if there's an unmatched vehicle with the same `model_id` (and `model_paint_id`)
+- If found: update the original vehicle with the new pledge ID and sync timestamp, delete the newly created one, move the ID from `imported_vehicles` to `found_vehicles`
+
+### Step 3: Verify existing tests still pass
+Run the full hangar sync spec to ensure no regressions.
+
+## Files to Modify
+
+- `app/lib/hangar_sync.rb` — add reconciliation pass
+- `spec/loaders/hangar_sync_spec.rb` — add pledge ID change test
+
+## Risk Assessment
+
+Low risk — the reconciliation pass only acts on vehicles that were just created in the same sync run, matching them against vehicles that are about to be moved to wanted. No existing behavior changes for normal sync flows.

--- a/spec/loaders/hangar_sync_spec.rb
+++ b/spec/loaders/hangar_sync_spec.rb
@@ -68,4 +68,31 @@ RSpec.describe HangarSync do
       expect(pirate_ship.reload.name).to eq("Enterprise")
     end
   end
+
+  context "when rsi_pledge_id changes" do
+    let(:andromeda_model) { Model.find_by!(slug: "constellation-andromeda") }
+
+    let!(:andromeda_ship) do
+      create(:vehicle, user: user, model: andromeda_model, name: "USS Troi", wanted: false, public: true,
+        rsi_pledge_id: "OLD_PLEDGE_ID", rsi_pledge_synced_at: 1.day.ago)
+    end
+
+    it "updates the existing vehicle instead of creating a duplicate" do
+      Timecop.freeze(1.minute.from_now)
+
+      result = ::HangarSync.new(input).run(user.id)
+
+      expect(result[:found_vehicles]).to include(andromeda_ship.id)
+      expect(result[:moved_vehicles_to_wanted]).not_to include(andromeda_ship.id)
+
+      andromeda_ship.reload
+      expect(andromeda_ship.rsi_pledge_id).to eq("00064313")
+      expect(andromeda_ship.wanted).to be(false)
+      expect(andromeda_ship.name).to eq("USS Troi")
+
+      # No duplicate should exist
+      andromeda_vehicles = Vehicle.where(user_id: user.id, model_id: andromeda_model.id)
+      expect(andromeda_vehicles.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a reconciliation pass in `HangarSync#sync_vehicles` that detects when a newly created vehicle matches an existing unmatched vehicle by `model_id` + `model_paint_id`
- Transfers pledge data to the original vehicle and destroys the duplicate, preserving custom names and other attributes
- Adds test coverage for the pledge ID change scenario

Closes #3632

## Test plan

- [x] New test: vehicle with old pledge ID is updated (not duplicated/moved to wanted)
- [x] Existing sync test still passes
- [x] Manual test: run sync with a vehicle whose pledge ID changed on RSI

🤖 Generated with [Claude Code](https://claude.com/claude-code)