### PR TITLE
feat(api): add ship crew positions system

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/model_position_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_position_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ModelPositionInput
+          include Rswag::SchemaComponents::Component
+
+          schema({
+            type: :object,
+            properties: {
+              modelId: {type: :string, format: :uuid},
+              name: {type: :string},
+              positionType: {type: :string},
+              source: {type: :string},
+              position: {type: :integer},
+              hardpointId: {type: :string, format: :uuid, nullable: true}
+            },
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/model_position.rb
+++ b/app/api_components/admin/v1/schemas/model_position.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class ModelPosition
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            positionType: {type: :string},
+            source: {type: :string},
+            position: {type: :integer},
+            hardpointId: {type: :string, format: :uuid, nullable: true},
+            modelId: {type: :string, format: :uuid},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id name positionType source position modelId createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/model_positions.rb
+++ b/app/api_components/admin/v1/schemas/model_positions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class ModelPositions < ::Shared::V1::Schemas::BaseList
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/ModelPosition"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/model.rb
+++ b/app/api_components/admin/v1/schemas/models/model.rb
@@ -12,6 +12,7 @@ module Admin
               hidden: {type: :boolean},
               active: {type: :boolean},
               scKey: {type: :string},
+              positionsNeedCuration: {type: :boolean},
               scLength: {type: :number},
               scBeam: {type: :number},
               scHeight: {type: :number},

--- a/app/api_components/admin/v1/schemas/queries/model_position_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_position_query.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class ModelPositionQuery
+          include Rswag::SchemaComponents::Component
+
+          schema({
+            type: :object,
+            properties: {
+              modelIdEq: {type: :string, format: :uuid},
+              positionTypeEq: {type: :string},
+              sourceEq: {type: :string},
+              nameCont: {type: :string}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/model_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_query.rb
@@ -23,6 +23,7 @@ module Admin
               holoBlank: {type: :boolean},
               topViewColoredBlank: {type: :boolean},
               frontViewBlank: {type: :boolean},
+              positionsNeedCurationEq: {type: :boolean},
               sorts: {anyOf: [{
                 type: :array, items: {"$ref": "#/components/schemas/ModelSortEnum"}
               }, {

--- a/app/api_components/v1/schemas/models/positions/model_position.rb
+++ b/app/api_components/v1/schemas/models/positions/model_position.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Positions
+        class ModelPosition
+          include Rswag::SchemaComponents::Component
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              name: {type: :string},
+              positionType: {type: :string, enum: %w[pilot copilot turret_gunner engineer gunner loadmaster passenger operator custom]},
+              source: {type: :string, enum: %w[sc_data curated]},
+              position: {type: :integer},
+              createdAt: {type: :string, format: "date-time"},
+              updatedAt: {type: :string, format: "date-time"}
+            },
+            additionalProperties: false,
+            required: %w[id name positionType source position createdAt updatedAt]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/model_positions_controller.rb
+++ b/app/controllers/admin/api/v1/model_positions_controller.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class ModelPositionsController < ::Admin::Api::BaseController
+        before_action :set_model_position, only: %i[show update destroy]
+
+        def index
+          authorize! with: ::Admin::ModelPositionPolicy
+
+          model_position_query_params["sorts"] = "position asc"
+
+          @q = authorized_scope(ModelPosition.all).ransack(model_position_query_params)
+
+          @model_positions = @q.result
+            .page(params.fetch(:page, nil))
+            .per(params.fetch(:per_page, nil))
+        end
+
+        def create
+          @model_position = ModelPosition.new(model_position_params)
+
+          authorize! @model_position, with: ::Admin::ModelPositionPolicy
+
+          if @model_position.save
+            render :show, status: :created
+          else
+            render json: ValidationError.new("model_position.create", errors: @model_position.errors), status: :bad_request
+          end
+        end
+
+        def show
+        end
+
+        def update
+          if @model_position.update(model_position_params)
+            render :show, status: :ok
+          else
+            render json: ValidationError.new("model_position.update", errors: @model_position.errors), status: :bad_request
+          end
+        end
+
+        def destroy
+          @model_position.destroy
+
+          head :no_content
+        end
+
+        def regenerate
+          authorize! with: ::Admin::ModelPositionPolicy
+
+          model = Model.find(params[:model_id])
+          ModelPosition.generate_for_model!(model)
+
+          @model_positions = model.model_positions.order(position: :asc)
+            .page(params.fetch(:page, nil))
+            .per(params.fetch(:per_page, nil))
+
+          render :index
+        end
+
+        private def set_model_position
+          @model_position = ModelPosition.find(params[:id])
+
+          authorize! @model_position, with: ::Admin::ModelPositionPolicy
+        end
+
+        private def model_position_params
+          @model_position_params ||= params.permit(
+            :model_id, :name, :position_type, :hardpoint_id, :source, :position
+          )
+        end
+
+        private def model_position_query_params
+          @model_position_query_params ||= params.permit(q: [
+            :model_id_eq, :position_type_eq, :source_eq, :name_cont, :sorts
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -140,6 +140,13 @@ module Api
         end
       end
 
+      def positions
+        model = find_model_by_slug!
+        return if performed?
+
+        @positions = model.model_positions.order(position: :asc)
+      end
+
       def images
         model = find_model_by_slug!
         return if performed?

--- a/app/frontend/admin/components/Models/FilterForm/index.vue
+++ b/app/frontend/admin/components/Models/FilterForm/index.vue
@@ -33,6 +33,7 @@ const prefillFormValues = () => {
     holoBlank: filters.value.holoBlank,
     topViewColoredBlank: filters.value.topViewColoredBlank,
     frontViewBlank: filters.value.frontViewBlank,
+    positionsNeedCurationEq: filters.value.positionsNeedCurationEq,
   };
 };
 
@@ -120,6 +121,14 @@ watch(
       :reset-label="t('labels.all')"
       :options="booleanOptions"
       name="scKeyBlank"
+    />
+
+    <RadioList
+      v-model="form.positionsNeedCurationEq"
+      :label="t('labels.filters.models.positionsNeedCuration')"
+      :reset-label="t('labels.all')"
+      :options="booleanOptions"
+      name="positionsNeedCurationEq"
     />
 
     <br />

--- a/app/frontend/admin/pages/models/[id]/edit/positions.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/positions.vue
@@ -1,0 +1,336 @@
+<script lang="ts">
+export default {
+  name: "AdminModelEditPositionsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import {
+  type ModelExtended,
+  type ModelPosition,
+  type ModelPositionInput,
+  useListModelPositions as useListModelPositionsQuery,
+  useCreateModelPosition as useCreateModelPositionMutation,
+  useUpdateModelPosition as useUpdateModelPositionMutation,
+  useDestroyModelPosition as useDestroyModelPositionMutation,
+  useRegenerateModelPositions as useRegenerateModelPositionsMutation,
+  getListModelPositionsQueryKey,
+  type FilterOption,
+} from "@/services/fyAdminApi";
+import { useQueryClient } from "@tanstack/vue-query";
+import { usePagination } from "@/shared/composables/usePagination";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+
+type Props = {
+  model: ModelExtended;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const queryClient = useQueryClient();
+
+const editableList = ref<{
+  editingId: string | null;
+  creating: boolean;
+  startCreate: () => void;
+  finishEdit: () => void;
+  finishCreate: () => void;
+} | null>(null);
+
+const positionTypeOptions: FilterOption[] = [
+  { label: "Pilot", value: "pilot" },
+  { label: "Copilot", value: "copilot" },
+  { label: "Turret Gunner", value: "turret_gunner" },
+  { label: "Engineer", value: "engineer" },
+  { label: "Gunner", value: "gunner" },
+  { label: "Loadmaster", value: "loadmaster" },
+  { label: "Passenger", value: "passenger" },
+  { label: "Operator", value: "operator" },
+  { label: "Custom", value: "custom" },
+];
+
+const sourceOptions: FilterOption[] = [
+  { label: "SC Data", value: "sc_data" },
+  { label: "Curated", value: "curated" },
+];
+
+const positionsQueryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+  q: {
+    modelIdEq: props.model.id,
+  },
+}));
+
+const positionsQueryKey = computed(() =>
+  getListModelPositionsQueryKey(positionsQueryParams.value),
+);
+
+const { perPage, page, updatePerPage } = usePagination(positionsQueryKey);
+
+const { data, isLoading } = useListModelPositionsQuery(positionsQueryParams);
+
+const invalidatePositions = () =>
+  queryClient.invalidateQueries({
+    queryKey: getListModelPositionsQueryKey(),
+  });
+
+// Edit
+const editForm = ref<ModelPositionInput>({});
+
+const onStartEdit = (record: ModelPosition) => {
+  editForm.value = {
+    name: record.name,
+    positionType: record.positionType,
+    source: record.source,
+    position: record.position,
+  };
+};
+
+const updateMutation = useUpdateModelPositionMutation({
+  mutation: {
+    onSettled: invalidatePositions,
+  },
+});
+
+const onSaveEdit = async () => {
+  const id = editableList.value?.editingId;
+  if (!id) return;
+
+  await updateMutation.mutateAsync({
+    id,
+    data: editForm.value,
+  });
+
+  editableList.value?.finishEdit();
+};
+
+// Delete
+const destroyMutation = useDestroyModelPositionMutation({
+  mutation: {
+    onSettled: invalidatePositions,
+  },
+});
+
+const onDestroy = async (record: ModelPosition) => {
+  await destroyMutation.mutateAsync({ id: record.id });
+};
+
+// Create
+const createForm = ref<ModelPositionInput>({
+  modelId: props.model.id,
+  source: "curated",
+  positionType: "custom",
+  position: 0,
+});
+
+const onStartCreate = () => {
+  createForm.value = {
+    modelId: props.model.id,
+    source: "curated",
+    positionType: "custom",
+    position: 0,
+  };
+};
+
+const createMutation = useCreateModelPositionMutation({
+  mutation: {
+    onSettled: invalidatePositions,
+  },
+});
+
+const onSaveCreate = async () => {
+  await createMutation.mutateAsync({
+    data: createForm.value,
+  });
+
+  editableList.value?.finishCreate();
+};
+
+// Regenerate
+const regenerating = ref(false);
+
+const regenerateMutation = useRegenerateModelPositionsMutation({
+  mutation: {
+    onSettled: async () => {
+      await invalidatePositions();
+      regenerating.value = false;
+    },
+  },
+});
+
+const onRegenerate = async () => {
+  regenerating.value = true;
+  await regenerateMutation.mutateAsync({
+    params: { model_id: props.model.id },
+  });
+};
+</script>
+
+<template>
+  <div class="flex items-center justify-between">
+    <Heading hero>
+      {{ t("headlines.admin.models.edit.positions") }}
+      <BasePill v-if="model.positionsNeedCuration" uppercase margin-left>
+        {{ t("labels.model.needsCuration") }}
+      </BasePill>
+    </Heading>
+    <div class="flex gap-2">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :disabled="regenerating"
+        @click="onRegenerate"
+      >
+        <i class="fa-duotone fa-arrows-rotate" />
+        {{ t("actions.regenerate") }}
+      </Btn>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :disabled="editableList?.creating"
+        @click="editableList?.startCreate()"
+      >
+        <i class="fa-duotone fa-plus" />
+        {{ t("actions.add") }}
+      </Btn>
+    </div>
+  </div>
+
+  <InlineEditableList
+    empty-name="Positions"
+    :loading="isLoading"
+    ref="editableList"
+    :items="(data?.items as ModelPosition[]) || []"
+    :confirm-destroy-text="t('messages.confirm.modelPosition.destroy')"
+    @start-edit="onStartEdit"
+    @save-edit="onSaveEdit"
+    @start-create="onStartCreate"
+    @save-create="onSaveCreate"
+    @destroy="onDestroy"
+  >
+    <template #display="{ item }">
+      <div class="position-display">
+        <BasePill uppercase margin-right>{{ item.positionType }}</BasePill>
+        <BasePill margin-right>{{ item.source }}</BasePill>
+        <span class="position-display__name">{{ item.name }}</span>
+        <span class="position-display__order text-muted">
+          #{{ item.position }}
+        </span>
+      </div>
+    </template>
+
+    <template #edit>
+      <div class="position-form">
+        <div class="position-form__row">
+          <FormInput
+            v-model="editForm.name"
+            name="edit-name"
+            translation-key="modelPosition.name"
+          />
+          <FormInput
+            v-model.number="editForm.position"
+            name="edit-position"
+            translation-key="modelPosition.position"
+            type="number"
+          />
+        </div>
+        <div class="position-form__row">
+          <FilterGroup
+            v-model="editForm.positionType"
+            name="edit-position-type"
+            :options="positionTypeOptions"
+            :nullable="false"
+            translation-key="modelPosition.positionType"
+          />
+          <FilterGroup
+            v-model="editForm.source"
+            name="edit-source"
+            :options="sourceOptions"
+            :nullable="false"
+            translation-key="modelPosition.source"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template #create>
+      <div class="position-form">
+        <div class="position-form__row">
+          <FormInput
+            v-model="createForm.name"
+            name="create-name"
+            translation-key="modelPosition.name"
+          />
+          <FormInput
+            v-model.number="createForm.position"
+            name="create-position"
+            translation-key="modelPosition.position"
+            type="number"
+          />
+        </div>
+        <div class="position-form__row">
+          <FilterGroup
+            v-model="createForm.positionType"
+            name="create-position-type"
+            :options="positionTypeOptions"
+            :nullable="false"
+            translation-key="modelPosition.positionType"
+          />
+          <FilterGroup
+            v-model="createForm.source"
+            name="create-source"
+            :options="sourceOptions"
+            :nullable="false"
+            translation-key="modelPosition.source"
+          />
+        </div>
+      </div>
+    </template>
+  </InlineEditableList>
+
+  <Paginator
+    v-if="data"
+    :query-result-ref="data"
+    :per-page="perPage"
+    :update-per-page="updatePerPage"
+  />
+</template>
+
+<style lang="scss" scoped>
+.position-display {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  &__name {
+    font-weight: 500;
+  }
+
+  &__order {
+    font-size: 0.85em;
+  }
+}
+
+.position-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  &__row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    > * {
+      flex: 1;
+      min-width: 150px;
+    }
+  }
+}
+</style>

--- a/app/frontend/admin/pages/models/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/[id]/edit/routes.ts
@@ -99,6 +99,18 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "positions/",
+    name: "admin-model-edit-positions",
+    component: () => import("@/admin/pages/models/[id]/edit/positions.vue"),
+    meta: {
+      title: "admin.models.edit.positions",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
+  {
     path: "hardpoints/",
     name: "admin-model-edit-hardpoints",
     component: () => import("@/admin/pages/models/[id]/edit/hardpoints.vue"),

--- a/app/frontend/admin/types/routes.ts
+++ b/app/frontend/admin/types/routes.ts
@@ -57,6 +57,7 @@ export type AdminRouteLocation =
   | ParamRoute<"admin-model-edit-fleetchart", IdParams>
   | ParamRoute<"admin-model-edit-images", IdParams>
   | ParamRoute<"admin-model-edit-videos", IdParams>
+  | ParamRoute<"admin-model-edit-positions", IdParams>
   | ParamRoute<"admin-model-edit-hardpoints", IdParams>
   | ParamRoute<"admin-model-edit-loaners", IdParams>
   | ParamRoute<"admin-model-edit-docks", IdParams>

--- a/app/frontend/frontend/components/Models/CrewPositions/index.scss
+++ b/app/frontend/frontend/components/Models/CrewPositions/index.scss
@@ -1,0 +1,40 @@
+.crew-positions {
+  margin-top: 20px;
+
+  &__label {
+    font-size: 20px;
+    font-family: "Orbitron", tahoma, sans-serif;
+    text-transform: uppercase;
+  }
+
+  &__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.05);
+    font-size: 0.9rem;
+  }
+
+  &__count {
+    font-weight: 600;
+    opacity: 0.7;
+  }
+
+  &__name {
+    font-weight: 500;
+  }
+
+  &__source {
+    opacity: 0.5;
+    font-size: 0.8em;
+  }
+}

--- a/app/frontend/frontend/components/Models/CrewPositions/index.vue
+++ b/app/frontend/frontend/components/Models/CrewPositions/index.vue
@@ -1,0 +1,105 @@
+<script lang="ts">
+export default {
+  name: "CrewPositions",
+};
+</script>
+
+<script lang="ts" setup>
+import Loader from "@/shared/components/Loader/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useModelPositions as useModelPositionsQuery,
+  type ModelPosition,
+  type Model,
+} from "@/services/fyApi";
+
+type Props = {
+  model: Model;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+
+const { isLoading, data: positions } = useModelPositionsQuery(
+  props.model.slug,
+  {
+    query: { enabled: !!props.model },
+  },
+);
+
+const positionIcon = (positionType: string) => {
+  switch (positionType) {
+    case "pilot":
+      return "fa-duotone fa-plane";
+    case "copilot":
+      return "fa-duotone fa-plane-up";
+    case "turret_gunner":
+      return "fa-duotone fa-crosshairs";
+    case "engineer":
+      return "fa-duotone fa-wrench";
+    case "gunner":
+      return "fa-duotone fa-gun";
+    case "loadmaster":
+      return "fa-duotone fa-boxes-stacked";
+    case "passenger":
+      return "fa-duotone fa-person-seat-reclined";
+    case "operator":
+      return "fa-duotone fa-desktop";
+    default:
+      return "fa-duotone fa-user";
+  }
+};
+
+const groupedPositions = computed(() => {
+  if (!positions.value?.length) return [];
+
+  const groups: Record<string, { position: ModelPosition; count: number }> = {};
+
+  positions.value.forEach((pos) => {
+    const key = `${pos.positionType}-${pos.name}`;
+    if (groups[key]) {
+      groups[key].count++;
+    } else {
+      groups[key] = { position: pos, count: 1 };
+    }
+  });
+
+  return Object.values(groups);
+});
+</script>
+
+<template>
+  <div v-if="positions?.length || isLoading" class="crew-positions">
+    <h2 class="crew-positions__label">
+      {{ t("labels.model.crewPositions") }}
+    </h2>
+    <div v-if="positions?.length" class="crew-positions__list">
+      <div
+        v-for="group in groupedPositions"
+        :key="`${group.position.positionType}-${group.position.name}`"
+        class="crew-positions__item"
+      >
+        <span class="crew-positions__count" v-if="group.count > 1">
+          {{ group.count }}x
+        </span>
+        <i :class="positionIcon(group.position.positionType)" />
+        <span class="crew-positions__name">{{ group.position.name }}</span>
+        <span
+          class="crew-positions__source"
+          v-if="group.position.source === 'curated'"
+        >
+          <i
+            class="fa-light fa-pen-to-square"
+            v-tooltip="t('labels.model.curatedPosition')"
+          />
+        </span>
+      </div>
+    </div>
+    <Loader :loading="isLoading" fixed />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -158,12 +158,6 @@ const {
             :group="group"
             :hardpoints="hardpointsForGroup(group)"
           />
-          <HardpointGroup
-            v-for="group in [HardpointGroupEnum.SEAT]"
-            :key="group"
-            :group="group"
-            :hardpoints="hardpointsForGroup(group)"
-          />
         </div>
       </div>
       <div v-else-if="!isLoading && !isFetching" class="row">

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -10,6 +10,7 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import BtnDropdown from "@/shared/components/base/BtnDropdown/index.vue";
 import Hardpoints from "@/frontend/components/Models/Hardpoints/index.vue";
+import CrewPositions from "@/frontend/components/Models/CrewPositions/index.vue";
 import PaintsList from "@/frontend/components/Models/PaintsList/index.vue";
 import LoanersList from "@/frontend/components/Models/LoanersList/index.vue";
 import VariantsList from "@/frontend/components/Models/VariantsList/index.vue";
@@ -458,6 +459,7 @@ const adiMap = computed(() => {
       />
       <hr />
       <Hardpoints :model="model" />
+      <CrewPositions :model="model" />
     </div>
   </div>
 

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -83,6 +83,7 @@
       "changePassword": "Change Password",
       "updatePassword": "Update Password",
       "copyBackupCodes": "Copy Backup Codes",
+      "regenerate": "Regenerate",
       "add": "Add",
       "create": "Create",
       "addToWishlist": "Add to Wishlist",

--- a/app/frontend/translations/en/filterGroup.json
+++ b/app/frontend/translations/en/filterGroup.json
@@ -20,6 +20,16 @@
           "label": "Loaner Model"
         }
       },
+      "modelPosition": {
+        "positionType": {
+          "label": "Position Type",
+          "prompt": "Select Position Type"
+        },
+        "source": {
+          "label": "Source",
+          "prompt": "Select Source"
+        }
+      },
       "modelHardpoint": {
         "source": {
           "label": "Source",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -24,6 +24,7 @@
           "edit": {
             "index": "Edit Model",
             "fleetchart": "Fleetchart Images",
+            "positions": "Crew Positions",
             "hardpoints": "Hardpoints",
             "cargoAndFuel": "Fuel",
             "cargoHolds": "Cargo Holds",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -440,6 +440,9 @@
         "addons": "Modules & Upgrade-Kits",
         "storeImage": "Store Image",
         "wiki": "Star Citizen Wiki",
+        "crewPositions": "Crew Positions",
+        "needsCuration": "Needs Curation",
+        "curatedPosition": "Manually curated position",
         "baseModel": "Base Model",
         "fleetchartOffsetLength": "Fleetchart Offset Length",
         "fleetchartOffsetBeam": "Fleetchart Offset Beam",
@@ -527,6 +530,12 @@
         "name": "Name",
         "dockType": "Dock Type",
         "shipSize": "Ship Size"
+      },
+      "modelPosition": {
+        "name": "Name",
+        "positionType": "Position Type",
+        "source": "Source",
+        "position": "Sort Order"
       },
       "modelHardpoint": {
         "name": "Name",
@@ -895,6 +904,7 @@
           "willItFit": "Will it Fit?",
           "withCargo": "With Cargo?",
           "scKeyBlank": "Without SC Key?",
+          "positionsNeedCuration": "Positions Need Curation?",
           "fleetchartImageBlank": "Without Fleetchart Image?",
           "holoBlank": "Without Holo?",
           "frontViewBlank": "Without Front View Image?",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -322,6 +322,9 @@
         "modelHardpoint": {
           "destroy": "Are you sure you want to delete this hardpoint? This action can't be reverted."
         },
+        "modelPosition": {
+          "destroy": "Are you sure you want to delete this position? This action can't be reverted."
+        },
         "modelHardpointLoadout": {
           "destroy": "Are you sure you want to delete this loadout? This action can't be reverted."
         },

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -100,6 +100,7 @@
             "cargoAndFuel": "Fuel",
             "cargoHolds": "Cargo Holds",
             "fleetchart": "Fleetchart Images",
+            "positions": "Positions",
             "hardpoints": "Hardpoints",
             "loaners": "Loaners",
             "upgrades": "Upgrades",

--- a/app/frontend/translations/en/placeholders.json
+++ b/app/frontend/translations/en/placeholders.json
@@ -163,6 +163,10 @@
       "dock": {
         "name": "Dock Name"
       },
+      "modelPosition": {
+        "name": "Position Name",
+        "position": "0"
+      },
       "modelHardpoint": {
         "name": "Hardpoint Name",
         "key": "hardpoint_key",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -105,6 +105,7 @@
             "metrics": "Edit %{manufacturer} %{model} Metrics",
             "prices": "Edit %{manufacturer} %{model} Prices",
             "fleetchart": "Edit %{manufacturer} %{model} Fleetchart Images",
+            "positions": "Edit %{manufacturer} %{model} Positions",
             "hardpoints": "Edit %{manufacturer} %{model} Hardpoints",
             "cargoAndFuel": "Edit %{manufacturer} %{model} Fuel",
             "cargoHolds": "Edit %{manufacturer} %{model} Cargo Holds",

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -26,6 +26,8 @@ module ScData
 
         model.reload
 
+        ModelPosition.generate_for_model!(model)
+
         model.set_fuel_consumption_from_hardpoints
 
         update_params = {}

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -48,6 +48,7 @@
 #  pitch                    :decimal(15, 2)
 #  pitch_boosted            :decimal(15, 2)
 #  pledge_price             :decimal(15, 2)
+#  positions_need_curation  :boolean          default(FALSE)
 #  price                    :decimal(15, 2)
 #  production_note          :string(255)
 #  production_status        :string(255)
@@ -191,6 +192,8 @@ class Model < ApplicationRecord
     source: :snub_craft
 
   has_many :item_prices, as: :item, dependent: :destroy
+
+  has_many :model_positions, dependent: :destroy
 
   has_many :docks, dependent: :destroy
 

--- a/app/models/model_position.rb
+++ b/app/models/model_position.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: model_positions
+#
+#  id            :uuid             not null, primary key
+#  name          :string           not null
+#  position      :integer          default(0), not null
+#  position_type :integer          not null
+#  source        :integer          default("sc_data"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  hardpoint_id  :uuid
+#  model_id      :uuid             not null
+#
+# Indexes
+#
+#  index_model_positions_on_model_id                   (model_id)
+#  index_model_positions_on_model_id_and_hardpoint_id  (model_id,hardpoint_id) UNIQUE WHERE (hardpoint_id IS NOT NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hardpoint_id => hardpoints.id)
+#  fk_rails_...  (model_id => models.id)
+#
+class ModelPosition < ApplicationRecord
+  belongs_to :model
+  belongs_to :hardpoint, optional: true
+
+  enum :position_type, {
+    pilot: 0, copilot: 1, turret_gunner: 2, engineer: 3,
+    gunner: 4, loadmaster: 5, passenger: 6, operator: 7, custom: 99
+  }
+
+  enum :source, {sc_data: 0, curated: 1}
+
+  validates :name, presence: true
+  validates :position_type, presence: true
+  validates :source, presence: true
+  validates :hardpoint_id, uniqueness: {scope: :model_id}, allow_nil: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[id model_id name position_type source position created_at updated_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[model hardpoint]
+  end
+
+  def self.generate_for_model!(model)
+    # Remove old auto-generated positions, keep curated ones
+    model.model_positions.sc_data.destroy_all
+
+    positions = []
+    sort_order = 0
+
+    # 1. Seat hardpoints (group: :seat, excluding _access)
+    seat_hardpoints = collect_seat_hardpoints(model)
+    seat_hardpoints.each do |hp|
+      next if hp.sc_name&.include?("_access")
+
+      type = infer_position_type(hp)
+      positions << {
+        name: derive_name(hp),
+        position_type: type,
+        hardpoint_id: hp.id,
+        source: :sc_data,
+        position: sort_order
+      }
+      sort_order += 1
+    end
+
+    # 2. Manned turrets without nested seat children
+    manned_turret_hardpoints = collect_manned_turret_hardpoints(model)
+    manned_turret_hardpoints.each do |hp|
+      next if seat_hardpoints.any? { |shp| shp.parent_id == hp.id || shp.sc_name&.include?(hp.sc_name.to_s) }
+
+      positions << {
+        name: derive_name_for_turret(hp),
+        position_type: :turret_gunner,
+        hardpoint_id: hp.id,
+        source: :sc_data,
+        position: sort_order
+      }
+      sort_order += 1
+    end
+
+    # 3. Loadmaster (if max_crew > 1 AND model has cargogrid hardpoint)
+    if model.max_crew.to_i > 1 && model.hardpoints.where(category: :cargogrid).exists?
+      positions << {
+        name: "Loadmaster",
+        position_type: :loadmaster,
+        hardpoint_id: nil,
+        source: :sc_data,
+        position: sort_order
+      }
+      sort_order += 1
+    end
+
+    # Bulk create
+    positions.each do |attrs|
+      model.model_positions.create!(attrs)
+    end
+
+    # 4. Gap detection
+    auto_count = model.model_positions.sc_data.count
+    curated_count = model.model_positions.curated.count
+    total = auto_count + curated_count
+    needs_curation = total < model.max_crew.to_i
+
+    model.update_column(:positions_need_curation, needs_curation) if model.positions_need_curation != needs_curation
+  end
+
+  def self.collect_seat_hardpoints(model)
+    model.hardpoints.includes(:component).where(group: :seat).select do |hp|
+      hp.sc_name.present? && !hp.sc_name.include?("_access")
+    end
+  end
+
+  def self.collect_manned_turret_hardpoints(model)
+    model.hardpoints.includes(:component).where.not(component: nil).select do |hp|
+      hp.component&.item_type == "manned_turrets" ||
+        (hp.component&.name == "Manned Turret" && hp.component&.component_type == "TurretBase")
+    end
+  end
+
+  def self.infer_position_type(hardpoint)
+    sc_name = hardpoint.sc_name.to_s
+
+    return :pilot if sc_name.include?("_pilot")
+    return :copilot if sc_name.include?("_copilot")
+    return :engineer if sc_name.include?("engineer_console") || sc_name.start_with?("hardpoint_engineering")
+    return :turret_gunner if sc_name.include?("turret_console")
+    return :operator if sc_name.include?("_seat_")
+
+    :operator
+  end
+
+  def self.derive_name(hardpoint)
+    sc_name = hardpoint.sc_name.to_s
+
+    return "Pilot" if sc_name.include?("_pilot")
+    return "Copilot" if sc_name.include?("_copilot")
+
+    if sc_name.include?("engineer_console")
+      return sc_name.sub(/.*?engineer_console/, "Engineer Console")
+          .sub(/^_/, "").tr("_", " ").strip.titleize
+    end
+
+    if sc_name.include?("turret_console")
+      return sc_name.sub(/.*turret_console/, "Turret Console")
+          .sub(/^_/, "").tr("_", " ").strip.titleize
+    end
+
+    if sc_name.start_with?("hardpoint_engineering")
+      return sc_name.sub(/hardpoint_engineering(screen)?_?/, "")
+          .tr("_", " ").strip.titleize.presence || "Engineer"
+    end
+
+    sc_name.sub(/^hardpoint_(seat_)?/, "").tr("_", " ").strip.titleize
+  end
+
+  def self.derive_name_for_turret(hardpoint)
+    sc_name = hardpoint.sc_name.to_s
+
+    if sc_name.start_with?("turret_")
+      return sc_name.sub("turret_", "Turret ").tr("_", " ").strip.titleize
+    end
+
+    sc_name.sub(/^hardpoint_/, "").tr("_", " ").strip.titleize
+  end
+end

--- a/app/policies/admin/model_position_policy.rb
+++ b/app/policies/admin/model_position_policy.rb
@@ -1,0 +1,7 @@
+module Admin
+  class ModelPositionPolicy < BasePolicy
+    private def resource_access
+      [:model_positions]
+    end
+  end
+end

--- a/app/tasks/maintenance/generate_model_positions_task.rb
+++ b/app/tasks/maintenance/generate_model_positions_task.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class GenerateModelPositionsTask < MaintenanceTasks::Task
+    def collection
+      Model.where(in_game: true)
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(model)
+      ModelPosition.generate_for_model!(model)
+    end
+  end
+end

--- a/app/views/admin/api/v1/model_positions/_base.jbuilder
+++ b/app/views/admin/api/v1/model_positions/_base.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.id model_position.id
+json.name model_position.name
+json.position_type model_position.position_type
+json.source model_position.source
+json.position model_position.position
+json.hardpoint_id model_position.hardpoint_id
+json.model_id model_position.model_id
+
+json.partial! "api/shared/dates", record: model_position

--- a/app/views/admin/api/v1/model_positions/_model_position.jbuilder
+++ b/app/views/admin/api/v1/model_positions/_model_position.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", model_position] do
+  json.partial!("admin/api/v1/model_positions/base", model_position:)
+end

--- a/app/views/admin/api/v1/model_positions/index.jbuilder
+++ b/app/views/admin/api/v1/model_positions/index.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @model_positions, partial: "admin/api/v1/model_positions/model_position", as: :model_position
+end
+
+json.partial! "api/shared/meta", result: @model_positions

--- a/app/views/admin/api/v1/model_positions/show.jbuilder
+++ b/app/views/admin/api/v1/model_positions/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/model_positions/model_position", model_position: @model_position

--- a/app/views/admin/api/v1/models/_base.jbuilder
+++ b/app/views/admin/api/v1/models/_base.jbuilder
@@ -8,6 +8,7 @@ json.name model.name
 json.slug model.slug
 json.hidden model.hidden
 json.active model.active
+json.positions_need_curation model.positions_need_curation
 
 json.base_model_id model.base_model_id
 

--- a/app/views/api/v1/model_positions/_base.jbuilder
+++ b/app/views/api/v1/model_positions/_base.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.id model_position.id
+json.name model_position.name
+json.position_type model_position.position_type
+json.source model_position.source
+json.position model_position.position
+
+json.partial! "api/shared/dates", record: model_position

--- a/app/views/api/v1/model_positions/_model_position.jbuilder
+++ b/app/views/api/v1/model_positions/_model_position.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", model_position] do
+  json.partial!("api/v1/model_positions/base", model_position:)
+end

--- a/app/views/api/v1/models/positions.jbuilder
+++ b/app/views/api/v1/models/positions.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @positions, partial: "api/v1/model_positions/model_position", as: :model_position

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -54,6 +54,11 @@ v1_admin_api_routes = lambda do
     end
   end
   resources :model_module_packages, path: "model-module-packages", only: %i[index show create update destroy]
+  resources :model_positions, path: "model-positions", only: %i[index show create update destroy] do
+    collection do
+      put :regenerate
+    end
+  end
   resources :docks, only: %i[index show create update destroy]
   resources :model_hardpoints, path: "model-hardpoints", only: %i[index show create update destroy]
   resources :model_hardpoint_loadouts, path: "model-hardpoint-loadouts", only: %i[index show create update destroy]

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -9,6 +9,7 @@ resources :models, param: :slug, only: %i[index show] do
   end
   member do
     get :hardpoints
+    get :positions
     get :images
     get :videos
     get :variants

--- a/db/migrate/20260426120000_create_model_positions.rb
+++ b/db/migrate/20260426120000_create_model_positions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateModelPositions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :model_positions, id: :uuid do |t|
+      t.uuid :model_id, null: false
+      t.string :name, null: false
+      t.integer :position_type, null: false
+      t.uuid :hardpoint_id
+      t.integer :source, null: false, default: 0
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :model_positions, :model_id
+    add_index :model_positions, %i[model_id hardpoint_id], unique: true, where: "hardpoint_id IS NOT NULL"
+
+    add_foreign_key :model_positions, :models
+    add_foreign_key :model_positions, :hardpoints
+
+    add_column :models, :positions_need_curation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -579,6 +579,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "model_positions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "hardpoint_id"
+    t.uuid "model_id", null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "position_type", null: false
+    t.integer "source", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["model_id", "hardpoint_id"], name: "index_model_positions_on_model_id_and_hardpoint_id", unique: true, where: "(hardpoint_id IS NOT NULL)"
+    t.index ["model_id"], name: "index_model_positions_on_model_id"
+  end
+
   create_table "model_snub_crafts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "model_id", null: false
@@ -644,6 +657,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
     t.decimal "pitch", precision: 15, scale: 2
     t.decimal "pitch_boosted", precision: 15, scale: 2
     t.decimal "pledge_price", precision: 15, scale: 2
+    t.boolean "positions_need_curation", default: false
     t.decimal "price", precision: 15, scale: 2
     t.string "production_note", limit: 255
     t.string "production_status", limit: 255
@@ -996,6 +1010,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
   add_foreign_key "fleet_memberships", "fleet_roles"
   add_foreign_key "fleet_roles", "fleets"
   add_foreign_key "hardpoints", "components"
+  add_foreign_key "model_positions", "hardpoints"
+  add_foreign_key "model_positions", "models"
   add_foreign_key "notification_preferences", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/docs/exec-plans/ship-positions.md
+++ b/docs/exec-plans/ship-positions.md
@@ -1,0 +1,198 @@
+# Ship Position System
+
+## Context
+
+The mission builder needs to reference crew positions on ships, but there's no reliable position data. The current approach (walking hardpoints in the frontend, detecting seats and manned turrets client-side) is fragile — it produces "Unknown" labels, misses jumpseats, and breaks when the FilterGroup re-emits. We need a proper server-side `ModelPosition` model that's auto-generated from SC data and can be curated by admins.
+
+Resolves #3791.
+
+## Data Model
+
+### `model_positions`
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| id | uuid | PK |
+| model_id | uuid | FK → models, NOT NULL |
+| name | string | NOT NULL ("Pilot", "Turret Gunner 1", "Loadmaster") |
+| position_type | integer | NOT NULL, enum |
+| hardpoint_id | uuid | FK → hardpoints, nullable (for SC-derived positions) |
+| source | integer | NOT NULL, enum (sc_data, curated) |
+| position | integer | NOT NULL, default: 0 (sort order) |
+| timestamps | | |
+
+Indexes: `(model_id)`, `(model_id, hardpoint_id)` unique where hardpoint_id not null
+
+**position_type enum:**
+```ruby
+enum :position_type, {
+  pilot: 0, copilot: 1, turret_gunner: 2, engineer: 3,
+  gunner: 4, loadmaster: 5, passenger: 6, operator: 7, custom: 99
+}
+```
+
+**source enum:**
+```ruby
+enum :source, { sc_data: 0, curated: 1 }
+```
+
+## Auto-Generation Logic
+
+Runs after SC data import (hook into `ModelsLoader.load_model` after `update_loadout`).
+
+For each in-game model:
+
+1. **Seat hardpoints** (`group: :seat`, excluding `_access`):
+   - `hardpoint_seat_pilot` → position_type: :pilot
+   - `hardpoint_seat_copilot` → position_type: :copilot
+   - `hardpoint_seat_*` → infer type from name, default :operator
+   - `hardpoint_component_room_*_engineer_console` → position_type: :engineer
+   - `hardpoint_turret_console_*` → position_type: :turret_gunner
+
+2. **Manned turrets** (`component.name == "Manned Turret"`, no nested seat child):
+   - Create position_type: :turret_gunner, name from `sc_name` (e.g. "Turret Top")
+
+3. **Loadmaster** (if `max_crew > 1` AND model has cargogrid hardpoint):
+   - Create position_type: :loadmaster, hardpoint_id: null
+
+4. **Gap detection**: If auto-generated position count < `max_crew`, set `model.positions_need_curation = true` (boolean flag on models table)
+
+**Key rule:** Only overwrite `source: :sc_data` positions on re-import. Positions with `source: :curated` survive re-imports.
+
+### Name Derivation
+
+```ruby
+def self.derive_name(hardpoint)
+  sc_name = hardpoint.sc_name
+  return "Pilot" if sc_name.include?("_pilot")
+  return "Copilot" if sc_name.include?("_copilot")
+  if sc_name.include?("engineer_console")
+    return sc_name.sub(/.*?_engineer_console/, "Engineer Console")
+                  .sub(/^_/, "").tr("_", " ").titleize
+  end
+  if sc_name.start_with?("turret_")
+    return sc_name.sub("turret_", "Turret ").tr("_", " ").titleize
+  end
+  if sc_name.include?("turret_console")
+    return sc_name.sub(/.*turret_console/, "Turret Console")
+                  .sub(/^_/, "").tr("_", " ").titleize
+  end
+  sc_name.sub(/^hardpoint_(seat_)?/, "").tr("_", " ").titleize
+end
+```
+
+## Admin Curation
+
+### Migration: Add `positions_need_curation` to models
+
+```ruby
+add_column :models, :positions_need_curation, :boolean, default: false
+```
+
+### Admin Controller
+
+`Admin::Api::V1::ModelPositionsController`:
+- `GET /admin/models/:slug/positions` — list positions for a model
+- `POST /admin/models/:slug/positions` — add curated position
+- `PUT /admin/models/:slug/positions/:id` — update position
+- `DELETE /admin/models/:slug/positions/:id` — delete position
+- `POST /admin/models/:slug/positions/regenerate` — re-run auto-generation (clears sc_data, keeps curated)
+
+### Admin UI
+
+Add to the existing admin model edit page:
+- Positions section showing all positions (auto + curated)
+- Add/edit/remove positions
+- "Regenerate from SC data" button
+- Badge showing "Needs curation" when `positions_need_curation` is true
+- Filter for models needing curation in admin models list
+
+## Public API
+
+`GET /api/v1/models/:slug/positions` — returns positions for a model:
+```json
+[
+  { "id": "uuid", "name": "Pilot", "positionType": "pilot", "source": "sc_data", "position": 0 },
+  { "id": "uuid", "name": "Turret Top", "positionType": "turret_gunner", "source": "sc_data", "position": 1 },
+  { "id": "uuid", "name": "Loadmaster", "positionType": "loadmaster", "source": "curated", "position": 5 }
+]
+```
+
+## Integration Points
+
+### Model Detail Page (frontend)
+Replace the current seat display in the hardpoints component with a dedicated crew positions section showing position names with types.
+
+### SC Data Import Hook
+In `ModelsLoader.load_model`, after `update_loadout(model, model_data)`:
+```ruby
+ModelPosition.generate_for_model!(model)
+```
+
+### Future: Mission Builder
+The mission builder will reference `ModelPosition` instead of walking hardpoints client-side. This replaces `MissionTeamVehicleSeat` with a proper server-side position reference.
+
+## Implementation Phases
+
+### Phase 1 — Migration, Model, Auto-Generation
+- Create `model_positions` table
+- Add `positions_need_curation` to models
+- `ModelPosition` model with enums, validations, associations
+- `ModelPosition.generate_for_model!(model)` class method
+- Hook into ModelsLoader
+- MaintenanceTask to generate positions for all existing models
+
+### Phase 2 — Public API
+- `Api::V1::ModelPositionsController` with index action
+- JBuilder view
+- API schema component
+- RSpec request spec
+- Generate OpenAPI schema
+
+### Phase 3 — Admin API
+- `Admin::Api::V1::ModelPositionsController` with CRUD + regenerate
+- Admin policy
+- Admin JBuilder views + API schemas
+- RSpec specs
+
+### Phase 4 — Frontend
+- Ship detail page: replace seat hardpoints display with crew positions section
+- Remove the current seat display from hardpoints component
+- Admin model edit: positions management UI
+- Admin models list: "needs curation" filter/badge
+- Orval client regeneration
+
+### Phase 5 — Data Quality
+- Run generation for all models
+- Identify and curate dropships (Valkyrie, Prowler, Hoplite)
+- Review models flagged as needs_curation
+- Verify position counts match max_crew where possible
+
+## Files to Create/Modify
+
+**Create:**
+- `db/migrate/xxx_create_model_positions.rb`
+- `app/models/model_position.rb`
+- `app/controllers/api/v1/model_positions_controller.rb`
+- `app/controllers/admin/api/v1/model_positions_controller.rb`
+- `app/policies/model_position_policy.rb`
+- `app/views/api/v1/model_positions/`
+- `app/api_components/v1/schemas/models/model_position.rb`
+- `spec/requests/api/v1/model_positions/`
+- `spec/factories/model_positions.rb`
+- `app/tasks/maintenance/generate_model_positions_task.rb`
+- Frontend: position components + admin UI
+
+**Modify:**
+- `app/models/model.rb` — add `has_many :model_positions` + `positions_need_curation`
+- `app/lib/sc_data/loader/models_loader.rb` — hook position generation
+- `app/frontend/frontend/components/Models/Hardpoints/` — remove seat display, add positions
+- Admin routes, admin model views
+
+## Verification
+
+1. Run MaintenanceTask → positions auto-generated for all models
+2. `bundle exec rspec spec/requests/api/v1/model_positions/` → specs pass
+3. `GET /api/v1/models/aegs-hammerhead/positions` → returns pilot, copilot, 6 turret gunners, 2 engineers, captain's quarters, loadmaster
+4. Admin: edit Valkyrie → add 20 passenger jumpseats → re-import SC data → jumpseats preserved
+5. Ship detail page shows crew positions instead of seat hardpoints

--- a/spec/factories/model_positions.rb
+++ b/spec/factories/model_positions.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: model_positions
+#
+#  id            :uuid             not null, primary key
+#  name          :string           not null
+#  position      :integer          default(0), not null
+#  position_type :integer          not null
+#  source        :integer          default("sc_data"), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  hardpoint_id  :uuid
+#  model_id      :uuid             not null
+#
+# Indexes
+#
+#  index_model_positions_on_model_id                   (model_id)
+#  index_model_positions_on_model_id_and_hardpoint_id  (model_id,hardpoint_id) UNIQUE WHERE (hardpoint_id IS NOT NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hardpoint_id => hardpoints.id)
+#  fk_rails_...  (model_id => models.id)
+#
+FactoryBot.define do
+  factory :model_position do
+    model
+    name { "Pilot" }
+    position_type { :pilot }
+    source { :sc_data }
+    position { 0 }
+
+    trait :copilot do
+      name { "Copilot" }
+      position_type { :copilot }
+      position { 1 }
+    end
+
+    trait :turret_gunner do
+      name { "Turret Gunner" }
+      position_type { :turret_gunner }
+      position { 2 }
+    end
+
+    trait :engineer do
+      name { "Engineer" }
+      position_type { :engineer }
+      position { 3 }
+    end
+
+    trait :loadmaster do
+      name { "Loadmaster" }
+      position_type { :loadmaster }
+      position { 4 }
+    end
+
+    trait :curated do
+      source { :curated }
+    end
+
+    trait :passenger do
+      name { "Passenger" }
+      position_type { :passenger }
+      source { :curated }
+    end
+  end
+end

--- a/spec/factories/models.rb
+++ b/spec/factories/models.rb
@@ -46,6 +46,7 @@
 #  pitch                    :decimal(15, 2)
 #  pitch_boosted            :decimal(15, 2)
 #  pledge_price             :decimal(15, 2)
+#  positions_need_curation  :boolean          default(FALSE)
 #  price                    :decimal(15, 2)
 #  production_note          :string(255)
 #  production_status        :string(255)

--- a/spec/requests/admin/api/v1/model_positions/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/create_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model) { create(:model) }
+  let(:input) do
+    {
+      modelId: model.id,
+      name: "Passenger 1",
+      positionType: "passenger",
+      source: "curated",
+      position: 5
+    }
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-positions" do
+    post("Create new Model Position") do
+      operationId "createModelPosition"
+      tags "ModelPositions"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :input, in: :body, schema: {"$ref": "#/components/schemas/ModelPositionInput"}, required: true
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/ModelPosition"
+
+        run_test!
+      end
+
+      response(400, "bad request") do
+        schema "$ref": "#/components/schemas/ValidationError"
+
+        let(:input) { {modelId: model.id} }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_positions/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/destroy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model_position) { create(:model_position) }
+  let(:id) { model_position.id }
+
+  before do
+    sign_in user if user.present?
+  end
+
+  path "/model-positions/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    delete("Model Position destroy") do
+      operationId "destroyModelPosition"
+      tags "ModelPositions"
+
+      response(204, "successful") do
+        run_test!
+      end
+
+      response(404, "not_found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_positions/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/index_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model_positions) { create_list(:model_position, 3) }
+
+  before do
+    sign_in user if user.present?
+
+    model_positions
+  end
+
+  path "/model-positions" do
+    get("Model Positions list") do
+      operationId "listModelPositions"
+      tags "ModelPositions"
+
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string, default: ModelPosition.default_per_page}, required: false
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/ModelPositionQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelPositions"
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          expect(data["items"].count).to eq(3)
+        end
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_positions/regenerate_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/regenerate_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model) { create(:model) }
+  let(:model_id) { model.id }
+
+  before do
+    sign_in(user) if user.present?
+
+    create(:model_position, model: model)
+  end
+
+  path "/model-positions/regenerate" do
+    put("Regenerate Model Positions") do
+      operationId "regenerateModelPositions"
+      tags "ModelPositions"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :model_id, in: :query, schema: {type: :string, format: :uuid}, required: true
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelPositions"
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_positions/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/show_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model_position) { create(:model_position) }
+  let(:id) { model_position.id }
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-positions/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    get("Get Model Position") do
+      operationId "modelPosition"
+      tags "ModelPositions"
+
+      consumes "application/json"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelPosition"
+
+        run_test!
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_positions/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_positions/update_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "admin/api/v1/model_positions", type: :request, swagger_doc: "admin/v1/schema.yaml" do
+  let(:user) { create(:admin_user, resource_access: [:model_positions]) }
+  let(:model_position) { create(:model_position) }
+  let(:id) { model_position.id }
+  let(:input) do
+    {
+      name: "Updated Position"
+    }
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-positions/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    put("Update Model Position") do
+      operationId "updateModelPosition"
+      tags "ModelPositions"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :input, in: :body, schema: {"$ref": "#/components/schemas/ModelPositionInput"}, required: true
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelPosition"
+
+        run_test!
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/api/v1/models/positions_spec.rb
+++ b/spec/requests/api/v1/models/positions_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/models", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:model) { create(:model) }
+  let(:slug) { model.slug }
+
+  before do
+    create(:model_position, model: model)
+    create(:model_position, :copilot, model: model)
+  end
+
+  path "/models/{slug}/positions" do
+    parameter name: "slug", in: :path, type: :string, description: "Model slug", required: true
+
+    get("Model Positions") do
+      operationId "modelPositions"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema type: :array,
+          items: {"$ref": "#/components/schemas/ModelPosition"}
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          expect(data.count).to eq(2)
+          expect(data.first["name"]).to eq("Pilot")
+        end
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:slug) { "unknown-model" }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -3063,6 +3063,206 @@ paths:
             schema:
               "$ref": "#/components/schemas/ModelPaintInput"
         required: true
+  "/model-positions":
+    post:
+      summary: Create new Model Position
+      operationId: createModelPosition
+      tags:
+      - ModelPositions
+      parameters: []
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPosition"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ModelPositionInput"
+        required: true
+    get:
+      summary: Model Positions list
+      operationId: listModelPositions
+      tags:
+      - ModelPositions
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 25
+        required: false
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/ModelPositionQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPositions"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/model-positions/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: id
+      required: true
+    delete:
+      summary: Model Position destroy
+      operationId: destroyModelPosition
+      tags:
+      - ModelPositions
+      responses:
+        '204':
+          description: successful
+        '404':
+          description: not_found
+        '403':
+          description: forbidden
+        '401':
+          description: unauthorized
+    get:
+      summary: Get Model Position
+      operationId: modelPosition
+      tags:
+      - ModelPositions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPosition"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    put:
+      summary: Update Model Position
+      operationId: updateModelPosition
+      tags:
+      - ModelPositions
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPosition"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ModelPositionInput"
+        required: true
+  "/model-positions/regenerate":
+    put:
+      summary: Regenerate Model Positions
+      operationId: regenerateModelPositions
+      tags:
+      - ModelPositions
+      parameters:
+      - name: model_id
+        in: query
+        schema:
+          type: string
+          format: uuid
+        required: true
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPositions"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/model-upgrades":
     post:
       summary: Create Model Upgrade
@@ -7713,6 +7913,8 @@ components:
           type: boolean
         scKey:
           type: string
+        positionsNeedCuration:
+          type: boolean
         scLength:
           type: number
         scBeam:
@@ -8084,6 +8286,8 @@ components:
           type: boolean
         scKey:
           type: string
+        positionsNeedCuration:
+          type: boolean
         scLength:
           type: number
         scBeam:
@@ -9122,6 +9326,93 @@ components:
       - meta
       - items
       title: ModelPaints
+    ModelPosition:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        positionType:
+          type: string
+        source:
+          type: string
+        position:
+          type: integer
+        hardpointId:
+          type: string
+          format: uuid
+          nullable: true
+        modelId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - positionType
+      - source
+      - position
+      - modelId
+      - createdAt
+      - updatedAt
+      title: ModelPosition
+    ModelPositionInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        positionType:
+          type: string
+        source:
+          type: string
+        position:
+          type: integer
+        hardpointId:
+          type: string
+          format: uuid
+          nullable: true
+      additionalProperties: false
+      title: ModelPositionInput
+    ModelPositionQuery:
+      type: object
+      properties:
+        modelIdEq:
+          type: string
+          format: uuid
+        positionTypeEq:
+          type: string
+        sourceEq:
+          type: string
+        nameCont:
+          type: string
+      additionalProperties: false
+      example: {}
+      title: ModelPositionQuery
+    ModelPositions:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelPosition"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: ModelPositions
     ModelQuery:
       type: object
       properties:
@@ -9160,6 +9451,8 @@ components:
         topViewColoredBlank:
           type: boolean
         frontViewBlank:
+          type: boolean
+        positionsNeedCurationEq:
           type: boolean
         sorts:
           anyOf:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2872,6 +2872,34 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/models/{slug}/positions":
+    parameters:
+    - name: slug
+      in: path
+      description: Model slug
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Model Positions
+      operationId: modelPositions
+      tags:
+      - Models
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/ModelPosition"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/models/{slug}":
     parameters:
     - name: slug
@@ -9786,6 +9814,49 @@ components:
       additionalProperties: false
       example: {}
       title: ModelPaintQuery
+    ModelPosition:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        positionType:
+          type: string
+          enum:
+          - pilot
+          - copilot
+          - turret_gunner
+          - engineer
+          - gunner
+          - loadmaster
+          - passenger
+          - operator
+          - custom
+        source:
+          type: string
+          enum:
+          - sc_data
+          - curated
+        position:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - positionType
+      - source
+      - position
+      - createdAt
+      - updatedAt
+      title: ModelPosition
     ModelQuery:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- Add `ModelPosition` model auto-generated from SC data (seats, manned turrets, cargo grids) with admin curation support
- Public API: `GET /api/v1/models/:slug/positions` returns ordered crew positions
- Admin API: full CRUD + regenerate endpoint at `/admin/api/v1/model-positions`
- Ship detail page: new crew positions section below hardpoints (replaces seat display in hardpoints)
- Admin: positions edit tab on model edit page with inline editing and "Regenerate from SC data" button
- Admin: "Positions Need Curation" filter on models list
- Maintenance task to bulk-generate positions for all in-game models

## Test plan

- [x] Run `Maintenance::GenerateModelPositionsTask` to generate positions for all models
- [x] Verify `GET /api/v1/models/aegs-hammerhead/positions` returns pilot, copilot, 6 turret gunners, 2 engineers, captains quarters, loadmaster
- [x] Check ship detail page shows crew positions section below hardpoints
- [x] Admin: edit a model's positions tab, add a curated passenger position, regenerate — curated position survives
- [x] Admin: filter models list by "Positions Need Curation"
- [x] `bundle exec rspec spec/requests/api/v1/models/positions_spec.rb spec/requests/admin/api/v1/model_positions/` — 24 specs pass

Resolves #3791

🤖 Generated with [Claude Code](https://claude.com/claude-code)