### PR TITLE
refactor: extract shared examples for spec auth and import patterns

### DIFF
--- a/spec/jobs/loaders/model_job_spec.rb
+++ b/spec/jobs/loaders/model_job_spec.rb
@@ -3,32 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Loaders::ModelJob do
-  describe "#perform" do
-    it "creates an import, runs the loader, and finishes the import" do
-      loader = instance_double(Rsi::ModelsLoader)
-      allow(Rsi::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:one)
-
-      described_class.new.perform(123)
-
-      import = Imports::ModelImport.last
-
-      expect(import).to be_present
-      expect(import.aasm_state).to eq("finished")
-      expect(loader).to have_received(:one).with(123)
-    end
-
-    it "marks import as failed on error" do
-      loader = instance_double(Rsi::ModelsLoader)
-      allow(Rsi::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:one).and_raise(StandardError, "loader error")
-
-      expect { described_class.new.perform(123) }.to raise_error(StandardError, "loader error")
-
-      import = Imports::ModelImport.last
-
-      expect(import.aasm_state).to eq("failed")
-      expect(import.info).to eq("loader error")
-    end
-  end
+  include_examples "import_wrapping_job",
+    import_class: Imports::ModelImport,
+    loader_class: Rsi::ModelsLoader,
+    loader_method: :one,
+    perform_args: [123],
+    loader_args: [123]
 end

--- a/spec/jobs/loaders/models_job_spec.rb
+++ b/spec/jobs/loaders/models_job_spec.rb
@@ -3,32 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Loaders::ModelsJob do
-  describe "#perform" do
-    it "creates an import, runs the loader, and finishes the import" do
-      loader = instance_double(Rsi::ModelsLoader)
-      allow(Rsi::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:all)
-
-      described_class.new.perform
-
-      import = Imports::ModelsImport.last
-
-      expect(import).to be_present
-      expect(import.aasm_state).to eq("finished")
-      expect(loader).to have_received(:all)
-    end
-
-    it "marks import as failed on error" do
-      loader = instance_double(Rsi::ModelsLoader)
-      allow(Rsi::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:all).and_raise(StandardError, "loader error")
-
-      expect { described_class.new.perform }.to raise_error(StandardError, "loader error")
-
-      import = Imports::ModelsImport.last
-
-      expect(import.aasm_state).to eq("failed")
-      expect(import.info).to eq("loader error")
-    end
-  end
+  include_examples "import_wrapping_job",
+    import_class: Imports::ModelsImport,
+    loader_class: Rsi::ModelsLoader,
+    loader_method: :all
 end

--- a/spec/jobs/loaders/sc_data/models_job_spec.rb
+++ b/spec/jobs/loaders/sc_data/models_job_spec.rb
@@ -3,36 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Loaders::ScData::ModelsJob do
-  describe "#perform" do
-    before do
-      allow(Rails.configuration).to receive(:sc_data).and_return({version: "3.24.0", environment: "live"})
-    end
-
-    it "creates an import, runs the loader, and finishes the import" do
-      loader = instance_double(ScData::Loader::ModelsLoader)
-      allow(ScData::Loader::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:all)
-
-      described_class.new.perform
-
-      import = Imports::ScData::ModelsImport.last
-
-      expect(import).to be_present
-      expect(import.aasm_state).to eq("finished")
-      expect(loader).to have_received(:all)
-    end
-
-    it "marks import as failed on error" do
-      loader = instance_double(ScData::Loader::ModelsLoader)
-      allow(ScData::Loader::ModelsLoader).to receive(:new).and_return(loader)
-      allow(loader).to receive(:all).and_raise(StandardError, "sc data error")
-
-      expect { described_class.new.perform }.to raise_error(StandardError, "sc data error")
-
-      import = Imports::ScData::ModelsImport.last
-
-      expect(import.aasm_state).to eq("failed")
-      expect(import.info).to eq("sc data error")
-    end
-  end
+  include_examples "import_wrapping_job",
+    import_class: Imports::ScData::ModelsImport,
+    loader_class: ScData::Loader::ModelsLoader,
+    loader_method: :all,
+    before_perform: -> { allow(Rails.configuration).to receive(:sc_data).and_return({version: "3.24.0", environment: "live"}) }
 end

--- a/spec/requests/admin/api/v1/admin_users/create_spec.rb
+++ b/spec/requests/admin/api/v1/admin_users/create_spec.rb
@@ -36,21 +36,7 @@ RSpec.describe "admin/api/v1/admin_users", type: :request, swagger_doc: "admin/v
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, super_admin: false) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth", forbidden_user: -> { create(:admin_user, super_admin: false) }
     end
   end
 end

--- a/spec/requests/admin/api/v1/admin_users/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/admin_users/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/admin_users", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, super_admin: false) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth", forbidden_user: -> { create(:admin_user, super_admin: false) }
     end
   end
 end

--- a/spec/requests/admin/api/v1/admin_users/index_spec.rb
+++ b/spec/requests/admin/api/v1/admin_users/index_spec.rb
@@ -23,21 +23,7 @@ RSpec.describe "admin/api/v1/admin_users", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, super_admin: false) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth", forbidden_user: -> { create(:admin_user, super_admin: false) }
     end
   end
 end

--- a/spec/requests/admin/api/v1/admin_users/show_spec.rb
+++ b/spec/requests/admin/api/v1/admin_users/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/admin_users", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/admin_users/update_spec.rb
+++ b/spec/requests/admin/api/v1/admin_users/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/admin_users", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, super_admin: false) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth", forbidden_user: -> { create(:admin_user, super_admin: false) }
     end
   end
 end

--- a/spec/requests/admin/api/v1/cargo_holds/index_spec.rb
+++ b/spec/requests/admin/api/v1/cargo_holds/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/cargo_holds", type: :request, swagger_doc: "admin/v
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/cargo_holds/update_spec.rb
+++ b/spec/requests/admin/api/v1/cargo_holds/update_spec.rb
@@ -50,21 +50,7 @@ RSpec.describe "admin/api/v1/cargo_holds", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/components/create_spec.rb
+++ b/spec/requests/admin/api/v1/components/create_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/components", type: :request, swagger_doc: "admin/v1
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/components/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/components/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/components", type: :request, swagger_doc: "admin/v1
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/components/index_spec.rb
+++ b/spec/requests/admin/api/v1/components/index_spec.rb
@@ -72,21 +72,7 @@ RSpec.describe "admin/api/v1/components", type: :request, swagger_doc: "admin/v1
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/components/show_spec.rb
+++ b/spec/requests/admin/api/v1/components/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/components", type: :request, swagger_doc: "admin/v1
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/components/update_spec.rb
+++ b/spec/requests/admin/api/v1/components/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/components", type: :request, swagger_doc: "admin/v1
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/docks/create_spec.rb
+++ b/spec/requests/admin/api/v1/docks/create_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/docks", type: :request, swagger_doc: "admin/v1/sche
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/docks/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/docks/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/docks", type: :request, swagger_doc: "admin/v1/sche
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/docks/index_spec.rb
+++ b/spec/requests/admin/api/v1/docks/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/docks", type: :request, swagger_doc: "admin/v1/sche
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/docks/show_spec.rb
+++ b/spec/requests/admin/api/v1/docks/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/docks", type: :request, swagger_doc: "admin/v1/sche
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/docks/update_spec.rb
+++ b/spec/requests/admin/api/v1/docks/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/docks", type: :request, swagger_doc: "admin/v1/sche
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/features/destroy_spec.rb
@@ -28,17 +28,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/disable_actor_spec.rb
+++ b/spec/requests/admin/api/v1/features/disable_actor_spec.rb
@@ -37,17 +37,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/disable_group_spec.rb
+++ b/spec/requests/admin/api/v1/features/disable_group_spec.rb
@@ -36,17 +36,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/disable_spec.rb
+++ b/spec/requests/admin/api/v1/features/disable_spec.rb
@@ -30,17 +30,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/enable_actor_spec.rb
+++ b/spec/requests/admin/api/v1/features/enable_actor_spec.rb
@@ -36,17 +36,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/enable_group_spec.rb
+++ b/spec/requests/admin/api/v1/features/enable_group_spec.rb
@@ -35,17 +35,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/enable_percentage_of_actors_spec.rb
+++ b/spec/requests/admin/api/v1/features/enable_percentage_of_actors_spec.rb
@@ -35,17 +35,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/enable_percentage_of_time_spec.rb
+++ b/spec/requests/admin/api/v1/features/enable_percentage_of_time_spec.rb
@@ -35,17 +35,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/enable_spec.rb
+++ b/spec/requests/admin/api/v1/features/enable_spec.rb
@@ -30,17 +30,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/index_spec.rb
+++ b/spec/requests/admin/api/v1/features/index_spec.rb
@@ -26,17 +26,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/show_spec.rb
+++ b/spec/requests/admin/api/v1/features/show_spec.rb
@@ -30,17 +30,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/features/toggle_self_service_spec.rb
+++ b/spec/requests/admin/api/v1/features/toggle_self_service_spec.rb
@@ -30,17 +30,7 @@ RSpec.describe "admin/api/v1/features", type: :request, swagger_doc: "admin/v1/s
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/fleets/create_spec.rb
+++ b/spec/requests/admin/api/v1/fleets/create_spec.rb
@@ -34,21 +34,7 @@ RSpec.describe "admin/api/v1/fleets", type: :request, swagger_doc: "admin/v1/sch
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/fleets/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/fleets/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/fleets", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/fleets/index_spec.rb
+++ b/spec/requests/admin/api/v1/fleets/index_spec.rb
@@ -26,21 +26,7 @@ RSpec.describe "admin/api/v1/fleets", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/fleets/show_spec.rb
+++ b/spec/requests/admin/api/v1/fleets/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/fleets", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/fleets/update_spec.rb
+++ b/spec/requests/admin/api/v1/fleets/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/fleets", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/images/create_spec.rb
+++ b/spec/requests/admin/api/v1/images/create_spec.rb
@@ -39,21 +39,7 @@ RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/images/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/images/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/images/index_spec.rb
+++ b/spec/requests/admin/api/v1/images/index_spec.rb
@@ -58,21 +58,7 @@ RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/sch
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/images/update_bulk_spec.rb
+++ b/spec/requests/admin/api/v1/images/update_bulk_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
-
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/images/update_spec.rb
+++ b/spec/requests/admin/api/v1/images/update_spec.rb
@@ -37,21 +37,7 @@ RSpec.describe "admin/api/v1/images", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
-
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
+      include_examples "admin_auth"
 
       response(404, "not_found") do
         schema "$ref": "#/components/schemas/StandardError"

--- a/spec/requests/admin/api/v1/imports/show_spec.rb
+++ b/spec/requests/admin/api/v1/imports/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/imports", type: :request, swagger_doc: "admin/v1/sc
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/item_prices/create_spec.rb
+++ b/spec/requests/admin/api/v1/item_prices/create_spec.rb
@@ -43,21 +43,7 @@ RSpec.describe "admin/api/v1/item_prices", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/item_prices/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/item_prices/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/item_prices", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/item_prices/index_spec.rb
+++ b/spec/requests/admin/api/v1/item_prices/index_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "admin/api/v1/item_prices", type: :request, swagger_doc: "admin/v
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/item_prices/show_spec.rb
+++ b/spec/requests/admin/api/v1/item_prices/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/item_prices", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/item_prices/update_spec.rb
+++ b/spec/requests/admin/api/v1/item_prices/update_spec.rb
@@ -54,21 +54,7 @@ RSpec.describe "admin/api/v1/item_prices", type: :request, swagger_doc: "admin/v
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/manufacturers/create_spec.rb
+++ b/spec/requests/admin/api/v1/manufacturers/create_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/manufacturers", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/manufacturers/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/manufacturers/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/manufacturers", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/manufacturers/index_spec.rb
+++ b/spec/requests/admin/api/v1/manufacturers/index_spec.rb
@@ -73,21 +73,7 @@ RSpec.describe "admin/api/v1/manufacturers", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/manufacturers/show_spec.rb
+++ b/spec/requests/admin/api/v1/manufacturers/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/manufacturers", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/manufacturers/update_spec.rb
+++ b/spec/requests/admin/api/v1/manufacturers/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/manufacturers", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoint_loadouts/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoint_loadouts/create_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/model_hardpoint_loadouts", type: :request, swagger_
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoint_loadouts/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoint_loadouts/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/model_hardpoint_loadouts", type: :request, swagger_
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoint_loadouts/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoint_loadouts/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/model_hardpoint_loadouts", type: :request, swagger_
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoint_loadouts/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoint_loadouts/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_hardpoint_loadouts", type: :request, swagger_
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoint_loadouts/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoint_loadouts/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/model_hardpoint_loadouts", type: :request, swagger_
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoints/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoints/create_spec.rb
@@ -44,21 +44,7 @@ RSpec.describe "admin/api/v1/model_hardpoints", type: :request, swagger_doc: "ad
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoints/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoints/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/model_hardpoints", type: :request, swagger_doc: "ad
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoints/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoints/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/model_hardpoints", type: :request, swagger_doc: "ad
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoints/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoints/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_hardpoints", type: :request, swagger_doc: "ad
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_hardpoints/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_hardpoints/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/model_hardpoints", type: :request, swagger_doc: "ad
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_loaners/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_loaners/create_spec.rb
@@ -41,21 +41,7 @@ RSpec.describe "admin/api/v1/model_loaners", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_loaners/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_loaners/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/model_loaners", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_loaners/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_loaners/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/model_loaners", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_loaners/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_loaners/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_loaners", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_loaners/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_loaners/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/model_loaners", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_module_packages/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_module_packages/create_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_module_packages", type: :request, swagger_doc
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_module_packages/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_module_packages/destroy_spec.rb
@@ -31,21 +31,7 @@ RSpec.describe "admin/api/v1/model_module_packages", type: :request, swagger_doc
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_module_packages/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_module_packages/index_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "admin/api/v1/model_module_packages", type: :request, swagger_doc
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_module_packages/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_module_packages/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/model_module_packages", type: :request, swagger_doc
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_module_packages/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_module_packages/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/model_module_packages", type: :request, swagger_doc
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/create_spec.rb
@@ -37,21 +37,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/index_spec.rb
@@ -40,21 +40,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/link_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/link_spec.rb
@@ -39,21 +39,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 
@@ -88,21 +74,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_modules/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_modules/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/model_modules", type: :request, swagger_doc: "admin
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_paints/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_paints/create_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/model_paints", type: :request, swagger_doc: "admin/
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_paints/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_paints/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/model_paints", type: :request, swagger_doc: "admin/
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_paints/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_paints/index_spec.rb
@@ -70,21 +70,7 @@ RSpec.describe "admin/api/v1/model_paints", type: :request, swagger_doc: "admin/
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_paints/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_paints/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/model_paints", type: :request, swagger_doc: "admin/
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_paints/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_paints/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/model_paints", type: :request, swagger_doc: "admin/
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/create_spec.rb
@@ -36,21 +36,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/index_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/link_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/link_spec.rb
@@ -39,21 +39,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 
@@ -88,21 +74,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/model_upgrades/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_upgrades/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/model_upgrades", type: :request, swagger_doc: "admi
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/create_spec.rb
+++ b/spec/requests/admin/api/v1/models/create_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/models/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/filters/production_status_spec.rb
+++ b/spec/requests/admin/api/v1/models/filters/production_status_spec.rb
@@ -21,21 +21,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/index_spec.rb
+++ b/spec/requests/admin/api/v1/models/index_spec.rb
@@ -70,21 +70,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/reload_matrix_spec.rb
+++ b/spec/requests/admin/api/v1/models/reload_matrix_spec.rb
@@ -25,21 +25,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/reload_one_matrix_spec.rb
+++ b/spec/requests/admin/api/v1/models/reload_one_matrix_spec.rb
@@ -37,21 +37,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/reload_one_scdata_spec.rb
+++ b/spec/requests/admin/api/v1/models/reload_one_scdata_spec.rb
@@ -37,21 +37,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/reload_one_spec.rb
+++ b/spec/requests/admin/api/v1/models/reload_one_spec.rb
@@ -38,21 +38,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/reload_scdata_spec.rb
+++ b/spec/requests/admin/api/v1/models/reload_scdata_spec.rb
@@ -25,21 +25,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/show_spec.rb
+++ b/spec/requests/admin/api/v1/models/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/update_spec.rb
+++ b/spec/requests/admin/api/v1/models/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/models/use_rsi_image_spec.rb
+++ b/spec/requests/admin/api/v1/models/use_rsi_image_spec.rb
@@ -41,21 +41,7 @@ RSpec.describe "admin/api/v1/models", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/oauth_applications/create_spec.rb
+++ b/spec/requests/admin/api/v1/oauth_applications/create_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/oauth_applications", type: :request, swagger_doc: "
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/oauth_applications/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/oauth_applications/destroy_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/oauth_applications", type: :request, swagger_doc: "
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/oauth_applications/index_spec.rb
+++ b/spec/requests/admin/api/v1/oauth_applications/index_spec.rb
@@ -25,21 +25,7 @@ RSpec.describe "admin/api/v1/oauth_applications", type: :request, swagger_doc: "
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/oauth_applications/show_spec.rb
+++ b/spec/requests/admin/api/v1/oauth_applications/show_spec.rb
@@ -33,21 +33,7 @@ RSpec.describe "admin/api/v1/oauth_applications", type: :request, swagger_doc: "
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/oauth_applications/update_spec.rb
+++ b/spec/requests/admin/api/v1/oauth_applications/update_spec.rb
@@ -45,21 +45,7 @@ RSpec.describe "admin/api/v1/oauth_applications", type: :request, swagger_doc: "
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/rsi_request_logs/index_spec.rb
+++ b/spec/requests/admin/api/v1/rsi_request_logs/index_spec.rb
@@ -33,17 +33,7 @@ RSpec.describe "admin/api/v1/rsi_request_logs", type: :request, swagger_doc: "ad
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/rsi_request_logs/resolve_spec.rb
+++ b/spec/requests/admin/api/v1/rsi_request_logs/resolve_spec.rb
@@ -24,17 +24,7 @@ RSpec.describe "admin/api/v1/rsi_request_logs", type: :request, swagger_doc: "ad
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { create(:admin_user, resource_access: []) }
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-        let(:user) { nil }
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/users/index_spec.rb
+++ b/spec/requests/admin/api/v1/users/index_spec.rb
@@ -73,21 +73,7 @@ RSpec.describe "admin/api/v1/users", type: :request, swagger_doc: "admin/v1/sche
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/vehicles/index_spec.rb
+++ b/spec/requests/admin/api/v1/vehicles/index_spec.rb
@@ -72,21 +72,7 @@ RSpec.describe "admin/api/v1/vehicles", type: :request, swagger_doc: "admin/v1/s
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/videos/create_spec.rb
+++ b/spec/requests/admin/api/v1/videos/create_spec.rb
@@ -41,21 +41,7 @@ RSpec.describe "admin/api/v1/videos", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/videos/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/videos/destroy_spec.rb
@@ -30,21 +30,7 @@ RSpec.describe "admin/api/v1/videos", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/videos/index_spec.rb
+++ b/spec/requests/admin/api/v1/videos/index_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "admin/api/v1/videos", type: :request, swagger_doc: "admin/v1/sch
         end
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/videos/show_spec.rb
+++ b/spec/requests/admin/api/v1/videos/show_spec.rb
@@ -35,21 +35,7 @@ RSpec.describe "admin/api/v1/videos", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/admin/api/v1/videos/update_spec.rb
+++ b/spec/requests/admin/api/v1/videos/update_spec.rb
@@ -42,21 +42,7 @@ RSpec.describe "admin/api/v1/videos", type: :request, swagger_doc: "admin/v1/sch
         run_test!
       end
 
-      response(403, "forbidden") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { create(:admin_user, resource_access: []) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "admin_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/check_spec.rb
+++ b/spec/requests/api/v1/fleets/check_spec.rb
@@ -60,29 +60,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/destroy_spec.rb
+++ b/spec/requests/api/v1/fleets/destroy_spec.rb
@@ -47,21 +47,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         run_test!
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -85,14 +71,6 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { create(:user) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/find_by_invite_spec.rb
+++ b/spec/requests/api/v1/fleets/find_by_invite_spec.rb
@@ -53,29 +53,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/invite_urls/create_spec.rb
+++ b/spec/requests/api/v1/fleets/invite_urls/create_spec.rb
@@ -65,21 +65,7 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         end
       end
 
-      response(201, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 201
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/ValidationError"
@@ -105,14 +91,6 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/invite_urls/destroy_spec.rb
+++ b/spec/requests/api/v1/fleets/invite_urls/destroy_spec.rb
@@ -50,21 +50,7 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         run_test!
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -86,14 +72,6 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/invite_urls/index_spec.rb
+++ b/spec/requests/api/v1/fleets/invite_urls/index_spec.rb
@@ -61,21 +61,7 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful") do
         schema type: :array,
@@ -102,14 +88,6 @@ RSpec.describe "api/v1/fleets/invite_urls", type: :request, swagger_doc: "v1/sch
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/invites_spec.rb
+++ b/spec/requests/api/v1/fleets/invites_spec.rb
@@ -52,29 +52,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/members/accept_request_spec.rb
+++ b/spec/requests/api/v1/fleets/members/accept_request_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/ValidationError"
@@ -102,14 +88,6 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/members/create_spec.rb
+++ b/spec/requests/api/v1/fleets/members/create_spec.rb
@@ -67,21 +67,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         end
       end
 
-      response(201, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 201
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/ValidationError"
@@ -107,14 +93,6 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/members/decline_request_spec.rb
+++ b/spec/requests/api/v1/fleets/members/decline_request_spec.rb
@@ -53,21 +53,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/ValidationError"
@@ -98,14 +84,6 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/members/demote_spec.rb
+++ b/spec/requests/api/v1/fleets/members/demote_spec.rb
@@ -54,21 +54,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -99,14 +85,6 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { another_member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/members/destroy_spec.rb
+++ b/spec/requests/api/v1/fleets/members/destroy_spec.rb
@@ -50,21 +50,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         run_test!
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
 
       response(204, "successful") do
         description "Delete own membership if not admin"

--- a/spec/requests/api/v1/fleets/members/index_spec.rb
+++ b/spec/requests/api/v1/fleets/members/index_spec.rb
@@ -144,34 +144,12 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:fleetSlug) { "unknown-fleet" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/members/promote_spec.rb
+++ b/spec/requests/api/v1/fleets/members/promote_spec.rb
@@ -53,21 +53,7 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -90,14 +76,6 @@ RSpec.describe "api/v1/fleets/members", type: :request, swagger_doc: "v1/schema.
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { another_member }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/my_spec.rb
+++ b/spec/requests/api/v1/fleets/my_spec.rb
@@ -52,29 +52,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/roles/index_spec.rb
+++ b/spec/requests/api/v1/fleets/roles/index_spec.rb
@@ -57,34 +57,12 @@ RSpec.describe "api/v1/fleets/roles", type: :request, swagger_doc: "v1/schema.ya
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:fleetSlug) { "unknown-fleet" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/show_spec.rb
+++ b/spec/requests/api/v1/fleets/show_spec.rb
@@ -58,21 +58,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(403, "forbidden") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -90,13 +76,6 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         run_test!
       end
 
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
     end
   end
 end

--- a/spec/requests/api/v1/fleets/show_spec.rb
+++ b/spec/requests/api/v1/fleets/show_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
 
         run_test!
       end
-
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/members_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/members_spec.rb
@@ -57,21 +57,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/model_counts_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/model_counts_spec.rb
@@ -77,21 +77,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/FleetModelCountsStats"
@@ -115,14 +101,6 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:fleetSlug) { "unknown-fleet" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/stats/models_by_classification_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/models_by_classification_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/models_by_manufacturer_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/models_by_manufacturer_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/models_by_production_status_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/models_by_production_status_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/models_by_size_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/models_by_size_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/vehicles_by_model_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/vehicles_by_model_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/fleets/stats/vehicles_spec.rb
+++ b/spec/requests/api/v1/fleets/stats/vehicles_spec.rb
@@ -48,21 +48,7 @@ RSpec.describe "api/v1/fleets/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "successful") do
         schema "$ref": "#/components/schemas/StandardError"

--- a/spec/requests/api/v1/fleets/update_spec.rb
+++ b/spec/requests/api/v1/fleets/update_spec.rb
@@ -82,21 +82,7 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -120,14 +106,6 @@ RSpec.describe "api/v1/fleets", type: :request, swagger_doc: "v1/schema.yaml" do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { create(:user) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/vehicles/export_spec.rb
+++ b/spec/requests/api/v1/fleets/vehicles/export_spec.rb
@@ -69,21 +69,7 @@ RSpec.describe "api/v1/fleets/vehicles", type: :request, swagger_doc: "v1/schema
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful") do
         schema type: :array, items: {"$ref": "#/components/schemas/FleetVehicleExport"}
@@ -119,14 +105,6 @@ RSpec.describe "api/v1/fleets/vehicles", type: :request, swagger_doc: "v1/schema
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:fleetSlug) { "unknown-fleet" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/fleets/vehicles/index_spec.rb
+++ b/spec/requests/api/v1/fleets/vehicles/index_spec.rb
@@ -124,34 +124,12 @@ RSpec.describe "api/v1/fleets/vehicles", type: :request, swagger_doc: "v1/schema
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:fleetSlug) { "unknown-fleet" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/hangar/destroy_spec.rb
+++ b/spec/requests/api/v1/hangar/destroy_spec.rb
@@ -44,29 +44,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/hangar/export_spec.rb
+++ b/spec/requests/api/v1/hangar/export_spec.rb
@@ -61,29 +61,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/groups/create_spec.rb
+++ b/spec/requests/api/v1/hangar/groups/create_spec.rb
@@ -57,29 +57,7 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(201, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 201
     end
   end
 end

--- a/spec/requests/api/v1/hangar/groups/destroy_spec.rb
+++ b/spec/requests/api/v1/hangar/groups/destroy_spec.rb
@@ -48,21 +48,7 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(403, "forbidden") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -76,14 +62,6 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:id) { SecureRandom.uuid }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/hangar/groups/index_spec.rb
+++ b/spec/requests/api/v1/hangar/groups/index_spec.rb
@@ -51,29 +51,7 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/groups/sort_spec.rb
+++ b/spec/requests/api/v1/hangar/groups/sort_spec.rb
@@ -60,29 +60,7 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/groups/update_spec.rb
+++ b/spec/requests/api/v1/hangar/groups/update_spec.rb
@@ -61,21 +61,7 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -89,14 +75,6 @@ RSpec.describe "api/v1/hangar/groups", type: :request, swagger_doc: "v1/schema.y
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:user) { create(:user) }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/hangar/import_spec.rb
+++ b/spec/requests/api/v1/hangar/import_spec.rb
@@ -61,21 +61,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/ValidationError"
@@ -94,14 +80,6 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         schema "$ref": "#/components/schemas/ValidationError"
 
         let(:input) { nil }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/hangar/items_spec.rb
+++ b/spec/requests/api/v1/hangar/items_spec.rb
@@ -51,29 +51,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/move_all_ingame_to_wishlist_spec.rb
+++ b/spec/requests/api/v1/hangar/move_all_ingame_to_wishlist_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/hangar/show_spec.rb
+++ b/spec/requests/api/v1/hangar/show_spec.rb
@@ -66,21 +66,7 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/Hangar"
@@ -121,14 +107,6 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
             "foo" => "bar"
           }
         end
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/hangar/stats/models_by_classification_spec.rb
+++ b/spec/requests/api/v1/hangar/stats/models_by_classification_spec.rb
@@ -47,29 +47,7 @@ RSpec.describe "api/v1/hangar/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/stats/models_by_manufacturer_spec.rb
+++ b/spec/requests/api/v1/hangar/stats/models_by_manufacturer_spec.rb
@@ -47,29 +47,7 @@ RSpec.describe "api/v1/hangar/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/stats/models_by_production_status_spec.rb
+++ b/spec/requests/api/v1/hangar/stats/models_by_production_status_spec.rb
@@ -47,29 +47,7 @@ RSpec.describe "api/v1/hangar/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/stats/models_by_size_spec.rb
+++ b/spec/requests/api/v1/hangar/stats/models_by_size_spec.rb
@@ -47,29 +47,7 @@ RSpec.describe "api/v1/hangar/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/stats/show_spec.rb
+++ b/spec/requests/api/v1/hangar/stats/show_spec.rb
@@ -56,29 +56,7 @@ RSpec.describe "api/v1/hangar/stats", type: :request, swagger_doc: "v1/schema.ya
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/hangar/sync_rsi_hangar_spec.rb
+++ b/spec/requests/api/v1/hangar/sync_rsi_hangar_spec.rb
@@ -59,34 +59,12 @@ RSpec.describe "api/v1/hangar", type: :request, swagger_doc: "v1/schema.yaml" do
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(400, "bad request") do
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:input) { nil }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/notification_preferences/index_spec.rb
+++ b/spec/requests/api/v1/notification_preferences/index_spec.rb
@@ -53,29 +53,7 @@ RSpec.describe "api/v1/notification_preferences", type: :request, swagger_doc: "
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/notifications/destroy_all_spec.rb
+++ b/spec/requests/api/v1/notifications/destroy_all_spec.rb
@@ -44,29 +44,7 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/notifications/destroy_spec.rb
+++ b/spec/requests/api/v1/notifications/destroy_spec.rb
@@ -48,21 +48,7 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
 
       response(401, "unauthorized") do
         schema "$ref": "#/components/schemas/StandardError"

--- a/spec/requests/api/v1/notifications/index_spec.rb
+++ b/spec/requests/api/v1/notifications/index_spec.rb
@@ -63,21 +63,7 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful with type filter") do
         schema "$ref": "#/components/schemas/Notifications"
@@ -92,14 +78,6 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
 
           expect(items.count).to eq(3)
         end
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
       end
     end
   end

--- a/spec/requests/api/v1/notifications/read_all_spec.rb
+++ b/spec/requests/api/v1/notifications/read_all_spec.rb
@@ -44,29 +44,7 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/notifications/read_spec.rb
+++ b/spec/requests/api/v1/notifications/read_spec.rb
@@ -54,21 +54,7 @@ RSpec.describe "api/v1/notifications", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(401, "unauthorized") do
         schema "$ref": "#/components/schemas/StandardError"

--- a/spec/requests/api/v1/user_features/disable_spec.rb
+++ b/spec/requests/api/v1/user_features/disable_spec.rb
@@ -49,21 +49,7 @@ RSpec.describe "api/v1/user_features", type: :request, swagger_doc: "v1/schema.y
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(403, "forbidden") do
         schema type: :object, properties: {code: {type: :string}, message: {type: :string}}

--- a/spec/requests/api/v1/user_features/enable_spec.rb
+++ b/spec/requests/api/v1/user_features/enable_spec.rb
@@ -48,21 +48,7 @@ RSpec.describe "api/v1/user_features", type: :request, swagger_doc: "v1/schema.y
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(403, "forbidden") do
         schema type: :object, properties: {code: {type: :string}, message: {type: :string}}

--- a/spec/requests/api/v1/user_features/index_spec.rb
+++ b/spec/requests/api/v1/user_features/index_spec.rb
@@ -50,21 +50,7 @@ RSpec.describe "api/v1/user_features", type: :request, swagger_doc: "v1/schema.y
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(401, "unauthorized") do
         schema "$ref": "#/components/schemas/StandardError"

--- a/spec/requests/api/v1/vehicles/create_spec.rb
+++ b/spec/requests/api/v1/vehicles/create_spec.rb
@@ -74,29 +74,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(201, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 201
     end
   end
 end

--- a/spec/requests/api/v1/vehicles/destroy_all_ingame_spec.rb
+++ b/spec/requests/api/v1/vehicles/destroy_all_ingame_spec.rb
@@ -50,29 +50,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/vehicles/destroy_bulk_spec.rb
+++ b/spec/requests/api/v1/vehicles/destroy_bulk_spec.rb
@@ -51,29 +51,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         run_test!
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/vehicles/destroy_spec.rb
+++ b/spec/requests/api/v1/vehicles/destroy_spec.rb
@@ -50,21 +50,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         run_test!
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -78,14 +64,6 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:id) { other_vehicle.id }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/vehicles/update_bulk_spec.rb
+++ b/spec/requests/api/v1/vehicles/update_bulk_spec.rb
@@ -52,29 +52,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         run_test!
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/vehicles/update_spec.rb
+++ b/spec/requests/api/v1/vehicles/update_spec.rb
@@ -74,21 +74,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(404, "not found") do
         schema "$ref": "#/components/schemas/StandardError"
@@ -102,14 +88,6 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
         schema "$ref": "#/components/schemas/StandardError"
 
         let(:id) { other_vehicle.id }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
 
         run_test!
       end

--- a/spec/requests/api/v1/wishlist/destroy_spec.rb
+++ b/spec/requests/api/v1/wishlist/destroy_spec.rb
@@ -44,29 +44,7 @@ RSpec.describe "api/v1/wishlist", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(204, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth", success_status: 204
     end
   end
 end

--- a/spec/requests/api/v1/wishlist/export_spec.rb
+++ b/spec/requests/api/v1/wishlist/export_spec.rb
@@ -49,29 +49,7 @@ RSpec.describe "api/v1/wishlist", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/wishlist/items_spec.rb
+++ b/spec/requests/api/v1/wishlist/items_spec.rb
@@ -48,29 +48,7 @@ RSpec.describe "api/v1/wishlist", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
     end
   end
 end

--- a/spec/requests/api/v1/wishlist/show_spec.rb
+++ b/spec/requests/api/v1/wishlist/show_spec.rb
@@ -63,21 +63,7 @@ RSpec.describe "api/v1/wishlist", type: :request, swagger_doc: "v1/schema.yaml" 
         end
       end
 
-      response(200, "successful with OAuth token") do
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{oauth_access_token.token}" }
-
-        run_test!
-      end
-
-      response(401, "unauthorized with wrong scope token") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-        let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
-
-        run_test!
-      end
+      include_examples "oauth_auth"
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/Hangar"
@@ -108,14 +94,6 @@ RSpec.describe "api/v1/wishlist", type: :request, swagger_doc: "v1/schema.yaml" 
 
           expect(items.count).to eq(1)
         end
-      end
-
-      response(401, "unauthorized") do
-        schema "$ref": "#/components/schemas/StandardError"
-
-        let(:user) { nil }
-
-        run_test!
       end
     end
   end

--- a/spec/support/shared_examples/admin_auth.rb
+++ b/spec/support/shared_examples/admin_auth.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Shared examples for the standard admin API 403/401 response pattern.
+# Use inside an rswag operation block (get/post/put/patch/delete):
+#
+#   include_examples "admin_auth", forbidden_user: -> { create(:admin_user, resource_access: []) }
+#
+# For super_admin-gated endpoints:
+#
+#   include_examples "admin_auth", forbidden_user: -> { create(:admin_user, super_admin: false) }
+
+RSpec.shared_examples "admin_auth" do |forbidden_user: -> { create(:admin_user, resource_access: []) }|
+  response(403, "forbidden") do
+    schema "$ref": "#/components/schemas/StandardError"
+
+    let(:user) { instance_exec(&forbidden_user) }
+
+    run_test!
+  end
+
+  response(401, "unauthorized") do
+    schema "$ref": "#/components/schemas/StandardError"
+
+    let(:user) { nil }
+
+    run_test!
+  end
+end

--- a/spec/support/shared_examples/import_wrapping_job.rb
+++ b/spec/support/shared_examples/import_wrapping_job.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Shared examples for the import-wrapping job pattern.
+# Tests that a job creates an import record, runs the loader, finishes the import on success,
+# and marks it as failed on error.
+#
+# Required parameters:
+#   import_class: The import model class (e.g. Imports::ModelImport)
+#   loader_class: The loader class to mock (e.g. Rsi::ModelsLoader)
+#   loader_method: The method called on the loader (e.g. :one or :all)
+#   perform_args: Array of arguments to pass to perform (default: [])
+#   loader_args: Array of expected arguments the loader receives (default: [])
+#   before_perform: Optional proc to run before perform (e.g. for config stubs)
+#
+# Example:
+#   include_examples "import_wrapping_job",
+#     import_class: Imports::ModelImport,
+#     loader_class: Rsi::ModelsLoader,
+#     loader_method: :one,
+#     perform_args: [123],
+#     loader_args: [123]
+
+RSpec.shared_examples "import_wrapping_job" do |import_class:, loader_class:, loader_method:, perform_args: [], loader_args: [], before_perform: nil|
+  describe "#perform" do
+    it "creates an import, runs the loader, and finishes the import" do
+      loader = instance_double(loader_class)
+      allow(loader_class).to receive(:new).and_return(loader)
+      allow(loader).to receive(loader_method)
+      instance_exec(&before_perform) if before_perform
+
+      described_class.new.perform(*perform_args)
+
+      import = import_class.last
+
+      expect(import).to be_present
+      expect(import.aasm_state).to eq("finished")
+      if loader_args.empty?
+        expect(loader).to have_received(loader_method).with(no_args)
+      else
+        expect(loader).to have_received(loader_method).with(*loader_args)
+      end
+    end
+
+    it "marks import as failed on error" do
+      loader = instance_double(loader_class)
+      allow(loader_class).to receive(:new).and_return(loader)
+      allow(loader).to receive(loader_method).and_raise(StandardError, "loader error")
+      instance_exec(&before_perform) if before_perform
+
+      expect { described_class.new.perform(*perform_args) }.to raise_error(StandardError, "loader error")
+
+      import = import_class.last
+
+      expect(import.aasm_state).to eq("failed")
+      expect(import.info).to eq("loader error")
+    end
+  end
+end

--- a/spec/support/shared_examples/oauth_auth.rb
+++ b/spec/support/shared_examples/oauth_auth.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Shared examples for the standard OAuth authentication response pattern.
+# Requires `oauth_access_token` and `wrong_scope_access_token` to be defined via let.
+# Use inside an rswag operation block (get/post/put/patch/delete):
+#
+#   include_examples "oauth_auth"
+#   include_examples "oauth_auth", success_status: 201
+#   include_examples "oauth_auth", success_status: 204
+
+RSpec.shared_examples "oauth_auth" do |success_status: 200|
+  response(success_status, "successful with OAuth token") do
+    let(:user) { nil }
+    let(:Authorization) { "Bearer #{oauth_access_token.token}" }
+
+    run_test!
+  end
+
+  response(401, "unauthorized with wrong scope token") do
+    schema "$ref": "#/components/schemas/StandardError"
+
+    let(:user) { nil }
+    let(:Authorization) { "Bearer #{wrong_scope_access_token.token}" }
+
+    run_test!
+  end
+
+  response(401, "unauthorized") do
+    schema "$ref": "#/components/schemas/StandardError"
+
+    let(:user) { nil }
+
+    run_test!
+  end
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -1361,7 +1361,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/FleetMembersStats"
         '401':
-          description: unauthorized with wrong scope token
+          description: unauthorized
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- Extract 3 shared examples (`admin_auth`, `oauth_auth`, `import_wrapping_job`) to replace repeated boilerplate across 180 spec files
- Remove ~3,000 lines of duplicated 403/401 admin auth blocks, OAuth token auth blocks, and import-wrapping job test patterns
- All 1,336 examples pass with 0 failures

## Test plan
- [x] Full test suite: 1,336 examples, 0 failures
- [x] Admin specs (495 examples): verified 403/401 shared example works with both `resource_access: []` and `super_admin: false` variants
- [x] API specs (617 examples): verified OAuth shared example works with 200/201/204 success status codes
- [x] Loader job specs (16 examples): verified import wrapping shared example

🤖 Generated with [Claude Code](https://claude.com/claude-code)