### PR TITLE
feat: module hardpoints and cargo grids on model detail page

### DIFF
--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -336,7 +336,15 @@ module Api
 
         scope = scope.with_dock if model_query_params.delete("with_dock")
         scope = scope.where(cargo: 0.1..) if model_query_params.delete("with_cargo")
-        scope = scope.joins(:cargo_holds_db).distinct if model_query_params.delete("with_cargo_grids")
+        if model_query_params.delete("with_cargo_grids")
+          scope = scope.where(
+            id: Model.joins(:cargo_holds_db).select(:id)
+          ).or(
+            scope.where(
+              id: Model.joins(:module_hardpoints).select(:id)
+            )
+          ).distinct
+        end
         scope = scope.where(id: current_resource_owner.models.select(:id)) if model_query_params.delete("in_hangar") && current_resource_owner.present?
         scope = container_fit(scope) if model_query_params["container_fit"].present?
         scope = will_it_fit?(scope) if model_query_params["will_it_fit"].present?

--- a/app/frontend/frontend/components/Models/CargoMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CargoMetrics/index.vue
@@ -16,9 +16,12 @@ const { t, toNumber } = useI18n();
 
 type Props = {
   model: Model;
+  cargoHolds?: CargoHold[];
 };
 
 const props = defineProps<Props>();
+
+const holds = computed(() => props.cargoHolds || props.model.cargoHolds || []);
 
 type ContainerCapacity = {
   size: number;
@@ -66,15 +69,17 @@ function computeMaxPerSize(holds: CargoHold[]): ContainerCapacity[] {
 }
 
 const containerCapacities = computed(() => {
-  if (!props.model.cargoHolds?.length) return [];
-  return computeMaxPerSize(props.model.cargoHolds);
+  if (!holds.value.length) return [];
+  return computeMaxPerSize(holds.value);
+});
+
+const totalCargo = computed(() => {
+  return holds.value.reduce((sum, h) => sum + (h.capacity || 0), 0);
 });
 
 const maxContainerSize = computed(() => {
-  if (!props.model.cargoHolds?.length) return null;
-  return Math.max(
-    ...props.model.cargoHolds.map((h) => h.maxContainerSize?.size || 0),
-  );
+  if (!holds.value.length) return null;
+  return Math.max(...holds.value.map((h) => h.maxContainerSize?.size || 0));
 });
 </script>
 
@@ -93,7 +98,7 @@ const maxContainerSize = computed(() => {
         <div class="col-6 col-lg-4">
           <div class="metrics-label">{{ t("model.cargo") }}:</div>
           <div class="metrics-value">
-            {{ toNumber(model.metrics.cargo || "", "cargo") }}
+            {{ toNumber(totalCargo || model.metrics.cargo || "", "cargo") }}
           </div>
         </div>
         <div class="col-6 col-lg-4">

--- a/app/frontend/frontend/components/Models/Hardpoints/Items/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Items/index.vue
@@ -10,6 +10,7 @@ import { groupByHoldName } from "@/shared/utils/CargoHolds";
 import HardpointBaseItem from "@/frontend/components/Models/Hardpoints/BaseItem/index.vue";
 import HardpointCargoItem from "@/frontend/components/Models/Hardpoints/CargoItem/index.vue";
 import HardpointFuelItem from "@/frontend/components/Models/Hardpoints/FuelItem/index.vue";
+import HardpointModuleItem from "@/frontend/components/Models/Hardpoints/ModuleItem/index.vue";
 import HardpointThrusterItem from "@/frontend/components/Models/Hardpoints/ThrusterItem/index.vue";
 import HardpointSeatItem from "@/frontend/components/Models/Hardpoints/SeatItem/index.vue";
 import { type Hardpoint } from "@/services/fyApi";
@@ -50,6 +51,9 @@ const cargoHoldGroups = computed(() => {
 const itemComponent = computed(() => {
   if (props.category === HardpointCategoryEnum.CARGOGRID) {
     return HardpointCargoItem;
+  }
+  if (props.category === HardpointCategoryEnum.MODULE) {
+    return HardpointModuleItem;
   }
   if (props.category === HardpointCategoryEnum.FUELTANKS) {
     return HardpointFuelItem;

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.scss
@@ -1,0 +1,34 @@
+.module-item {
+  .module-image {
+    max-width: 100px;
+    flex: none;
+  }
+
+  .module-panel {
+    cursor: pointer;
+
+    .module-panel-selected {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: $success;
+      border-radius: 0 10px 0 $panelContentBorderRadius;
+
+      i,
+      svg {
+        color: #fff;
+      }
+    }
+  }
+}
+
+@media (max-width: $desktop-breakpoint) {
+  .module-item {
+    margin: 0;
+  }
+}

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.vue
@@ -1,0 +1,126 @@
+<script lang="ts">
+export default {
+  name: "ModuleSelectModal",
+};
+</script>
+
+<script lang="ts" setup>
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelImage from "@/shared/components/base/Panel/Image/index.vue";
+import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useI18n } from "@/shared/composables/useI18n";
+import { type ModelModule } from "@/services/fyApi";
+import { PanelAlignmentsEnum } from "@/shared/components/base/Panel/types";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { useWebpCheck } from "@/shared/composables/useWebpCheck";
+import { useMobile } from "@/shared/composables/useMobile";
+import fallbackImageJpg from "@/images/fallback/store_image.jpg";
+import fallbackImage from "@/images/fallback/store_image.webp";
+
+type Props = {
+  modules: ModelModule[];
+  selectedModuleId?: string;
+  onSelect: (mod: ModelModule | null) => void;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+
+const comlink = useComlink();
+
+const { supported: webpSupported } = useWebpCheck();
+
+const mobile = useMobile();
+
+const storeImage = (mod: ModelModule) => {
+  if (mobile.value && mod.media.storeImage?.mediumUrl) {
+    return mod.media.storeImage?.mediumUrl;
+  }
+
+  if (mod.media.storeImage?.smallUrl) {
+    return mod.media.storeImage?.smallUrl;
+  }
+
+  if (webpSupported) {
+    return fallbackImage;
+  }
+
+  return fallbackImageJpg;
+};
+
+const selectModule = (mod: ModelModule) => {
+  props.onSelect(mod);
+  comlink.emit("close-modal");
+};
+
+const clearModule = () => {
+  props.onSelect(null);
+  comlink.emit("close-modal");
+};
+
+const isSelected = (mod: ModelModule) => mod.id === props.selectedModuleId;
+</script>
+
+<template>
+  <Modal :title="t('labels.hardpoint.selectModule')">
+    <div class="row">
+      <div
+        v-for="mod in modules"
+        :key="mod.id"
+        class="col-12 col-md-6 module-item"
+      >
+        <Panel
+          :alignment="PanelAlignmentsEnum.LEFT"
+          slim
+          class="module-panel"
+          @click="selectModule(mod)"
+        >
+          <PanelImage
+            :image="storeImage(mod)"
+            image-size="auto"
+            rounded="left"
+            class="module-image"
+            :alt="mod.name"
+          />
+          <div>
+            <PanelHeading
+              :level="HeadingLevelEnum.H3"
+              title-align="right"
+              multiline
+            >
+              {{ mod.name }}
+            </PanelHeading>
+            <div
+              v-if="isSelected(mod)"
+              v-tooltip="t('labels.selected')"
+              class="module-panel-selected"
+            >
+              <i class="fa fa-check" />
+            </div>
+          </div>
+        </Panel>
+      </div>
+    </div>
+    <template #footer>
+      <div class="float-sm-right">
+        <Btn
+          v-if="selectedModuleId"
+          :size="BtnSizesEnum.SMALL"
+          :inline="true"
+          @click="clearModule"
+        >
+          {{ t("labels.hardpoint.clearModule") }}
+        </Btn>
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.scss
@@ -1,0 +1,73 @@
+.module-select-btn {
+  cursor: pointer;
+  color: color.scale($text-color, $lightness: -20%);
+
+  i {
+    margin-right: 4px;
+  }
+
+  &:hover,
+  &-active {
+    color: $text-color;
+  }
+}
+
+.module-expand-toggle {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: color.scale($text-color, $lightness: -20%);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+
+  &:hover {
+    color: $text-color;
+  }
+}
+
+.module-loadout {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 8px 0 0;
+}
+
+.module-cargo-holds {
+  margin-bottom: 8px;
+
+  &__label {
+    font-size: 0.875rem;
+    color: $text-color;
+    margin-bottom: 4px;
+
+    i {
+      margin-right: 4px;
+    }
+  }
+}
+
+.module-cargo-hold {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border: $panel-border-width solid $panel-inner-border;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  font-size: 0.8125rem;
+
+  &__name {
+    flex: 1;
+    min-width: 80px;
+  }
+
+  &__capacity {
+    font-weight: 600;
+  }
+
+  &__max-container {
+    font-size: 0.75rem;
+  }
+}

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.vue
@@ -1,0 +1,202 @@
+<script lang="ts">
+export default {
+  name: "HardpointModuleItem",
+};
+</script>
+
+<script lang="ts" setup>
+import { type ComputedRef } from "vue";
+import HardpointItem from "@/frontend/components/Models/Hardpoints/Item/index.vue";
+import HardpointSize from "@/frontend/components/Models/Hardpoints/Size/index.vue";
+import HardpointComponent from "@/frontend/components/Models/Hardpoints/Component/index.vue";
+import HardpointCategory from "@/frontend/components/Models/Hardpoints/Category/index.vue";
+import { groupBy, sortBy } from "@/shared/utils/Array";
+import {
+  type Hardpoint,
+  type ModelModule,
+  HardpointCategoryEnum,
+} from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useComlink } from "@/shared/composables/useComlink";
+import { humanizeHoldName } from "@/shared/utils/CargoHolds";
+
+type Props = {
+  hardpoints: Hardpoint[];
+};
+
+const props = defineProps<Props>();
+
+const { t, toNumber } = useI18n();
+
+const comlink = useComlink();
+
+const modelModules = inject<ComputedRef<ModelModule[]>>(
+  "modelModules",
+  computed(() => []),
+);
+
+const equippedModules = inject<Ref<Record<string, ModelModule | null>>>(
+  "equippedModules",
+  ref({}),
+);
+
+const setEquippedModule = inject<
+  (slotId: string, mod: ModelModule | null) => void
+>("setEquippedModule", () => {});
+
+const hardpoint = computed(() => props.hardpoints[0]);
+
+const count = computed(() => props.hardpoints.length);
+
+const slotId = computed(() => hardpoint.value.groupKey || hardpoint.value.id);
+
+const SLOT_POSITION_KEYWORDS = ["front", "rear", "bow", "stern"] as const;
+
+const slotPosition = computed(() => {
+  const name = (hardpoint.value.name || "").toLowerCase();
+  return SLOT_POSITION_KEYWORDS.find((kw) => name.includes(kw)) || null;
+});
+
+const compatibleModules = computed(() => {
+  if (!slotPosition.value || modelModules.value.length <= 1) {
+    return modelModules.value;
+  }
+
+  const pos = slotPosition.value;
+  const filtered = modelModules.value.filter((m) => {
+    const moduleName = (m.name || "").toLowerCase();
+    const moduleKey = (m.scKey || "").toLowerCase();
+    return moduleName.includes(pos) || moduleKey.includes(pos);
+  });
+
+  return filtered.length > 0 ? filtered : modelModules.value;
+});
+
+const selectedModule = computed(
+  () => equippedModules.value[slotId.value] || null,
+);
+
+const expanded = ref(false);
+
+const onModuleSelect = (mod: ModelModule | null) => {
+  setEquippedModule(slotId.value, mod);
+  expanded.value = !!mod;
+};
+
+const openModuleModal = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.vue"),
+    props: {
+      modules: compatibleModules.value,
+      selectedModuleId: selectedModule.value?.id,
+      onSelect: onModuleSelect,
+    },
+  });
+};
+
+const toggleExpanded = () => {
+  if (selectedModule.value) {
+    expanded.value = !expanded.value;
+  }
+};
+
+const moduleCategories = computed(() => {
+  if (!selectedModule.value?.hardpoints?.length) return {};
+
+  const sorted = sortBy<Hardpoint>(selectedModule.value.hardpoints, "category");
+  const grouped = groupBy<Hardpoint>(sorted, "category");
+
+  const result: { [key in HardpointCategoryEnum]?: Hardpoint[] } = {};
+
+  Object.keys(grouped).forEach((category) => {
+    if (
+      category === HardpointCategoryEnum.CONTROLLER ||
+      category === HardpointCategoryEnum.UNKNOWN
+    ) {
+      return;
+    }
+    result[category as HardpointCategoryEnum] = grouped[category];
+  });
+
+  return result;
+});
+
+const moduleCargoHolds = computed(() => selectedModule.value?.cargoHolds || []);
+
+const hasExpandableContent = computed(
+  () =>
+    Object.keys(moduleCategories.value).length > 0 ||
+    moduleCargoHolds.value.length > 0,
+);
+</script>
+
+<template>
+  <HardpointItem :count="count">
+    <template #default>
+      <HardpointSize :size="hardpoint.maxSize" />
+      <HardpointComponent>
+        <span
+          class="module-select-btn"
+          :class="{ 'module-select-btn-active': selectedModule }"
+          @click="openModuleModal"
+        >
+          <i class="fa-duotone fa-puzzle" />
+          {{ selectedModule?.name || t("labels.hardpoint.moduleSlotEmpty") }}
+        </span>
+      </HardpointComponent>
+      <button
+        v-if="selectedModule && hasExpandableContent"
+        class="module-expand-toggle"
+        @click="toggleExpanded"
+      >
+        <i
+          class="fa-light"
+          :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'"
+        />
+      </button>
+    </template>
+    <template #loadout>
+      <div
+        v-if="expanded && selectedModule && hasExpandableContent"
+        class="module-loadout"
+      >
+        <div v-if="moduleCargoHolds.length" class="module-cargo-holds">
+          <div class="module-cargo-holds__label">
+            <i class="fa-duotone fa-thin fa-cubes" />
+            {{ t("labels.hardpoint.categories.cargogrid") }}
+          </div>
+          <div
+            v-for="(hold, index) in moduleCargoHolds"
+            :key="index"
+            class="module-cargo-hold"
+          >
+            <span class="module-cargo-hold__name">
+              {{ humanizeHoldName(hold.name || "") }}
+            </span>
+            <span class="module-cargo-hold__capacity">
+              {{ toNumber(hold.capacity || "", "cargo") }}
+            </span>
+            <span
+              v-if="hold.maxContainerSize?.size"
+              class="module-cargo-hold__max-container text-muted"
+            >
+              {{ t("labels.hardpoint.maxContainerSize") }}:
+              {{ hold.maxContainerSize.size }} SCU
+            </span>
+          </div>
+        </div>
+        <HardpointCategory
+          v-for="(items, category) in moduleCategories"
+          :key="category"
+          :hardpoints="items || []"
+          :category="category"
+        />
+      </div>
+    </template>
+  </HardpointItem>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Models/ModulesList/index.vue
+++ b/app/frontend/frontend/components/Models/ModulesList/index.vue
@@ -8,22 +8,34 @@ export default {
 import AsyncData from "@/shared/components/AsyncData.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import ModulePanel from "@/frontend/components/Modules/Panel/index.vue";
-import { useModelModules as useModelModulesQuery } from "@/services/fyApi";
+import {
+  useModelModules as useModelModulesQuery,
+  type ModelModule,
+} from "@/services/fyApi";
 
 type Props = {
   modelSlug: string;
+  modules?: ModelModule[];
 };
 
 const props = defineProps<Props>();
 
-const { data: modules, ...asyncStatus } = useModelModulesQuery(props.modelSlug);
+const { data: fetchedModules, ...asyncStatus } = useModelModulesQuery(
+  props.modelSlug,
+  undefined,
+  { query: { enabled: !props.modules?.length } },
+);
+
+const modules = computed(
+  () => props.modules || fetchedModules.value?.items || [],
+);
 
 const { t } = useI18n();
 </script>
 
 <template>
   <AsyncData :async-status="asyncStatus" hide-error>
-    <template v-if="modules?.items.length" #resolved>
+    <template v-if="modules.length" #resolved>
       <hr />
       <div id="modules" class="row">
         <div class="col-12">
@@ -32,7 +44,7 @@ const { t } = useI18n();
           </h2>
           <transition-group name="fade-list" class="row" tag="div" appear>
             <div
-              v-for="item in modules.items"
+              v-for="item in modules"
               :key="`modules-${item.id}`"
               class="col-12 col-md-6 col-xxl-4 col-xxlg-2-4 fade-list-item"
             >

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -15,6 +15,10 @@ import LoanersList from "@/frontend/components/Models/LoanersList/index.vue";
 import VariantsList from "@/frontend/components/Models/VariantsList/index.vue";
 import UpgradesList from "@/frontend/components/Models/UpgradesList/index.vue";
 import ModulesList from "@/frontend/components/Models/ModulesList/index.vue";
+import {
+  useModelModules as useModelModulesQuery,
+  type ModelModule,
+} from "@/services/fyApi";
 import FleetchartImages from "@/frontend/components/Models/FleetchartImages/index.vue";
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
@@ -52,6 +56,33 @@ useWishlistItems();
 const { t, toDollar } = useI18n();
 
 const { updateMetaInfo } = useMetaInfo();
+
+const { data: modulesData } = useModelModulesQuery(props.model.slug);
+
+const modelModules = computed<ModelModule[]>(
+  () => modulesData.value?.items || [],
+);
+
+const equippedModules = ref<Record<string, ModelModule | null>>({});
+
+const setEquippedModule = (slotId: string, mod: ModelModule | null) => {
+  equippedModules.value = { ...equippedModules.value, [slotId]: mod };
+};
+
+provide("modelModules", modelModules);
+provide("equippedModules", equippedModules);
+provide("setEquippedModule", setEquippedModule);
+
+const moduleCargoHolds = computed(() => {
+  return Object.values(equippedModules.value)
+    .filter((mod): mod is ModelModule => mod !== null)
+    .flatMap((mod) => mod.cargoHolds || []);
+});
+
+const combinedCargoHolds = computed(() => [
+  ...(props.model.cargoHolds || []),
+  ...moduleCargoHolds.value,
+]);
 
 const route = useRoute();
 
@@ -420,14 +451,18 @@ const adiMap = computed(() => {
         </div>
       </div>
       <FleetchartImages :model="model" />
-      <ModelCargoMetrics v-if="model.cargoHolds?.length" :model="model" />
+      <ModelCargoMetrics
+        v-if="combinedCargoHolds.length"
+        :model="model"
+        :cargo-holds="combinedCargoHolds"
+      />
       <hr />
       <Hardpoints :model="model" />
     </div>
   </div>
 
   <PaintsList :model-slug="model.slug" />
-  <ModulesList :model-slug="model.slug" />
+  <ModulesList :model-slug="model.slug" :modules="modelModules" />
   <UpgradesList :model-slug="model.slug" />
   <VariantsList :model-slug="model.slug" />
   <LoanersList :model-slug="model.slug" />

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -11,6 +11,15 @@
   }
 }
 
+.module-toggles {
+  margin-bottom: 1rem;
+
+  &__label {
+    color: color.scale($text-color, $lightness: -20%);
+    margin-right: 0.5rem;
+  }
+}
+
 .filters {
   display: flex;
   flex-wrap: wrap;

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -18,9 +18,11 @@ import FilterGroup, {
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useModel as useModelQuery,
+  useModelModules as useModelModulesQuery,
   models as fetchModels,
   ModelProductionStatusEnum,
   type Model,
+  type ModelModule,
   type ModelQuery,
   type Models,
 } from "@/services/fyApi";
@@ -70,8 +72,8 @@ const requestedContainers = computed<ContainerRequest[]>(() => {
 });
 
 const fillGreedy = () => {
-  if (!selectedModel.value?.cargoHolds?.length) return;
-  const counts = computeGreedyFill(selectedModel.value.cargoHolds);
+  if (!combinedCargoHolds.value.length) return;
+  const counts = computeGreedyFill(combinedCargoHolds.value);
   for (const size of CONTAINER_SIZES) {
     containerRequests.value[size] = counts[size] || 0;
   }
@@ -137,6 +139,45 @@ const { data: modelData } = useModelQuery(
   },
 );
 
+const { data: modulesData } = useModelModulesQuery(
+  computed(() => selectedSlug.value || ""),
+  undefined,
+  {
+    query: {
+      enabled: computed(() => !!selectedSlug.value),
+    },
+  },
+);
+
+const availableModules = computed<ModelModule[]>(
+  () => modulesData.value?.items || [],
+);
+
+const modulesWithCargo = computed(() =>
+  availableModules.value.filter((m) => m.cargoHolds?.length),
+);
+
+const selectedModuleIds = ref<Set<string>>(new Set());
+
+const toggleModule = (moduleId: string) => {
+  const next = new Set(selectedModuleIds.value);
+  if (next.has(moduleId)) {
+    next.delete(moduleId);
+  } else {
+    next.add(moduleId);
+  }
+  selectedModuleIds.value = next;
+  fillGreedy();
+};
+
+const combinedCargoHolds = computed(() => {
+  const base = selectedModel.value?.cargoHolds || [];
+  const moduleCargo = availableModules.value
+    .filter((m) => selectedModuleIds.value.has(m.id))
+    .flatMap((m) => m.cargoHolds || []);
+  return [...base, ...moduleCargo];
+});
+
 watch(
   modelData,
   (data) => {
@@ -197,6 +238,7 @@ const resetFilters = () => {
 
 const onModelSelect = (value: ValueType<Model> | undefined) => {
   selectedSlug.value = (value as string) || undefined;
+  selectedModuleIds.value = new Set();
   if (!value) {
     selectedModel.value = undefined;
   }
@@ -296,11 +338,28 @@ const onModelSelect = (value: ValueType<Model> | undefined) => {
     </div>
 
     <template v-if="selectedModel">
-      <div v-if="selectedModel.cargoHolds?.length">
+      <div v-if="modulesWithCargo.length" class="row module-toggles">
+        <div class="col-12">
+          <span class="module-toggles__label">
+            {{ t("labels.model.modules") }}:
+          </span>
+          <Btn
+            v-for="mod in modulesWithCargo"
+            :key="mod.id"
+            :size="BtnSizesEnum.SMALL"
+            :active="selectedModuleIds.has(mod.id)"
+            inline
+            @click="toggleModule(mod.id)"
+          >
+            {{ mod.name }}
+          </Btn>
+        </div>
+      </div>
+      <div v-if="combinedCargoHolds.length">
         <div class="row">
           <div class="col-12">
             <CargoGridViewer
-              :cargo-holds="selectedModel.cargoHolds"
+              :cargo-holds="combinedCargoHolds"
               :container-requests="requestedContainers"
             />
           </div>

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -645,6 +645,9 @@
           "emp": "EMP",
           "qed": "QED"
         },
+        "moduleSlotEmpty": "— Select Module —",
+        "selectModule": "Select Module",
+        "clearModule": "Clear Selection",
         "categories": {
           "radar": "Radar",
           "armor": "Armor",

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -80,6 +80,12 @@ module ScData
         self.translations = parse_translations
 
         FileUtils.mkdir_p(export_path) unless File.directory?(export_path)
+
+        File.write("#{export_path}/version.json", JSON.pretty_generate({
+          version: sc_version,
+          environment: sc_environment,
+          parsed_at: Time.now.utc.iso8601
+        }))
       end
 
       private def load_data(path)

--- a/app/views/api/v1/model_modules/_base.jbuilder
+++ b/app/views/api/v1/model_modules/_base.jbuilder
@@ -37,6 +37,8 @@ json.manufacturer do
   json.partial! "api/v1/manufacturers/base", manufacturer: model_module.manufacturer if model_module.manufacturer.present?
 end
 
+json.cargo_holds model_module.cargo_holds
+
 json.hardpoints do
   json.array! model_module.hardpoints, partial: "api/v1/hardpoints/hardpoint", as: :hardpoint
 end

--- a/data/sc_data/parsed/live-preview/version.json
+++ b/data/sc_data/parsed/live-preview/version.json
@@ -1,0 +1,5 @@
+{
+  "version": "4.0-live-preview (estimated)",
+  "environment": "live-preview",
+  "parsed_at": "2024-12-21 (estimated from git history)"
+}

--- a/data/sc_data/parsed/live/version.json
+++ b/data/sc_data/parsed/live/version.json
@@ -1,0 +1,5 @@
+{
+  "version": "4.7.1-live.11638371",
+  "environment": "live",
+  "parsed_at": "unknown"
+}


### PR DESCRIPTION
## Summary

- Module slots in the hardpoints display now act as equip slots with a modal selector to pick which module to install
- Selecting a module expands to show its hardpoints (weapons, shields, etc.) and cargo grid data
- Equipped modules' cargo holds are merged into CargoMetrics and the cargo grid viewer tool
- Slot compatibility filtering by naming convention (front/rear) for ships like the Retaliator
- Cargo grid tool now includes modular ships and shows module toggle buttons

## Test plan

- [x] Open the Retaliator detail page → hardpoints section should show MODULE slots with "Select Module" labels
- [x] Click a module slot → modal opens with compatible modules (front modules for front slot, rear for rear)
- [x] Select a cargo module → slot expands showing cargo grid data and hardpoints; CargoMetrics section updates
- [x] Open the cargo grids tool → search for "Retaliator" (should now appear in results)
- [x] Select Retaliator → toggle cargo module buttons → containers auto-fill for the module's cargo holds
- [x] Verify Aurora Mk II module slots also work (single slot, all modules shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)