### PR TITLE
feat(tools): cargo grids ship comparison

### DIFF
--- a/app/frontend/frontend/components/CargoGridViewer/CargoGridDragHandler.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/CargoGridDragHandler.vue
@@ -1,0 +1,145 @@
+<script lang="ts">
+export default {
+  name: "CargoGridDragHandler",
+};
+</script>
+
+<script lang="ts" setup>
+import { useTres } from "@tresjs/core";
+import { Raycaster, Vector2, Vector3, Plane, type Group } from "three";
+import { SCU_UNIT } from "./index.vue";
+
+type Props = {
+  shipGroups: { ref: Group | null; shipIndex: number }[];
+  enabled: boolean;
+};
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  dragStart: [shipIndex: number];
+  dragMove: [shipIndex: number, offset: [number, number, number]];
+  dragEnd: [shipIndex: number];
+}>();
+
+const { camera, renderer } = useTres();
+
+const raycaster = new Raycaster();
+const mouse = new Vector2();
+const dragPlane = new Plane(new Vector3(0, 1, 0), 0);
+const dragStartPoint = new Vector3();
+const dragGroupStartPos = new Vector3();
+
+const isDragging = ref(false);
+const dragShipIndex = ref<number | null>(null);
+
+defineExpose({ isDragging });
+
+const getCanvasElement = (): HTMLCanvasElement | null => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r = renderer as any;
+  return r?.value?.domElement || r?.domElement || null;
+};
+
+const updateMouse = (event: PointerEvent, canvas: HTMLCanvasElement) => {
+  const rect = canvas.getBoundingClientRect();
+  mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+};
+
+const snapToGrid = (value: number): number => {
+  return Math.round(value / SCU_UNIT) * SCU_UNIT;
+};
+
+const onPointerDown = (event: PointerEvent) => {
+  if (!props.enabled || !camera.value) return;
+
+  const canvas = getCanvasElement();
+  if (!canvas) return;
+
+  updateMouse(event, canvas);
+  raycaster.setFromCamera(mouse, camera.value);
+
+  // Test intersection with ship group children
+  for (const shipGroup of props.shipGroups) {
+    if (!shipGroup.ref) continue;
+
+    const intersects = raycaster.intersectObjects(
+      shipGroup.ref.children,
+      true,
+    );
+    if (intersects.length > 0) {
+      isDragging.value = true;
+      dragShipIndex.value = shipGroup.shipIndex;
+
+      // Record start point on drag plane
+      raycaster.ray.intersectPlane(dragPlane, dragStartPoint);
+      dragGroupStartPos.copy(shipGroup.ref.position);
+
+      emit("dragStart", shipGroup.shipIndex);
+      canvas.style.cursor = "grabbing";
+      event.preventDefault();
+      return;
+    }
+  }
+};
+
+const onPointerMove = (event: PointerEvent) => {
+  if (!isDragging.value || dragShipIndex.value === null || !camera.value)
+    return;
+
+  const canvas = getCanvasElement();
+  if (!canvas) return;
+
+  updateMouse(event, canvas);
+  raycaster.setFromCamera(mouse, camera.value);
+
+  const currentPoint = new Vector3();
+  raycaster.ray.intersectPlane(dragPlane, currentPoint);
+
+  const dx = currentPoint.x - dragStartPoint.x;
+  const dz = currentPoint.z - dragStartPoint.z;
+
+  const newX = snapToGrid(dragGroupStartPos.x + dx);
+  const newZ = snapToGrid(dragGroupStartPos.z + dz);
+
+  emit("dragMove", dragShipIndex.value, [
+    newX - dragGroupStartPos.x,
+    0,
+    newZ - dragGroupStartPos.z,
+  ]);
+};
+
+const onPointerUp = () => {
+  if (!isDragging.value || dragShipIndex.value === null) return;
+
+  const canvas = getCanvasElement();
+  if (canvas) canvas.style.cursor = "";
+
+  emit("dragEnd", dragShipIndex.value);
+  isDragging.value = false;
+  dragShipIndex.value = null;
+};
+
+onMounted(() => {
+  const canvas = getCanvasElement();
+  if (canvas) {
+    canvas.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+  }
+});
+
+onUnmounted(() => {
+  const canvas = getCanvasElement();
+  if (canvas) {
+    canvas.removeEventListener("pointerdown", onPointerDown);
+  }
+  window.removeEventListener("pointermove", onPointerMove);
+  window.removeEventListener("pointerup", onPointerUp);
+});
+</script>
+
+<template>
+  <!-- Renderless component - provides drag functionality inside TresCanvas -->
+</template>

--- a/app/frontend/frontend/components/CargoGridViewer/CargoGridDragHandler.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/CargoGridDragHandler.vue
@@ -7,7 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useTres } from "@tresjs/core";
 import { Raycaster, Vector2, Vector3, Plane, type Group } from "three";
-import { SCU_UNIT } from "./index.vue";
+import { SCU_UNIT } from "./constants";
 
 type Props = {
   shipGroups: { ref: Group | null; shipIndex: number }[];
@@ -64,10 +64,7 @@ const onPointerDown = (event: PointerEvent) => {
   for (const shipGroup of props.shipGroups) {
     if (!shipGroup.ref) continue;
 
-    const intersects = raycaster.intersectObjects(
-      shipGroup.ref.children,
-      true,
-    );
+    const intersects = raycaster.intersectObjects(shipGroup.ref.children, true);
     if (intersects.length > 0) {
       isDragging.value = true;
       dragShipIndex.value = shipGroup.shipIndex;

--- a/app/frontend/frontend/components/CargoGridViewer/constants.ts
+++ b/app/frontend/frontend/components/CargoGridViewer/constants.ts
@@ -1,5 +1,4 @@
-import type { CargoHold, MediaFile } from "@/services/fyApi";
-import type { RouteLocationRaw } from "vue-router";
+import type { CargoHold } from "@/services/fyApi";
 
 export type ContainerRequest = {
   size: number;
@@ -10,8 +9,6 @@ export type ShipEntry = {
   name: string;
   cargoHolds: CargoHold[];
   color: string;
-  image?: MediaFile;
-  route?: RouteLocationRaw;
 };
 
 export const SHIP_COLORS = ["#82dbc5", "#ff9e80", "#b39ddb", "#90caf9"];

--- a/app/frontend/frontend/components/CargoGridViewer/constants.ts
+++ b/app/frontend/frontend/components/CargoGridViewer/constants.ts
@@ -1,0 +1,105 @@
+import type { CargoHold } from "@/services/fyApi";
+
+export type ContainerRequest = {
+  size: number;
+  quantity: number;
+};
+
+export type ShipEntry = {
+  name: string;
+  cargoHolds: CargoHold[];
+  color: string;
+};
+
+export const SHIP_COLORS = ["#82dbc5", "#ff9e80", "#b39ddb", "#90caf9"];
+
+export const SCU_UNIT = 1.25;
+
+export const CONTAINER_DEFS = [
+  { size: 32, x: 8, y: 2, z: 2 },
+  { size: 24, x: 6, y: 2, z: 2 },
+  { size: 16, x: 4, y: 2, z: 2 },
+  { size: 8, x: 2, y: 2, z: 2 },
+  { size: 4, x: 2, y: 2, z: 1 },
+  { size: 2, x: 2, y: 1, z: 1 },
+  { size: 1, x: 1, y: 1, z: 1 },
+];
+
+export const CONTAINER_COLORS: Record<number, string> = {
+  1: "#4fc3f7",
+  2: "#81c784",
+  4: "#fff176",
+  8: "#ffb74d",
+  16: "#ff8a65",
+  24: "#ba68c8",
+  32: "#e57373",
+};
+
+function tryPlaceInGrid(
+  def: { x: number; y: number; z: number },
+  gridX: number,
+  gridY: number,
+  gridZ: number,
+  occupied: Uint8Array,
+): boolean {
+  const idx = (x: number, y: number, z: number) =>
+    x + y * gridX + z * gridX * gridY;
+
+  const orientations = [
+    { cx: def.x, cy: def.y, cz: def.z },
+    { cx: def.y, cy: def.x, cz: def.z },
+  ];
+
+  for (const orient of orientations) {
+    if (orient.cx > gridX || orient.cy > gridY || orient.cz > gridZ) continue;
+
+    for (let gz = 0; gz <= gridZ - orient.cz; gz++) {
+      for (let gy = 0; gy <= gridY - orient.cy; gy++) {
+        for (let gx = 0; gx <= gridX - orient.cx; gx++) {
+          let fits = true;
+          for (let dz = 0; dz < orient.cz && fits; dz++) {
+            for (let dy = 0; dy < orient.cy && fits; dy++) {
+              for (let dx = 0; dx < orient.cx && fits; dx++) {
+                if (occupied[idx(gx + dx, gy + dy, gz + dz)]) fits = false;
+              }
+            }
+          }
+          if (!fits) continue;
+
+          for (let dz = 0; dz < orient.cz; dz++) {
+            for (let dy = 0; dy < orient.cy; dy++) {
+              for (let dx = 0; dx < orient.cx; dx++) {
+                occupied[idx(gx + dx, gy + dy, gz + dz)] = 1;
+              }
+            }
+          }
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+export function computeGreedyFill(
+  cargoHolds: CargoHold[],
+): Record<number, number> {
+  const counts: Record<number, number> = {};
+
+  for (const hold of cargoHolds) {
+    const gridX = Math.floor(hold.dimensions.x / SCU_UNIT);
+    const gridY = Math.floor(hold.dimensions.y / SCU_UNIT);
+    const gridZ = Math.floor(hold.dimensions.z / SCU_UNIT);
+    const occupied = new Uint8Array(gridX * gridY * gridZ);
+    const maxSize = hold.maxContainerSize?.size || 32;
+
+    for (const def of CONTAINER_DEFS) {
+      if (def.size > maxSize) continue;
+      while (tryPlaceInGrid(def, gridX, gridY, gridZ, occupied)) {
+        counts[def.size] = (counts[def.size] || 0) + 1;
+      }
+    }
+  }
+
+  return counts;
+}

--- a/app/frontend/frontend/components/CargoGridViewer/constants.ts
+++ b/app/frontend/frontend/components/CargoGridViewer/constants.ts
@@ -1,4 +1,5 @@
-import type { CargoHold } from "@/services/fyApi";
+import type { CargoHold, MediaFile } from "@/services/fyApi";
+import type { RouteLocationRaw } from "vue-router";
 
 export type ContainerRequest = {
   size: number;
@@ -9,6 +10,8 @@ export type ShipEntry = {
   name: string;
   cargoHolds: CargoHold[];
   color: string;
+  image?: MediaFile;
+  route?: RouteLocationRaw;
 };
 
 export const SHIP_COLORS = ["#82dbc5", "#ff9e80", "#b39ddb", "#90caf9"];

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -45,7 +45,7 @@
   &__canvas {
     position: relative;
     flex: 1;
-    min-height: 500px;
+    min-height: 300px;
     overflow: hidden;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -59,7 +59,7 @@
   }
 
   &--compact &__canvas {
-    min-height: 400px;
+    min-height: 250px;
   }
 
   &__ship-label {

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  min-height: 100%;
 
   &__stats {
     display: flex;

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -112,9 +112,10 @@
     flex: 1;
     color: inherit;
     text-decoration: none;
+    transition: color 0.15s ease;
 
     &:hover {
-      text-decoration: underline;
+      color: var(--link-color);
     }
   }
 }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,8 +2,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 90vh;
-  min-height: 500px;
 
   &__stats {
     display: flex;
@@ -45,7 +43,8 @@
 
   &__canvas {
     position: relative;
-    flex: 1;
+    height: 90vh;
+    min-height: 500px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
   }
@@ -57,7 +56,7 @@
     z-index: 10;
   }
 
-  &--compact {
+  &--compact &__canvas {
     height: 45vh;
     min-height: 300px;
   }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -57,8 +57,8 @@
   }
 
   &--compact &__canvas {
-    height: 45vh;
-    min-height: 300px;
+    height: 60vh;
+    min-height: 400px;
   }
 
   &__ship-label {

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,9 +2,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: calc(100dvh - 100px);
-  min-height: 500px;
-
   &__stats {
     display: flex;
     flex-wrap: wrap;
@@ -84,18 +81,6 @@
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     padding: 0.75rem;
-  }
-
-  &__ship-image {
-    display: flex;
-    justify-content: center;
-    margin-top: 0.5rem;
-
-    img {
-      max-width: 100%;
-      height: auto;
-      border-radius: var(--border-radius);
-    }
   }
 
   &__ship-stats-header {

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -97,10 +97,10 @@
     flex: 1;
     color: inherit;
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: opacity 0.15s ease;
 
     &:hover {
-      color: var(--link-color);
+      opacity: 0.7;
     }
   }
 }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -43,7 +43,7 @@
 
   &__canvas {
     position: relative;
-    height: 90vh;
+    flex: 1;
     min-height: 500px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -57,7 +57,6 @@
   }
 
   &--compact &__canvas {
-    height: 60vh;
     min-height: 400px;
   }
 

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -44,6 +44,7 @@
     position: relative;
     flex: 1;
     min-height: 500px;
+    overflow: hidden;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
   }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: calc(100dvh - 100px);
+  min-height: 500px;
 
   &__stats {
     display: flex;

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-height: 100%;
+
   &__stats {
     display: flex;
     flex-wrap: wrap;

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 70vh;
-  min-height: 400px;
+  height: 80vh;
+  min-height: 500px;
 
   &__stats {
     display: flex;
@@ -86,15 +86,29 @@
     padding: 0.75rem;
   }
 
+  &__ship-image {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5rem;
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: var(--border-radius);
+    }
+  }
+
   &__ship-stats-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.5rem;
+    flex-wrap: wrap;
   }
 
   &__ship-stats-name {
     font-weight: 600;
     font-size: 1rem;
+    flex: 1;
   }
 }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -76,25 +76,11 @@
   }
 
   &__ship-stats {
-    position: relative;
     flex: 1;
     min-width: 250px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     padding: 0.75rem;
-  }
-
-  &__ship-thumb {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    width: 80px;
-
-    img {
-      width: 100%;
-      height: auto;
-      border-radius: var(--border-radius);
-    }
   }
 
   &__ship-stats-header {
@@ -103,7 +89,6 @@
     gap: 0.5rem;
     margin-bottom: 0.5rem;
     flex-wrap: wrap;
-    padding-right: 90px;
   }
 
   &__ship-stats-name {

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -76,11 +76,25 @@
   }
 
   &__ship-stats {
+    position: relative;
     flex: 1;
     min-width: 250px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     padding: 0.75rem;
+  }
+
+  &__ship-thumb {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 80px;
+
+    img {
+      width: 100%;
+      height: auto;
+      border-radius: var(--border-radius);
+    }
   }
 
   &__ship-stats-header {
@@ -89,11 +103,18 @@
     gap: 0.5rem;
     margin-bottom: 0.5rem;
     flex-wrap: wrap;
+    padding-right: 90px;
   }
 
   &__ship-stats-name {
     font-weight: 600;
     font-size: 1rem;
     flex: 1;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -56,4 +56,45 @@
     bottom: 10px;
     z-index: 10;
   }
+
+  &--compact {
+    height: 45vh;
+    min-height: 300px;
+  }
+
+  &__ship-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    white-space: nowrap;
+    text-shadow: 0 1px 3px rgb(0 0 0 / 80%);
+    pointer-events: none;
+    user-select: none;
+  }
+
+  &__multi-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    padding: 10px 0;
+  }
+
+  &__ship-stats {
+    flex: 1;
+    min-width: 250px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 0.75rem;
+  }
+
+  &__ship-stats-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  &__ship-stats-name {
+    font-weight: 600;
+    font-size: 1rem;
+  }
 }

--- a/app/frontend/frontend/components/CargoGridViewer/index.scss
+++ b/app/frontend/frontend/components/CargoGridViewer/index.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 80vh;
+  height: 90vh;
   min-height: 500px;
 
   &__stats {

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -20,8 +20,6 @@ import {
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
-import ViewImage from "@/shared/components/ViewImage/index.vue";
-import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useMobile } from "@/shared/composables/useMobile";
 import { humanizeHoldName } from "@/shared/utils/CargoHolds";
@@ -1551,18 +1549,6 @@ const onDragEnd = (_shipIndex: number) => {
             </div>
           </template>
         </div>
-        <router-link
-          v-if="props.ships[shipResult.shipIndex]?.route"
-          :to="props.ships[shipResult.shipIndex].route!"
-          class="cargo-grid-viewer__ship-image"
-        >
-          <ViewImage
-            v-if="props.ships[shipResult.shipIndex]?.image"
-            :image="props.ships[shipResult.shipIndex].image"
-            alt="image"
-            :variant="LazyImageVariantsEnum.WIDE"
-          />
-        </router-link>
       </div>
     </div>
   </div>

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -20,6 +20,8 @@ import {
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import ViewImage from "@/shared/components/ViewImage/index.vue";
+import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useMobile } from "@/shared/composables/useMobile";
 import { humanizeHoldName } from "@/shared/utils/CargoHolds";
@@ -1458,12 +1460,34 @@ const onDragEnd = (_shipIndex: number) => {
         :key="`stats-${shipResult.shipIndex}`"
         class="cargo-grid-viewer__ship-stats"
       >
+        <router-link
+          v-if="
+            props.ships[shipResult.shipIndex]?.image &&
+            props.ships[shipResult.shipIndex]?.route
+          "
+          :to="props.ships[shipResult.shipIndex].route!"
+          class="cargo-grid-viewer__ship-thumb"
+        >
+          <ViewImage
+            :image="props.ships[shipResult.shipIndex].image"
+            size="small"
+            alt="image"
+            :variant="LazyImageVariantsEnum.WIDE_SMALL"
+          />
+        </router-link>
         <div class="cargo-grid-viewer__ship-stats-header">
           <span
             class="cargo-grid-viewer__stat-color"
             :style="{ backgroundColor: shipResult.color }"
           />
-          <span class="cargo-grid-viewer__ship-stats-name">
+          <router-link
+            v-if="props.ships[shipResult.shipIndex]?.route"
+            :to="props.ships[shipResult.shipIndex].route!"
+            class="cargo-grid-viewer__ship-stats-name"
+          >
+            {{ shipResult.name }}
+          </router-link>
+          <span v-else class="cargo-grid-viewer__ship-stats-name">
             {{ shipResult.name }}
           </span>
           <Btn

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -20,6 +20,8 @@ import {
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import ViewImage from "@/shared/components/ViewImage/index.vue";
+import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useMobile } from "@/shared/composables/useMobile";
 import { humanizeHoldName } from "@/shared/utils/CargoHolds";
@@ -50,6 +52,11 @@ const props = withDefaults(defineProps<Props>(), {
   containerRequests: () => [],
   compact: false,
 });
+
+const emit = defineEmits<{
+  autoFill: [shipIndex: number];
+  removeShip: [shipIndex: number];
+}>();
 
 const isMultiShipMode = computed(() => props.ships.length > 1);
 
@@ -1461,6 +1468,22 @@ const onDragEnd = (_shipIndex: number) => {
           <span class="cargo-grid-viewer__ship-stats-name">
             {{ shipResult.name }}
           </span>
+          <Btn
+            :size="BtnSizesEnum.SMALL"
+            inline
+            @click="emit('autoFill', shipResult.shipIndex)"
+          >
+            {{ t("labels.cargoGridViewer.autoFillShip") }}
+          </Btn>
+          <Btn
+            v-tooltip="t('actions.remove')"
+            :size="BtnSizesEnum.SMALL"
+            :data-test="`remove-ship-${shipResult.shipIndex}`"
+            inline
+            @click="emit('removeShip', shipResult.shipIndex)"
+          >
+            <i class="fa-light fa-times" />
+          </Btn>
         </div>
         <div class="cargo-grid-viewer__stats">
           <div class="cargo-grid-viewer__stat">
@@ -1528,6 +1551,18 @@ const onDragEnd = (_shipIndex: number) => {
             </div>
           </template>
         </div>
+        <router-link
+          v-if="props.ships[shipResult.shipIndex]?.route"
+          :to="props.ships[shipResult.shipIndex].route!"
+          class="cargo-grid-viewer__ship-image"
+        >
+          <ViewImage
+            v-if="props.ships[shipResult.shipIndex]?.image"
+            :image="props.ships[shipResult.shipIndex].image"
+            alt="image"
+            :variant="LazyImageVariantsEnum.WIDE"
+          />
+        </router-link>
       </div>
     </div>
   </div>

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -11,6 +11,19 @@ export type ContainerRequest = {
   quantity: number;
 };
 
+export type ShipEntry = {
+  name: string;
+  cargoHolds: CargoHold[];
+  color: string;
+};
+
+export const SHIP_COLORS = [
+  "#82dbc5",
+  "#ff9e80",
+  "#b39ddb",
+  "#90caf9",
+];
+
 export const SCU_UNIT = 1.25;
 
 export const CONTAINER_DEFS = [
@@ -105,7 +118,9 @@ export function computeGreedyFill(
 
 <script lang="ts" setup>
 import { TresCanvas } from "@tresjs/core";
-import { OrbitControls, Grid } from "@tresjs/cientos";
+import { OrbitControls, Grid, Html } from "@tresjs/cientos";
+import type { Group } from "three";
+import CargoGridDragHandler from "./CargoGridDragHandler.vue";
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
@@ -129,12 +144,18 @@ const powerPreference = computed<WebGLPowerPreference>(() =>
 
 type Props = {
   cargoHolds: CargoHold[];
+  ships?: ShipEntry[];
   containerRequests?: ContainerRequest[];
+  compact?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
+  ships: () => [],
   containerRequests: () => [],
+  compact: false,
 });
+
+const isMultiShipMode = computed(() => props.ships.length > 1);
 
 type PlacedContainer = {
   size: number;
@@ -508,7 +529,10 @@ function findBestHoldArrangement(
 }
 
 const isPreviewMode = computed(
-  () => !props.cargoHolds?.length && props.containerRequests.length > 0,
+  () =>
+    !isMultiShipMode.value &&
+    !props.cargoHolds?.length &&
+    props.containerRequests.length > 0,
 );
 
 // Preview layout: render containers in a row without cargo holds
@@ -827,8 +851,269 @@ const packVersion = computed(() =>
   ),
 );
 
+// Multi-ship: pack each ship independently, position side by side
+type ShipPackResult = {
+  shipIndex: number;
+  name: string;
+  color: string;
+  groups: HoldGroupLayout[];
+  placed: Record<number, number>;
+  notPlaced: Record<number, number>;
+  totalSCU: number;
+  maxContainerSize: number;
+  packedSCU: number;
+  notPlacedSCU: number;
+  sceneOffset: [number, number, number];
+  // Bounding dimensions for this ship's holds (in world units)
+  boundingWidth: number;
+  boundingDepth: number;
+  boundingHeight: number;
+};
+
+function packSingleShip(
+  cargoHolds: CargoHold[],
+  containerRequests: ContainerRequest[],
+): PackResult {
+  if (!cargoHolds.length) {
+    return { groups: [], placed: {}, notPlaced: {} };
+  }
+
+  const containersToPlace: number[] = [];
+  for (const req of containerRequests) {
+    for (let i = 0; i < req.quantity; i++) {
+      containersToPlace.push(req.size);
+    }
+  }
+  containersToPlace.sort((a, b) => b - a);
+
+  const holdGroups = groupCargoHolds(cargoHolds);
+  const groupGapSCU = 2;
+  let groupOffsetX = 0;
+
+  const groups: HoldGroupLayout[] = [];
+  const holdGridsByIndex: (HoldGrid | null)[] = new Array(cargoHolds.length).fill(null);
+  const layoutsByIndex: (HoldLayout | null)[] = new Array(cargoHolds.length).fill(null);
+  const placed: Record<number, number> = {};
+  const notPlaced: Record<number, number> = {};
+
+  const groupInfos: {
+    arrangement: ArrangeResult;
+    group: (typeof holdGroups)[number];
+  }[] = [];
+
+  for (const group of holdGroups) {
+    const arrangement = findBestHoldArrangement(cargoHolds, group.holdIndices);
+    groupInfos.push({ arrangement, group });
+  }
+
+  // Position hold groups starting at x=0 (left-aligned), centered on Z
+  for (const { arrangement, group } of groupInfos) {
+    const zOffsetSCU = -Math.floor(arrangement.groupDepthSCU / 2);
+    const groupPos: [number, number, number] = [
+      groupOffsetX * SCU_UNIT,
+      0,
+      zOffsetSCU * SCU_UNIT,
+    ];
+    groupOffsetX += arrangement.groupWidthSCU + groupGapSCU;
+
+    const holdLayouts: HoldLayout[] = [];
+
+    for (const p of arrangement.positions) {
+      const { hi, pos: holdPos, dims: dims3d, gridX, gridY, gridZ } = p;
+      const hg: HoldGrid = {
+        hold: cargoHolds[hi],
+        holdPosition: holdPos,
+        gridX,
+        gridY,
+        gridZ,
+        occupied: new Uint8Array(gridX * gridY * gridZ),
+      };
+      holdGridsByIndex[hi] = hg;
+
+      const layout: HoldLayout = {
+        holdIndex: hi,
+        dimensions: dims3d,
+        position: holdPos,
+        containers: [],
+      };
+      layoutsByIndex[hi] = layout;
+      holdLayouts.push(layout);
+    }
+
+    groups.push({
+      key: group.key,
+      label: group.label,
+      position: groupPos,
+      holds: holdLayouts,
+    });
+  }
+
+  const holdIndicesByVolume = holdGridsByIndex
+    .map((hg, hi) => ({ hi, volume: hg ? hg.hold.capacity : 0 }))
+    .filter((h) => holdGridsByIndex[h.hi] !== null)
+    .sort((a, b) => a.volume - b.volume)
+    .map((h) => h.hi);
+
+  for (const containerSize of containersToPlace) {
+    const def = CONTAINER_DEFS.find((d) => d.size === containerSize);
+    if (!def) {
+      notPlaced[containerSize] = (notPlaced[containerSize] || 0) + 1;
+      continue;
+    }
+
+    let wasPlaced = false;
+    for (const hi of holdIndicesByVolume) {
+      const hg = holdGridsByIndex[hi];
+      const layout = layoutsByIndex[hi];
+      if (!hg || !layout) continue;
+
+      const maxSize = hg.hold.maxContainerSize?.size || 32;
+      if (def.size > maxSize) continue;
+
+      const result = tryPlaceOne(def, hg, layout);
+      if (result) {
+        wasPlaced = true;
+        placed[containerSize] = (placed[containerSize] || 0) + 1;
+        break;
+      }
+    }
+
+    if (!wasPlaced) {
+      notPlaced[containerSize] = (notPlaced[containerSize] || 0) + 1;
+    }
+  }
+
+  return { groups, placed, notPlaced };
+}
+
+// Per-ship drag offsets (user-dragged positions)
+const shipDragOffsets = ref<Map<number, [number, number, number]>>(new Map());
+
+const multiShipPackResults = computed<ShipPackResult[]>(() => {
+  if (!isMultiShipMode.value) return [];
+
+  const results: ShipPackResult[] = [];
+  const shipGapSCU = 4;
+  let shipOffsetX = 0;
+
+  // First pass: compute each ship's pack result and bounding box
+  const shipInfos: {
+    result: PackResult;
+    widthSCU: number;
+    depthSCU: number;
+    heightSCU: number;
+  }[] = [];
+
+  let totalWidthSCU = 0;
+  for (const ship of props.ships) {
+    const result = packSingleShip(ship.cargoHolds, props.containerRequests);
+
+    const holdGroups = groupCargoHolds(ship.cargoHolds);
+    const groupGapSCU = 2;
+    let widthSCU = 0;
+    let maxHeightSCU = 0;
+    let maxDepthSCU = 0;
+
+    for (const group of holdGroups) {
+      const arr = findBestHoldArrangement(ship.cargoHolds, group.holdIndices);
+      widthSCU += arr.groupWidthSCU;
+      maxHeightSCU = Math.max(maxHeightSCU, arr.groupHeightSCU);
+      maxDepthSCU = Math.max(maxDepthSCU, arr.groupDepthSCU);
+    }
+    widthSCU += Math.max(0, holdGroups.length - 1) * groupGapSCU;
+
+    shipInfos.push({
+      result,
+      widthSCU: widthSCU || 2,
+      depthSCU: maxDepthSCU || 2,
+      heightSCU: maxHeightSCU || 2,
+    });
+    totalWidthSCU += (widthSCU || 2) + shipGapSCU;
+  }
+  totalWidthSCU -= shipGapSCU;
+
+  const startX = -Math.floor(totalWidthSCU / 2);
+
+  for (let i = 0; i < props.ships.length; i++) {
+    const ship = props.ships[i];
+    const info = shipInfos[i];
+
+    const sceneOffset: [number, number, number] = [
+      (startX + shipOffsetX) * SCU_UNIT,
+      0,
+      0,
+    ];
+
+    let packedSCU = 0;
+    for (const [size, count] of Object.entries(info.result.placed)) {
+      packedSCU += Number(size) * count;
+    }
+    let notPlacedSCU = 0;
+    for (const [size, count] of Object.entries(info.result.notPlaced)) {
+      notPlacedSCU += Number(size) * count;
+    }
+
+    results.push({
+      shipIndex: i,
+      name: ship.name,
+      color: ship.color,
+      groups: info.result.groups,
+      placed: info.result.placed,
+      notPlaced: info.result.notPlaced,
+      totalSCU: ship.cargoHolds.reduce((sum, h) => sum + h.capacity, 0),
+      maxContainerSize: Math.max(
+        ...ship.cargoHolds.map((h) => h.maxContainerSize?.size || 0),
+      ),
+      packedSCU,
+      notPlacedSCU,
+      sceneOffset,
+      boundingWidth: info.widthSCU * SCU_UNIT,
+      boundingDepth: info.depthSCU * SCU_UNIT,
+      boundingHeight: info.heightSCU * SCU_UNIT,
+    });
+
+    shipOffsetX += info.widthSCU + shipGapSCU;
+  }
+
+  return results;
+});
+
+const multiShipPackVersion = computed(() =>
+  multiShipPackResults.value.reduce(
+    (acc, s) =>
+      acc +
+      s.groups.reduce(
+        (ga, g) => ga + g.holds.reduce((a, l) => a + l.containers.length, 0),
+        0,
+      ),
+    0,
+  ),
+);
+
+const shipEdgeMaterials = computed(() =>
+  props.ships.map(
+    (ship) =>
+      new LineBasicMaterial({ color: new Color(ship.color), linewidth: 1 }),
+  ),
+);
+
 // Camera based on hold geometry only (not affected by container changes)
 const holdGeometry = computed(() => {
+  if (isMultiShipMode.value) {
+    if (!multiShipPackResults.value.length) return null;
+    let totalWidth = 0;
+    let maxY = 0;
+    let maxZ = 0;
+    for (const s of multiShipPackResults.value) {
+      totalWidth += s.boundingWidth;
+      maxY = Math.max(maxY, s.boundingHeight);
+      maxZ = Math.max(maxZ, s.boundingDepth);
+    }
+    const shipGapSCU = 4;
+    totalWidth += (multiShipPackResults.value.length - 1) * shipGapSCU * SCU_UNIT;
+    return { totalWidth, maxY: maxY * SCU_UNIT, maxZ: maxZ * SCU_UNIT };
+  }
+
   if (!props.cargoHolds?.length) return null;
 
   const holdGroups = groupCargoHolds(props.cargoHolds);
@@ -926,11 +1211,60 @@ const canvasKey = ref(0);
 const resetCamera = () => {
   canvasKey.value++;
 };
+
+// Drag support for multi-ship mode
+const isDragging = ref(false);
+const shipGroupRefs = ref<Map<number, Group>>(new Map());
+const setShipGroupRef = (el: unknown, shipIndex: number) => {
+  if (el) {
+    shipGroupRefs.value.set(shipIndex, el as Group);
+  } else {
+    shipGroupRefs.value.delete(shipIndex);
+  }
+};
+
+const shipGroupsForDrag = computed(() =>
+  multiShipPackResults.value.map((s) => ({
+    ref: shipGroupRefs.value.get(s.shipIndex) || null,
+    shipIndex: s.shipIndex,
+  })),
+);
+
+const getShipPosition = (shipResult: ShipPackResult): [number, number, number] => {
+  const drag = shipDragOffsets.value.get(shipResult.shipIndex);
+  if (!drag) return shipResult.sceneOffset;
+  return [
+    shipResult.sceneOffset[0] + drag[0],
+    shipResult.sceneOffset[1] + drag[1],
+    shipResult.sceneOffset[2] + drag[2],
+  ];
+};
+
+const onDragStart = (_shipIndex: number) => {
+  isDragging.value = true;
+};
+
+const onDragMove = (shipIndex: number, offset: [number, number, number]) => {
+  shipDragOffsets.value = new Map(shipDragOffsets.value);
+  shipDragOffsets.value.set(shipIndex, offset);
+};
+
+const onDragEnd = (_shipIndex: number) => {
+  isDragging.value = false;
+};
 </script>
 
 <template>
-  <div class="cargo-grid-viewer" data-test="cargo-grid-viewer">
-    <div class="cargo-grid-viewer__stats" data-test="cargo-grid-viewer-stats">
+  <div
+    class="cargo-grid-viewer"
+    :class="{ 'cargo-grid-viewer--compact': compact }"
+    data-test="cargo-grid-viewer"
+  >
+    <div
+      v-if="!isMultiShipMode"
+      class="cargo-grid-viewer__stats"
+      data-test="cargo-grid-viewer-stats"
+    >
       <template v-if="isPreviewMode">
         <div class="cargo-grid-viewer__stat">
           <span class="cargo-grid-viewer__stat-label">{{
@@ -1038,10 +1372,10 @@ const resetCamera = () => {
         <OrbitControls
           :target="sceneCenter"
           :auto-rotate="false"
-          :enable-rotate="true"
-          :enable-zoom="true"
+          :enable-rotate="!isDragging"
+          :enable-zoom="!isDragging"
           :zoom-speed="0.5"
-          :enable-pan="true"
+          :enable-pan="!isDragging"
           enable-damping
           :damping-factor="0.25"
           make-default
@@ -1092,8 +1426,80 @@ const resetCamera = () => {
           </TresGroup>
         </template>
 
-        <!-- Cargo Hold Groups -->
-        <template v-else>
+        <!-- Drag handler for multi-ship mode -->
+        <CargoGridDragHandler
+          v-if="isMultiShipMode"
+          :ship-groups="shipGroupsForDrag"
+          :enabled="isMultiShipMode"
+          @drag-start="onDragStart"
+          @drag-move="onDragMove"
+          @drag-end="onDragEnd"
+        />
+
+        <!-- Multi-ship mode -->
+        <template v-if="isMultiShipMode">
+          <TresGroup
+            v-for="shipResult in multiShipPackResults"
+            :ref="(el: unknown) => setShipGroupRef(el, shipResult.shipIndex)"
+            :key="`ship-${shipResult.shipIndex}-${multiShipPackVersion}`"
+            :position="getShipPosition(shipResult)"
+          >
+            <!-- Ship label (Html from cientos) -->
+            <Html
+              :position="[0, shipResult.boundingHeight + 1, 0]"
+              center
+            >
+              <span
+                class="cargo-grid-viewer__ship-label"
+                :style="{ color: shipResult.color }"
+              >
+                {{ shipResult.name }}
+              </span>
+            </Html>
+
+            <!-- Hold groups for this ship -->
+            <TresGroup
+              v-for="group in shipResult.groups"
+              :key="`group-${shipResult.shipIndex}-${group.key}`"
+              :position="group.position"
+            >
+              <TresGroup
+                v-for="layout in group.holds"
+                :key="`hold-${shipResult.shipIndex}-${layout.holdIndex}`"
+                :position="layout.position"
+              >
+                <!-- Hold wireframe in ship color -->
+                <TresLineSegments
+                  :geometry="createEdgesGeometry(layout.dimensions)"
+                  :material="shipEdgeMaterials[shipResult.shipIndex]"
+                />
+
+                <!-- Containers inside hold -->
+                <TresGroup
+                  v-for="(container, cIdx) in layout.containers"
+                  :key="`c-${shipResult.shipIndex}-${layout.holdIndex}-${cIdx}`"
+                >
+                  <TresMesh :position="container.position">
+                    <TresBoxGeometry :args="container.dimensions" />
+                    <TresMeshStandardMaterial
+                      :color="container.color"
+                      :transparent="true"
+                      :opacity="0.6"
+                    />
+                  </TresMesh>
+                  <TresLineSegments
+                    :position="container.position"
+                    :geometry="createEdgesGeometry(container.dimensions)"
+                    :material="containerEdgeMaterial(container.color)"
+                  />
+                </TresGroup>
+              </TresGroup>
+            </TresGroup>
+          </TresGroup>
+        </template>
+
+        <!-- Single-ship Cargo Hold Groups -->
+        <template v-else-if="!isPreviewMode">
           <TresGroup
             v-for="group in groupLayouts"
             :key="`group-${group.key}-${packVersion}`"
@@ -1134,6 +1540,97 @@ const resetCamera = () => {
           </TresGroup>
         </template>
       </TresCanvas>
+    </div>
+
+    <!-- Multi-ship per-ship stats -->
+    <div
+      v-if="isMultiShipMode"
+      class="cargo-grid-viewer__multi-stats"
+      data-test="cargo-grid-viewer-multi-stats"
+    >
+      <div
+        v-for="shipResult in multiShipPackResults"
+        :key="`stats-${shipResult.shipIndex}`"
+        class="cargo-grid-viewer__ship-stats"
+      >
+        <div class="cargo-grid-viewer__ship-stats-header">
+          <span
+            class="cargo-grid-viewer__stat-color"
+            :style="{ backgroundColor: shipResult.color }"
+          />
+          <span class="cargo-grid-viewer__ship-stats-name">
+            {{ shipResult.name }}
+          </span>
+        </div>
+        <div class="cargo-grid-viewer__stats">
+          <div class="cargo-grid-viewer__stat">
+            <span class="cargo-grid-viewer__stat-label">{{
+              t("labels.cargoGridViewer.capacity")
+            }}</span>
+            <span class="cargo-grid-viewer__stat-value"
+              >{{ shipResult.totalSCU }} SCU</span
+            >
+          </div>
+          <div class="cargo-grid-viewer__stat">
+            <span class="cargo-grid-viewer__stat-label">{{
+              t("labels.cargoGridViewer.maxContainerSize")
+            }}</span>
+            <span class="cargo-grid-viewer__stat-value"
+              >{{ shipResult.maxContainerSize }} SCU</span
+            >
+          </div>
+          <div class="cargo-grid-viewer__stat">
+            <span class="cargo-grid-viewer__stat-label">{{
+              t("labels.cargoGridViewer.packed")
+            }}</span>
+            <span class="cargo-grid-viewer__stat-value"
+              >{{ shipResult.packedSCU }} SCU</span
+            >
+          </div>
+          <div
+            v-for="(count, size) in shipResult.placed"
+            :key="`ship-${shipResult.shipIndex}-placed-${size}`"
+            class="cargo-grid-viewer__stat"
+          >
+            <span
+              class="cargo-grid-viewer__stat-color"
+              :style="{ backgroundColor: CONTAINER_COLORS[Number(size)] }"
+            />
+            <span class="cargo-grid-viewer__stat-label">{{ size }} SCU</span>
+            <span class="cargo-grid-viewer__stat-value"
+              >&times;{{ count }}</span
+            >
+          </div>
+          <template
+            v-if="
+              Object.values(shipResult.notPlaced).some((v: number) => v > 0)
+            "
+          >
+            <div
+              class="cargo-grid-viewer__stat cargo-grid-viewer__stat--warning"
+            >
+              <span class="cargo-grid-viewer__stat-label">{{
+                t("labels.cargoGridViewer.didNotFit")
+              }}</span>
+              <span class="cargo-grid-viewer__stat-value"
+                >{{ shipResult.notPlacedSCU }} SCU</span
+              >
+            </div>
+            <div
+              v-for="(count, size) in shipResult.notPlaced"
+              :key="`ship-${shipResult.shipIndex}-np-${size}`"
+              class="cargo-grid-viewer__stat cargo-grid-viewer__stat--warning"
+            >
+              <span class="cargo-grid-viewer__stat-label"
+                >{{ size }} SCU</span
+              >
+              <span class="cargo-grid-viewer__stat-value"
+                >&times;{{ count }}</span
+              >
+            </div>
+          </template>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -20,8 +20,6 @@ import {
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
-import ViewImage from "@/shared/components/ViewImage/index.vue";
-import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useMobile } from "@/shared/composables/useMobile";
 import { humanizeHoldName } from "@/shared/utils/CargoHolds";
@@ -1460,21 +1458,6 @@ const onDragEnd = (_shipIndex: number) => {
         :key="`stats-${shipResult.shipIndex}`"
         class="cargo-grid-viewer__ship-stats"
       >
-        <router-link
-          v-if="
-            props.ships[shipResult.shipIndex]?.image &&
-            props.ships[shipResult.shipIndex]?.route
-          "
-          :to="props.ships[shipResult.shipIndex].route!"
-          class="cargo-grid-viewer__ship-thumb"
-        >
-          <ViewImage
-            :image="props.ships[shipResult.shipIndex].image"
-            size="small"
-            alt="image"
-            :variant="LazyImageVariantsEnum.WIDE_SMALL"
-          />
-        </router-link>
         <div class="cargo-grid-viewer__ship-stats-header">
           <span
             class="cargo-grid-viewer__stat-color"

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -1,119 +1,7 @@
-<!-- eslint-disable import/no-self-import -->
 <script lang="ts">
-import type { CargoHold } from "@/services/fyApi";
-
 export default {
   name: "CargoGridViewer",
 };
-
-export type ContainerRequest = {
-  size: number;
-  quantity: number;
-};
-
-export type ShipEntry = {
-  name: string;
-  cargoHolds: CargoHold[];
-  color: string;
-};
-
-export const SHIP_COLORS = [
-  "#82dbc5",
-  "#ff9e80",
-  "#b39ddb",
-  "#90caf9",
-];
-
-export const SCU_UNIT = 1.25;
-
-export const CONTAINER_DEFS = [
-  { size: 32, x: 8, y: 2, z: 2 },
-  { size: 24, x: 6, y: 2, z: 2 },
-  { size: 16, x: 4, y: 2, z: 2 },
-  { size: 8, x: 2, y: 2, z: 2 },
-  { size: 4, x: 2, y: 2, z: 1 },
-  { size: 2, x: 2, y: 1, z: 1 },
-  { size: 1, x: 1, y: 1, z: 1 },
-];
-
-export const CONTAINER_COLORS: Record<number, string> = {
-  1: "#4fc3f7",
-  2: "#81c784",
-  4: "#fff176",
-  8: "#ffb74d",
-  16: "#ff8a65",
-  24: "#ba68c8",
-  32: "#e57373",
-};
-
-function tryPlaceInGrid(
-  def: { x: number; y: number; z: number },
-  gridX: number,
-  gridY: number,
-  gridZ: number,
-  occupied: Uint8Array,
-): boolean {
-  const idx = (x: number, y: number, z: number) =>
-    x + y * gridX + z * gridX * gridY;
-
-  const orientations = [
-    { cx: def.x, cy: def.y, cz: def.z },
-    { cx: def.y, cy: def.x, cz: def.z },
-  ];
-
-  for (const orient of orientations) {
-    if (orient.cx > gridX || orient.cy > gridY || orient.cz > gridZ) continue;
-
-    for (let gz = 0; gz <= gridZ - orient.cz; gz++) {
-      for (let gy = 0; gy <= gridY - orient.cy; gy++) {
-        for (let gx = 0; gx <= gridX - orient.cx; gx++) {
-          let fits = true;
-          for (let dz = 0; dz < orient.cz && fits; dz++) {
-            for (let dy = 0; dy < orient.cy && fits; dy++) {
-              for (let dx = 0; dx < orient.cx && fits; dx++) {
-                if (occupied[idx(gx + dx, gy + dy, gz + dz)]) fits = false;
-              }
-            }
-          }
-          if (!fits) continue;
-
-          for (let dz = 0; dz < orient.cz; dz++) {
-            for (let dy = 0; dy < orient.cy; dy++) {
-              for (let dx = 0; dx < orient.cx; dx++) {
-                occupied[idx(gx + dx, gy + dy, gz + dz)] = 1;
-              }
-            }
-          }
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
-export function computeGreedyFill(
-  cargoHolds: CargoHold[],
-): Record<number, number> {
-  const counts: Record<number, number> = {};
-
-  for (const hold of cargoHolds) {
-    const gridX = Math.floor(hold.dimensions.x / SCU_UNIT);
-    const gridY = Math.floor(hold.dimensions.y / SCU_UNIT);
-    const gridZ = Math.floor(hold.dimensions.z / SCU_UNIT);
-    const occupied = new Uint8Array(gridX * gridY * gridZ);
-    const maxSize = hold.maxContainerSize?.size || 32;
-
-    for (const def of CONTAINER_DEFS) {
-      if (def.size > maxSize) continue;
-      while (tryPlaceInGrid(def, gridX, gridY, gridZ, occupied)) {
-        counts[def.size] = (counts[def.size] || 0) + 1;
-      }
-    }
-  }
-
-  return counts;
-}
 </script>
 
 <script lang="ts" setup>
@@ -121,6 +9,14 @@ import { TresCanvas } from "@tresjs/core";
 import { OrbitControls, Grid, Html } from "@tresjs/cientos";
 import type { Group } from "three";
 import CargoGridDragHandler from "./CargoGridDragHandler.vue";
+import type { CargoHold } from "@/services/fyApi";
+import {
+  type ContainerRequest,
+  type ShipEntry,
+  SCU_UNIT,
+  CONTAINER_DEFS,
+  CONTAINER_COLORS,
+} from "./constants";
 import { BoxGeometry, EdgesGeometry, LineBasicMaterial, Color } from "three";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
@@ -891,8 +787,12 @@ function packSingleShip(
   let groupOffsetX = 0;
 
   const groups: HoldGroupLayout[] = [];
-  const holdGridsByIndex: (HoldGrid | null)[] = new Array(cargoHolds.length).fill(null);
-  const layoutsByIndex: (HoldLayout | null)[] = new Array(cargoHolds.length).fill(null);
+  const holdGridsByIndex: (HoldGrid | null)[] = new Array(
+    cargoHolds.length,
+  ).fill(null);
+  const layoutsByIndex: (HoldLayout | null)[] = new Array(
+    cargoHolds.length,
+  ).fill(null);
   const placed: Record<number, number> = {};
   const notPlaced: Record<number, number> = {};
 
@@ -1110,7 +1010,8 @@ const holdGeometry = computed(() => {
       maxZ = Math.max(maxZ, s.boundingDepth);
     }
     const shipGapSCU = 4;
-    totalWidth += (multiShipPackResults.value.length - 1) * shipGapSCU * SCU_UNIT;
+    totalWidth +=
+      (multiShipPackResults.value.length - 1) * shipGapSCU * SCU_UNIT;
     return { totalWidth, maxY: maxY * SCU_UNIT, maxZ: maxZ * SCU_UNIT };
   }
 
@@ -1230,7 +1131,9 @@ const shipGroupsForDrag = computed(() =>
   })),
 );
 
-const getShipPosition = (shipResult: ShipPackResult): [number, number, number] => {
+const getShipPosition = (
+  shipResult: ShipPackResult,
+): [number, number, number] => {
   const drag = shipDragOffsets.value.get(shipResult.shipIndex);
   if (!drag) return shipResult.sceneOffset;
   return [
@@ -1445,10 +1348,7 @@ const onDragEnd = (_shipIndex: number) => {
             :position="getShipPosition(shipResult)"
           >
             <!-- Ship label (Html from cientos) -->
-            <Html
-              :position="[0, shipResult.boundingHeight + 1, 0]"
-              center
-            >
+            <Html :position="[0, shipResult.boundingHeight + 1, 0]" center>
               <span
                 class="cargo-grid-viewer__ship-label"
                 :style="{ color: shipResult.color }"
@@ -1621,9 +1521,7 @@ const onDragEnd = (_shipIndex: number) => {
               :key="`ship-${shipResult.shipIndex}-np-${size}`"
               class="cargo-grid-viewer__stat cargo-grid-viewer__stat--warning"
             >
-              <span class="cargo-grid-viewer__stat-label"
-                >{{ size }} SCU</span
-              >
+              <span class="cargo-grid-viewer__stat-label">{{ size }} SCU</span>
               <span class="cargo-grid-viewer__stat-value"
                 >&times;{{ count }}</span
               >

--- a/app/frontend/frontend/components/Compare/Models/Cargo/index.vue
+++ b/app/frontend/frontend/components/Compare/Models/Cargo/index.vue
@@ -15,7 +15,7 @@ import type { Model, CargoHold } from "@/services/fyApi";
 import {
   CONTAINER_DEFS,
   SCU_UNIT,
-} from "@/frontend/components/CargoGridViewer/index.vue";
+} from "@/frontend/components/CargoGridViewer/constants";
 
 type Props = {
   models: Model[];

--- a/app/frontend/frontend/components/Models/CargoMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CargoMetrics/index.vue
@@ -9,7 +9,7 @@ import type { Model, CargoHold } from "@/services/fyApi";
 import {
   CONTAINER_DEFS,
   SCU_UNIT,
-} from "@/frontend/components/CargoGridViewer/index.vue";
+} from "@/frontend/components/CargoGridViewer/constants";
 import { useI18n } from "@/shared/composables/useI18n";
 
 const { t, toNumber } = useI18n();

--- a/app/frontend/frontend/composables/useCargoGridShip.ts
+++ b/app/frontend/frontend/composables/useCargoGridShip.ts
@@ -1,0 +1,110 @@
+import {
+  useModel as useModelQuery,
+  useModelModules as useModelModulesQuery,
+  type Model,
+  type ModelModule,
+} from "@/services/fyApi";
+import { computeGreedyFill } from "@/frontend/components/CargoGridViewer/index.vue";
+import type { CargoHold } from "@/services/fyApi";
+
+export function useCargoGridShip(slug: Ref<string | undefined>) {
+  const model = ref<Model>();
+
+  const { data: modelData } = useModelQuery(
+    computed(() => slug.value || ""),
+    {
+      query: {
+        enabled: computed(() => !!slug.value),
+      },
+    },
+  );
+
+  const { data: modulesData } = useModelModulesQuery(
+    computed(() => slug.value || ""),
+    undefined,
+    {
+      query: {
+        enabled: computed(() => !!slug.value),
+      },
+    },
+  );
+
+  watch(
+    modelData,
+    (data) => {
+      if (data) {
+        model.value = data;
+      }
+    },
+    { immediate: true },
+  );
+
+  watch(slug, (newSlug, oldSlug) => {
+    if (newSlug !== oldSlug) {
+      model.value = undefined;
+      selectedModuleSlugs.value = new Set();
+    }
+  });
+
+  const availableModules = computed<ModelModule[]>(
+    () => modulesData.value?.items || [],
+  );
+
+  const modulesWithCargo = computed(() =>
+    availableModules.value.filter((m) => m.cargoHolds?.length),
+  );
+
+  const selectedModuleSlugs = ref<Set<string>>(new Set());
+
+  const toggleModule = (moduleSlug: string) => {
+    const next = new Set(selectedModuleSlugs.value);
+    if (next.has(moduleSlug)) {
+      next.delete(moduleSlug);
+    } else {
+      next.add(moduleSlug);
+    }
+    selectedModuleSlugs.value = next;
+  };
+
+  const setModuleSlugs = (slugs: string[]) => {
+    selectedModuleSlugs.value = new Set(slugs);
+  };
+
+  const combinedCargoHolds = computed<CargoHold[]>(() => {
+    const base = model.value?.cargoHolds || [];
+    const moduleCargo = availableModules.value
+      .filter((m) => selectedModuleSlugs.value.has(m.slug))
+      .flatMap((m) => m.cargoHolds || []);
+    return [...base, ...moduleCargo];
+  });
+
+  const angledImage = computed(() => {
+    if (!model.value) return undefined;
+    return (
+      model.value.media.angledViewColored || model.value.media.angledView
+    );
+  });
+
+  const shipRoute = computed(() => {
+    if (!model.value) return undefined;
+    return { name: "ship", params: { slug: model.value.slug } };
+  });
+
+  const getGreedyFillCounts = () => {
+    if (!combinedCargoHolds.value.length) return {};
+    return computeGreedyFill(combinedCargoHolds.value);
+  };
+
+  return {
+    model: computed(() => model.value),
+    availableModules,
+    modulesWithCargo,
+    selectedModuleSlugs: computed(() => selectedModuleSlugs.value),
+    combinedCargoHolds,
+    angledImage,
+    shipRoute,
+    toggleModule,
+    setModuleSlugs,
+    getGreedyFillCounts,
+  };
+}

--- a/app/frontend/frontend/composables/useCargoGridShip.ts
+++ b/app/frontend/frontend/composables/useCargoGridShip.ts
@@ -46,9 +46,10 @@ export function useCargoGridShip(slug: Ref<string | undefined>) {
     }
   });
 
-  const availableModules = computed<ModelModule[]>(
-    () => modulesData.value?.items || [],
-  );
+  const availableModules = computed<ModelModule[]>(() => {
+    if (!slug.value) return [];
+    return modulesData.value?.items || [];
+  });
 
   const modulesWithCargo = computed(() =>
     availableModules.value.filter((m) => m.cargoHolds?.length),

--- a/app/frontend/frontend/composables/useCargoGridShip.ts
+++ b/app/frontend/frontend/composables/useCargoGridShip.ts
@@ -4,7 +4,7 @@ import {
   type Model,
   type ModelModule,
 } from "@/services/fyApi";
-import { computeGreedyFill } from "@/frontend/components/CargoGridViewer/index.vue";
+import { computeGreedyFill } from "@/frontend/components/CargoGridViewer/constants";
 import type { CargoHold } from "@/services/fyApi";
 
 export function useCargoGridShip(slug: Ref<string | undefined>) {
@@ -80,9 +80,7 @@ export function useCargoGridShip(slug: Ref<string | undefined>) {
 
   const angledImage = computed(() => {
     if (!model.value) return undefined;
-    return (
-      model.value.media.angledViewColored || model.value.media.angledView
-    );
+    return model.value.media.angledViewColored || model.value.media.angledView;
   });
 
   const shipRoute = computed(() => {

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -51,3 +51,33 @@
     font-weight: 600;
   }
 }
+
+.ship-infos {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.ship-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-decoration: none;
+  text-align: right;
+
+  &__image {
+    max-width: 200px;
+  }
+
+  &__name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+    transition: opacity 0.15s ease;
+  }
+
+  &:hover &__name {
+    opacity: 0.8;
+  }
+}

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -1,3 +1,22 @@
+.cargo-grids-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100dvh - var(--header-height, 60px));
+
+  &__viewer {
+    flex: 1;
+    min-height: 0;
+
+    > .col-12 {
+      height: 100%;
+    }
+
+    .cargo-grid-viewer {
+      height: 100%;
+    }
+  }
+}
+
 .container-fields {
   display: flex;
   flex-wrap: wrap;

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -6,13 +6,14 @@
   &__viewer {
     flex: 1;
     min-height: 0;
+    overflow: auto;
 
     > .col-12 {
       height: 100%;
     }
 
     .cargo-grid-viewer {
-      height: 100%;
+      min-height: 100%;
     }
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -23,21 +23,12 @@
   margin-bottom: 0.5rem;
 }
 
-.ship-entries {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
 .ship-entry {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 0.25rem;
-  flex-wrap: wrap;
 
   &__name {
     font-weight: 600;
-    margin-right: 0.25rem;
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -11,51 +11,42 @@
   }
 }
 
-.module-toggles {
-  margin-bottom: 1rem;
-
-  &__label {
-    color: color.scale($text-color, $lightness: -20%);
-    margin-right: 0.5rem;
-  }
-}
-
-.filters {
+.filters__actions {
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-
-  &__actions {
-    display: flex;
-    align-items: flex-end;
-    margin-bottom: 1rem;
-  }
+  align-items: flex-end;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
 }
 
 .toolbar {
   align-items: flex-start;
 }
 
-.ship-info {
+.ship-selectors {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   align-items: flex-end;
-  text-decoration: none;
-  text-align: right;
-  float: right;
+  margin-bottom: 0.5rem;
+}
 
-  &__image {
-    max-width: 300px;
+.ship-selector {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.cargo-grid-comparison {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(550px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+
+  &--single {
+    grid-template-columns: 1fr;
   }
 
-  &__name {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: $text-color;
-    margin-top: 0.25rem;
-  }
-
-  &:hover &__name {
-    color: $primary;
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -1,15 +1,7 @@
 .cargo-grids-page {
-  display: flex;
-  flex-direction: column;
-  min-height: calc(100dvh - var(--header-height, 60px));
-
   &__viewer {
-    flex: 1;
-    height: auto;
-    min-height: 100%;
-
     .cargo-grid-viewer {
-      min-height: 100%;
+      height: calc(100dvh - 200px);
     }
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -1,16 +1,12 @@
 .cargo-grids-page {
   display: flex;
   flex-direction: column;
-  height: calc(100dvh - var(--header-height, 60px));
+  min-height: calc(100dvh - var(--header-height, 60px));
 
   &__viewer {
     flex: 1;
-    min-height: 0;
-    overflow: auto;
-
-    > .col-12 {
-      height: 100%;
-    }
+    height: auto;
+    min-height: 100%;
 
     .cargo-grid-viewer {
       min-height: 100%;
@@ -58,6 +54,9 @@
   gap: 1rem;
   justify-content: flex-end;
   flex-wrap: wrap;
+  top: 0;
+  right: 1rem;
+  position: absolute;
 }
 
 .ship-info {
@@ -80,5 +79,11 @@
 
   &:hover &__name {
     opacity: 0.8;
+  }
+}
+
+@media (max-width: $desktop-breakpoint) {
+  .ship-infos {
+    display: none;
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -11,42 +11,33 @@
   }
 }
 
-.filters__actions {
-  display: flex;
-  align-items: flex-end;
-  margin-bottom: 1rem;
-  gap: 0.5rem;
-}
-
 .toolbar {
   align-items: flex-start;
 }
 
-.ship-selectors {
+.ship-selector-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.5rem;
   align-items: flex-end;
   margin-bottom: 0.5rem;
 }
 
-.ship-selector {
+.ship-entries {
   display: flex;
-  align-items: flex-end;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
-.cargo-grid-comparison {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(550px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1rem;
+.ship-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
 
-  &--single {
-    grid-template-columns: 1fr;
-  }
-
-  @media (max-width: 600px) {
-    grid-template-columns: 1fr;
+  &__name {
+    font-weight: 600;
+    margin-right: 0.25rem;
   }
 }

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -6,10 +6,11 @@ export default {
 
 <script lang="ts" setup>
 import Heading from "@/shared/components/base/Heading/index.vue";
-import CargoGridViewer, {
+import CargoGridViewer from "@/frontend/components/CargoGridViewer/index.vue";
+import {
   SHIP_COLORS,
-} from "@/frontend/components/CargoGridViewer/index.vue";
-import type { ShipEntry } from "@/frontend/components/CargoGridViewer/index.vue";
+  type ShipEntry,
+} from "@/frontend/components/CargoGridViewer/constants";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FilterGroup, {
@@ -29,7 +30,7 @@ import {
   InputAlignmentsEnum,
 } from "@/shared/components/base/FormInput/types";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
-import type { ContainerRequest } from "@/frontend/components/CargoGridViewer/index.vue";
+import type { ContainerRequest } from "@/frontend/components/CargoGridViewer/constants";
 import { useSessionStore } from "@/frontend/stores/session";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
 import { useCargoGridShip } from "@/frontend/composables/useCargoGridShip";

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -7,8 +7,9 @@ export default {
 <script lang="ts" setup>
 import Heading from "@/shared/components/base/Heading/index.vue";
 import CargoGridViewer, {
-  computeGreedyFill,
+  SHIP_COLORS,
 } from "@/frontend/components/CargoGridViewer/index.vue";
+import type { ShipEntry } from "@/frontend/components/CargoGridViewer/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FilterGroup, {
@@ -17,12 +18,9 @@ import FilterGroup, {
 } from "@/shared/components/base/FilterGroup/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
-  useModel as useModelQuery,
-  useModelModules as useModelModulesQuery,
   models as fetchModels,
   ModelProductionStatusEnum,
   type Model,
-  type ModelModule,
   type ModelQuery,
   type Models,
 } from "@/services/fyApi";
@@ -34,8 +32,8 @@ import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import type { ContainerRequest } from "@/frontend/components/CargoGridViewer/index.vue";
 import { useSessionStore } from "@/frontend/stores/session";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
-import ViewImage from "@/shared/components/ViewImage/index.vue";
-import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
+import { useCargoGridShip } from "@/frontend/composables/useCargoGridShip";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 
 const { t } = useI18n();
 
@@ -43,6 +41,7 @@ const route = useRoute();
 const router = useRouter();
 
 const sessionStore = useSessionStore();
+const { displayConfirm } = useAppNotifications();
 
 const hangarOnly = ref(false);
 
@@ -50,10 +49,82 @@ const containerFilterActive = ref(false);
 
 const CONTAINER_SIZES = [1, 2, 4, 8, 16, 24, 32] as const;
 
-const selectedSlug = ref<string | undefined>(
-  (route.query.ship as string) || undefined,
+const MAX_SHIPS = 4;
+
+// Parse initial slugs from URL (backward compat: ?ship= or new ?ships=)
+const parseInitialSlugs = (): (string | undefined)[] => {
+  if (route.query.ships) {
+    return (route.query.ships as string).split(",").filter(Boolean);
+  }
+  if (route.query.ship) {
+    return [route.query.ship as string];
+  }
+  return [undefined];
+};
+
+const selectedSlugs = ref<(string | undefined)[]>(parseInitialSlugs());
+
+const activeSlugs = computed(() =>
+  selectedSlugs.value.filter((s): s is string => !!s),
 );
-const selectedModel = ref<Model>();
+
+// Pre-allocate composable slots for each possible ship
+const shipSlots = Array.from({ length: MAX_SHIPS }, (_, i) => {
+  const slug = computed(() => selectedSlugs.value[i]);
+  return useCargoGridShip(slug);
+});
+
+// Parse and apply initial modules from URL
+const applyInitialModules = () => {
+  for (const key of Object.keys(route.query)) {
+    if (key.startsWith("modules.")) {
+      const slug = key.slice("modules.".length);
+      const val = route.query[key] as string;
+      if (val) {
+        const mods = val.split(",").filter(Boolean);
+        const idx = selectedSlugs.value.indexOf(slug);
+        if (idx >= 0) {
+          shipSlots[idx].setModuleSlugs(mods);
+        }
+      }
+    }
+  }
+  // Backward compat: ?modules= applies to single ship
+  if (
+    route.query.modules &&
+    selectedSlugs.value.length === 1 &&
+    selectedSlugs.value[0]
+  ) {
+    const mods = (route.query.modules as string).split(",").filter(Boolean);
+    shipSlots[0].setModuleSlugs(mods);
+  }
+};
+applyInitialModules();
+
+// Build ships array for the unified viewer
+const ships = computed<ShipEntry[]>(() => {
+  return selectedSlugs.value
+    .map((slug, idx) => {
+      if (!slug) return null;
+      const slot = shipSlots[idx];
+      const model = slot.model.value;
+      if (!model) return null;
+      const holds = slot.combinedCargoHolds.value;
+      if (!holds.length) return null;
+      return {
+        name: model.name,
+        cargoHolds: holds,
+        color: SHIP_COLORS[idx % SHIP_COLORS.length],
+      };
+    })
+    .filter((s): s is ShipEntry => s !== null);
+});
+
+// Single-ship mode: use first slot's cargo holds directly
+const singleShipCargoHolds = computed(() => {
+  if (activeSlugs.value.length !== 1) return [];
+  return shipSlots[0].combinedCargoHolds.value;
+});
 
 // Container requests: how many of each size the user wants to load
 const containerRequests = ref<Record<number, number>>(
@@ -72,14 +143,6 @@ const requestedContainers = computed<ContainerRequest[]>(() => {
     quantity: Number(containerRequests.value[s]),
   }));
 });
-
-const fillGreedy = () => {
-  if (!combinedCargoHolds.value.length) return;
-  const counts = computeGreedyFill(combinedCargoHolds.value);
-  for (const size of CONTAINER_SIZES) {
-    containerRequests.value[size] = counts[size] || 0;
-  }
-};
 
 const clearContainers = () => {
   containerFilterActive.value = false;
@@ -132,166 +195,101 @@ const formatModels = (response: Models) => {
   }));
 };
 
-const { data: modelData } = useModelQuery(
-  computed(() => selectedSlug.value || ""),
-  {
-    query: {
-      enabled: computed(() => !!selectedSlug.value),
-    },
-  },
-);
-
-const { data: modulesData } = useModelModulesQuery(
-  computed(() => selectedSlug.value || ""),
-  undefined,
-  {
-    query: {
-      enabled: computed(() => !!selectedSlug.value),
-    },
-  },
-);
-
-const availableModules = computed<ModelModule[]>(
-  () => modulesData.value?.items || [],
-);
-
-const modulesWithCargo = computed(() =>
-  availableModules.value.filter((m) => m.cargoHolds?.length),
-);
-
-const initialModuleSlugs = route.query.modules
-  ? (route.query.modules as string).split(",")
-  : [];
-const selectedModuleSlugs = ref<Set<string>>(new Set(initialModuleSlugs));
-
-const syncModulesToUrl = () => {
-  const query = { ...route.query };
-  if (selectedModuleSlugs.value.size > 0) {
-    query.modules = [...selectedModuleSlugs.value].join(",");
-  } else {
-    delete query.modules;
-  }
-  void router.replace({ query });
-};
-
-const toggleModule = (moduleSlug: string) => {
-  const next = new Set(selectedModuleSlugs.value);
-  if (next.has(moduleSlug)) {
-    next.delete(moduleSlug);
-  } else {
-    next.add(moduleSlug);
-  }
-  selectedModuleSlugs.value = next;
-  syncModulesToUrl();
-  fillGreedy();
-};
-
-const combinedCargoHolds = computed(() => {
-  const base = selectedModel.value?.cargoHolds || [];
-  const moduleCargo = availableModules.value
-    .filter((m) => selectedModuleSlugs.value.has(m.slug))
-    .flatMap((m) => m.cargoHolds || []);
-  return [...base, ...moduleCargo];
-});
-
-watch(
-  modelData,
-  (data) => {
-    if (data) {
-      selectedModel.value = data;
-      if (data.cargoHolds?.length && !hasContainerRequests.value) {
-        fillGreedy();
-      }
-    }
-  },
-  { immediate: true },
-);
-
-watch(selectedModel, (model) => {
-  if (model?.cargoHolds?.length && !hasContainerRequests.value) {
-    fillGreedy();
-  }
-});
-
-watch(modulesData, () => {
-  if (selectedModuleSlugs.value.size > 0) {
-    fillGreedy();
-  }
-});
-
 const containerFilterVersion = ref(0);
 
 const filterKey = computed(
   () => `cargo-grid-model-${hangarOnly.value}-${containerFilterVersion.value}`,
 );
 
+// URL sync
+const syncUrl = () => {
+  const query: Record<string, string> = {};
+  const active = activeSlugs.value;
+
+  if (active.length === 1) {
+    query.ship = active[0];
+  } else if (active.length > 1) {
+    query.ships = active.join(",");
+  }
+
+  // Per-ship modules
+  for (let i = 0; i < selectedSlugs.value.length; i++) {
+    const slug = selectedSlugs.value[i];
+    if (!slug) continue;
+    const mods = [...shipSlots[i].selectedModuleSlugs.value];
+    if (mods.length) {
+      query[`modules.${slug}`] = mods.join(",");
+    }
+  }
+
+  void router.replace({ query });
+};
+
+// Ship management
+const addShip = () => {
+  if (selectedSlugs.value.length < MAX_SHIPS) {
+    selectedSlugs.value = [...selectedSlugs.value, undefined];
+  }
+};
+
+const removeShip = (index: number) => {
+  const next = [...selectedSlugs.value];
+  next.splice(index, 1);
+
+  if (next.length === 0) {
+    next.push(undefined);
+  }
+
+  selectedSlugs.value = next;
+  syncUrl();
+};
+
+const onShipSelect = (index: number, value: ValueType<Model> | undefined) => {
+  const next = [...selectedSlugs.value];
+  next[index] = (value as string) || undefined;
+  selectedSlugs.value = next;
+  syncUrl();
+};
+
+const handleToggleModule = (slotIndex: number, moduleSlug: string) => {
+  shipSlots[slotIndex].toggleModule(moduleSlug);
+  syncUrl();
+};
+
+const handleFillGreedy = (slotIndex: number) => {
+  const counts = shipSlots[slotIndex].getGreedyFillCounts();
+  for (const size of CONTAINER_SIZES) {
+    containerRequests.value[size] = counts[size] || 0;
+  }
+};
+
 const applyContainerFilter = () => {
   containerFilterActive.value = true;
   containerFilterVersion.value++;
-  selectedSlug.value = undefined;
-  selectedModel.value = undefined;
-  selectedModuleSlugs.value = new Set();
-
-  const query = { ...route.query };
-  delete query.ship;
-  delete query.modules;
-  void router.replace({ query });
+  selectedSlugs.value = [undefined];
+  syncUrl();
 };
 
 const toggleHangarOnly = () => {
   hangarOnly.value = !hangarOnly.value;
-  selectedSlug.value = undefined;
-  selectedModel.value = undefined;
-  selectedModuleSlugs.value = new Set();
-
-  const query = { ...route.query };
-  delete query.ship;
-  delete query.modules;
-  void router.replace({ query });
+  containerFilterVersion.value++;
+  selectedSlugs.value = [undefined];
+  syncUrl();
 };
 
-const resetFilters = () => {
+const doResetFilters = () => {
   hangarOnly.value = false;
   containerFilterActive.value = false;
   clearContainers();
-  selectedSlug.value = undefined;
-  selectedModel.value = undefined;
-  selectedModuleSlugs.value = new Set();
-
-  const query = { ...route.query };
-  delete query.ship;
-  delete query.modules;
-  void router.replace({ query });
+  selectedSlugs.value = [undefined];
+  syncUrl();
 };
 
-const angledImage = computed(() => {
-  if (!selectedModel.value) return undefined;
-  return (
-    selectedModel.value.media.angledViewColored ||
-    selectedModel.value.media.angledView
-  );
-});
-
-const shipRoute = computed(() => {
-  if (!selectedModel.value) return undefined;
-  return { name: "ship", params: { slug: selectedModel.value.slug } };
-});
-
-const onModelSelect = (value: ValueType<Model> | undefined) => {
-  selectedSlug.value = (value as string) || undefined;
-  selectedModuleSlugs.value = new Set();
-  if (!value) {
-    selectedModel.value = undefined;
-  }
-
-  const query = { ...route.query };
-  if (value) {
-    query.ship = value as string;
-  } else {
-    delete query.ship;
-  }
-  delete query.modules;
-  void router.replace({ query });
+const resetFilters = () => {
+  displayConfirm({
+    text: t("messages.cargoGridViewer.confirmReset"),
+    onConfirm: doResetFilters,
+  });
 };
 </script>
 
@@ -300,36 +298,79 @@ const onModelSelect = (value: ValueType<Model> | undefined) => {
     <Heading hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
 
     <div class="row toolbar">
-      <div class="col-12 col-lg-8">
-        <div class="filters">
-          <FilterGroup
-            :key="filterKey"
-            :model-value="selectedSlug"
-            :label="t('labels.selectModel')"
-            :search-label="t('labels.findModel')"
-            :query-fn="fetchCargoModels"
-            :query-response-formatter="formatModels"
-            name="cargo-grid-model"
-            :paginated="true"
-            :searchable="true"
-            :multiple="false"
-            no-label
-            @update:model-value="onModelSelect"
-          />
-          <div class="filters__actions" data-test="filters-actions">
-            <Btn
-              v-if="sessionStore.isAuthenticated"
-              :size="BtnSizesEnum.SMALL"
-              :active="hangarOnly"
+      <div class="col-12">
+        <div class="ship-selectors">
+          <div
+            v-for="(_slug, idx) in selectedSlugs"
+            :key="idx"
+            class="ship-selector"
+          >
+            <FilterGroup
+              :key="`${filterKey}-${idx}`"
+              :model-value="selectedSlugs[idx]"
+              :label="t('labels.selectModel')"
+              :search-label="t('labels.findModel')"
+              :query-fn="fetchCargoModels"
+              :query-response-formatter="formatModels"
+              :name="`cargo-grid-model-${idx}`"
+              :paginated="true"
+              :searchable="true"
+              :multiple="false"
+              no-label
               inline
-              @click="toggleHangarOnly"
+              @update:model-value="onShipSelect(idx, $event)"
+            />
+            <template v-if="shipSlots[idx].modulesWithCargo.value.length">
+              <Btn
+                v-for="mod in shipSlots[idx].modulesWithCargo.value"
+                :key="mod.id"
+                :size="BtnSizesEnum.SMALL"
+                :active="shipSlots[idx].selectedModuleSlugs.value.has(mod.slug)"
+                inline
+                @click="handleToggleModule(idx, mod.slug)"
+              >
+                {{ mod.name }}
+              </Btn>
+            </template>
+            <Btn
+              v-if="shipSlots[idx].model.value?.cargoHolds?.length"
+              :size="BtnSizesEnum.SMALL"
+              inline
+              @click="handleFillGreedy(idx)"
             >
-              {{ t("labels.cargoGridViewer.myHangar") }}
+              {{ t("labels.cargoGridViewer.autoFillShip") }}
             </Btn>
-            <Btn :size="BtnSizesEnum.SMALL" inline @click="resetFilters">
-              {{ t("actions.reset") }}
+            <Btn
+              v-if="selectedSlugs.length > 1"
+              :size="BtnSizesEnum.SMALL"
+              inline
+              @click="removeShip(idx)"
+            >
+              <i class="fa-light fa-times" />
             </Btn>
           </div>
+          <Btn
+            v-if="selectedSlugs.length < MAX_SHIPS"
+            :size="BtnSizesEnum.SMALL"
+            inline
+            @click="addShip"
+          >
+            {{ t("labels.cargoGridViewer.addShip") }}
+          </Btn>
+        </div>
+        <div class="filters__actions" data-test="filters-actions">
+          <Btn
+            v-if="sessionStore.isAuthenticated"
+            :size="BtnSizesEnum.SMALL"
+            :active="hangarOnly"
+            inline
+            @click="toggleHangarOnly"
+          >
+            {{ t("labels.cargoGridViewer.myHangar") }}
+          </Btn>
+          <Btn :size="BtnSizesEnum.SMALL" inline @click="resetFilters">
+            {{ t("actions.reset") }}
+          </Btn>
         </div>
         <div class="container-fields">
           <div
@@ -366,68 +407,23 @@ const onModelSelect = (value: ValueType<Model> | undefined) => {
             >
               {{ t("actions.clear") }}
             </Btn>
-            <Btn
-              v-if="selectedModel?.cargoHolds?.length"
-              :size="BtnSizesEnum.SMALL"
-              inline
-              @click="fillGreedy"
-            >
-              {{ t("actions.reset") }}
-            </Btn>
           </div>
         </div>
-      </div>
-      <div v-if="selectedModel" class="col-12 col-lg-4">
-        <router-link v-if="shipRoute" :to="shipRoute" class="ship-info">
-          <ViewImage
-            v-if="angledImage"
-            :image="angledImage"
-            size="medium"
-            :alt="selectedModel.name"
-            :variant="LazyImageVariantsEnum.WIDE"
-            transparent
-            without-fallback
-            class="ship-info__image"
-          />
-          <span class="ship-info__name">{{ selectedModel.name }}</span>
-        </router-link>
       </div>
     </div>
 
-    <template v-if="selectedModel">
-      <div v-if="modulesWithCargo.length" class="row module-toggles">
-        <div class="col-12">
-          <span class="module-toggles__label">
-            {{ t("labels.model.modules") }}:
-          </span>
-          <Btn
-            v-for="mod in modulesWithCargo"
-            :key="mod.id"
-            :size="BtnSizesEnum.SMALL"
-            :active="selectedModuleSlugs.has(mod.slug)"
-            inline
-            @click="toggleModule(mod.slug)"
-          >
-            {{ mod.name }}
-          </Btn>
-        </div>
+    <!-- Unified cargo grid viewer -->
+    <div v-if="ships.length" class="row">
+      <div class="col-12">
+        <CargoGridViewer
+          :cargo-holds="singleShipCargoHolds"
+          :ships="ships.length > 1 ? ships : []"
+          :container-requests="requestedContainers"
+        />
       </div>
-      <div v-if="combinedCargoHolds.length">
-        <div class="row">
-          <div class="col-12">
-            <CargoGridViewer
-              :cargo-holds="combinedCargoHolds"
-              :container-requests="requestedContainers"
-            />
-          </div>
-        </div>
-      </div>
-      <div v-else class="row mt-3">
-        <div class="col-12">
-          <p>{{ t("messages.cargoGridViewer.noCargoHolds") }}</p>
-        </div>
-      </div>
-    </template>
+    </div>
+
+    <!-- Preview mode: containers without ship -->
     <template v-else-if="hasContainerRequests">
       <div class="row">
         <div class="col-12">

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -102,21 +102,23 @@ const applyInitialModules = () => {
 applyInitialModules();
 
 // Build ships array for the unified viewer
-const ships = computed<ShipEntry[]>(() => {
-  return selectedSlugs.value
-    .map((_slug, idx) => {
-      const slot = shipSlots[idx];
-      const model = slot.model.value;
-      if (!model) return null;
-      const holds = slot.combinedCargoHolds.value;
-      if (!holds.length) return null;
-      return {
-        name: model.name,
-        cargoHolds: holds,
-        color: SHIP_COLORS[idx % SHIP_COLORS.length],
-      };
-    })
-    .filter((s): s is ShipEntry => s !== null);
+const ships = computed(() => {
+  const result: ShipEntry[] = [];
+  for (let idx = 0; idx < selectedSlugs.value.length; idx++) {
+    const slot = shipSlots[idx];
+    const model = slot.model.value;
+    if (!model) continue;
+    const holds = slot.combinedCargoHolds.value;
+    if (!holds.length) continue;
+    result.push({
+      name: model.name,
+      cargoHolds: holds,
+      color: SHIP_COLORS[idx % SHIP_COLORS.length],
+      image: slot.angledImage.value,
+      route: slot.shipRoute.value,
+    });
+  }
+  return result;
 });
 
 // Single-ship mode: use first slot's cargo holds directly
@@ -316,21 +318,16 @@ const resetFilters = () => {
             inline
             @update:model-value="handleShipSelect"
           />
-          <div
-            v-for="(slug, idx) in selectedSlugs"
-            :key="slug"
-            class="ship-entry"
-            :data-test="`ship-entry-${idx}`"
-          >
-            <span
-              class="ship-entry__name"
-              :style="{
-                color: SHIP_COLORS[idx % SHIP_COLORS.length],
-              }"
-            >
-              {{ shipSlots[idx].model.value?.name || slug }}
-            </span>
+          <template v-for="(slug, idx) in selectedSlugs" :key="slug">
             <template v-if="shipSlots[idx].modulesWithCargo.value.length">
+              <span
+                class="ship-entry__name"
+                :style="{
+                  color: SHIP_COLORS[idx % SHIP_COLORS.length],
+                }"
+              >
+                {{ shipSlots[idx].model.value?.name }}
+              </span>
               <Btn
                 v-for="mod in shipSlots[idx].modulesWithCargo.value"
                 :key="mod.id"
@@ -342,24 +339,7 @@ const resetFilters = () => {
                 {{ mod.name }}
               </Btn>
             </template>
-            <Btn
-              v-if="shipSlots[idx].model.value?.cargoHolds?.length"
-              :size="BtnSizesEnum.SMALL"
-              inline
-              @click="handleFillGreedy(idx)"
-            >
-              {{ t("labels.cargoGridViewer.autoFillShip") }}
-            </Btn>
-            <Btn
-              v-tooltip="t('actions.remove')"
-              :size="BtnSizesEnum.SMALL"
-              :data-test="`remove-ship-${idx}`"
-              inline
-              @click="removeShip(idx)"
-            >
-              <i class="fa-light fa-times" />
-            </Btn>
-          </div>
+          </template>
           <Btn
             v-if="sessionStore.isAuthenticated"
             :size="BtnSizesEnum.SMALL"
@@ -428,6 +408,8 @@ const resetFilters = () => {
           :cargo-holds="singleShipCargoHolds"
           :ships="ships.length > 1 ? ships : []"
           :container-requests="requestedContainers"
+          @auto-fill="handleFillGreedy"
+          @remove-ship="removeShip"
         />
       </div>
     </div>

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -344,6 +344,7 @@ const resetFilters = () => {
             <Btn
               v-if="selectedSlugs.length > 1"
               :size="BtnSizesEnum.SMALL"
+              v-tooltip="t('actions.remove')"
               :data-test="`remove-ship-${idx}`"
               inline
               @click="removeShip(idx)"
@@ -354,14 +355,13 @@ const resetFilters = () => {
           <Btn
             v-if="selectedSlugs.length < MAX_SHIPS"
             :size="BtnSizesEnum.SMALL"
+            v-tooltip="t('labels.cargoGridViewer.addShip')"
             data-test="add-ship"
             inline
             @click="addShip"
           >
             <i class="fa-light fa-plus" />
           </Btn>
-        </div>
-        <div class="filters__actions" data-test="filters-actions">
           <Btn
             v-if="sessionStore.isAuthenticated"
             :size="BtnSizesEnum.SMALL"
@@ -371,8 +371,15 @@ const resetFilters = () => {
           >
             {{ t("labels.cargoGridViewer.myHangar") }}
           </Btn>
-          <Btn :size="BtnSizesEnum.SMALL" inline @click="resetFilters">
-            {{ t("actions.reset") }}
+          <Btn
+            v-if="activeSlugs.length > 0"
+            :size="BtnSizesEnum.SMALL"
+            v-tooltip="t('actions.reset')"
+            data-test="reset-filters"
+            inline
+            @click="resetFilters"
+          >
+            <i class="fa-light fa-undo" />
           </Btn>
         </div>
         <div class="container-fields">

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -114,6 +114,8 @@ const ships = computed(() => {
       name: model.name,
       cargoHolds: holds,
       color: SHIP_COLORS[idx % SHIP_COLORS.length],
+      image: slot.angledImage.value,
+      route: slot.shipRoute.value,
     });
   }
   return result;

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import { ComponentExposed } from "vue-component-type-helpers";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import CargoGridViewer from "@/frontend/components/CargoGridViewer/index.vue";
 import {
@@ -52,22 +53,20 @@ const CONTAINER_SIZES = [1, 2, 4, 8, 16, 24, 32] as const;
 
 const MAX_SHIPS = 4;
 
+const modelFilterGroup = ref<ComponentExposed<typeof FilterGroup>>();
+
 // Parse initial slugs from URL (backward compat: ?ship= or new ?ships=)
-const parseInitialSlugs = (): (string | undefined)[] => {
+const parseInitialSlugs = (): string[] => {
   if (route.query.ships) {
     return (route.query.ships as string).split(",").filter(Boolean);
   }
   if (route.query.ship) {
     return [route.query.ship as string];
   }
-  return [undefined];
+  return [];
 };
 
-const selectedSlugs = ref<(string | undefined)[]>(parseInitialSlugs());
-
-const activeSlugs = computed(() =>
-  selectedSlugs.value.filter((s): s is string => !!s),
-);
+const selectedSlugs = ref<string[]>(parseInitialSlugs());
 
 // Pre-allocate composable slots for each possible ship
 const shipSlots = Array.from({ length: MAX_SHIPS }, (_, i) => {
@@ -105,8 +104,7 @@ applyInitialModules();
 // Build ships array for the unified viewer
 const ships = computed<ShipEntry[]>(() => {
   return selectedSlugs.value
-    .map((slug, idx) => {
-      if (!slug) return null;
+    .map((_slug, idx) => {
       const slot = shipSlots[idx];
       const model = slot.model.value;
       if (!model) return null;
@@ -123,7 +121,7 @@ const ships = computed<ShipEntry[]>(() => {
 
 // Single-ship mode: use first slot's cargo holds directly
 const singleShipCargoHolds = computed(() => {
-  if (activeSlugs.value.length !== 1) return [];
+  if (selectedSlugs.value.length !== 1) return [];
   return shipSlots[0].combinedCargoHolds.value;
 });
 
@@ -202,21 +200,22 @@ const filterKey = computed(
   () => `cargo-grid-model-${hangarOnly.value}-${containerFilterVersion.value}`,
 );
 
+const selectDisabled = computed(() => selectedSlugs.value.length >= MAX_SHIPS);
+
 // URL sync
 const syncUrl = () => {
   const query: Record<string, string> = {};
-  const active = activeSlugs.value;
+  const slugs = selectedSlugs.value;
 
-  if (active.length === 1) {
-    query.ship = active[0];
-  } else if (active.length > 1) {
-    query.ships = active.join(",");
+  if (slugs.length === 1) {
+    query.ship = slugs[0];
+  } else if (slugs.length > 1) {
+    query.ships = slugs.join(",");
   }
 
   // Per-ship modules
-  for (let i = 0; i < selectedSlugs.value.length; i++) {
-    const slug = selectedSlugs.value[i];
-    if (!slug) continue;
+  for (let i = 0; i < slugs.length; i++) {
+    const slug = slugs[i];
     const mods = [...shipSlots[i].selectedModuleSlugs.value];
     if (mods.length) {
       query[`modules.${slug}`] = mods.join(",");
@@ -227,27 +226,27 @@ const syncUrl = () => {
 };
 
 // Ship management
-const addShip = () => {
-  if (selectedSlugs.value.length < MAX_SHIPS) {
-    selectedSlugs.value = [...selectedSlugs.value, undefined];
+const handleShipSelect = (value: ValueType<Model> | undefined) => {
+  const slug = value as string;
+  if (!slug) return;
+
+  // Prevent duplicates and enforce max
+  if (
+    selectedSlugs.value.includes(slug) ||
+    selectedSlugs.value.length >= MAX_SHIPS
+  ) {
+    modelFilterGroup.value?.clear();
+    return;
   }
+
+  selectedSlugs.value = [...selectedSlugs.value, slug];
+  modelFilterGroup.value?.clear();
+  syncUrl();
 };
 
 const removeShip = (index: number) => {
   const next = [...selectedSlugs.value];
   next.splice(index, 1);
-
-  if (next.length === 0) {
-    next.push(undefined);
-  }
-
-  selectedSlugs.value = next;
-  syncUrl();
-};
-
-const onShipSelect = (index: number, value: ValueType<Model> | undefined) => {
-  const next = [...selectedSlugs.value];
-  next[index] = (value as string) || undefined;
   selectedSlugs.value = next;
   syncUrl();
 };
@@ -267,14 +266,14 @@ const handleFillGreedy = (slotIndex: number) => {
 const applyContainerFilter = () => {
   containerFilterActive.value = true;
   containerFilterVersion.value++;
-  selectedSlugs.value = [undefined];
+  selectedSlugs.value = [];
   syncUrl();
 };
 
 const toggleHangarOnly = () => {
   hangarOnly.value = !hangarOnly.value;
   containerFilterVersion.value++;
-  selectedSlugs.value = [undefined];
+  selectedSlugs.value = [];
   syncUrl();
 };
 
@@ -282,7 +281,7 @@ const doResetFilters = () => {
   hangarOnly.value = false;
   containerFilterActive.value = false;
   clearContainers();
-  selectedSlugs.value = [undefined];
+  selectedSlugs.value = [];
   syncUrl();
 };
 
@@ -300,27 +299,63 @@ const resetFilters = () => {
 
     <div class="row toolbar">
       <div class="col-12">
-        <div class="ship-selectors">
-          <div
-            v-for="(_slug, idx) in selectedSlugs"
-            :key="idx"
-            class="ship-selector"
+        <div class="ship-selector-row">
+          <FilterGroup
+            ref="modelFilterGroup"
+            :key="filterKey"
+            :label="t('labels.selectModel')"
+            :search-label="t('labels.findModel')"
+            :query-fn="fetchCargoModels"
+            :query-response-formatter="formatModels"
+            name="cargo-grid-model"
+            :paginated="true"
+            :searchable="true"
+            :multiple="false"
+            :disabled="selectDisabled"
+            no-label
+            inline
+            @update:model-value="handleShipSelect"
+          />
+          <Btn
+            v-if="sessionStore.isAuthenticated"
+            :size="BtnSizesEnum.SMALL"
+            :active="hangarOnly"
+            inline
+            @click="toggleHangarOnly"
           >
-            <FilterGroup
-              :key="`${filterKey}-${idx}`"
-              :model-value="selectedSlugs[idx]"
-              :label="t('labels.selectModel')"
-              :search-label="t('labels.findModel')"
-              :query-fn="fetchCargoModels"
-              :query-response-formatter="formatModels"
-              :name="`cargo-grid-model-${idx}`"
-              :paginated="true"
-              :searchable="true"
-              :multiple="false"
-              no-label
-              inline
-              @update:model-value="onShipSelect(idx, $event)"
-            />
+            {{ t("labels.cargoGridViewer.myHangar") }}
+          </Btn>
+          <Btn
+            v-if="selectedSlugs.length > 0"
+            v-tooltip="t('actions.reset')"
+            :size="BtnSizesEnum.SMALL"
+            data-test="reset-filters"
+            inline
+            @click="resetFilters"
+          >
+            <i class="fa-light fa-undo" />
+          </Btn>
+        </div>
+
+        <div
+          v-if="selectedSlugs.length"
+          class="ship-entries"
+          data-test="ship-entries"
+        >
+          <div
+            v-for="(slug, idx) in selectedSlugs"
+            :key="slug"
+            class="ship-entry"
+            :data-test="`ship-entry-${idx}`"
+          >
+            <span
+              class="ship-entry__name"
+              :style="{
+                color: SHIP_COLORS[idx % SHIP_COLORS.length],
+              }"
+            >
+              {{ shipSlots[idx].model.value?.name || slug }}
+            </span>
             <template v-if="shipSlots[idx].modulesWithCargo.value.length">
               <Btn
                 v-for="mod in shipSlots[idx].modulesWithCargo.value"
@@ -342,9 +377,8 @@ const resetFilters = () => {
               {{ t("labels.cargoGridViewer.autoFillShip") }}
             </Btn>
             <Btn
-              v-if="selectedSlugs.length > 1"
-              :size="BtnSizesEnum.SMALL"
               v-tooltip="t('actions.remove')"
+              :size="BtnSizesEnum.SMALL"
               :data-test="`remove-ship-${idx}`"
               inline
               @click="removeShip(idx)"
@@ -352,36 +386,8 @@ const resetFilters = () => {
               <i class="fa-light fa-times" />
             </Btn>
           </div>
-          <Btn
-            v-if="selectedSlugs.length < MAX_SHIPS"
-            :size="BtnSizesEnum.SMALL"
-            v-tooltip="t('labels.cargoGridViewer.addShip')"
-            data-test="add-ship"
-            inline
-            @click="addShip"
-          >
-            <i class="fa-light fa-plus" />
-          </Btn>
-          <Btn
-            v-if="sessionStore.isAuthenticated"
-            :size="BtnSizesEnum.SMALL"
-            :active="hangarOnly"
-            inline
-            @click="toggleHangarOnly"
-          >
-            {{ t("labels.cargoGridViewer.myHangar") }}
-          </Btn>
-          <Btn
-            v-if="activeSlugs.length > 0"
-            :size="BtnSizesEnum.SMALL"
-            v-tooltip="t('actions.reset')"
-            data-test="reset-filters"
-            inline
-            @click="resetFilters"
-          >
-            <i class="fa-light fa-undo" />
-          </Btn>
         </div>
+
         <div class="container-fields">
           <div
             v-for="size in CONTAINER_SIZES"

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -344,6 +344,7 @@ const resetFilters = () => {
             <Btn
               v-if="selectedSlugs.length > 1"
               :size="BtnSizesEnum.SMALL"
+              :data-test="`remove-ship-${idx}`"
               inline
               @click="removeShip(idx)"
             >

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -354,10 +354,11 @@ const resetFilters = () => {
           <Btn
             v-if="selectedSlugs.length < MAX_SHIPS"
             :size="BtnSizesEnum.SMALL"
+            data-test="add-ship"
             inline
             @click="addShip"
           >
-            {{ t("labels.cargoGridViewer.addShip") }}
+            <i class="fa-light fa-plus" />
           </Btn>
         </div>
         <div class="filters__actions" data-test="filters-actions">

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -114,8 +114,6 @@ const ships = computed(() => {
       name: model.name,
       cargoHolds: holds,
       color: SHIP_COLORS[idx % SHIP_COLORS.length],
-      image: slot.angledImage.value,
-      route: slot.shipRoute.value,
     });
   }
   return result;
@@ -297,126 +295,131 @@ const resetFilters = () => {
 
 <template>
   <FeatureGuard feature="tools_cargo_grids">
-    <Heading hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
+    <div class="cargo-grids-page">
+      <Heading hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
 
-    <div class="row toolbar">
-      <div class="col-12">
-        <div class="ship-selector-row" data-test="ship-entries">
-          <FilterGroup
-            ref="modelFilterGroup"
-            :key="filterKey"
-            :label="t('labels.selectModel')"
-            :search-label="t('labels.findModel')"
-            :query-fn="fetchCargoModels"
-            :query-response-formatter="formatModels"
-            name="cargo-grid-model"
-            :paginated="true"
-            :searchable="true"
-            :multiple="false"
-            :disabled="selectDisabled"
-            no-label
-            inline
-            @update:model-value="handleShipSelect"
-          />
-          <template v-for="(slug, idx) in selectedSlugs" :key="slug">
-            <template v-if="shipSlots[idx].modulesWithCargo.value.length">
-              <span
-                class="ship-entry__name"
-                :style="{
-                  color: SHIP_COLORS[idx % SHIP_COLORS.length],
-                }"
-              >
-                {{ shipSlots[idx].model.value?.name }}
-              </span>
-              <Btn
-                v-for="mod in shipSlots[idx].modulesWithCargo.value"
-                :key="mod.id"
-                :size="BtnSizesEnum.SMALL"
-                :active="shipSlots[idx].selectedModuleSlugs.value.has(mod.slug)"
-                inline
-                @click="handleToggleModule(idx, mod.slug)"
-              >
-                {{ mod.name }}
-              </Btn>
-            </template>
-          </template>
-          <Btn
-            v-if="sessionStore.isAuthenticated"
-            :size="BtnSizesEnum.SMALL"
-            :active="hangarOnly"
-            inline
-            @click="toggleHangarOnly"
-          >
-            {{ t("labels.cargoGridViewer.myHangar") }}
-          </Btn>
-          <Btn
-            v-if="selectedSlugs.length > 0"
-            v-tooltip="t('actions.reset')"
-            :size="BtnSizesEnum.SMALL"
-            data-test="reset-filters"
-            inline
-            @click="resetFilters"
-          >
-            <i class="fa-light fa-undo" />
-          </Btn>
-        </div>
-
-        <div class="container-fields">
-          <div
-            v-for="size in CONTAINER_SIZES"
-            :key="size"
-            style="width: 5rem; flex-shrink: 0"
-            class="container-field"
-            :data-test="`container-field-${size}`"
-          >
-            <FormInput
-              v-model.number="containerRequests[size]"
-              :name="`container-${size}`"
-              :label="`${size} SCU`"
-              :type="InputTypesEnum.NUMBER"
-              :min="0"
-              :step="1"
-              :alignment="InputAlignmentsEnum.RIGHT"
+      <div class="row toolbar">
+        <div class="col-12">
+          <div class="ship-selector-row" data-test="ship-entries">
+            <FilterGroup
+              ref="modelFilterGroup"
+              :key="filterKey"
+              :label="t('labels.selectModel')"
+              :search-label="t('labels.findModel')"
+              :query-fn="fetchCargoModels"
+              :query-response-formatter="formatModels"
+              name="cargo-grid-model"
+              :paginated="true"
+              :searchable="true"
+              :multiple="false"
+              :disabled="selectDisabled"
+              no-label
+              inline
+              @update:model-value="handleShipSelect"
             />
+            <template v-for="(slug, idx) in selectedSlugs" :key="slug">
+              <template v-if="shipSlots[idx].modulesWithCargo.value.length">
+                <span
+                  class="ship-entry__name"
+                  :style="{
+                    color: SHIP_COLORS[idx % SHIP_COLORS.length],
+                  }"
+                >
+                  {{ shipSlots[idx].model.value?.name }}
+                </span>
+                <Btn
+                  v-for="mod in shipSlots[idx].modulesWithCargo.value"
+                  :key="mod.id"
+                  :size="BtnSizesEnum.SMALL"
+                  :active="
+                    shipSlots[idx].selectedModuleSlugs.value.has(mod.slug)
+                  "
+                  inline
+                  @click="handleToggleModule(idx, mod.slug)"
+                >
+                  {{ mod.name }}
+                </Btn>
+              </template>
+            </template>
+            <Btn
+              v-if="sessionStore.isAuthenticated"
+              :size="BtnSizesEnum.SMALL"
+              :active="hangarOnly"
+              inline
+              @click="toggleHangarOnly"
+            >
+              {{ t("labels.cargoGridViewer.myHangar") }}
+            </Btn>
+            <Btn
+              v-if="selectedSlugs.length > 0"
+              v-tooltip="t('actions.reset')"
+              :size="BtnSizesEnum.SMALL"
+              data-test="reset-filters"
+              inline
+              @click="resetFilters"
+            >
+              <i class="fa-light fa-undo" />
+            </Btn>
           </div>
-          <div class="container-fields__actions">
-            <Btn
-              v-if="hasContainerRequests"
-              :size="BtnSizesEnum.SMALL"
-              inline
-              @click="applyContainerFilter"
+
+          <div class="container-fields">
+            <div
+              v-for="size in CONTAINER_SIZES"
+              :key="size"
+              style="width: 5rem; flex-shrink: 0"
+              class="container-field"
+              :data-test="`container-field-${size}`"
             >
-              {{ t("labels.cargoGridViewer.filterShips") }}
-            </Btn>
-            <Btn
-              v-if="hasContainerRequests"
-              :size="BtnSizesEnum.SMALL"
-              inline
-              @click="clearContainers"
-            >
-              {{ t("actions.clear") }}
-            </Btn>
+              <FormInput
+                v-model.number="containerRequests[size]"
+                :name="`container-${size}`"
+                :label="`${size} SCU`"
+                :type="InputTypesEnum.NUMBER"
+                :min="0"
+                :step="1"
+                :alignment="InputAlignmentsEnum.RIGHT"
+              />
+            </div>
+            <div class="container-fields__actions">
+              <Btn
+                v-if="hasContainerRequests"
+                :size="BtnSizesEnum.SMALL"
+                inline
+                @click="applyContainerFilter"
+              >
+                {{ t("labels.cargoGridViewer.filterShips") }}
+              </Btn>
+              <Btn
+                v-if="hasContainerRequests"
+                :size="BtnSizesEnum.SMALL"
+                inline
+                @click="clearContainers"
+              >
+                {{ t("actions.clear") }}
+              </Btn>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Unified cargo grid viewer -->
-    <div v-if="ships.length" class="row">
-      <div class="col-12">
-        <CargoGridViewer
-          :cargo-holds="singleShipCargoHolds"
-          :ships="ships.length > 1 ? ships : []"
-          :container-requests="requestedContainers"
-          @auto-fill="handleFillGreedy"
-          @remove-ship="removeShip"
-        />
+      <!-- Unified cargo grid viewer -->
+      <div v-if="ships.length" class="row cargo-grids-page__viewer">
+        <div class="col-12">
+          <CargoGridViewer
+            :cargo-holds="singleShipCargoHolds"
+            :ships="ships.length > 1 ? ships : []"
+            :container-requests="requestedContainers"
+            @auto-fill="handleFillGreedy"
+            @remove-ship="removeShip"
+          />
+        </div>
       </div>
-    </div>
 
-    <!-- Preview mode: containers without ship -->
-    <template v-else-if="hasContainerRequests">
-      <div class="row">
+      <!-- Preview mode: containers without ship -->
+      <div
+        v-else-if="hasContainerRequests"
+        class="row cargo-grids-page__viewer"
+      >
         <div class="col-12">
           <CargoGridViewer
             :cargo-holds="[]"
@@ -424,7 +427,7 @@ const resetFilters = () => {
           />
         </div>
       </div>
-    </template>
+    </div>
   </FeatureGuard>
 </template>
 

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -14,6 +14,8 @@ import {
 } from "@/frontend/components/CargoGridViewer/constants";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
+import ViewImage from "@/shared/components/ViewImage/index.vue";
+import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import FilterGroup, {
   type FilterGroupParams,
   type ValueType,
@@ -301,7 +303,7 @@ const resetFilters = () => {
       <Heading hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
 
       <div class="row toolbar">
-        <div class="col-12">
+        <div class="col-12 col-lg-8">
           <div class="ship-selector-row" data-test="ship-entries">
             <FilterGroup
               ref="modelFilterGroup"
@@ -400,6 +402,35 @@ const resetFilters = () => {
                 {{ t("actions.clear") }}
               </Btn>
             </div>
+          </div>
+        </div>
+        <div v-if="selectedSlugs.length" class="col-12 col-lg-4">
+          <div class="ship-infos">
+            <router-link
+              v-for="(slug, idx) in selectedSlugs"
+              :key="slug"
+              :to="shipSlots[idx].shipRoute.value || {}"
+              class="ship-info"
+            >
+              <ViewImage
+                v-if="shipSlots[idx].angledImage.value"
+                :image="shipSlots[idx].angledImage.value"
+                size="medium"
+                :alt="shipSlots[idx].model.value?.name || slug"
+                :variant="LazyImageVariantsEnum.WIDE"
+                transparent
+                without-fallback
+                class="ship-info__image"
+              />
+              <span
+                class="ship-info__name"
+                :style="{
+                  color: SHIP_COLORS[idx % SHIP_COLORS.length],
+                }"
+              >
+                {{ shipSlots[idx].model.value?.name || slug }}
+              </span>
+            </router-link>
           </div>
         </div>
       </div>

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -38,6 +38,7 @@ import { useSessionStore } from "@/frontend/stores/session";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
 import { useCargoGridShip } from "@/frontend/composables/useCargoGridShip";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useMobile } from "@/shared/composables/useMobile";
 
 const { t } = useI18n();
 
@@ -46,6 +47,8 @@ const router = useRouter();
 
 const sessionStore = useSessionStore();
 const { displayConfirm } = useAppNotifications();
+
+const mobile = useMobile();
 
 const hangarOnly = ref(false);
 
@@ -404,7 +407,7 @@ const resetFilters = () => {
             </div>
           </div>
         </div>
-        <div v-if="selectedSlugs.length" class="col-12 col-lg-4">
+        <div v-if="selectedSlugs.length && !mobile" class="col-12 col-lg-4">
           <div class="ship-infos">
             <router-link
               v-for="(slug, idx) in selectedSlugs"

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -299,7 +299,7 @@ const resetFilters = () => {
 
     <div class="row toolbar">
       <div class="col-12">
-        <div class="ship-selector-row">
+        <div class="ship-selector-row" data-test="ship-entries">
           <FilterGroup
             ref="modelFilterGroup"
             :key="filterKey"
@@ -316,32 +316,6 @@ const resetFilters = () => {
             inline
             @update:model-value="handleShipSelect"
           />
-          <Btn
-            v-if="sessionStore.isAuthenticated"
-            :size="BtnSizesEnum.SMALL"
-            :active="hangarOnly"
-            inline
-            @click="toggleHangarOnly"
-          >
-            {{ t("labels.cargoGridViewer.myHangar") }}
-          </Btn>
-          <Btn
-            v-if="selectedSlugs.length > 0"
-            v-tooltip="t('actions.reset')"
-            :size="BtnSizesEnum.SMALL"
-            data-test="reset-filters"
-            inline
-            @click="resetFilters"
-          >
-            <i class="fa-light fa-undo" />
-          </Btn>
-        </div>
-
-        <div
-          v-if="selectedSlugs.length"
-          class="ship-entries"
-          data-test="ship-entries"
-        >
           <div
             v-for="(slug, idx) in selectedSlugs"
             :key="slug"
@@ -386,6 +360,25 @@ const resetFilters = () => {
               <i class="fa-light fa-times" />
             </Btn>
           </div>
+          <Btn
+            v-if="sessionStore.isAuthenticated"
+            :size="BtnSizesEnum.SMALL"
+            :active="hangarOnly"
+            inline
+            @click="toggleHangarOnly"
+          >
+            {{ t("labels.cargoGridViewer.myHangar") }}
+          </Btn>
+          <Btn
+            v-if="selectedSlugs.length > 0"
+            v-tooltip="t('actions.reset')"
+            :size="BtnSizesEnum.SMALL"
+            data-test="reset-filters"
+            inline
+            @click="resetFilters"
+          >
+            <i class="fa-light fa-undo" />
+          </Btn>
         </div>
 
         <div class="container-fields">

--- a/app/frontend/shared/components/base/FilterGroup/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/index.scss
@@ -123,6 +123,10 @@
       color: darken($input-color, 15%);
     }
   }
+
+  &.inline {
+    margin-bottom: 0;
+  }
 }
 
 .has-error .filter-group-title {

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -67,6 +67,7 @@ type Props = {
   noLabel?: boolean;
   bigIcon?: boolean;
   hideSelected?: boolean;
+  inline?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -89,6 +90,7 @@ const props = withDefaults(defineProps<Props>(), {
   noLabel: false,
   bigIcon: false,
   hideSelected: false,
+  inline: false,
 });
 
 type FilterOptionValue = FilterOption["value"];
@@ -276,6 +278,7 @@ const filteredOptions = computed(() => {
 
 const cssClasses = computed(() => ({
   "has-error has-feedback": props.error,
+  inline: props.inline,
 }));
 
 onMounted(() => {

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1056,7 +1056,10 @@
         "didNotFit": "Passte nicht",
         "openInTool": "Im Frachtraster-Tool öffnen",
         "myHangar": "Nur meine Schiffe anzeigen",
-        "filterShips": "Schiffe nach Containergröße filtern"
+        "filterShips": "Schiffe nach Containergröße filtern",
+        "addShip": "Schiff hinzufügen",
+        "removeShip": "Entfernen",
+        "autoFillShip": "Auto-Fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -260,7 +260,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "Dieses Schiff hat keine Frachträume."
+        "noCargoHolds": "Dieses Schiff hat keine Frachträume.",
+        "confirmReset": "Möchtest du wirklich alle Schiffe und Container-Einstellungen zurücksetzen?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1050,7 +1050,10 @@
         "didNotFit": "Did not fit",
         "openInTool": "Open in Cargo Grid Tool",
         "myHangar": "Show only my Ships",
-        "filterShips": "Filter Ships by Container Size"
+        "filterShips": "Filter Ships by Container Size",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -260,7 +260,8 @@
         "webglNotSupported": "3D viewer is not available on this device."
       },
       "cargoGridViewer": {
-        "noCargoHolds": "This ship has no cargo holds."
+        "noCargoHolds": "This ship has no cargo holds.",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1056,7 +1056,10 @@
         "didNotFit": "No cabe",
         "openInTool": "Abrir en la herramienta de grilla de carga",
         "myHangar": "Mostrar solo mis naves",
-        "filterShips": "Filtrar naves por tamaño de contenedor"
+        "filterShips": "Filtrar naves por tamaño de contenedor",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -260,7 +260,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "Esta nave no tiene bodegas de carga."
+        "noCargoHolds": "Esta nave no tiene bodegas de carga.",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1056,7 +1056,10 @@
         "didNotFit": "Ne rentre pas",
         "openInTool": "Ouvrir dans l'outil de grille de cargaison",
         "myHangar": "Afficher uniquement mes vaisseaux",
-        "filterShips": "Filtrer les vaisseaux par taille de conteneur"
+        "filterShips": "Filtrer les vaisseaux par taille de conteneur",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -260,7 +260,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "Ce vaisseau n'a pas de soutes à cargaison."
+        "noCargoHolds": "Ce vaisseau n'a pas de soutes à cargaison.",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1056,7 +1056,10 @@
         "didNotFit": "Non entra",
         "openInTool": "Apri nello strumento griglia di carico",
         "myHangar": "Mostra solo le mie navi",
-        "filterShips": "Filtra navi per dimensione container"
+        "filterShips": "Filtra navi per dimensione container",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -259,7 +259,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "Questa nave non ha stive di carico."
+        "noCargoHolds": "Questa nave non ha stive di carico.",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1052,7 +1052,10 @@
         "didNotFit": "放不下",
         "openInTool": "在货物网格工具中打开",
         "myHangar": "仅显示我的飞船",
-        "filterShips": "按集装箱大小筛选飞船"
+        "filterShips": "按集装箱大小筛选飞船",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -259,7 +259,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "此飞船没有货舱。"
+        "noCargoHolds": "此飞船没有货舱。",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1052,7 +1052,10 @@
         "didNotFit": "放不下",
         "openInTool": "在貨物網格工具中開啟",
         "myHangar": "僅顯示我的飛船",
-        "filterShips": "按貨櫃大小篩選飛船"
+        "filterShips": "按貨櫃大小篩選飛船",
+        "addShip": "Add Ship",
+        "removeShip": "Remove",
+        "autoFillShip": "Auto-fill"
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -259,7 +259,8 @@
         }
       },
       "cargoGridViewer": {
-        "noCargoHolds": "此飛船沒有貨艙。"
+        "noCargoHolds": "此飛船沒有貨艙。",
+        "confirmReset": "Are you sure you want to reset all ships and container settings?"
       },
       "confirm": {
         "vehicle": {

--- a/docs/exec-plans/cargo-grids-comparison.md
+++ b/docs/exec-plans/cargo-grids-comparison.md
@@ -1,0 +1,69 @@
+# Cargo Grids: Ship Comparison — Unified 3D Viewer
+
+**Issue:** fleetyards/fleetyards#3783
+**Branch:** `feature/cargo-grids-comparison`
+
+## Context
+
+When accepting hauling missions, players need to check cargo crate sizes and determine which ship handles them best. Currently the Cargo Grids tool only shows one ship at a time, requiring tedious back-and-forth switching. This feature adds a unified 3D viewer that renders up to 4 ships' cargo grids in one scene, color-coded per ship, with draggable groups and per-ship stats.
+
+## Design Decisions
+
+- **Unified 3D viewer:** All ships rendered in a single TresJS/Three.js canvas — one WebGL context, direct visual size comparison.
+- **Color-coded wireframes:** Each ship's hold outlines rendered in a distinct color (cyan, orange, purple, blue). Container colors shared across ships.
+- **Ship name labels:** HTML labels (via `@tresjs/cientos` Html component) floating above each ship's grid group.
+- **Draggable groups:** Each ship's cargo grid can be dragged in the XZ plane with snap-to-grid (1 SCU / 1.25m). OrbitControls disabled during drag.
+- **Per-ship stats:** Stats section below the viewer with one panel per ship showing capacity, max container, packed SCU, and warnings.
+- **Selection UX:** "Add Ship" button adds additional FilterGroup dropdowns (up to 4). Remove button is a `×` icon. Reset behind confirm dialog.
+- **Auto-fill:** Per-ship "Auto-fill" button fills shared container inputs optimally for that ship.
+- **Module toggles:** Inline with each ship selector row.
+- **URL scheme:** `?ship=slug` (backward compat single), `?ships=a,b,c` (multi), `?modules.slug=mod1,mod2` (per-ship modules).
+
+## Implementation
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `composables/useCargoGridShip.ts` | Per-ship composable: model query, modules query, combined holds, module toggle, greedy fill |
+| `components/CargoGridViewer/CargoGridDragHandler.vue` | Renderless component inside TresCanvas for raycasting-based drag with 1 SCU snap |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `components/CargoGridViewer/index.vue` | `ships` prop, `ShipEntry` type, `SHIP_COLORS`, multi-ship pack results, color-coded wireframes, Html labels, drag handler integration, per-ship stats template |
+| `components/CargoGridViewer/index.scss` | Ship label, multi-stats, ship-stats styles, compact variant |
+| `pages/tools/cargo-grids.vue` | Multi-ship selectors with pre-allocated 4 composable slots, inline module toggles + auto-fill per ship, unified viewer, confirm on reset |
+| `pages/tools/cargo-grids.scss` | Ship selectors layout |
+| `translations/*/labels.json` | addShip, removeShip, autoFillShip keys |
+| `translations/*/messages.json` | confirmReset key |
+| `spec/playwright/e2e/CargoGrids.spec.ts` | Updated for unified viewer, multi-ship tests |
+
+### Architecture
+
+```
+cargo-grids.vue (page)
+  ├── 4x useCargoGridShip(slug) — pre-allocated composable slots
+  ├── builds ships: ShipEntry[] from active slots
+  └── CargoGridViewer
+        ├── ships prop → multiShipPackResults (per-ship packing)
+        ├── CargoGridDragHandler (raycasting + snap drag)
+        ├── TresCanvas with per-ship TresGroups (color-coded)
+        └── Per-ship stats section below canvas
+```
+
+### Key Technical Details
+
+- **packSingleShip()** — extracted packing logic, left-aligns holds at x=0 so multi-ship layout controls positioning
+- **multiShipPackResults** — positions ships sequentially along X with 4 SCU gaps, centers the entire scene
+- **shipDragOffsets** — decoupled from pack computation; applied via `getShipPosition()` in template only, preventing scene rebuilds on drag
+- **isPreviewMode** — excludes multi-ship mode to prevent preview containers rendering alongside ship grids
+
+## Verification
+
+1. Single ship: `?ship=drak-caterpillar` — identical to previous behavior
+2. Multi ship: `?ships=anvl-carrack,drak-caterpillar` — color-coded grids side by side, per-ship stats
+3. Drag: click and drag a ship's grid — snaps to 1 SCU grid, camera stays stable
+4. Reset: click "Reset" — confirm dialog appears
+5. Mobile: stacks vertically, reduced DPI

--- a/spec/playwright/app_commands/scenarios/tools.rb
+++ b/spec/playwright/app_commands/scenarios/tools.rb
@@ -29,6 +29,20 @@ model.update!(cargo_holds: [
   }
 ])
 
+misc = Manufacturer.find_or_create_by!(name: "Musashi Industrial & Starflight Concern") { |m| m.code = "MISC" }
+freelancer_max = Model.find_or_initialize_by(name: "Freelancer MAX")
+if freelancer_max.new_record?
+  freelancer_max = FactoryBot.create(:model, :with_legacy_images, name: "Freelancer MAX", production_status: "flight-ready", manufacturer: misc)
+end
+freelancer_max.update!(cargo_holds: [
+  {
+    "name" => "cargo",
+    "capacity" => 120,
+    "dimensions" => {"x" => 12.5, "y" => 5.0, "z" => 5.0},
+    "max_container_size" => {"size" => 32, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}}
+  }
+])
+
 unless Model.exists?(name: "Aurora MR")
   rsi = Manufacturer.find_or_create_by!(name: "Roberts Space Industries") { |m| m.code = "RSI" }
   FactoryBot.create(:model, :with_legacy_images, name: "Aurora MR", production_status: "flight-ready", manufacturer: rsi)

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -40,9 +40,6 @@ test.describe("Cargo Grids", () => {
 
     await expect(page).toHaveURL(/ship=drak-caterpillar/);
 
-    // The ship entry should appear
-    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
-
     // The cargo grid viewer should appear with stats
     await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
     await expect(page.getByTestId("cargo-grid-viewer-stats")).toBeVisible();
@@ -104,8 +101,8 @@ test.describe("Cargo Grids", () => {
     // Container inputs should be cleared
     await expect(page.locator('input[name="container-8"]')).toHaveValue("0");
 
-    // Ship should be removed
-    await expect(page.getByTestId("ship-entries")).not.toBeVisible();
+    // Ship should be removed — viewer gone
+    await expect(page.getByTestId("cargo-grid-viewer")).not.toBeVisible();
   });
 
   test("Shows container preview when containers set but no model selected", async ({
@@ -129,17 +126,18 @@ test.describe("Cargo Grids", () => {
     await filterGroup.locator("input").first().fill("Caterpillar");
     await page.getByText("Caterpillar").first().click();
 
-    // First ship entry should appear
-    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
+    // First ship should appear in viewer
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
 
     // Select second ship
     await filterGroup.getByTestId("filter-group-title").click();
     await filterGroup.locator("input").first().fill("Freelancer");
     await page.getByText("Freelancer MAX").first().click();
 
-    // Both entries should be visible
-    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
-    await expect(page.getByTestId("ship-entry-1")).toBeVisible();
+    // Multi-ship stats should appear
+    await expect(
+      page.getByTestId("cargo-grid-viewer-multi-stats"),
+    ).toBeVisible();
   });
 
   test("Loads multiple ships via URL and shows unified viewer with multi-ship stats", async ({
@@ -166,15 +164,20 @@ test.describe("Cargo Grids", () => {
     await page.goto(
       "/tools/cargo-grids/?ships=drak-caterpillar,misc-freelancer-max",
     );
-    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
-    await expect(page.getByTestId("ship-entry-1")).toBeVisible();
+
+    // Multi-ship stats with remove buttons
+    await expect(
+      page.getByTestId("cargo-grid-viewer-multi-stats"),
+    ).toBeVisible();
 
     // Remove the second ship
     await page.getByTestId("remove-ship-1").click();
 
-    // Should be back to one ship entry
-    await expect(page.getByTestId("ship-entry-1")).not.toBeVisible();
-    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
+    // Should be back to single-ship view
+    await expect(page.getByTestId("cargo-grid-viewer-stats")).toBeVisible();
+    await expect(
+      page.getByTestId("cargo-grid-viewer-multi-stats"),
+    ).not.toBeVisible();
   });
 
   test("Backward compat: single ship URL still works", async ({ page }) => {

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -114,12 +114,12 @@ test.describe("Cargo Grids", () => {
     await expect(filterBtn).toBeVisible();
   });
 
-  test("Shows Add Ship button", async ({ page }) => {
-    await expect(page.getByText("Add Ship")).toBeVisible();
+  test("Shows add ship button", async ({ page }) => {
+    await expect(page.getByTestId("add-ship")).toBeVisible();
   });
 
   test("Adds a second ship selector", async ({ page }) => {
-    await page.getByText("Add Ship").click();
+    await page.getByTestId("add-ship").click();
 
     // Should now have two filter groups
     await expect(
@@ -154,7 +154,7 @@ test.describe("Cargo Grids", () => {
 
   test("Removes a ship from comparison", async ({ page }) => {
     // Add second ship
-    await page.getByText("Add Ship").click();
+    await page.getByTestId("add-ship").click();
     await expect(
       page.getByTestId("filter-group-cargo-grid-model-1"),
     ).toBeVisible();

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -9,7 +9,7 @@ test.describe("Cargo Grids", () => {
     await page.goto("/tools/cargo-grids/");
 
     // Wait for the filter component to be interactive
-    await page.getByTestId("filter-group-cargo-grid-model-0").waitFor();
+    await page.getByTestId("filter-group-cargo-grid-model").waitFor();
   });
 
   test("Loads the page", async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe("Cargo Grids", () => {
     page,
   }) => {
     // Open the model filter dropdown and search for Caterpillar
-    const filterGroup = page.getByTestId("filter-group-cargo-grid-model-0");
+    const filterGroup = page.getByTestId("filter-group-cargo-grid-model");
     await filterGroup.getByTestId("filter-group-title").click();
     await filterGroup.locator("input").first().fill("Caterpillar");
 
@@ -39,6 +39,9 @@ test.describe("Cargo Grids", () => {
     await option.click();
 
     await expect(page).toHaveURL(/ship=drak-caterpillar/);
+
+    // The ship entry should appear
+    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
 
     // The cargo grid viewer should appear with stats
     await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
@@ -100,6 +103,9 @@ test.describe("Cargo Grids", () => {
 
     // Container inputs should be cleared
     await expect(page.locator('input[name="container-8"]')).toHaveValue("0");
+
+    // Ship should be removed
+    await expect(page.getByTestId("ship-entries")).not.toBeVisible();
   });
 
   test("Shows container preview when containers set but no model selected", async ({
@@ -114,23 +120,26 @@ test.describe("Cargo Grids", () => {
     await expect(filterBtn).toBeVisible();
   });
 
-  test("Shows add ship button", async ({ page }) => {
-    await expect(page.getByTestId("add-ship")).toBeVisible();
-  });
+  test("Adds multiple ships by selecting from the same filter", async ({
+    page,
+  }) => {
+    // Select first ship
+    const filterGroup = page.getByTestId("filter-group-cargo-grid-model");
+    await filterGroup.getByTestId("filter-group-title").click();
+    await filterGroup.locator("input").first().fill("Caterpillar");
+    await page.getByText("Caterpillar").first().click();
 
-  test("Adds a second ship selector", async ({ page }) => {
-    await page.getByTestId("add-ship").click();
+    // First ship entry should appear
+    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
 
-    // Should now have two filter groups
-    await expect(
-      page.getByTestId("filter-group-cargo-grid-model-0"),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("filter-group-cargo-grid-model-1"),
-    ).toBeVisible();
+    // Select second ship
+    await filterGroup.getByTestId("filter-group-title").click();
+    await filterGroup.locator("input").first().fill("Freelancer");
+    await page.getByText("Freelancer MAX").first().click();
 
-    // Remove buttons should appear
-    await expect(page.getByTestId("remove-ship-0")).toBeVisible();
+    // Both entries should be visible
+    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
+    await expect(page.getByTestId("ship-entry-1")).toBeVisible();
   });
 
   test("Loads multiple ships via URL and shows unified viewer with multi-ship stats", async ({
@@ -153,22 +162,19 @@ test.describe("Cargo Grids", () => {
   });
 
   test("Removes a ship from comparison", async ({ page }) => {
-    // Add second ship
-    await page.getByTestId("add-ship").click();
-    await expect(
-      page.getByTestId("filter-group-cargo-grid-model-1"),
-    ).toBeVisible();
+    // Load two ships via URL
+    await page.goto(
+      "/tools/cargo-grids/?ships=drak-caterpillar,misc-freelancer-max",
+    );
+    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
+    await expect(page.getByTestId("ship-entry-1")).toBeVisible();
 
-    // Remove the second ship selector
+    // Remove the second ship
     await page.getByTestId("remove-ship-1").click();
 
-    // Should be back to one filter group
-    await expect(
-      page.getByTestId("filter-group-cargo-grid-model-1"),
-    ).not.toBeVisible();
-    await expect(
-      page.getByTestId("filter-group-cargo-grid-model-0"),
-    ).toBeVisible();
+    // Should be back to one ship entry
+    await expect(page.getByTestId("ship-entry-1")).not.toBeVisible();
+    await expect(page.getByTestId("ship-entry-0")).toBeVisible();
   });
 
   test("Backward compat: single ship URL still works", async ({ page }) => {

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -84,15 +84,15 @@ test.describe("Cargo Grids", () => {
   });
 
   test("Resets filters", async ({ page }) => {
+    // Select a ship first (reset button only visible with a ship selected)
+    await page.goto("/tools/cargo-grids/?ship=drak-caterpillar");
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
+
     // Set some container counts
     await page.locator('input[name="container-8"]').fill("3");
 
     // Click reset
-    const resetBtn = page
-      .getByTestId("filters-actions")
-      .getByText("Reset")
-      .first();
-    await resetBtn.click();
+    await page.getByTestId("reset-filters").click();
 
     // Confirm the reset dialog
     await page.getByTestId("confirm-dialog").waitFor({ state: "visible" });

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -173,11 +173,13 @@ test.describe("Cargo Grids", () => {
     // Remove the second ship
     await page.getByTestId("remove-ship-1").click();
 
-    // Should be back to single-ship view
-    await expect(page.getByTestId("cargo-grid-viewer-stats")).toBeVisible();
+    // Multi-ship stats should disappear
     await expect(
       page.getByTestId("cargo-grid-viewer-multi-stats"),
     ).not.toBeVisible();
+
+    // Should be back to single-ship view
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
   });
 
   test("Backward compat: single ship URL still works", async ({ page }) => {

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -9,7 +9,7 @@ test.describe("Cargo Grids", () => {
     await page.goto("/tools/cargo-grids/");
 
     // Wait for the filter component to be interactive
-    await page.getByTestId("filter-group-cargo-grid-model").waitFor();
+    await page.getByTestId("filter-group-cargo-grid-model-0").waitFor();
   });
 
   test("Loads the page", async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe("Cargo Grids", () => {
     page,
   }) => {
     // Open the model filter dropdown and search for Caterpillar
-    const filterGroup = page.getByTestId("filter-group-cargo-grid-model");
+    const filterGroup = page.getByTestId("filter-group-cargo-grid-model-0");
     await filterGroup.getByTestId("filter-group-title").click();
     await filterGroup.locator("input").first().fill("Caterpillar");
 
@@ -54,35 +54,6 @@ test.describe("Cargo Grids", () => {
     // The cargo grid viewer should appear
     await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
     await expect(page.getByTestId("cargo-grid-viewer-stats")).toBeVisible();
-  });
-
-  test("Auto-fills container counts when selecting a model with cargo holds", async ({
-    page,
-  }) => {
-    const filterGroup = page.getByTestId("filter-group-cargo-grid-model");
-    await filterGroup.getByTestId("filter-group-title").click();
-    await filterGroup.locator("input").first().fill("Caterpillar");
-
-    const option = page.getByText("Caterpillar").first();
-    await option.click();
-
-    // Wait for model to load and cargo grid viewer to appear
-    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
-
-    // At least one container input should have a value > 0 after greedy fill
-    await expect(async () => {
-      const containerFields = page.locator("[data-test^='container-field-'] input");
-      const count = await containerFields.count();
-      let hasNonZero = false;
-      for (let i = 0; i < count; i++) {
-        const value = await containerFields.nth(i).inputValue();
-        if (Number(value) > 0) {
-          hasNonZero = true;
-          break;
-        }
-      }
-      expect(hasNonZero).toBe(true);
-    }).toPass();
   });
 
   test("Clears container counts", async ({ page }) => {
@@ -137,5 +108,69 @@ test.describe("Cargo Grids", () => {
     // Click the filter ships button to apply
     const filterBtn = page.getByText("Filter Ships by Container Size");
     await expect(filterBtn).toBeVisible();
+  });
+
+  test("Shows Add Ship button", async ({ page }) => {
+    await expect(page.getByText("Add Ship")).toBeVisible();
+  });
+
+  test("Adds a second ship selector", async ({ page }) => {
+    await page.getByText("Add Ship").click();
+
+    // Should now have two filter groups
+    await expect(
+      page.getByTestId("filter-group-cargo-grid-model-0"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("filter-group-cargo-grid-model-1"),
+    ).toBeVisible();
+
+    // Remove buttons should appear
+    await expect(page.getByText("Remove").first()).toBeVisible();
+  });
+
+  test("Loads multiple ships via URL and shows unified viewer with multi-ship stats", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/tools/cargo-grids/?ships=drak-caterpillar,misc-freelancer-max",
+    );
+    await page.waitForLoadState("networkidle");
+
+    // Should show ONE cargo grid viewer (unified)
+    await expect(page.getByTestId("cargo-grid-viewer")).toHaveCount(1);
+
+    // Should show multi-ship stats (not single-ship stats)
+    await expect(
+      page.getByTestId("cargo-grid-viewer-multi-stats"),
+    ).toBeVisible();
+  });
+
+  test("Removes a ship from comparison", async ({ page }) => {
+    // Add second ship
+    await page.getByText("Add Ship").click();
+    await expect(
+      page.getByTestId("filter-group-cargo-grid-model-1"),
+    ).toBeVisible();
+
+    // Remove the second ship selector
+    const removeButtons = page.getByText("Remove");
+    await removeButtons.last().click();
+
+    // Should be back to one filter group
+    await expect(
+      page.getByTestId("filter-group-cargo-grid-model-1"),
+    ).not.toBeVisible();
+    await expect(
+      page.getByTestId("filter-group-cargo-grid-model-0"),
+    ).toBeVisible();
+  });
+
+  test("Backward compat: single ship URL still works", async ({ page }) => {
+    await page.goto("/tools/cargo-grids/?ship=drak-caterpillar");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
+    await expect(page.getByTestId("cargo-grid-viewer-stats")).toBeVisible();
   });
 });

--- a/spec/playwright/e2e/CargoGrids.spec.ts
+++ b/spec/playwright/e2e/CargoGrids.spec.ts
@@ -94,6 +94,10 @@ test.describe("Cargo Grids", () => {
       .first();
     await resetBtn.click();
 
+    // Confirm the reset dialog
+    await page.getByTestId("confirm-dialog").waitFor({ state: "visible" });
+    await page.getByTestId("confirm-ok").click();
+
     // Container inputs should be cleared
     await expect(page.locator('input[name="container-8"]')).toHaveValue("0");
   });
@@ -126,7 +130,7 @@ test.describe("Cargo Grids", () => {
     ).toBeVisible();
 
     // Remove buttons should appear
-    await expect(page.getByText("Remove").first()).toBeVisible();
+    await expect(page.getByTestId("remove-ship-0")).toBeVisible();
   });
 
   test("Loads multiple ships via URL and shows unified viewer with multi-ship stats", async ({
@@ -135,7 +139,9 @@ test.describe("Cargo Grids", () => {
     await page.goto(
       "/tools/cargo-grids/?ships=drak-caterpillar,misc-freelancer-max",
     );
-    await page.waitForLoadState("networkidle");
+
+    // Wait for the viewer to render (models load async)
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
 
     // Should show ONE cargo grid viewer (unified)
     await expect(page.getByTestId("cargo-grid-viewer")).toHaveCount(1);
@@ -154,8 +160,7 @@ test.describe("Cargo Grids", () => {
     ).toBeVisible();
 
     // Remove the second ship selector
-    const removeButtons = page.getByText("Remove");
-    await removeButtons.last().click();
+    await page.getByTestId("remove-ship-1").click();
 
     // Should be back to one filter group
     await expect(


### PR DESCRIPTION
## Summary

- Add multi-ship comparison to the Cargo Grids tool — select up to 4 ships and see all cargo grids rendered in a single unified 3D viewer
- Color-coded wireframes per ship (cyan, orange, purple, blue) with floating ship name labels
- Draggable ship groups with snap-to-grid (1 SCU / 1.25m) for manual arrangement
- Per-ship stats below the viewer (capacity, max container, packed SCU, warnings)
- Per-ship auto-fill and inline module toggles
- Reset behind confirm dialog, remove button as × icon
- Backward compatible URL scheme (`?ship=` still works, `?ships=` for multi)

## Test plan

- [x] Select a single ship — verify identical behavior to current production
- [x] Add 2-4 ships — verify color-coded grids render side by side without overlap
- [x] Enter container quantities — verify packing shown per ship independently
- [x] Click "Auto-fill" on a ship — verify shared container inputs update
- [x] Drag a ship's grid — verify snap to grid, camera stays stable
- [x] Click "Reset" — verify confirm dialog appears
- [x] Load `?ships=anvl-carrack,drak-caterpillar` — verify both ships load
- [x] Load `?ship=drak-caterpillar` — verify backward compat

Closes #3783

🤖 Generated with [Claude Code](https://claude.com/claude-code)