### PR TITLE
feat(loadouts): vehicle loadout system with weapon stats

### DIFF
--- a/app/api_components/shared/v1/schemas/component.rb
+++ b/app/api_components/shared/v1/schemas/component.rb
@@ -61,7 +61,11 @@ module Shared
                 {"$ref": "#/components/schemas/ComponentQuantumDrive"},
                 {"$ref": "#/components/schemas/CargoHold"},
                 {"$ref": "#/components/schemas/FuelTank"},
-                {"$ref": "#/components/schemas/ComponentThruster"}
+                {"$ref": "#/components/schemas/ComponentThruster"},
+                {"$ref": "#/components/schemas/ComponentWeapon"},
+                {"$ref": "#/components/schemas/ComponentShield"},
+                {"$ref": "#/components/schemas/ComponentCooler"},
+                {"$ref": "#/components/schemas/ComponentPowerPlant"}
               ]
             },
 

--- a/app/api_components/shared/v1/schemas/component_cooler.rb
+++ b/app/api_components/shared/v1/schemas/component_cooler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentCooler
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            coolingRate: {type: :number}
+          },
+          additionalProperties: false,
+          required: %w[coolingRate]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_power_plant.rb
+++ b/app/api_components/shared/v1/schemas/component_power_plant.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentPowerPlant
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            powerBase: {type: :number},
+            powerDraw: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_shield.rb
+++ b/app/api_components/shared/v1/schemas/component_shield.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentShield
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            maxHealth: {type: :number},
+            maxRegen: {type: :number},
+            decayRatio: {type: :number},
+            downedRegenDelay: {type: :number},
+            damagedRegenDelay: {type: :number}
+          },
+          additionalProperties: false,
+          required: %w[maxHealth maxRegen]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_weapon.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentWeapon
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            weaponClass: {type: :string},
+            fireRate: {type: :number},
+            heatPerShot: {type: :number},
+            damagePerShot: {
+              type: :object,
+              properties: {
+                physical: {type: :number},
+                energy: {type: :number},
+                distortion: {type: :number},
+                thermal: {type: :number},
+                biochemical: {type: :number},
+                stun: {type: :number}
+              },
+              additionalProperties: false
+            },
+            pelletsPerShot: {type: :integer},
+            speed: {type: :number},
+            range: {type: :number},
+            ammoCost: {type: :integer}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
@@ -9,8 +9,8 @@ module V1
         schema({
           type: :object,
           properties: {
-            name: {type: :string},
-            url: {type: :string, nullable: true},
+            name: {type: :string, nullable: true},
+            url: {type: :string},
             fromDefaults: {type: :boolean},
             vehicleLoadoutHardpointsAttributes: {
               type: :array,

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class VehicleLoadoutInput
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            erkulUrl: {type: :string, nullable: true},
+            spviewerUrl: {type: :string, nullable: true},
+            fromDefaults: {type: :boolean},
+            vehicleLoadoutHardpointsAttributes: {
+              type: :array,
+              items: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  modelHardpointId: {type: :string, format: :uuid},
+                  componentId: {type: :string, format: :uuid, nullable: true},
+                  _destroy: {type: :boolean}
+                }
+              }
+            }
+          },
+          additionalProperties: false,
+          required: %w[name]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
@@ -10,9 +10,7 @@ module V1
           type: :object,
           properties: {
             name: {type: :string},
-            url: {type: :string, description: "Auto-detected as erkul or spviewer URL"},
-            erkulUrl: {type: :string, nullable: true},
-            spviewerUrl: {type: :string, nullable: true},
+            url: {type: :string, nullable: true},
             fromDefaults: {type: :boolean},
             vehicleLoadoutHardpointsAttributes: {
               type: :array,

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
@@ -10,6 +10,7 @@ module V1
           type: :object,
           properties: {
             name: {type: :string},
+            url: {type: :string, description: "Auto-detected as erkul or spviewer URL"},
             erkulUrl: {type: :string, nullable: true},
             spviewerUrl: {type: :string, nullable: true},
             fromDefaults: {type: :boolean},
@@ -26,8 +27,7 @@ module V1
               }
             }
           },
-          additionalProperties: false,
-          required: %w[name]
+          additionalProperties: false
         })
       end
     end

--- a/app/api_components/v1/schemas/vehicles/vehicle.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle.rb
@@ -30,6 +30,7 @@ module V1
             saleNotify: {type: :boolean},
             upgrade: {"$ref": "#/components/schemas/ModelUpgrade"},
             wanted: {type: :boolean},
+            activeLoadout: {"$ref": "#/components/schemas/VehicleLoadoutMinimal"},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
@@ -12,8 +12,8 @@ module V1
             id: {type: :string, format: :uuid},
             name: {type: :string},
             active: {type: :boolean},
-            erkulUrl: {type: :string, nullable: true},
-            spviewerUrl: {type: :string, nullable: true},
+            url: {type: :string, nullable: true},
+            urlSource: {type: :string, nullable: true},
             hardpoints: {
               type: :array,
               items: {

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class VehicleLoadout
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            active: {type: :boolean},
+            erkulUrl: {type: :string, nullable: true},
+            spviewerUrl: {type: :string, nullable: true},
+            hardpoints: {
+              type: :array,
+              items: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  modelHardpointId: {type: :string, format: :uuid},
+                  hardpoint: {"$ref": "#/components/schemas/ModelHardpoint"},
+                  component: {"$ref": "#/components/schemas/Component"}
+                }
+              }
+            },
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id name active hardpoints createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
@@ -12,8 +12,8 @@ module V1
             id: {type: :string, format: :uuid},
             name: {type: :string},
             active: {type: :boolean},
-            url: {type: :string, nullable: true},
-            urlSource: {type: :string, nullable: true},
+            url: {type: :string},
+            urlSource: {type: :string},
             hardpoints: {
               type: :array,
               items: {
@@ -30,7 +30,7 @@ module V1
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id name active hardpoints createdAt updatedAt]
+          required: %w[id active url hardpoints createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
@@ -11,10 +11,11 @@ module V1
           properties: {
             id: {type: :string, format: :uuid},
             name: {type: :string},
-            url: {type: :string, nullable: true}
+            url: {type: :string},
+            urlSource: {type: :string}
           },
           additionalProperties: false,
-          required: %w[id name]
+          required: %w[id name url]
         })
       end
     end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
@@ -11,8 +11,7 @@ module V1
           properties: {
             id: {type: :string, format: :uuid},
             name: {type: :string},
-            erkulUrl: {type: :string, nullable: true},
-            spviewerUrl: {type: :string, nullable: true}
+            url: {type: :string, nullable: true}
           },
           additionalProperties: false,
           required: %w[id name]

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class VehicleLoadoutMinimal
+        include Rswag::SchemaComponents::Component
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            erkulUrl: {type: :string, nullable: true},
+            spviewerUrl: {type: :string, nullable: true}
+          },
+          additionalProperties: false,
+          required: %w[id name]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_public.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_public.rb
@@ -25,6 +25,7 @@ module V1
             modulePackage: {"$ref": "#/components/schemas/ModelModulePackage"},
             upgrade: {"$ref": "#/components/schemas/ModelUpgrade"},
             paint: {"$ref": "#/components/schemas/ModelPaint"},
+            activeLoadout: {"$ref": "#/components/schemas/VehicleLoadoutMinimal"},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },

--- a/app/controllers/api/v1/vehicle_loadouts_controller.rb
+++ b/app/controllers/api/v1/vehicle_loadouts_controller.rb
@@ -74,7 +74,7 @@ module Api
       private def vehicle_loadout_params
         @vehicle_loadout_params ||= params.transform_keys(&:underscore)
           .permit(
-            :name, :erkul_url, :spviewer_url,
+            :name, :url, :erkul_url, :spviewer_url,
             vehicle_loadout_hardpoints_attributes: [:id, :model_hardpoint_id, :component_id, :_destroy]
           )
       end

--- a/app/controllers/api/v1/vehicle_loadouts_controller.rb
+++ b/app/controllers/api/v1/vehicle_loadouts_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class VehicleLoadoutsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "hangar", "hangar:read" },
+        unless: -> { warden.authenticate?(scope: :user) },
+        only: %i[index show]
+      before_action -> { doorkeeper_authorize! "hangar", "hangar:write" },
+        unless: -> { warden.authenticate?(scope: :user) },
+        except: %i[index show]
+
+      before_action :set_vehicle
+      before_action :set_vehicle_loadout, only: %i[show update destroy activate]
+
+      def index
+        authorize! with: VehicleLoadoutPolicy
+
+        @vehicle_loadouts = @vehicle.vehicle_loadouts
+          .includes(vehicle_loadout_hardpoints: [:model_hardpoint, :component])
+      end
+
+      def show
+      end
+
+      def create
+        authorize! with: VehicleLoadoutPolicy
+
+        @vehicle_loadout = @vehicle.vehicle_loadouts.new(vehicle_loadout_params)
+
+        if @vehicle_loadout.save
+          @vehicle_loadout.create_from_defaults! if params[:from_defaults]
+          @vehicle_loadout.reload
+          render status: :created
+        else
+          render json: ValidationError.new("vehicle_loadout.create", errors: @vehicle_loadout.errors),
+            status: :bad_request
+        end
+      end
+
+      def update
+        return if @vehicle_loadout.update(vehicle_loadout_params)
+
+        render json: ValidationError.new("vehicle_loadout.update", errors: @vehicle_loadout.errors),
+          status: :bad_request
+      end
+
+      def destroy
+        return if @vehicle_loadout.destroy
+
+        render json: ValidationError.new("vehicle_loadout.destroy", errors: @vehicle_loadout.errors),
+          status: :bad_request
+      end
+
+      def activate
+        @vehicle_loadout.activate!
+      end
+
+      private def set_vehicle
+        @vehicle = current_resource_owner.vehicles.find(params[:vehicle_id])
+      end
+
+      private def set_vehicle_loadout
+        @vehicle_loadout = @vehicle.vehicle_loadouts.find(params[:id])
+        authorize! @vehicle_loadout
+      end
+
+      private def vehicle_loadout_params
+        @vehicle_loadout_params ||= params.transform_keys(&:underscore)
+          .permit(
+            :name, :erkul_url, :spviewer_url,
+            vehicle_loadout_hardpoints_attributes: [:id, :model_hardpoint_id, :component_id, :_destroy]
+          )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/vehicle_loadouts_controller.rb
+++ b/app/controllers/api/v1/vehicle_loadouts_controller.rb
@@ -75,7 +75,7 @@ module Api
       private def vehicle_loadout_params
         @vehicle_loadout_params ||= params.transform_keys(&:underscore)
           .permit(
-            :name, :url, :erkul_url, :spviewer_url,
+            :name, :url,
             vehicle_loadout_hardpoints_attributes: [:id, :model_hardpoint_id, :component_id, :_destroy]
           )
       end

--- a/app/controllers/api/v1/vehicle_loadouts_controller.rb
+++ b/app/controllers/api/v1/vehicle_loadouts_controller.rb
@@ -58,7 +58,12 @@ module Api
       end
 
       private def set_vehicle
-        @vehicle = current_resource_owner.vehicles.find(params[:vehicle_id])
+        vehicle_id = params[:vehicle_id]
+        @vehicle = if vehicle_id.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-/i)
+          current_resource_owner.vehicles.find(vehicle_id)
+        else
+          current_resource_owner.vehicles.find_by!(serial: vehicle_id.upcase)
+        end
       end
 
       private def set_vehicle_loadout

--- a/app/controllers/api/v1/vehicle_loadouts_controller.rb
+++ b/app/controllers/api/v1/vehicle_loadouts_controller.rb
@@ -18,6 +18,7 @@ module Api
         authorize! with: VehicleLoadoutPolicy
 
         @vehicle_loadouts = @vehicle.vehicle_loadouts
+          .order(active: :desc, name: :asc)
           .includes(vehicle_loadout_hardpoints: [:model_hardpoint, :component])
       end
 

--- a/app/controllers/api/v1/vehicles_controller.rb
+++ b/app/controllers/api/v1/vehicles_controller.rb
@@ -151,9 +151,17 @@ module Api
       end
 
       private def set_vehicle
-        @vehicle = current_resource_owner.vehicles.find(params[:id])
+        @vehicle = find_vehicle(params[:id])
 
         authorize! @vehicle
+      end
+
+      private def find_vehicle(identifier)
+        if identifier.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-/i)
+          current_resource_owner.vehicles.find(identifier)
+        else
+          current_resource_owner.vehicles.find_by!(serial: identifier.upcase)
+        end
       end
 
       private def vehicle_params

--- a/app/frontend/frontend/components/Fleets/VehiclePanel/index.vue
+++ b/app/frontend/frontend/components/Fleets/VehiclePanel/index.vue
@@ -176,25 +176,16 @@ const route = useRoute();
       />
       <div v-if="activeLoadout" class="fleet-vehicle-panel-loadout">
         <i class="fa-duotone fa-crosshairs" />
-        <span>{{ activeLoadout.name }}</span>
         <a
-          v-if="activeLoadout.erkulUrl"
-          :href="activeLoadout.erkulUrl"
+          v-if="activeLoadout.url"
+          :href="activeLoadout.url"
           target="_blank"
           rel="noopener"
           @click.stop
         >
-          Erkul
+          {{ activeLoadout.name }}
         </a>
-        <a
-          v-if="activeLoadout.spviewerUrl"
-          :href="activeLoadout.spviewerUrl"
-          target="_blank"
-          rel="noopener"
-          @click.stop
-        >
-          SPViewer
-        </a>
+        <span v-else>{{ activeLoadout.name }}</span>
       </div>
     </template>
   </ModelPanel>

--- a/app/frontend/frontend/components/Fleets/VehiclePanel/index.vue
+++ b/app/frontend/frontend/components/Fleets/VehiclePanel/index.vue
@@ -104,6 +104,10 @@ const filterManufacturerQuery = (manufacturer: string) => {
   return { manufacturerIn: [manufacturer] };
 };
 
+const activeLoadout = computed(
+  () => (props.fleetVehicle as VehiclePublic).activeLoadout,
+);
+
 const route = useRoute();
 </script>
 
@@ -170,6 +174,28 @@ const route = useRoute();
         :model-slug="fleetVehicle.slug"
         :fleet-slug="fleetSlug"
       />
+      <div v-if="activeLoadout" class="fleet-vehicle-panel-loadout">
+        <i class="fa-duotone fa-crosshairs" />
+        <span>{{ activeLoadout.name }}</span>
+        <a
+          v-if="activeLoadout.erkulUrl"
+          :href="activeLoadout.erkulUrl"
+          target="_blank"
+          rel="noopener"
+          @click.stop
+        >
+          Erkul
+        </a>
+        <a
+          v-if="activeLoadout.spviewerUrl"
+          :href="activeLoadout.spviewerUrl"
+          target="_blank"
+          rel="noopener"
+          @click.stop
+        >
+          SPViewer
+        </a>
+      </div>
     </template>
   </ModelPanel>
 </template>
@@ -188,5 +214,21 @@ const route = useRoute();
 .serial {
   font-size: 0.85em;
   opacity: 0.8;
+}
+
+.fleet-vehicle-panel-loadout {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  padding: 5px 10px;
+  font-size: 0.75rem;
+  opacity: 0.8;
+
+  a {
+    text-decoration: underline;
+  }
 }
 </style>

--- a/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
@@ -16,6 +16,11 @@ import {
   HardpointSourceEnum,
   HardpointCategoryEnum,
   type Hardpoint,
+  type ComponentWeapon,
+  type ComponentShield,
+  type ComponentCooler,
+  type ComponentPowerPlant,
+  type ComponentQuantumDrive,
 } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 
@@ -28,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
   intended: false,
 });
 
-const { t } = useI18n();
+const { t, toNumber } = useI18n();
 
 const hardpoint = computed(() => {
   return props.hardpoints[0];
@@ -68,6 +73,25 @@ const hardpointNames = computed(() => {
     })
     .join(", ");
 });
+
+const typeData = computed(() => {
+  return hardpoint.value.component?.typeData;
+});
+
+const weaponDps = computed(() => {
+  if (!typeData.value || !("fireRate" in typeData.value)) return null;
+
+  const weapon = typeData.value as ComponentWeapon;
+  if (!weapon.fireRate || !weapon.damagePerShot) return null;
+
+  const totalDamage = Object.values(weapon.damagePerShot).reduce(
+    (sum: number, val) => sum + (typeof val === "number" ? val : 0),
+    0,
+  );
+  const pellets = weapon.pelletsPerShot || 1;
+
+  return Math.round(totalDamage * pellets * weapon.fireRate * 100) / 100;
+});
 </script>
 
 <template>
@@ -82,6 +106,63 @@ const hardpointNames = computed(() => {
               {{ hardpoint.component.itemClassLabel }}
               {{ t("labels.component.grade") }}
               {{ hardpoint.component.gradeLabel }}
+            </span>
+            <span
+              v-if="
+                hardpoint.category === HardpointCategoryEnum.WEAPONS &&
+                weaponDps
+              "
+            >
+              {{ toNumber(weaponDps) }}
+              {{ t("labels.hardpoint.weapons.dps") }}
+            </span>
+            <span
+              v-else-if="
+                hardpoint.category === HardpointCategoryEnum.SHIELDGENERATOR &&
+                typeData &&
+                'maxHealth' in typeData
+              "
+            >
+              {{ toNumber((typeData as ComponentShield).maxHealth) }}
+              {{ t("labels.hardpoint.shields.hp") }}
+              /
+              {{ toNumber((typeData as ComponentShield).maxRegen) }}
+              {{ t("labels.hardpoint.shields.regen") }}
+            </span>
+            <span
+              v-else-if="
+                hardpoint.category === HardpointCategoryEnum.COOLER &&
+                typeData &&
+                'coolingRate' in typeData
+              "
+            >
+              {{ toNumber((typeData as ComponentCooler).coolingRate) }}
+              {{ t("labels.hardpoint.coolers.coolingRate") }}
+            </span>
+            <span
+              v-else-if="
+                hardpoint.category === HardpointCategoryEnum.POWERPLANT &&
+                typeData &&
+                'powerBase' in typeData
+              "
+            >
+              {{ toNumber((typeData as ComponentPowerPlant).powerBase) }}
+              {{ t("labels.hardpoint.powerPlants.output") }}
+            </span>
+            <span
+              v-else-if="
+                hardpoint.category === HardpointCategoryEnum.QUANTUMDRIVE &&
+                typeData &&
+                'fuelRate' in typeData
+              "
+            >
+              {{
+                toNumber(
+                  (typeData as ComponentQuantumDrive).standardJump?.speed,
+                  "speed",
+                )
+              }}
+              {{ t("labels.hardpoint.quantumDrives.speed") }}
             </span>
           </template>
           <template v-else>

--- a/app/frontend/frontend/components/Navigation/index.vue
+++ b/app/frontend/frontend/components/Navigation/index.vue
@@ -130,7 +130,7 @@ const settingsActive = computed(() => {
             name: 'hangar',
             query: filterFor('hangar'),
           }"
-          :label="t('nav.hangar')"
+          :label="t('nav.hangar.index')"
           :active="isHangarRoute"
           icon="fa-duotone fa-warehouse"
           prefix="02"
@@ -138,7 +138,7 @@ const settingsActive = computed(() => {
         <NavItem
           v-else
           :to="{ name: 'hangar-preview' }"
-          :label="t('nav.hangar')"
+          :label="t('nav.hangar.index')"
           icon="fa-light fa-warehouse"
           prefix="02"
         />

--- a/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
+++ b/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
@@ -200,16 +200,10 @@ const openAddonsModal = () => {
   });
 };
 
-const openLoadoutsModal = () => {
-  comlink.emit("open-modal", {
-    wide: true,
-    component: () =>
-      import("@/frontend/components/Vehicles/LoadoutsModal/index.vue"),
-    props: {
-      vehicle: props.vehicle,
-    },
-  });
-};
+const loadoutsRoute = computed(() => ({
+  name: "hangar-vehicle-loadouts",
+  params: { id: props.vehicle.id },
+}));
 </script>
 
 <template>
@@ -300,7 +294,7 @@ const openLoadoutsModal = () => {
       v-if="editable && vehicle.model?.inGame"
       :aria-label="t('actions.hangar.manageLoadouts')"
       :size="BtnSizesEnum.SMALL"
-      @click="openLoadoutsModal"
+      :to="loadoutsRoute"
     >
       <i class="fa-duotone fa-crosshairs" />
       <span>{{ t("actions.hangar.manageLoadouts") }}</span>

--- a/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
+++ b/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
@@ -202,7 +202,7 @@ const openAddonsModal = () => {
 
 const loadoutsRoute = computed(() => ({
   name: "hangar-vehicle-loadouts",
-  params: { id: props.vehicle.id },
+  params: { id: props.vehicle.serial || props.vehicle.id },
 }));
 </script>
 

--- a/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
+++ b/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
@@ -297,7 +297,7 @@ const openLoadoutsModal = () => {
       <span>{{ t("labels.model.addons") }}</span>
     </Btn>
     <Btn
-      v-if="editable && vehicle.boughtVia === 'ingame'"
+      v-if="editable && vehicle.model?.inGame"
       :aria-label="t('actions.hangar.manageLoadouts')"
       :size="BtnSizesEnum.SMALL"
       @click="openLoadoutsModal"

--- a/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
+++ b/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
@@ -199,6 +199,17 @@ const openAddonsModal = () => {
     },
   });
 };
+
+const openLoadoutsModal = () => {
+  comlink.emit("open-modal", {
+    wide: true,
+    component: () =>
+      import("@/frontend/components/Vehicles/LoadoutsModal/index.vue"),
+    props: {
+      vehicle: props.vehicle,
+    },
+  });
+};
 </script>
 
 <template>
@@ -284,6 +295,15 @@ const openAddonsModal = () => {
     >
       <i class="fa fa-plus-octagon" />
       <span>{{ t("labels.model.addons") }}</span>
+    </Btn>
+    <Btn
+      v-if="editable"
+      :aria-label="t('actions.hangar.manageLoadouts')"
+      :size="BtnSizesEnum.SMALL"
+      @click="openLoadoutsModal"
+    >
+      <i class="fa-duotone fa-crosshairs" />
+      <span>{{ t("actions.hangar.manageLoadouts") }}</span>
     </Btn>
     <Btn
       v-if="editable"

--- a/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
+++ b/app/frontend/frontend/components/Vehicles/ContextMenu/index.vue
@@ -297,7 +297,7 @@ const openLoadoutsModal = () => {
       <span>{{ t("labels.model.addons") }}</span>
     </Btn>
     <Btn
-      v-if="editable"
+      v-if="editable && vehicle.boughtVia === 'ingame'"
       :aria-label="t('actions.hangar.manageLoadouts')"
       :size="BtnSizesEnum.SMALL"
       @click="openLoadoutsModal"

--- a/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.scss
+++ b/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.scss
@@ -1,0 +1,79 @@
+.loadouts-modal {
+  min-height: 100px;
+
+  &__create-form {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin-bottom: 20px;
+
+    .form-input {
+      flex: 1;
+    }
+  }
+
+  &__loading {
+    text-align: center;
+    padding: 20px;
+  }
+
+  &__empty {
+    text-align: center;
+    padding: 20px;
+    opacity: 0.6;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 15px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+
+    &--active {
+      border-color: var(--primary);
+    }
+  }
+
+  &__item-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__item-name {
+    font-weight: 600;
+  }
+
+  &__item-badge {
+    font-size: 0.75rem;
+    color: var(--primary);
+    text-transform: uppercase;
+  }
+
+  &__item-links {
+    display: flex;
+    gap: 10px;
+    font-size: 0.85rem;
+  }
+
+  &__item-actions {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+  }
+
+  &__item-edit {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+  }
+}

--- a/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.scss
+++ b/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.scss
@@ -1,6 +1,18 @@
 .loadouts-modal {
   min-height: 100px;
 
+  &__ship-links {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 20px;
+
+    > span {
+      opacity: 0.6;
+      white-space: nowrap;
+    }
+  }
+
   &__create-form {
     display: flex;
     gap: 10px;

--- a/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.vue
+++ b/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.vue
@@ -1,0 +1,288 @@
+<script lang="ts">
+export default {
+  name: "VehicleLoadoutsModal",
+};
+</script>
+
+<script lang="ts" setup>
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import {
+  type Vehicle,
+  type VehicleLoadout,
+  useVehicleLoadouts,
+  useCreateVehicleLoadout,
+  useUpdateVehicleLoadout,
+  useDestroyVehicleLoadout,
+  useActivateVehicleLoadout,
+  getVehicleLoadoutsQueryKey,
+} from "@/services/fyApi";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  vehicle: Vehicle;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const comlink = useComlink();
+const queryClient = useQueryClient();
+const { displayConfirm, displayAlert } = useAppNotifications();
+
+const { data: loadouts, isLoading } = useVehicleLoadouts(props.vehicle.id);
+
+const createMutation = useCreateVehicleLoadout();
+const updateMutation = useUpdateVehicleLoadout();
+const destroyMutation = useDestroyVehicleLoadout();
+const activateMutation = useActivateVehicleLoadout();
+
+const newLoadoutName = ref("");
+const editingLoadout = ref<VehicleLoadout | null>(null);
+const editName = ref("");
+const editErkulUrl = ref("");
+const editSpviewerUrl = ref("");
+const submitting = ref(false);
+
+const invalidateLoadouts = () => {
+  void queryClient.invalidateQueries({
+    queryKey: getVehicleLoadoutsQueryKey(props.vehicle.id),
+  });
+};
+
+const createLoadout = async () => {
+  if (!newLoadoutName.value.trim()) return;
+
+  submitting.value = true;
+
+  await createMutation
+    .mutateAsync({
+      vehicleId: props.vehicle.id,
+      data: {
+        name: newLoadoutName.value.trim(),
+        fromDefaults: true,
+      },
+    })
+    .then(() => {
+      newLoadoutName.value = "";
+      invalidateLoadouts();
+    })
+    .catch((error) => {
+      displayAlert({ text: error.response?.data?.message || "Error" });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+};
+
+const startEdit = (loadout: VehicleLoadout) => {
+  editingLoadout.value = loadout;
+  editName.value = loadout.name;
+  editErkulUrl.value = loadout.erkulUrl || "";
+  editSpviewerUrl.value = loadout.spviewerUrl || "";
+};
+
+const cancelEdit = () => {
+  editingLoadout.value = null;
+};
+
+const saveEdit = async () => {
+  if (!editingLoadout.value || !editName.value.trim()) return;
+
+  submitting.value = true;
+
+  await updateMutation
+    .mutateAsync({
+      vehicleId: props.vehicle.id,
+      id: editingLoadout.value.id,
+      data: {
+        name: editName.value.trim(),
+        erkulUrl: editErkulUrl.value || null,
+        spviewerUrl: editSpviewerUrl.value || null,
+      },
+    })
+    .then(() => {
+      editingLoadout.value = null;
+      invalidateLoadouts();
+    })
+    .catch((error) => {
+      displayAlert({ text: error.response?.data?.message || "Error" });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+};
+
+const activate = async (loadout: VehicleLoadout) => {
+  await activateMutation
+    .mutateAsync({
+      vehicleId: props.vehicle.id,
+      id: loadout.id,
+    })
+    .then(() => {
+      invalidateLoadouts();
+    })
+    .catch((error) => {
+      displayAlert({ text: error.response?.data?.message || "Error" });
+    });
+};
+
+const remove = (loadout: VehicleLoadout) => {
+  displayConfirm({
+    text: t("messages.confirm.vehicle.destroy"),
+    onConfirm: async () => {
+      await destroyMutation
+        .mutateAsync({
+          vehicleId: props.vehicle.id,
+          id: loadout.id,
+        })
+        .then(() => {
+          invalidateLoadouts();
+        })
+        .catch((error) => {
+          displayAlert({ text: error.response?.data?.message || "Error" });
+        });
+    },
+  });
+};
+</script>
+
+<template>
+  <Modal
+    :title="
+      t('headlines.myVehicleLoadouts', {
+        vehicle: vehicle.model?.name,
+      })
+    "
+  >
+    <div class="loadouts-modal">
+      <div class="loadouts-modal__create">
+        <form
+          class="loadouts-modal__create-form"
+          @submit.prevent="createLoadout"
+        >
+          <FormInput
+            v-model="newLoadoutName"
+            name="newLoadoutName"
+            :placeholder="t('labels.loadout.namePlaceholder')"
+            :no-label="true"
+          />
+          <Btn
+            :loading="submitting"
+            :disabled="!newLoadoutName.trim()"
+            :inline="true"
+            @click="createLoadout"
+          >
+            {{ t("actions.add") }}
+          </Btn>
+        </form>
+      </div>
+
+      <div v-if="isLoading" class="loadouts-modal__loading">
+        <i class="fa fa-spinner fa-spin" />
+      </div>
+
+      <div v-else-if="!loadouts?.length" class="loadouts-modal__empty">
+        {{ t("labels.loadout.empty") }}
+      </div>
+
+      <div v-else class="loadouts-modal__list">
+        <div
+          v-for="loadout in loadouts"
+          :key="loadout.id"
+          class="loadouts-modal__item"
+          :class="{ 'loadouts-modal__item--active': loadout.active }"
+        >
+          <template v-if="editingLoadout?.id === loadout.id">
+            <div class="loadouts-modal__item-edit">
+              <FormInput v-model="editName" name="editName" :no-label="true" />
+              <FormInput
+                v-model="editErkulUrl"
+                name="editErkulUrl"
+                :placeholder="t('labels.loadout.erkulUrl')"
+                :no-label="true"
+              />
+              <FormInput
+                v-model="editSpviewerUrl"
+                name="editSpviewerUrl"
+                :placeholder="t('labels.loadout.spviewerUrl')"
+                :no-label="true"
+              />
+              <div class="loadouts-modal__item-actions">
+                <Btn :loading="submitting" :inline="true" @click="saveEdit">
+                  {{ t("actions.save") }}
+                </Btn>
+                <Btn :inline="true" @click="cancelEdit">
+                  {{ t("actions.cancel") }}
+                </Btn>
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <div class="loadouts-modal__item-info">
+              <span class="loadouts-modal__item-name">
+                {{ loadout.name }}
+              </span>
+              <span v-if="loadout.active" class="loadouts-modal__item-badge">
+                {{ t("labels.loadout.active") }}
+              </span>
+              <div
+                v-if="loadout.erkulUrl || loadout.spviewerUrl"
+                class="loadouts-modal__item-links"
+              >
+                <a
+                  v-if="loadout.erkulUrl"
+                  :href="loadout.erkulUrl"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Erkul
+                </a>
+                <a
+                  v-if="loadout.spviewerUrl"
+                  :href="loadout.spviewerUrl"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  SPViewer
+                </a>
+              </div>
+            </div>
+            <div class="loadouts-modal__item-actions">
+              <Btn
+                v-if="!loadout.active"
+                :inline="true"
+                size="small"
+                @click="activate(loadout)"
+              >
+                {{ t("labels.loadout.activate") }}
+              </Btn>
+              <Btn :inline="true" size="small" @click="startEdit(loadout)">
+                <i class="fa fa-pencil" />
+              </Btn>
+              <Btn :inline="true" size="small" @click="remove(loadout)">
+                <i class="fa-light fa-trash" />
+              </Btn>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="float-sm-right">
+        <Btn :inline="true" size="large" @click="comlink.emit('close-modal')">
+          {{ t("actions.close") }}
+        </Btn>
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.vue
+++ b/app/frontend/frontend/components/Vehicles/LoadoutsModal/index.vue
@@ -11,6 +11,7 @@ import FormInput from "@/shared/components/base/FormInput/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import {
   type Vehicle,
   type VehicleLoadout,
@@ -30,6 +31,19 @@ type Props = {
 const props = defineProps<Props>();
 
 const { t } = useI18n();
+
+const erkulShipUrl = computed(() => {
+  const identifier =
+    props.vehicle.model?.erkulIdentifier || props.vehicle.model?.scIdentifier;
+  if (!identifier) return undefined;
+  return `https://www.erkul.games/ship/${identifier}`;
+});
+
+const spviewerShipUrl = computed(() => {
+  const identifier = props.vehicle.model?.scIdentifier;
+  if (!identifier) return undefined;
+  return `https://www.spviewer.eu/performance?ship=${identifier}`;
+});
 const comlink = useComlink();
 const queryClient = useQueryClient();
 const { displayConfirm, displayAlert } = useAppNotifications();
@@ -160,6 +174,27 @@ const remove = (loadout: VehicleLoadout) => {
     "
   >
     <div class="loadouts-modal">
+      <div
+        v-if="erkulShipUrl || spviewerShipUrl"
+        class="loadouts-modal__ship-links"
+      >
+        <span>{{ t("labels.loadout.planOn") }}</span>
+        <BtnGroup>
+          <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
+            <i />
+            {{ t("labels.hardpoints.erkul") }}
+          </Btn>
+          <Btn
+            v-if="spviewerShipUrl"
+            :href="spviewerShipUrl"
+            class="spviewer-link"
+          >
+            <i />
+            {{ t("labels.hardpoints.spviewer") }}
+          </Btn>
+        </BtnGroup>
+      </div>
+
       <div class="loadouts-modal__create">
         <form
           class="loadouts-modal__create-form"

--- a/app/frontend/frontend/components/Vehicles/Panel/index.scss
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.scss
@@ -63,6 +63,22 @@
     right: 5px;
     bottom: 0;
   }
+
+  &-loadout {
+    position: absolute;
+    bottom: 0;
+    left: 45px;
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    padding: 5px 10px;
+    font-size: 0.75rem;
+    opacity: 0.8;
+
+    a {
+      text-decoration: underline;
+    }
+  }
 }
 
 // Tailwind CSS Placeholder Classes

--- a/app/frontend/frontend/components/Vehicles/Panel/index.scss
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.scss
@@ -46,7 +46,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: $warning;
+    background-color: $gray;
     border-radius: 0 10px 10px 0;
     cursor: pointer;
 

--- a/app/frontend/frontend/components/Vehicles/Panel/index.scss
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.scss
@@ -34,6 +34,28 @@
     }
   }
 
+  &-loadouts {
+    position: absolute;
+    bottom: 50%;
+    left: 0;
+
+    transform: translateY(50%);
+
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $warning;
+    border-radius: 0 10px 10px 0;
+    cursor: pointer;
+
+    i,
+    svg {
+      color: #fff;
+    }
+  }
+
   &-addons {
     position: absolute;
     bottom: 0;

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -123,6 +123,8 @@ const openAddonsModal = () => {
   });
 };
 
+const activeLoadout = computed(() => props.vehicle.activeLoadout);
+
 const shouldHighlight = computed(() => {
   return props.highlight || (props.vehicle as Vehicle).flagship;
 });
@@ -225,6 +227,28 @@ const shouldHighlight = computed(() => {
         :groups="vehicle.hangarGroups"
         class="vehicle-panel-hangar-groups"
       />
+      <div v-if="activeLoadout" class="vehicle-panel-loadout">
+        <i class="fa-duotone fa-crosshairs" />
+        <span>{{ activeLoadout.name }}</span>
+        <a
+          v-if="activeLoadout.erkulUrl"
+          :href="activeLoadout.erkulUrl"
+          target="_blank"
+          rel="noopener"
+          @click.stop
+        >
+          Erkul
+        </a>
+        <a
+          v-if="activeLoadout.spviewerUrl"
+          :href="activeLoadout.spviewerUrl"
+          target="_blank"
+          rel="noopener"
+          @click.stop
+        >
+          SPViewer
+        </a>
+      </div>
       <div
         v-if="upgradable && vehicle"
         v-tooltip="t('labels.model.addons')"

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -232,11 +232,20 @@ const shouldHighlight = computed(() => {
         v-tooltip="activeLoadout.name"
         :aria-label="activeLoadout.name"
         class="vehicle-panel-loadouts"
+        :class="{
+          'erkul-link': activeLoadout.urlSource === 'erkul',
+          'spviewer-link': activeLoadout.urlSource === 'spviewer',
+        }"
         :href="activeLoadout.url"
         target="_blank"
         rel="noopener"
       >
-        <i class="fa-duotone fa-crosshairs" />
+        <template v-if="activeLoadout.urlSource">
+          <i />
+        </template>
+        <template v-else>
+          <i class="fa-duotone fa-crosshairs" />
+        </template>
       </a>
       <div
         v-if="upgradable && vehicle"

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -227,28 +227,17 @@ const shouldHighlight = computed(() => {
         :groups="vehicle.hangarGroups"
         class="vehicle-panel-hangar-groups"
       />
-      <div v-if="activeLoadout" class="vehicle-panel-loadout">
+      <a
+        v-if="activeLoadout"
+        v-tooltip="activeLoadout.name"
+        :aria-label="activeLoadout.name"
+        class="vehicle-panel-loadouts"
+        :href="activeLoadout.url"
+        target="_blank"
+        rel="noopener"
+      >
         <i class="fa-duotone fa-crosshairs" />
-        <span>{{ activeLoadout.name }}</span>
-        <a
-          v-if="activeLoadout.erkulUrl"
-          :href="activeLoadout.erkulUrl"
-          target="_blank"
-          rel="noopener"
-          @click.stop
-        >
-          Erkul
-        </a>
-        <a
-          v-if="activeLoadout.spviewerUrl"
-          :href="activeLoadout.spviewerUrl"
-          target="_blank"
-          rel="noopener"
-          @click.stop
-        >
-          SPViewer
-        </a>
-      </div>
+      </a>
       <div
         v-if="upgradable && vehicle"
         v-tooltip="t('labels.model.addons')"

--- a/app/frontend/frontend/pages/hangar/[id].vue
+++ b/app/frontend/frontend/pages/hangar/[id].vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+import AsyncData from "@/shared/components/AsyncData.vue";
+import { useShowVehicle } from "@/services/fyApi";
+
+const route = useRoute();
+
+const id = computed(() => route.params.id as string);
+
+const { data: vehicle, ...asyncStatus } = useShowVehicle(id);
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <router-view v-if="vehicle" :vehicle="vehicle" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/frontend/pages/hangar/[id].vue
+++ b/app/frontend/frontend/pages/hangar/[id].vue
@@ -1,18 +1,68 @@
+<script lang="ts">
+export default {
+  name: "HangarVehicleRouterView",
+};
+</script>
+
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import TabNavView from "@/shared/components/TabNavView/index.vue";
+import TabNavViewItems from "@/shared/components/TabNavView/Items/index.vue";
 import { useShowVehicle } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useSessionStore } from "@/frontend/stores/session";
+import { routes as vehicleRoutes } from "@/frontend/pages/hangar/[id]/routes";
+
+const { t } = useI18n();
 
 const route = useRoute();
+
+const sessionStore = useSessionStore();
 
 const id = computed(() => route.params.id as string);
 
 const { data: vehicle, ...asyncStatus } = useShowVehicle(id);
+
+const vehicleName = computed(() => {
+  if (!vehicle.value) return "";
+
+  const nameParts = [vehicle.value.name || vehicle.value.model?.name];
+
+  if (vehicle.value.serial) {
+    nameParts.push(`(${vehicle.value.serial})`);
+  }
+
+  return nameParts.join(" ");
+});
+
+const crumbs = computed(() => [
+  {
+    to: { name: "hangar" },
+    label: t("nav.hangar.index"),
+  },
+  {
+    to: { name: "hangar-vehicle-loadouts", params: { id: route.params.id } },
+    label: vehicleName.value,
+  },
+]);
 </script>
 
 <template>
   <AsyncData :async-status="asyncStatus">
     <template #resolved>
-      <router-view v-if="vehicle" :vehicle="vehicle" />
+      <BreadCrumbs :crumbs="crumbs" />
+      <TabNavView v-if="vehicle" :routes="vehicleRoutes">
+        <template #nav>
+          <TabNavViewItems
+            :routes="vehicleRoutes"
+            :authenticated="sessionStore.isAuthenticated"
+          />
+        </template>
+        <template #content>
+          <router-view :vehicle="vehicle" />
+        </template>
+      </TabNavView>
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -1,17 +1,9 @@
 .loadouts-page {
-  &__header {
-    margin-bottom: 20px;
-  }
-
-  &__back {
-    margin-bottom: 10px;
-  }
-
   &__ship-links {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-top: 10px;
+    margin-bottom: 20px;
 
     > span {
       opacity: 0.6;

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -11,51 +11,21 @@
     }
   }
 
-  &__create-form {
+  &__toolbar {
+    margin-bottom: 10px;
+  }
+
+  &__item-display {
     display: flex;
-    gap: 10px;
-    align-items: flex-start;
-    margin-bottom: 20px;
-
-    .form-input {
-      flex: 1;
-    }
-  }
-
-  &__loading {
-    text-align: center;
-    padding: 40px;
-  }
-
-  &__empty {
-    text-align: center;
-    padding: 40px;
-    opacity: 0.6;
-  }
-
-  &__list {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  &__item {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 15px 20px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-
-    &--active {
-      border-color: var(--primary);
-    }
+    gap: 10px;
+    flex: 1;
   }
 
   &__item-info {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
   }
 
   &__item-name {
@@ -66,24 +36,12 @@
     font-size: 0.75rem;
     color: var(--primary);
     text-transform: uppercase;
+    margin-left: 8px;
   }
 
   &__item-links {
     display: flex;
     gap: 10px;
     font-size: 0.85rem;
-  }
-
-  &__item-actions {
-    display: flex;
-    gap: 5px;
-    align-items: center;
-  }
-
-  &__item-edit {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    width: 100%;
   }
 }

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -32,11 +32,9 @@
     font-weight: 600;
   }
 
-  &__item-badge {
-    font-size: 0.75rem;
-    color: var(--primary);
-    text-transform: uppercase;
-    margin-left: 8px;
+  &__edit-name {
+    max-width: 100px;
+    flex: 0 0 100px !important;
   }
 
   &__item-links {

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -1,11 +1,17 @@
-.loadouts-modal {
-  min-height: 100px;
+.loadouts-page {
+  &__header {
+    margin-bottom: 20px;
+  }
+
+  &__back {
+    margin-bottom: 10px;
+  }
 
   &__ship-links {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-bottom: 20px;
+    margin-top: 10px;
 
     > span {
       opacity: 0.6;
@@ -26,12 +32,12 @@
 
   &__loading {
     text-align: center;
-    padding: 20px;
+    padding: 40px;
   }
 
   &__empty {
     text-align: center;
-    padding: 20px;
+    padding: 40px;
     opacity: 0.6;
   }
 
@@ -45,7 +51,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 15px;
+    padding: 15px 20px;
     border: 1px solid var(--border-color);
     border-radius: 4px;
 

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -33,8 +33,8 @@
   }
 
   &__edit-name {
-    max-width: 100px;
-    flex: 0 0 100px !important;
+    max-width: 200px;
+    flex: 0 0 200px !important;
   }
 
   &__item-links {

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.scss
@@ -33,8 +33,11 @@
   }
 
   &__edit-name {
-    max-width: 200px;
-    flex: 0 0 200px !important;
+    flex: 1 !important;
+  }
+
+  &__edit-url {
+    flex: 2 !important;
   }
 
   &__item-links {

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -8,6 +8,7 @@ export default {
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import Pill from "@/shared/components/base/Pill/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -90,8 +91,7 @@ const editForm = ref<VehicleLoadoutInput>({});
 const onStartEdit = (record: VehicleLoadout) => {
   editForm.value = {
     name: record.name,
-    erkulUrl: record.erkulUrl,
-    spviewerUrl: record.spviewerUrl,
+    url: record.erkulUrl || record.spviewerUrl || "",
   };
 };
 
@@ -144,7 +144,7 @@ const onActivate = async (record: VehicleLoadout) => {
       class="loadouts-page__ship-links"
     >
       <span>{{ t("labels.loadout.planOn") }}</span>
-      <BtnGroup>
+      <BtnGroup inline>
         <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
           <i />
           {{ t("labels.hardpoints.erkul") }}
@@ -185,12 +185,12 @@ const onActivate = async (record: VehicleLoadout) => {
     >
       <template #display="{ item }">
         <div class="loadouts-page__item-display">
+          <Pill v-if="item.active" variant="success" uppercase>
+            {{ t("labels.loadout.active") }}
+          </Pill>
           <div class="loadouts-page__item-info">
             <span class="loadouts-page__item-name">
               {{ item.name }}
-              <span v-if="item.active" class="loadouts-page__item-badge">
-                {{ t("labels.loadout.active") }}
-              </span>
             </span>
             <div
               v-if="item.erkulUrl || item.spviewerUrl"
@@ -234,6 +234,7 @@ const onActivate = async (record: VehicleLoadout) => {
           name="create-loadout-url"
           :placeholder="t('labels.loadout.urlPlaceholder')"
           :no-label="true"
+          inline
         />
       </template>
 
@@ -243,17 +244,12 @@ const onActivate = async (record: VehicleLoadout) => {
           name="edit-loadout-name"
           :placeholder="t('labels.loadout.namePlaceholder')"
           :no-label="true"
+          class="loadouts-page__edit-name"
         />
         <FormInput
-          v-model="editForm.erkulUrl"
-          name="edit-erkul-url"
-          :placeholder="t('labels.loadout.erkulUrl')"
-          :no-label="true"
-        />
-        <FormInput
-          v-model="editForm.spviewerUrl"
-          name="edit-spviewer-url"
-          :placeholder="t('labels.loadout.spviewerUrl')"
+          v-model="editForm.url"
+          name="edit-loadout-url"
+          :placeholder="t('labels.loadout.urlPlaceholder')"
           :no-label="true"
         />
       </template>

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -163,154 +163,134 @@ const remove = (loadout: VehicleLoadout) => {
 </script>
 
 <template>
-  <div class="row">
-    <div class="col-12">
-      <div class="loadouts-page__header">
-        <div class="loadouts-page__back">
-          <Btn :to="{ name: 'hangar' }" :inline="true" size="small">
-            <i class="fa fa-chevron-left" />
-            {{ t("actions.hangar.backToHangar") }}
-          </Btn>
-        </div>
-        <h1>
-          {{
-            t("headlines.myVehicleLoadouts", {
-              vehicle: vehicle.model?.name,
-            })
-          }}
-        </h1>
-        <div
-          v-if="erkulShipUrl || spviewerShipUrl"
-          class="loadouts-page__ship-links"
+  <div>
+    <div
+      v-if="erkulShipUrl || spviewerShipUrl"
+      class="loadouts-page__ship-links"
+    >
+      <span>{{ t("labels.loadout.planOn") }}</span>
+      <BtnGroup>
+        <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
+          <i />
+          {{ t("labels.hardpoints.erkul") }}
+        </Btn>
+        <Btn
+          v-if="spviewerShipUrl"
+          :href="spviewerShipUrl"
+          class="spviewer-link"
         >
-          <span>{{ t("labels.loadout.planOn") }}</span>
-          <BtnGroup>
-            <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
-              <i />
-              {{ t("labels.hardpoints.erkul") }}
-            </Btn>
-            <Btn
-              v-if="spviewerShipUrl"
-              :href="spviewerShipUrl"
-              class="spviewer-link"
-            >
-              <i />
-              {{ t("labels.hardpoints.spviewer") }}
-            </Btn>
-          </BtnGroup>
-        </div>
-      </div>
+          <i />
+          {{ t("labels.hardpoints.spviewer") }}
+        </Btn>
+      </BtnGroup>
+    </div>
 
-      <div class="loadouts-page__create">
-        <form
-          class="loadouts-page__create-form"
-          @submit.prevent="createLoadout"
+    <div class="loadouts-page__create">
+      <form class="loadouts-page__create-form" @submit.prevent="createLoadout">
+        <FormInput
+          v-model="newLoadoutName"
+          name="newLoadoutName"
+          :placeholder="t('labels.loadout.namePlaceholder')"
+          :no-label="true"
+        />
+        <Btn
+          :loading="submitting"
+          :disabled="!newLoadoutName.trim()"
+          :inline="true"
+          @click="createLoadout"
         >
-          <FormInput
-            v-model="newLoadoutName"
-            name="newLoadoutName"
-            :placeholder="t('labels.loadout.namePlaceholder')"
-            :no-label="true"
-          />
-          <Btn
-            :loading="submitting"
-            :disabled="!newLoadoutName.trim()"
-            :inline="true"
-            @click="createLoadout"
-          >
-            {{ t("actions.add") }}
-          </Btn>
-        </form>
-      </div>
+          {{ t("actions.add") }}
+        </Btn>
+      </form>
+    </div>
 
-      <div v-if="isLoading" class="loadouts-page__loading">
-        <i class="fa fa-spinner fa-spin" />
-      </div>
+    <div v-if="isLoading" class="loadouts-page__loading">
+      <i class="fa fa-spinner fa-spin" />
+    </div>
 
-      <div v-else-if="!loadouts?.length" class="loadouts-page__empty">
-        {{ t("labels.loadout.empty") }}
-      </div>
+    <div v-else-if="!loadouts?.length" class="loadouts-page__empty">
+      {{ t("labels.loadout.empty") }}
+    </div>
 
-      <div v-else class="loadouts-page__list">
-        <div
-          v-for="loadout in loadouts"
-          :key="loadout.id"
-          class="loadouts-page__item"
-          :class="{ 'loadouts-page__item--active': loadout.active }"
-        >
-          <template v-if="editingLoadout?.id === loadout.id">
-            <div class="loadouts-page__item-edit">
-              <FormInput v-model="editName" name="editName" :no-label="true" />
-              <FormInput
-                v-model="editErkulUrl"
-                name="editErkulUrl"
-                :placeholder="t('labels.loadout.erkulUrl')"
-                :no-label="true"
-              />
-              <FormInput
-                v-model="editSpviewerUrl"
-                name="editSpviewerUrl"
-                :placeholder="t('labels.loadout.spviewerUrl')"
-                :no-label="true"
-              />
-              <div class="loadouts-page__item-actions">
-                <Btn :loading="submitting" :inline="true" @click="saveEdit">
-                  {{ t("actions.save") }}
-                </Btn>
-                <Btn :inline="true" @click="cancelEdit">
-                  {{ t("actions.cancel") }}
-                </Btn>
-              </div>
-            </div>
-          </template>
-          <template v-else>
-            <div class="loadouts-page__item-info">
-              <span class="loadouts-page__item-name">
-                {{ loadout.name }}
-              </span>
-              <span v-if="loadout.active" class="loadouts-page__item-badge">
-                {{ t("labels.loadout.active") }}
-              </span>
-              <div
-                v-if="loadout.erkulUrl || loadout.spviewerUrl"
-                class="loadouts-page__item-links"
-              >
-                <a
-                  v-if="loadout.erkulUrl"
-                  :href="loadout.erkulUrl"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  Erkul
-                </a>
-                <a
-                  v-if="loadout.spviewerUrl"
-                  :href="loadout.spviewerUrl"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  SPViewer
-                </a>
-              </div>
-            </div>
+    <div v-else class="loadouts-page__list">
+      <div
+        v-for="loadout in loadouts"
+        :key="loadout.id"
+        class="loadouts-page__item"
+        :class="{ 'loadouts-page__item--active': loadout.active }"
+      >
+        <template v-if="editingLoadout?.id === loadout.id">
+          <div class="loadouts-page__item-edit">
+            <FormInput v-model="editName" name="editName" :no-label="true" />
+            <FormInput
+              v-model="editErkulUrl"
+              name="editErkulUrl"
+              :placeholder="t('labels.loadout.erkulUrl')"
+              :no-label="true"
+            />
+            <FormInput
+              v-model="editSpviewerUrl"
+              name="editSpviewerUrl"
+              :placeholder="t('labels.loadout.spviewerUrl')"
+              :no-label="true"
+            />
             <div class="loadouts-page__item-actions">
-              <Btn
-                v-if="!loadout.active"
-                :inline="true"
-                size="small"
-                @click="activate(loadout)"
-              >
-                {{ t("labels.loadout.activate") }}
+              <Btn :loading="submitting" :inline="true" @click="saveEdit">
+                {{ t("actions.save") }}
               </Btn>
-              <Btn :inline="true" size="small" @click="startEdit(loadout)">
-                <i class="fa fa-pencil" />
-              </Btn>
-              <Btn :inline="true" size="small" @click="remove(loadout)">
-                <i class="fa-light fa-trash" />
+              <Btn :inline="true" @click="cancelEdit">
+                {{ t("actions.cancel") }}
               </Btn>
             </div>
-          </template>
-        </div>
+          </div>
+        </template>
+        <template v-else>
+          <div class="loadouts-page__item-info">
+            <span class="loadouts-page__item-name">
+              {{ loadout.name }}
+            </span>
+            <span v-if="loadout.active" class="loadouts-page__item-badge">
+              {{ t("labels.loadout.active") }}
+            </span>
+            <div
+              v-if="loadout.erkulUrl || loadout.spviewerUrl"
+              class="loadouts-page__item-links"
+            >
+              <a
+                v-if="loadout.erkulUrl"
+                :href="loadout.erkulUrl"
+                target="_blank"
+                rel="noopener"
+              >
+                Erkul
+              </a>
+              <a
+                v-if="loadout.spviewerUrl"
+                :href="loadout.spviewerUrl"
+                target="_blank"
+                rel="noopener"
+              >
+                SPViewer
+              </a>
+            </div>
+          </div>
+          <div class="loadouts-page__item-actions">
+            <Btn
+              v-if="!loadout.active"
+              :inline="true"
+              size="small"
+              @click="activate(loadout)"
+            >
+              {{ t("labels.loadout.activate") }}
+            </Btn>
+            <Btn :inline="true" size="small" @click="startEdit(loadout)">
+              <i class="fa fa-pencil" />
+            </Btn>
+            <Btn :inline="true" size="small" @click="remove(loadout)">
+              <i class="fa-light fa-trash" />
+            </Btn>
+          </div>
+        </template>
       </div>
     </div>
   </div>

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -8,11 +8,13 @@ export default {
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
-import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import {
   type Vehicle,
   type VehicleLoadout,
+  type VehicleLoadoutInput,
   useVehicleLoadouts,
   useCreateVehicleLoadout,
   useUpdateVehicleLoadout,
@@ -30,7 +32,6 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
-const { displayConfirm, displayAlert } = useAppNotifications();
 
 const erkulShipUrl = computed(() => {
   const identifier =
@@ -47,17 +48,15 @@ const spviewerShipUrl = computed(() => {
 
 const { data: loadouts, isLoading } = useVehicleLoadouts(props.vehicle.id);
 
-const createMutation = useCreateVehicleLoadout();
-const updateMutation = useUpdateVehicleLoadout();
-const destroyMutation = useDestroyVehicleLoadout();
-const activateMutation = useActivateVehicleLoadout();
+const loadoutItems = computed(() => (loadouts.value as VehicleLoadout[]) || []);
 
-const newLoadoutName = ref("");
-const editingLoadout = ref<VehicleLoadout | null>(null);
-const editName = ref("");
-const editErkulUrl = ref("");
-const editSpviewerUrl = ref("");
-const submitting = ref(false);
+const editableList = ref<{
+  editingId: string | null;
+  creating: boolean;
+  startCreate: () => void;
+  finishEdit: () => void;
+  finishCreate: () => void;
+} | null>(null);
 
 const invalidateLoadouts = () => {
   void queryClient.invalidateQueries({
@@ -65,99 +64,75 @@ const invalidateLoadouts = () => {
   });
 };
 
-const createLoadout = async () => {
-  if (!newLoadoutName.value.trim()) return;
+// Create
+const createForm = ref<VehicleLoadoutInput>({});
 
-  submitting.value = true;
-
-  await createMutation
-    .mutateAsync({
-      vehicleId: props.vehicle.id,
-      data: {
-        name: newLoadoutName.value.trim(),
-        fromDefaults: true,
-      },
-    })
-    .then(() => {
-      newLoadoutName.value = "";
-      invalidateLoadouts();
-    })
-    .catch((error) => {
-      displayAlert({ text: error.response?.data?.message || "Error" });
-    })
-    .finally(() => {
-      submitting.value = false;
-    });
+const onStartCreate = () => {
+  createForm.value = {};
 };
 
-const startEdit = (loadout: VehicleLoadout) => {
-  editingLoadout.value = loadout;
-  editName.value = loadout.name;
-  editErkulUrl.value = loadout.erkulUrl || "";
-  editSpviewerUrl.value = loadout.spviewerUrl || "";
+const createMutation = useCreateVehicleLoadout({
+  mutation: { onSettled: invalidateLoadouts },
+});
+
+const onSaveCreate = async () => {
+  await createMutation.mutateAsync({
+    vehicleId: props.vehicle.id,
+    data: createForm.value,
+  });
+
+  editableList.value?.finishCreate();
 };
 
-const cancelEdit = () => {
-  editingLoadout.value = null;
+// Edit
+const editForm = ref<VehicleLoadoutInput>({});
+
+const onStartEdit = (record: VehicleLoadout) => {
+  editForm.value = {
+    name: record.name,
+    erkulUrl: record.erkulUrl,
+    spviewerUrl: record.spviewerUrl,
+  };
 };
 
-const saveEdit = async () => {
-  if (!editingLoadout.value || !editName.value.trim()) return;
+const updateMutation = useUpdateVehicleLoadout({
+  mutation: { onSettled: invalidateLoadouts },
+});
 
-  submitting.value = true;
+const onSaveEdit = async () => {
+  const id = editableList.value?.editingId;
+  if (!id) return;
 
-  await updateMutation
-    .mutateAsync({
-      vehicleId: props.vehicle.id,
-      id: editingLoadout.value.id,
-      data: {
-        name: editName.value.trim(),
-        erkulUrl: editErkulUrl.value || null,
-        spviewerUrl: editSpviewerUrl.value || null,
-      },
-    })
-    .then(() => {
-      editingLoadout.value = null;
-      invalidateLoadouts();
-    })
-    .catch((error) => {
-      displayAlert({ text: error.response?.data?.message || "Error" });
-    })
-    .finally(() => {
-      submitting.value = false;
-    });
+  await updateMutation.mutateAsync({
+    vehicleId: props.vehicle.id,
+    id,
+    data: editForm.value,
+  });
+
+  editableList.value?.finishEdit();
 };
 
-const activate = async (loadout: VehicleLoadout) => {
-  await activateMutation
-    .mutateAsync({
-      vehicleId: props.vehicle.id,
-      id: loadout.id,
-    })
-    .then(() => {
-      invalidateLoadouts();
-    })
-    .catch((error) => {
-      displayAlert({ text: error.response?.data?.message || "Error" });
-    });
+// Delete
+const destroyMutation = useDestroyVehicleLoadout({
+  mutation: { onSettled: invalidateLoadouts },
+});
+
+const onDestroy = async (record: VehicleLoadout) => {
+  await destroyMutation.mutateAsync({
+    vehicleId: props.vehicle.id,
+    id: record.id,
+  });
 };
 
-const remove = (loadout: VehicleLoadout) => {
-  displayConfirm({
-    text: t("messages.confirm.vehicle.destroy"),
-    onConfirm: async () => {
-      await destroyMutation
-        .mutateAsync({
-          vehicleId: props.vehicle.id,
-          id: loadout.id,
-        })
-        .then(() => {
-          invalidateLoadouts();
-        })
-        .catch((error) => {
-          displayAlert({ text: error.response?.data?.message || "Error" });
-        });
-    },
+// Activate
+const activateMutation = useActivateVehicleLoadout({
+  mutation: { onSettled: invalidateLoadouts },
+});
+
+const onActivate = async (record: VehicleLoadout) => {
+  await activateMutation.mutateAsync({
+    vehicleId: props.vehicle.id,
+    id: record.id,
   });
 };
 </script>
@@ -185,88 +160,53 @@ const remove = (loadout: VehicleLoadout) => {
       </BtnGroup>
     </div>
 
-    <div class="loadouts-page__create">
-      <form class="loadouts-page__create-form" @submit.prevent="createLoadout">
-        <FormInput
-          v-model="newLoadoutName"
-          name="newLoadoutName"
-          :placeholder="t('labels.loadout.namePlaceholder')"
-          :no-label="true"
-        />
-        <Btn
-          :loading="submitting"
-          :disabled="!newLoadoutName.trim()"
-          :inline="true"
-          @click="createLoadout"
-        >
-          {{ t("actions.add") }}
-        </Btn>
-      </form>
-    </div>
-
-    <div v-if="isLoading" class="loadouts-page__loading">
-      <i class="fa fa-spinner fa-spin" />
-    </div>
-
-    <div v-else-if="!loadouts?.length" class="loadouts-page__empty">
-      {{ t("labels.loadout.empty") }}
-    </div>
-
-    <div v-else class="loadouts-page__list">
-      <div
-        v-for="loadout in loadouts"
-        :key="loadout.id"
-        class="loadouts-page__item"
-        :class="{ 'loadouts-page__item--active': loadout.active }"
+    <div class="flex items-center justify-between loadouts-page__toolbar">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :disabled="editableList?.creating"
+        @click="editableList?.startCreate()"
       >
-        <template v-if="editingLoadout?.id === loadout.id">
-          <div class="loadouts-page__item-edit">
-            <FormInput v-model="editName" name="editName" :no-label="true" />
-            <FormInput
-              v-model="editErkulUrl"
-              name="editErkulUrl"
-              :placeholder="t('labels.loadout.erkulUrl')"
-              :no-label="true"
-            />
-            <FormInput
-              v-model="editSpviewerUrl"
-              name="editSpviewerUrl"
-              :placeholder="t('labels.loadout.spviewerUrl')"
-              :no-label="true"
-            />
-            <div class="loadouts-page__item-actions">
-              <Btn :loading="submitting" :inline="true" @click="saveEdit">
-                {{ t("actions.save") }}
-              </Btn>
-              <Btn :inline="true" @click="cancelEdit">
-                {{ t("actions.cancel") }}
-              </Btn>
-            </div>
-          </div>
-        </template>
-        <template v-else>
+        <i class="fa-duotone fa-plus" />
+        {{ t("actions.add") }}
+      </Btn>
+    </div>
+
+    <InlineEditableList
+      ref="editableList"
+      empty-name="loadouts"
+      :items="loadoutItems"
+      :loading="isLoading"
+      confirm-destroy-text="Are you sure you want to delete this loadout?"
+      @start-edit="onStartEdit"
+      @save-edit="onSaveEdit"
+      @start-create="onStartCreate"
+      @save-create="onSaveCreate"
+      @destroy="onDestroy"
+    >
+      <template #display="{ item }">
+        <div class="loadouts-page__item-display">
           <div class="loadouts-page__item-info">
             <span class="loadouts-page__item-name">
-              {{ loadout.name }}
-            </span>
-            <span v-if="loadout.active" class="loadouts-page__item-badge">
-              {{ t("labels.loadout.active") }}
+              {{ item.name }}
+              <span v-if="item.active" class="loadouts-page__item-badge">
+                {{ t("labels.loadout.active") }}
+              </span>
             </span>
             <div
-              v-if="loadout.erkulUrl || loadout.spviewerUrl"
+              v-if="item.erkulUrl || item.spviewerUrl"
               class="loadouts-page__item-links"
             >
               <a
-                v-if="loadout.erkulUrl"
-                :href="loadout.erkulUrl"
+                v-if="item.erkulUrl"
+                :href="item.erkulUrl"
                 target="_blank"
                 rel="noopener"
               >
                 Erkul
               </a>
               <a
-                v-if="loadout.spviewerUrl"
-                :href="loadout.spviewerUrl"
+                v-if="item.spviewerUrl"
+                :href="item.spviewerUrl"
                 target="_blank"
                 rel="noopener"
               >
@@ -274,25 +214,50 @@ const remove = (loadout: VehicleLoadout) => {
               </a>
             </div>
           </div>
-          <div class="loadouts-page__item-actions">
-            <Btn
-              v-if="!loadout.active"
-              :inline="true"
-              size="small"
-              @click="activate(loadout)"
-            >
-              {{ t("labels.loadout.activate") }}
-            </Btn>
-            <Btn :inline="true" size="small" @click="startEdit(loadout)">
-              <i class="fa fa-pencil" />
-            </Btn>
-            <Btn :inline="true" size="small" @click="remove(loadout)">
-              <i class="fa-light fa-trash" />
-            </Btn>
-          </div>
-        </template>
-      </div>
-    </div>
+        </div>
+      </template>
+
+      <template #actions="{ item }">
+        <Btn
+          v-if="!item.active"
+          v-tooltip="t('labels.loadout.activate')"
+          :size="BtnSizesEnum.SMALL"
+          @click="onActivate(item)"
+        >
+          <i class="fa-duotone fa-circle-check" />
+        </Btn>
+      </template>
+
+      <template #create>
+        <FormInput
+          v-model="createForm.url"
+          name="create-loadout-url"
+          :placeholder="t('labels.loadout.urlPlaceholder')"
+          :no-label="true"
+        />
+      </template>
+
+      <template #edit>
+        <FormInput
+          v-model="editForm.name"
+          name="edit-loadout-name"
+          :placeholder="t('labels.loadout.namePlaceholder')"
+          :no-label="true"
+        />
+        <FormInput
+          v-model="editForm.erkulUrl"
+          name="edit-erkul-url"
+          :placeholder="t('labels.loadout.erkulUrl')"
+          :no-label="true"
+        />
+        <FormInput
+          v-model="editForm.spviewerUrl"
+          name="edit-spviewer-url"
+          :placeholder="t('labels.loadout.spviewerUrl')"
+          :no-label="true"
+        />
+      </template>
+    </InlineEditableList>
   </div>
 </template>
 

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -1,17 +1,15 @@
 <script lang="ts">
 export default {
-  name: "VehicleLoadoutsModal",
+  name: "HangarVehicleLoadoutsPage",
 };
 </script>
 
 <script lang="ts" setup>
-import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
+import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
-import { useComlink } from "@/shared/composables/useComlink";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
-import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import {
   type Vehicle,
   type VehicleLoadout,
@@ -31,6 +29,8 @@ type Props = {
 const props = defineProps<Props>();
 
 const { t } = useI18n();
+const queryClient = useQueryClient();
+const { displayConfirm, displayAlert } = useAppNotifications();
 
 const erkulShipUrl = computed(() => {
   const identifier =
@@ -44,9 +44,6 @@ const spviewerShipUrl = computed(() => {
   if (!identifier) return undefined;
   return `https://www.spviewer.eu/performance?ship=${identifier}`;
 });
-const comlink = useComlink();
-const queryClient = useQueryClient();
-const { displayConfirm, displayAlert } = useAppNotifications();
 
 const { data: loadouts, isLoading } = useVehicleLoadouts(props.vehicle.id);
 
@@ -166,38 +163,47 @@ const remove = (loadout: VehicleLoadout) => {
 </script>
 
 <template>
-  <Modal
-    :title="
-      t('headlines.myVehicleLoadouts', {
-        vehicle: vehicle.model?.name,
-      })
-    "
-  >
-    <div class="loadouts-modal">
-      <div
-        v-if="erkulShipUrl || spviewerShipUrl"
-        class="loadouts-modal__ship-links"
-      >
-        <span>{{ t("labels.loadout.planOn") }}</span>
-        <BtnGroup>
-          <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
-            <i />
-            {{ t("labels.hardpoints.erkul") }}
+  <div class="row">
+    <div class="col-12">
+      <div class="loadouts-page__header">
+        <div class="loadouts-page__back">
+          <Btn :to="{ name: 'hangar' }" :inline="true" size="small">
+            <i class="fa fa-chevron-left" />
+            {{ t("actions.hangar.backToHangar") }}
           </Btn>
-          <Btn
-            v-if="spviewerShipUrl"
-            :href="spviewerShipUrl"
-            class="spviewer-link"
-          >
-            <i />
-            {{ t("labels.hardpoints.spviewer") }}
-          </Btn>
-        </BtnGroup>
+        </div>
+        <h1>
+          {{
+            t("headlines.myVehicleLoadouts", {
+              vehicle: vehicle.model?.name,
+            })
+          }}
+        </h1>
+        <div
+          v-if="erkulShipUrl || spviewerShipUrl"
+          class="loadouts-page__ship-links"
+        >
+          <span>{{ t("labels.loadout.planOn") }}</span>
+          <BtnGroup>
+            <Btn v-if="erkulShipUrl" :href="erkulShipUrl" class="erkul-link">
+              <i />
+              {{ t("labels.hardpoints.erkul") }}
+            </Btn>
+            <Btn
+              v-if="spviewerShipUrl"
+              :href="spviewerShipUrl"
+              class="spviewer-link"
+            >
+              <i />
+              {{ t("labels.hardpoints.spviewer") }}
+            </Btn>
+          </BtnGroup>
+        </div>
       </div>
 
-      <div class="loadouts-modal__create">
+      <div class="loadouts-page__create">
         <form
-          class="loadouts-modal__create-form"
+          class="loadouts-page__create-form"
           @submit.prevent="createLoadout"
         >
           <FormInput
@@ -217,23 +223,23 @@ const remove = (loadout: VehicleLoadout) => {
         </form>
       </div>
 
-      <div v-if="isLoading" class="loadouts-modal__loading">
+      <div v-if="isLoading" class="loadouts-page__loading">
         <i class="fa fa-spinner fa-spin" />
       </div>
 
-      <div v-else-if="!loadouts?.length" class="loadouts-modal__empty">
+      <div v-else-if="!loadouts?.length" class="loadouts-page__empty">
         {{ t("labels.loadout.empty") }}
       </div>
 
-      <div v-else class="loadouts-modal__list">
+      <div v-else class="loadouts-page__list">
         <div
           v-for="loadout in loadouts"
           :key="loadout.id"
-          class="loadouts-modal__item"
-          :class="{ 'loadouts-modal__item--active': loadout.active }"
+          class="loadouts-page__item"
+          :class="{ 'loadouts-page__item--active': loadout.active }"
         >
           <template v-if="editingLoadout?.id === loadout.id">
-            <div class="loadouts-modal__item-edit">
+            <div class="loadouts-page__item-edit">
               <FormInput v-model="editName" name="editName" :no-label="true" />
               <FormInput
                 v-model="editErkulUrl"
@@ -247,7 +253,7 @@ const remove = (loadout: VehicleLoadout) => {
                 :placeholder="t('labels.loadout.spviewerUrl')"
                 :no-label="true"
               />
-              <div class="loadouts-modal__item-actions">
+              <div class="loadouts-page__item-actions">
                 <Btn :loading="submitting" :inline="true" @click="saveEdit">
                   {{ t("actions.save") }}
                 </Btn>
@@ -258,16 +264,16 @@ const remove = (loadout: VehicleLoadout) => {
             </div>
           </template>
           <template v-else>
-            <div class="loadouts-modal__item-info">
-              <span class="loadouts-modal__item-name">
+            <div class="loadouts-page__item-info">
+              <span class="loadouts-page__item-name">
                 {{ loadout.name }}
               </span>
-              <span v-if="loadout.active" class="loadouts-modal__item-badge">
+              <span v-if="loadout.active" class="loadouts-page__item-badge">
                 {{ t("labels.loadout.active") }}
               </span>
               <div
                 v-if="loadout.erkulUrl || loadout.spviewerUrl"
-                class="loadouts-modal__item-links"
+                class="loadouts-page__item-links"
               >
                 <a
                   v-if="loadout.erkulUrl"
@@ -287,7 +293,7 @@ const remove = (loadout: VehicleLoadout) => {
                 </a>
               </div>
             </div>
-            <div class="loadouts-modal__item-actions">
+            <div class="loadouts-page__item-actions">
               <Btn
                 v-if="!loadout.active"
                 :inline="true"
@@ -307,17 +313,9 @@ const remove = (loadout: VehicleLoadout) => {
         </div>
       </div>
     </div>
-
-    <template #footer>
-      <div class="float-sm-right">
-        <Btn :inline="true" size="large" @click="comlink.emit('close-modal')">
-          {{ t("actions.close") }}
-        </Btn>
-      </div>
-    </template>
-  </Modal>
+  </div>
 </template>
 
 <style lang="scss" scoped>
-@import "index";
+@import "loadouts";
 </style>

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -91,7 +91,7 @@ const editForm = ref<VehicleLoadoutInput>({});
 const onStartEdit = (record: VehicleLoadout) => {
   editForm.value = {
     name: record.name,
-    url: record.erkulUrl || record.spviewerUrl || "",
+    url: record.url || "",
   };
 };
 
@@ -192,25 +192,9 @@ const onActivate = async (record: VehicleLoadout) => {
             <span class="loadouts-page__item-name">
               {{ item.name }}
             </span>
-            <div
-              v-if="item.erkulUrl || item.spviewerUrl"
-              class="loadouts-page__item-links"
-            >
-              <a
-                v-if="item.erkulUrl"
-                :href="item.erkulUrl"
-                target="_blank"
-                rel="noopener"
-              >
-                Erkul
-              </a>
-              <a
-                v-if="item.spviewerUrl"
-                :href="item.spviewerUrl"
-                target="_blank"
-                rel="noopener"
-              >
-                SPViewer
+            <div v-if="item.url" class="loadouts-page__item-links">
+              <a :href="item.url" target="_blank" rel="noopener">
+                {{ item.urlSource || item.url }}
               </a>
             </div>
           </div>

--- a/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/loadouts.vue
@@ -251,6 +251,7 @@ const onActivate = async (record: VehicleLoadout) => {
           name="edit-loadout-url"
           :placeholder="t('labels.loadout.urlPlaceholder')"
           :no-label="true"
+          class="loadouts-page__edit-url"
         />
       </template>
     </InlineEditableList>

--- a/app/frontend/frontend/pages/hangar/[id]/routes.ts
+++ b/app/frontend/frontend/pages/hangar/[id]/routes.ts
@@ -9,6 +9,7 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
       title: "hangar.vehicleLoadouts",
       backgroundImage: "bg-5",
+      customTitle: true,
     },
   },
 ];

--- a/app/frontend/frontend/pages/hangar/[id]/routes.ts
+++ b/app/frontend/frontend/pages/hangar/[id]/routes.ts
@@ -1,0 +1,14 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "loadouts/",
+    name: "hangar-vehicle-loadouts",
+    component: () => import("@/frontend/pages/hangar/[id]/loadouts.vue"),
+    meta: {
+      needsAuthentication: true,
+      title: "hangar.vehicleLoadouts",
+      backgroundImage: "bg-5",
+    },
+  },
+];

--- a/app/frontend/frontend/pages/hangar/routes.ts
+++ b/app/frontend/frontend/pages/hangar/routes.ts
@@ -1,4 +1,5 @@
 import type { RouteRecordRaw } from "vue-router";
+import { routes as vehicleRoutes } from "@/frontend/pages/hangar/[id]/routes";
 import { routes as publicHangarRoutes } from "@/frontend/pages/hangar/[username]/routes";
 
 export const routes: RouteRecordRaw[] = [
@@ -50,6 +51,14 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
       title: "hangar.stats",
       backgroundImage: "bg-5",
+    },
+  },
+  {
+    path: ":id/",
+    component: () => import("@/frontend/pages/hangar/[id].vue"),
+    children: vehicleRoutes,
+    meta: {
+      needsAuthentication: true,
     },
   },
   {

--- a/app/frontend/frontend/pages/hangar/routes.ts
+++ b/app/frontend/frontend/pages/hangar/routes.ts
@@ -57,6 +57,7 @@ export const routes: RouteRecordRaw[] = [
     path: ":id/",
     component: () => import("@/frontend/pages/hangar/[id].vue"),
     children: vehicleRoutes,
+    redirect: { name: vehicleRoutes[0].name },
     meta: {
       needsAuthentication: true,
     },

--- a/app/frontend/frontend/pages/hangar/stats.vue
+++ b/app/frontend/frontend/pages/hangar/stats.vue
@@ -180,7 +180,9 @@ const wishlistTotalCreditsCompact = computed(() =>
 </script>
 
 <template>
-  <BreadCrumbs :crumbs="[{ to: { name: 'hangar' }, label: t('nav.hangar') }]" />
+  <BreadCrumbs
+    :crumbs="[{ to: { name: 'hangar' }, label: t('nav.hangar.index') }]"
+  />
   <Heading size="hero" hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
 
   <Teleport to="#header-right">

--- a/app/frontend/frontend/pages/hangar/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/wishlist.vue
@@ -225,7 +225,9 @@ const openDisplayOptionsModal = () => {
 </script>
 
 <template>
-  <BreadCrumbs :crumbs="[{ to: { name: 'hangar' }, label: t('nav.hangar') }]" />
+  <BreadCrumbs
+    :crumbs="[{ to: { name: 'hangar' }, label: t('nav.hangar.index') }]"
+  />
   <Heading size="hero" hero>{{ t("headlines.hangar.wishlist") }}</Heading>
 
   <Teleport v-if="!mobile" to="#header-right">

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "Hersteller",
       "images": "Bilder",
       "videos": "Videos",
-      "hangar": "Mein Hangar",
+      "hangar": {
+        "index": "Mein Hangar",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "Anmelden",
       "logout": "Abmelden",
       "apiV1": "API v1",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -139,6 +139,7 @@
         "editGroups": "Add or remove Groups",
         "editName": "Name your Ship",
         "manageLoadouts": "Manage Loadouts",
+        "backToHangar": "Back to Hangar",
         "useName": "Use Name",
         "destroyAll": "Remove all Ships",
         "showOnPublicHangar": "Make Public",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -138,6 +138,7 @@
       "hangar": {
         "editGroups": "Add or remove Groups",
         "editName": "Name your Ship",
+        "manageLoadouts": "Manage Loadouts",
         "useName": "Use Name",
         "destroyAll": "Remove all Ships",
         "showOnPublicHangar": "Make Public",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -151,6 +151,7 @@
       "editGroups": "Edit Groups",
       "newVehicles": "Add Ships",
       "myVehicleAddons": "Add Modules / Upgrades for %{vehicle}",
+      "myVehicleLoadouts": "Loadouts for %{vehicle}",
       "addToHangar": "Add \"%{model}\" to your Hangar",
       "impressum": "Impressum",
       "privacy": "Privacy policy",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -388,7 +388,8 @@
       },
       "source": "Source",
       "loadout": {
-        "namePlaceholder": "New loadout name...",
+        "namePlaceholder": "Loadout name...",
+        "urlPlaceholder": "Paste erkul.games or spviewer.eu loadout URL...",
         "empty": "No loadouts yet. Create one to get started.",
         "active": "Active",
         "activate": "Set Active",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -393,8 +393,6 @@
         "empty": "No loadouts yet. Create one to get started.",
         "active": "Active",
         "activate": "Set Active",
-        "erkulUrl": "Erkul loadout URL",
-        "spviewerUrl": "SPViewer URL",
         "planOn": "Plan your loadout on"
       },
       "model": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -393,7 +393,8 @@
         "active": "Active",
         "activate": "Set Active",
         "erkulUrl": "Erkul loadout URL",
-        "spviewerUrl": "SPViewer URL"
+        "spviewerUrl": "SPViewer URL",
+        "planOn": "Plan your loadout on"
       },
       "model": {
         "hidden": "Hidden?",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -387,6 +387,14 @@
         "public": "Show on Public Hangar?"
       },
       "source": "Source",
+      "loadout": {
+        "namePlaceholder": "New loadout name...",
+        "empty": "No loadouts yet. Create one to get started.",
+        "active": "Active",
+        "activate": "Set Active",
+        "erkulUrl": "Erkul loadout URL",
+        "spviewerUrl": "SPViewer URL"
+      },
       "model": {
         "hidden": "Hidden?",
         "active": "Active?",
@@ -619,6 +627,26 @@
             "FlexThruster": "Flex",
             "Retro": "Fix"
           }
+        },
+        "weapons": {
+          "dps": "DPS",
+          "fireRate": "Fire Rate",
+          "speed": "Speed",
+          "range": "Range"
+        },
+        "shields": {
+          "hp": "HP",
+          "regen": "Regen"
+        },
+        "coolers": {
+          "coolingRate": "Cooling Rate"
+        },
+        "powerPlants": {
+          "output": "Output"
+        },
+        "quantumDrives": {
+          "speed": "Speed",
+          "range": "Range"
         },
         "sources": {
           "game_files": "Game Files",

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "Manufacturers",
       "images": "Images",
       "videos": "Videos",
-      "hangar": "My Hangar",
+      "hangar": {
+        "index": "My Hangar",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "Login",
       "logout": "Logout",
       "apiV1": "API v1",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -35,7 +35,8 @@
         "public": "%{user} Hangar",
         "publicStats": "%{user} Hangar Stats",
         "wishlist": "Wishlist",
-        "publicWishlist": "%{user} Wishlist"
+        "publicWishlist": "%{user} Wishlist",
+        "vehicleLoadouts": "Vehicle Loadouts"
       },
       "requestPassword": "Request Password",
       "changePassword": "Change Password",

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "Fabricantes",
       "images": "Imágenes",
       "videos": "Vídeos",
-      "hangar": "Mi Hangar",
+      "hangar": {
+        "index": "Mi Hangar",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "Iniciar sesión",
       "logout": "Cerrar sesión",
       "apiV1": "API v1",

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "Fabricants",
       "images": "Images",
       "videos": "Vidéos",
-      "hangar": "Mon Hangar",
+      "hangar": {
+        "index": "Mon Hangar",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "Connexion",
       "logout": "Déconnexion",
       "apiV1": "API v1",

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "Produttori",
       "images": "Immagini",
       "videos": "Video",
-      "hangar": "Il Mio Hangar",
+      "hangar": {
+        "index": "Il Mio Hangar",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "Accedi",
       "logout": "Esci",
       "apiV1": "API v1",

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "制造商",
       "images": "图片",
       "videos": "视频",
-      "hangar": "我的机库",
+      "hangar": {
+        "index": "我的机库",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "登录",
       "logout": "登出",
       "apiV1": "API v1",

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -14,7 +14,10 @@
       "manufacturers": "製造商",
       "images": "圖片",
       "videos": "影片",
-      "hangar": "我的機庫",
+      "hangar": {
+        "index": "我的機庫",
+        "vehicleLoadouts": "Loadouts"
+      },
       "login": "登入",
       "logout": "登出",
       "apiV1": "API v1",

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -369,25 +369,60 @@ module ScData
           }
         end
 
-        # if values.dig("Components", "SCItemToolArmParams")
-        #   item[:type_data] = values.dig("Components", "SCItemToolArmParams")
-        # end
+        if values.dig("Components", "SCItemWeaponComponentParams")
+          weapon_data = values.dig("Components", "SCItemWeaponComponentParams")
+          fire_actions = weapon_data.dig("fireActions", "SWeaponActionFireSingleParams") ||
+            weapon_data.dig("fireActions", "SWeaponActionSequenceParams")
+          fire_actions = fire_actions.is_a?(Array) ? fire_actions.first : fire_actions
 
-        # if values.dig("Components", "SCItemMissileRackParams")
-        #   item[:type_data] = values.dig("Components", "SCItemMissileRackParams")
-        # end
+          item[:type_data] = {
+            weapon_class: weapon_data["weaponClass"],
+            fire_rate: fire_actions&.dig("fireRate")&.to_f,
+            heat_per_shot: fire_actions&.dig("heatPerShot")&.to_f,
+            damage_per_shot: extract_weapon_damage(fire_actions),
+            pellets_per_shot: fire_actions&.dig("launchParams", "SProjectileLauncher", "pelletCount")&.to_i,
+            speed: fire_actions&.dig("launchParams", "SProjectileLauncher", "speed")&.to_f,
+            range: fire_actions&.dig("launchParams", "SProjectileLauncher", "lifetime")&.to_f,
+            ammo_cost: fire_actions&.dig("launchParams", "SProjectileLauncher", "ammoCost")&.to_i
+          }.compact
+        end
 
-        # if values.dig("Components", "SCItemWeaponComponentParams")
-        #   item[:type_data] = values.dig("Components", "SCItemWeaponComponentParams")
-        # end
+        if values.dig("Components", "SCItemMissileParams")
+          missile_data = values.dig("Components", "SCItemMissileParams")
+          item[:type_data] = {
+            damage: missile_data.dig("explosionParams", "damage")&.to_f,
+            radius: missile_data.dig("explosionParams", "radius")&.to_f,
+            lock_time: missile_data.dig("targetingParams", "lockTime")&.to_f,
+            lock_range: missile_data.dig("targetingParams", "lockRange")&.to_f,
+            tracking_signal: missile_data.dig("targetingParams", "trackingSignalType"),
+            speed: missile_data.dig("GCSParams", "linearSpeed")&.to_f
+          }.compact
+        end
 
-        # if values.dig("Components", "SCItemVehicleArmorParams")
-        #   item[:type_data] = values.dig("Components", "SCItemVehicleArmorParams")
-        # end
+        if values.dig("Components", "SCItemVehicleArmorParams")
+          armor_data = values.dig("Components", "SCItemVehicleArmorParams")
+          item[:type_data] = {
+            damage_physical: armor_data.dig("damageMultiplier", "DamageInfo", "DamagePhysical")&.to_f,
+            damage_energy: armor_data.dig("damageMultiplier", "DamageInfo", "DamageEnergy")&.to_f,
+            damage_distortion: armor_data.dig("damageMultiplier", "DamageInfo", "DamageDistortion")&.to_f,
+            damage_thermal: armor_data.dig("damageMultiplier", "DamageInfo", "DamageThermal")&.to_f,
+            damage_biochemical: armor_data.dig("damageMultiplier", "DamageInfo", "DamageBiochemical")&.to_f,
+            damage_stun: armor_data.dig("damageMultiplier", "DamageInfo", "DamageStun")&.to_f,
+            signal_infrared: armor_data.dig("signalCrossSection", "SItemSignalEmission", "Infrared")&.to_f,
+            signal_electromagnetic: armor_data.dig("signalCrossSection", "SItemSignalEmission", "Electromagnetic")&.to_f,
+            signal_cross_section: armor_data.dig("signalCrossSection", "SItemSignalEmission", "CrossSection")&.to_f
+          }.compact
+        end
 
-        # if values.dig("Components", "SCItemTurretParams")
-        #   item[:type_data] = values.dig("Components", "SCItemTurretParams")
-        # end
+        if values.dig("Components", "SCItemTurretParams")
+          turret_data = values.dig("Components", "SCItemTurretParams")
+          item[:type_data] = {
+            min_yaw: turret_data.dig("movementParams", "SItemTurretMovementParams", "yawLimits", "min")&.to_f,
+            max_yaw: turret_data.dig("movementParams", "SItemTurretMovementParams", "yawLimits", "max")&.to_f,
+            min_pitch: turret_data.dig("movementParams", "SItemTurretMovementParams", "pitchLimits", "min")&.to_f,
+            max_pitch: turret_data.dig("movementParams", "SItemTurretMovementParams", "pitchLimits", "max")&.to_f
+          }.compact
+        end
 
         item
       end
@@ -467,6 +502,29 @@ module ScData
             "itemPortName" => item.dig("portName"),
             "entityClassName" => item.dig("itemName")
           }
+        end
+      end
+
+      private def extract_weapon_damage(fire_actions)
+        return if fire_actions.blank?
+
+        ammo_ref = fire_actions.dig("launchParams", "SProjectileLauncher", "ammoRef")
+        return if ammo_ref.blank?
+
+        ammo_data = load_scripts_data(ammo_ref) if ammo_ref.is_a?(String) && ammo_ref.end_with?(".xml")
+
+        if ammo_data.present?
+          damage_info = ammo_data.dig(:values, "Components", "SCItemProjectileParams", "BulletImpactParams", "damage", "DamageInfo")
+          return if damage_info.blank?
+
+          {
+            physical: damage_info["DamagePhysical"]&.to_f,
+            energy: damage_info["DamageEnergy"]&.to_f,
+            distortion: damage_info["DamageDistortion"]&.to_f,
+            thermal: damage_info["DamageThermal"]&.to_f,
+            biochemical: damage_info["DamageBiochemical"]&.to_f,
+            stun: damage_info["DamageStun"]&.to_f
+          }.compact.presence
         end
       end
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -61,6 +61,8 @@ class Vehicle < ApplicationRecord
 
   has_many :fleet_vehicles, dependent: :destroy
 
+  has_many :vehicle_loadouts, dependent: :destroy
+
   has_many :vehicle_modules, dependent: :destroy
   has_many :model_modules, through: :vehicle_modules
 

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -4,14 +4,13 @@
 #
 # Table name: vehicle_loadouts
 #
-#  id           :uuid             not null, primary key
-#  active       :boolean          default(FALSE), not null
-#  erkul_url    :string
-#  name         :string           not null
-#  spviewer_url :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  vehicle_id   :uuid             not null
+#  id         :uuid             not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  name       :string           not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  vehicle_id :uuid             not null
 #
 # Indexes
 #
@@ -29,9 +28,6 @@ class VehicleLoadout < ApplicationRecord
 
   accepts_nested_attributes_for :vehicle_loadout_hardpoints, allow_destroy: true
 
-  attribute :url, :string
-
-  before_validation :detect_url_source, if: -> { url.present? }
   before_validation :set_default_name, if: -> { name.blank? }
 
   validates :name, presence: true, uniqueness: {scope: :vehicle_id}
@@ -53,30 +49,28 @@ class VehicleLoadout < ApplicationRecord
     end
   end
 
-  private def detect_url_source
-    uri = begin
-      URI.parse(url)
+  def url_source
+    return if url.blank?
+
+    host = begin
+      URI.parse(url).host&.downcase&.delete_prefix("www.")
     rescue
       nil
     end
-    return if uri.blank? || uri.host.blank?
-
-    host = uri.host.downcase.delete_prefix("www.")
+    return if host.blank?
 
     if host.include?("erkul.games")
-      self.erkul_url = url
+      "erkul"
     elsif host.include?("spviewer.eu")
-      self.spviewer_url = url
+      "spviewer"
     end
   end
 
   private def set_default_name
-    base = if erkul_url.present?
-      "Erkul Loadout"
-    elsif spviewer_url.present?
-      "SPViewer Loadout"
-    else
-      "Custom Loadout"
+    base = case url_source
+    when "erkul" then "Erkul Loadout"
+    when "spviewer" then "SPViewer Loadout"
+    else "Custom Loadout"
     end
 
     existing = vehicle.vehicle_loadouts.where("name LIKE ?", "#{base}%").pluck(:name)

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -29,6 +29,11 @@ class VehicleLoadout < ApplicationRecord
 
   accepts_nested_attributes_for :vehicle_loadout_hardpoints, allow_destroy: true
 
+  attribute :url, :string
+
+  before_validation :detect_url_source, if: -> { url.present? }
+  before_validation :set_default_name, if: -> { name.blank? }
+
   validates :name, presence: true, uniqueness: {scope: :vehicle_id}
 
   scope :active, -> { where(active: true) }
@@ -45,6 +50,33 @@ class VehicleLoadout < ApplicationRecord
     transaction do
       vehicle.vehicle_loadouts.where.not(id: id).update_all(active: false)
       update!(active: true)
+    end
+  end
+
+  private def detect_url_source
+    uri = begin
+      URI.parse(url)
+    rescue
+      nil
+    end
+    return if uri.blank? || uri.host.blank?
+
+    host = uri.host.downcase.delete_prefix("www.")
+
+    if host.include?("erkul.games")
+      self.erkul_url = url
+    elsif host.include?("spviewer.eu")
+      self.spviewer_url = url
+    end
+  end
+
+  private def set_default_name
+    self.name = if erkul_url.present?
+      "Erkul Loadout"
+    elsif spviewer_url.present?
+      "SPViewer Loadout"
+    else
+      "Loadout #{vehicle.vehicle_loadouts.count + 1}"
     end
   end
 end

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -71,12 +71,22 @@ class VehicleLoadout < ApplicationRecord
   end
 
   private def set_default_name
-    self.name = if erkul_url.present?
+    base = if erkul_url.present?
       "Erkul Loadout"
     elsif spviewer_url.present?
       "SPViewer Loadout"
     else
-      "Loadout #{vehicle.vehicle_loadouts.count + 1}"
+      "Loadout"
+    end
+
+    existing = vehicle.vehicle_loadouts.where("name LIKE ?", "#{base}%").pluck(:name)
+
+    self.name = if existing.exclude?(base)
+      base
+    else
+      counter = 2
+      counter += 1 while existing.include?("#{base} #{counter}")
+      "#{base} #{counter}"
     end
   end
 end

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -30,7 +30,8 @@ class VehicleLoadout < ApplicationRecord
 
   before_validation :set_default_name, if: -> { name.blank? }
 
-  validates :name, presence: true, uniqueness: {scope: :vehicle_id}
+  validates :url, presence: true
+  validates :name, uniqueness: {scope: :vehicle_id}, allow_nil: true
 
   scope :active, -> { where(active: true) }
 

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -76,7 +76,7 @@ class VehicleLoadout < ApplicationRecord
     elsif spviewer_url.present?
       "SPViewer Loadout"
     else
-      "Loadout"
+      "Custom Loadout"
     end
 
     existing = vehicle.vehicle_loadouts.where("name LIKE ?", "#{base}%").pluck(:name)

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicle_loadouts
+#
+#  id           :uuid             not null, primary key
+#  active       :boolean          default(FALSE), not null
+#  erkul_url    :string
+#  name         :string           not null
+#  spviewer_url :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  vehicle_id   :uuid             not null
+#
+# Indexes
+#
+#  index_vehicle_loadouts_on_vehicle_id           (vehicle_id)
+#  index_vehicle_loadouts_on_vehicle_id_and_name  (vehicle_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vehicle_id => vehicles.id)
+#
+class VehicleLoadout < ApplicationRecord
+  belongs_to :vehicle
+
+  has_many :vehicle_loadout_hardpoints, dependent: :destroy
+
+  accepts_nested_attributes_for :vehicle_loadout_hardpoints, allow_destroy: true
+
+  validates :name, presence: true, uniqueness: {scope: :vehicle_id}
+
+  scope :active, -> { where(active: true) }
+
+  def create_from_defaults!
+    vehicle.model.model_hardpoints.each do |mh|
+      vehicle_loadout_hardpoints.find_or_create_by!(model_hardpoint_id: mh.id) do |vlh|
+        vlh.component_id = mh.component_id
+      end
+    end
+  end
+
+  def activate!
+    transaction do
+      vehicle.vehicle_loadouts.where.not(id: id).update_all(active: false)
+      update!(active: true)
+    end
+  end
+end

--- a/app/models/vehicle_loadout_hardpoint.rb
+++ b/app/models/vehicle_loadout_hardpoint.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicle_loadout_hardpoints
+#
+#  id                 :uuid             not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  component_id       :uuid
+#  model_hardpoint_id :uuid             not null
+#  vehicle_loadout_id :uuid             not null
+#
+# Indexes
+#
+#  idx_vehicle_loadout_hardpoints_unique                   (vehicle_loadout_id,model_hardpoint_id) UNIQUE
+#  index_vehicle_loadout_hardpoints_on_vehicle_loadout_id  (vehicle_loadout_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (component_id => components.id)
+#  fk_rails_...  (model_hardpoint_id => model_hardpoints.id)
+#  fk_rails_...  (vehicle_loadout_id => vehicle_loadouts.id)
+#
+class VehicleLoadoutHardpoint < ApplicationRecord
+  belongs_to :vehicle_loadout
+  belongs_to :model_hardpoint
+  belongs_to :component, optional: true
+
+  validates :model_hardpoint_id, uniqueness: {scope: :vehicle_loadout_id}
+end

--- a/app/policies/vehicle_loadout_policy.rb
+++ b/app/policies/vehicle_loadout_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class VehicleLoadoutPolicy < ApplicationPolicy
+  alias_rule :index?, :create?, to: :access?
+
+  def access?
+    user.present?
+  end
+
+  def manage?
+    user&.id == record.vehicle.user_id
+  end
+
+  default_rule :manage?
+
+  relation_scope do |relation|
+    relation.joins(:vehicle).where(vehicles: {user_id: user.id})
+  end
+end

--- a/app/views/api/v1/public/vehicles/_base.jbuilder
+++ b/app/views/api/v1/public/vehicles/_base.jbuilder
@@ -42,8 +42,7 @@ json.active_loadout do
   if active_loadout.present?
     json.id active_loadout.id
     json.name active_loadout.name
-    json.erkul_url active_loadout.erkul_url
-    json.spviewer_url active_loadout.spviewer_url
+    json.url active_loadout.url
   end
 end
 json.active_loadout nil if active_loadout.blank?

--- a/app/views/api/v1/public/vehicles/_base.jbuilder
+++ b/app/views/api/v1/public/vehicles/_base.jbuilder
@@ -37,4 +37,15 @@ if vehicle.module_package.present?
     json.partial! "api/v1/model_module_packages/base", module_package: vehicle.module_package if vehicle.module_package.present?
   end
 end
+active_loadout = vehicle.vehicle_loadouts.active.first
+json.active_loadout do
+  if active_loadout.present?
+    json.id active_loadout.id
+    json.name active_loadout.name
+    json.erkul_url active_loadout.erkul_url
+    json.spviewer_url active_loadout.spviewer_url
+  end
+end
+json.active_loadout nil if active_loadout.blank?
+
 json.partial! "api/shared/dates", record: vehicle

--- a/app/views/api/v1/vehicle_loadouts/_base.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/_base.jbuilder
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+json.id vehicle_loadout.id
+json.name vehicle_loadout.name
+json.active vehicle_loadout.active
+json.erkul_url vehicle_loadout.erkul_url
+json.spviewer_url vehicle_loadout.spviewer_url
+
+json.hardpoints do
+  json.array! vehicle_loadout.vehicle_loadout_hardpoints do |vlh|
+    json.id vlh.id
+    json.model_hardpoint_id vlh.model_hardpoint_id
+
+    json.hardpoint do
+      json.partial! "api/v1/model_hardpoints/base", hardpoint: vlh.model_hardpoint
+    end
+
+    json.component do
+      json.partial! "api/v1/components/base", component: vlh.component if vlh.component.present?
+    end
+    json.component nil if vlh.component.blank?
+  end
+end
+
+json.partial! "api/shared/dates", record: vehicle_loadout

--- a/app/views/api/v1/vehicle_loadouts/_base.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/_base.jbuilder
@@ -3,8 +3,8 @@
 json.id vehicle_loadout.id
 json.name vehicle_loadout.name
 json.active vehicle_loadout.active
-json.erkul_url vehicle_loadout.erkul_url
-json.spviewer_url vehicle_loadout.spviewer_url
+json.url vehicle_loadout.url
+json.url_source vehicle_loadout.url_source
 
 json.hardpoints do
   json.array! vehicle_loadout.vehicle_loadout_hardpoints do |vlh|

--- a/app/views/api/v1/vehicle_loadouts/_vehicle_loadout.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/_vehicle_loadout.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", vehicle_loadout] do
+  json.partial!("api/v1/vehicle_loadouts/base", vehicle_loadout:)
+end

--- a/app/views/api/v1/vehicle_loadouts/activate.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/activate.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!("api/v1/vehicle_loadouts/vehicle_loadout", vehicle_loadout: @vehicle_loadout)

--- a/app/views/api/v1/vehicle_loadouts/create.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/create.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!("api/v1/vehicle_loadouts/vehicle_loadout", vehicle_loadout: @vehicle_loadout)

--- a/app/views/api/v1/vehicle_loadouts/destroy.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/destroy.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!("api/v1/vehicle_loadouts/vehicle_loadout", vehicle_loadout: @vehicle_loadout)

--- a/app/views/api/v1/vehicle_loadouts/index.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/index.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @vehicle_loadouts, partial: "api/v1/vehicle_loadouts/vehicle_loadout", as: :vehicle_loadout

--- a/app/views/api/v1/vehicle_loadouts/show.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!("api/v1/vehicle_loadouts/vehicle_loadout", vehicle_loadout: @vehicle_loadout)

--- a/app/views/api/v1/vehicle_loadouts/update.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/update.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!("api/v1/vehicle_loadouts/vehicle_loadout", vehicle_loadout: @vehicle_loadout)

--- a/app/views/api/v1/vehicles/_base.jbuilder
+++ b/app/views/api/v1/vehicles/_base.jbuilder
@@ -46,8 +46,7 @@ json.active_loadout do
   if active_loadout.present?
     json.id active_loadout.id
     json.name active_loadout.name
-    json.erkul_url active_loadout.erkul_url
-    json.spviewer_url active_loadout.spviewer_url
+    json.url active_loadout.url
   end
 end
 json.active_loadout nil if active_loadout.blank?

--- a/app/views/api/v1/vehicles/_base.jbuilder
+++ b/app/views/api/v1/vehicles/_base.jbuilder
@@ -41,4 +41,15 @@ json.module_package do
 end
 json.module_package nil if vehicle.module_package.blank?
 
+active_loadout = vehicle.vehicle_loadouts.active.first
+json.active_loadout do
+  if active_loadout.present?
+    json.id active_loadout.id
+    json.name active_loadout.name
+    json.erkul_url active_loadout.erkul_url
+    json.spviewer_url active_loadout.spviewer_url
+  end
+end
+json.active_loadout nil if active_loadout.blank?
+
 json.partial! "api/shared/dates", record: vehicle

--- a/app/views/api/v1/vehicles/_base.jbuilder
+++ b/app/views/api/v1/vehicles/_base.jbuilder
@@ -47,6 +47,7 @@ json.active_loadout do
     json.id active_loadout.id
     json.name active_loadout.name
     json.url active_loadout.url
+    json.url_source active_loadout.url_source
   end
 end
 json.active_loadout nil if active_loadout.blank?

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -7,6 +7,10 @@ de:
       create: Schiff konnte nicht hinzugefügt werden.
       destroy: Schiff konnte nicht entfernt werden.
       update: Schiff konnte nicht aktualisiert werden.
+    vehicle_loadout:
+      create: Loadout konnte nicht erstellt werden.
+      destroy: Loadout konnte nicht entfernt werden.
+      update: Loadout konnte nicht aktualisiert werden.
     fleet:
       create: Flotte konnte nicht erstellt werden.
       destroy: Flotte konnte nicht gelöscht werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -7,6 +7,10 @@ en:
       create: Ship could not be added.
       destroy: Ship could not be removed.
       update: Ship could not be updated.
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: Fleet could not be created.
       destroy: Fleet could not be destroyed.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -7,6 +7,10 @@ es:
       create: La nave no pudo ser agregada.
       destroy: La nave no pudo ser eliminada.
       update: La nave no pudo ser actualizada.
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: No se pudo crear la flota.
       destroy: No se pudo destruir la flota.

--- a/config/locales/fr/validation_error.yml
+++ b/config/locales/fr/validation_error.yml
@@ -7,6 +7,10 @@ fr:
       create: Le vaisseau n'a pas pu être ajouté.
       destroy: Le vaisseau n'a pas pu être retiré.
       update: Le vaisseau n'a pas pu être mis à jour.
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: La flotte n’a pas pu être créée.
       destroy: La flotte n’a pas pu être détruite.

--- a/config/locales/it/validation_error.yml
+++ b/config/locales/it/validation_error.yml
@@ -7,6 +7,10 @@ it:
       create: La nave non è stata aggiunta.
       destroy: La nave non è stata rimossa.
       update: La nave non è stata aggiornata.
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: Impossibile creare la flotta.
       destroy: Impossibile eliminare la flotta.

--- a/config/locales/zh-CN/validation_error.yml
+++ b/config/locales/zh-CN/validation_error.yml
@@ -7,6 +7,10 @@ zh-CN:
       create: 飞船无法添加。
       destroy: 飞船无法移除。
       update: 飞船无法更新。
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: 无法创建舰队。
       destroy: 无法删除舰队。

--- a/config/locales/zh-TW/validation_error.yml
+++ b/config/locales/zh-TW/validation_error.yml
@@ -7,6 +7,10 @@ zh-TW:
       create: 飛船無法新增。
       destroy: 飛船無法移除。
       update: 飛船無法更新。
+    vehicle_loadout:
+      create: Loadout could not be created.
+      destroy: Loadout could not be removed.
+      update: Loadout could not be updated.
     fleet:
       create: 無法建立艦隊。
       destroy: 無法刪除艦隊。

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -41,6 +41,7 @@ v1_api_routes = lambda do
   draw "api/models_routes"
   draw "api/hangar_routes"
   draw "api/vehicles_routes"
+  draw "api/vehicle_loadouts_routes"
   draw "api/fleets_routes"
   draw "api/components_routes"
   draw "api/notifications_routes"

--- a/config/routes/api/vehicle_loadouts_routes.rb
+++ b/config/routes/api/vehicle_loadouts_routes.rb
@@ -1,0 +1,7 @@
+resources :vehicles, only: [] do
+  resources :loadouts, controller: "vehicle_loadouts", only: %i[index show create update destroy] do
+    member do
+      put :activate
+    end
+  end
+end

--- a/config/routes/api/vehicles_routes.rb
+++ b/config/routes/api/vehicles_routes.rb
@@ -1,4 +1,4 @@
-resources :vehicles, only: %i[create update destroy] do
+resources :vehicles, only: %i[show create update destroy] do
   collection do
     post "bulk", to: "vehicles#create_bulk"
     put "bulk", to: "vehicles#update_bulk"

--- a/db/migrate/20260426093200_create_vehicle_loadouts.rb
+++ b/db/migrate/20260426093200_create_vehicle_loadouts.rb
@@ -1,0 +1,26 @@
+class CreateVehicleLoadouts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :vehicle_loadouts, id: :uuid do |t|
+      t.references :vehicle, type: :uuid, null: false, foreign_key: true, index: false
+      t.string :name, null: false
+      t.boolean :active, default: false, null: false
+      t.string :erkul_url
+      t.string :spviewer_url
+      t.timestamps
+    end
+
+    add_index :vehicle_loadouts, :vehicle_id
+    add_index :vehicle_loadouts, [:vehicle_id, :name], unique: true
+
+    create_table :vehicle_loadout_hardpoints, id: :uuid do |t|
+      t.references :vehicle_loadout, type: :uuid, null: false, foreign_key: true, index: false
+      t.references :model_hardpoint, type: :uuid, null: false, foreign_key: true, index: false
+      t.references :component, type: :uuid, foreign_key: true, index: false
+      t.timestamps
+    end
+
+    add_index :vehicle_loadout_hardpoints, :vehicle_loadout_id
+    add_index :vehicle_loadout_hardpoints, [:vehicle_loadout_id, :model_hardpoint_id],
+      unique: true, name: :idx_vehicle_loadout_hardpoints_unique
+  end
+end

--- a/db/migrate/20260426195601_replace_loadout_urls_with_single_url.rb
+++ b/db/migrate/20260426195601_replace_loadout_urls_with_single_url.rb
@@ -1,0 +1,33 @@
+class ReplaceLoadoutUrlsWithSingleUrl < ActiveRecord::Migration[7.2]
+  def up
+    add_column :vehicle_loadouts, :url, :string
+
+    execute <<~SQL
+      UPDATE vehicle_loadouts
+      SET url = COALESCE(erkul_url, spviewer_url)
+      WHERE erkul_url IS NOT NULL OR spviewer_url IS NOT NULL
+    SQL
+
+    remove_column :vehicle_loadouts, :erkul_url
+    remove_column :vehicle_loadouts, :spviewer_url
+  end
+
+  def down
+    add_column :vehicle_loadouts, :erkul_url, :string
+    add_column :vehicle_loadouts, :spviewer_url, :string
+
+    execute <<~SQL
+      UPDATE vehicle_loadouts
+      SET erkul_url = url
+      WHERE url LIKE '%erkul%'
+    SQL
+
+    execute <<~SQL
+      UPDATE vehicle_loadouts
+      SET spviewer_url = url
+      WHERE url LIKE '%spviewer%'
+    SQL
+
+    remove_column :vehicle_loadouts, :url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_195601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -939,10 +939,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_120000) do
   create_table "vehicle_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
-    t.string "erkul_url"
     t.string "name", null: false
-    t.string "spviewer_url"
     t.datetime "updated_at", null: false
+    t.string "url"
     t.uuid "vehicle_id", null: false
     t.index ["vehicle_id", "name"], name: "index_vehicle_loadouts_on_vehicle_id_and_name", unique: true
     t.index ["vehicle_id"], name: "index_vehicle_loadouts_on_vehicle_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -926,6 +926,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_120000) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  create_table "vehicle_loadout_hardpoints", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "component_id"
+    t.datetime "created_at", null: false
+    t.uuid "model_hardpoint_id", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "vehicle_loadout_id", null: false
+    t.index ["vehicle_loadout_id", "model_hardpoint_id"], name: "idx_vehicle_loadout_hardpoints_unique", unique: true
+    t.index ["vehicle_loadout_id"], name: "index_vehicle_loadout_hardpoints_on_vehicle_loadout_id"
+  end
+
+  create_table "vehicle_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "erkul_url"
+    t.string "name", null: false
+    t.string "spviewer_url"
+    t.datetime "updated_at", null: false
+    t.uuid "vehicle_id", null: false
+    t.index ["vehicle_id", "name"], name: "index_vehicle_loadouts_on_vehicle_id_and_name", unique: true
+    t.index ["vehicle_id"], name: "index_vehicle_loadouts_on_vehicle_id"
+  end
+
   create_table "vehicle_modules", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.uuid "model_module_id"
@@ -1020,4 +1042,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_120000) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "omniauth_connections", "users"
+  add_foreign_key "vehicle_loadout_hardpoints", "components"
+  add_foreign_key "vehicle_loadout_hardpoints", "model_hardpoints"
+  add_foreign_key "vehicle_loadout_hardpoints", "vehicle_loadouts"
+  add_foreign_key "vehicle_loadouts", "vehicles"
 end

--- a/docs/exec-plans/vehicle-loadouts-phase3b-research.md
+++ b/docs/exec-plans/vehicle-loadouts-phase3b-research.md
@@ -1,0 +1,119 @@
+# Phase 3b Research: Erkul/SPViewer/SC-Open Integration
+
+## Date: 2026-04-26
+
+## Summary
+
+No standard loadout interchange format exists in the SC community. Integration with erkul and spviewer is limited to link storage (already implemented). Deep-link generation from our data is not feasible without reverse-engineering proprietary formats.
+
+## Erkul.games
+
+### URL Format
+- Loadout URLs use the pattern: `erkul.games/loadout/<code>` (e.g., `3UDSChtK`, `djhXZ5Hc`)
+- These are **server-side saved loadout IDs**, not client-side encoded configurations
+- When users customize a loadout, erkul saves it server-side and generates a short code
+- There is no way to construct an erkul URL from component selections without using their backend
+
+### API / Integration
+- **No public API** — erkul.games is closed-source
+- **No documented import/export format**
+- GitHub (`github.com/DavidErkul`): only a HangarXPLOR fork, no erkul source code
+- The Hangar Transfer Format spec lists erkul as **"Reserved for future use"** — meaning even the SC-Open community hasn't established integration yet
+
+### Conclusion
+**Cannot generate erkul URLs from our data.** Users must create loadouts on erkul manually and paste the URL into FleetYards (already supported via `erkul_url` field on VehicleLoadout).
+
+## SPViewer.eu
+
+### HangarSync Extension
+- Firefox/Chrome extension for saving/restoring SC vehicle loadouts
+- **Local-only storage** — all data stays on the user's device, no server connection
+- MIT licensed, source on GitHub, but no documented data format
+- Only 16.4 KB — very lightweight, likely just localStorage backup/restore
+
+### Integration
+- No public API
+- No documented data exchange format
+- No way to generate spviewer URLs from external data
+
+### Conclusion
+**Cannot generate spviewer URLs from our data.** Same as erkul — users paste their URL manually (already supported via `spviewer_url` field).
+
+## SC-Open.dev / Hangar Transfer Format
+
+### What It Is
+- OpenAPI 3.0.1 spec at `docs.starcitizen.fans/hangar-transfer-format.yaml`
+- Defines a standard for transferring **hangar ownership data** (pledges, ships) between community tools
+- Supported tools: StarShip42, HangarXPLOR, starcitizen.fans
+
+### What It Covers
+- **Ship ownership**: ship codes, names, manufacturer codes, pledge IDs, dates, costs
+- **Pledge data**: LTI status, warbond, package vs standalone
+- **NOT loadout/component configurations** — no concept of hardpoint selections, equipped components, or weapon stats
+
+### Schemas Defined
+- `core.entity.json` — `{ name, entity_type: "ship"|"component"|"decoration" }`
+- `rsi.ship.json` — `{ ship_code, ship_name, manufacturer_code }`
+- `hangarxplor.ship.json` — extends with `lti`, `warbond` booleans
+- `starship42.ship.json` — minimal, just `name`
+- `erkul.ship.json` — extends core entity with `localName` (future use)
+
+### SC-Open GitHub Org
+- `github.com/SC-Open` — 22 repos
+- Includes `fleetyards.net` (our project!) and `fleetyards-sync`
+- `hangarlink-hangarexport` — Chrome extension for RSI pledge/buyback scraping (ownership only)
+- No loadout-specific repos or format definitions
+
+### Conclusion
+**The Hangar Transfer Format is for ship ownership, not loadouts.** There is no community standard for loadout data interchange. We could propose one, but adoption would require buy-in from erkul, spviewer, and HubCitizen.
+
+## HubCitizen
+
+### What It Offers
+- Ship loadout manager at `hubcitizen.com/ships`
+- Share codes: generates links/codes that others can use to view builds
+- Save slots for storing loadout configurations
+- **Most similar to our loadout feature** in terms of UX
+
+### Integration
+- No documented API or data format
+- Share codes are proprietary
+- No import/export in a standard format
+
+## Recommendations
+
+### What We Should Do Now
+1. **Keep the current approach** — erkul_url and spviewer_url fields for manual link pasting (already done)
+2. **Consider adding HubCitizen URL field** to VehicleLoadout as a third external link option
+3. **Display external links prominently** on loadout views to make it easy for users to jump between tools
+
+### What We Could Propose (Future)
+1. **Extend the Hangar Transfer Format** to include a loadout section — propose an RFC to the SC-Open community
+2. A loadout section could reference ships by `ship_code` and components by their SC game-data `sc_key` (which we already store)
+3. Example format:
+   ```json
+   {
+     "ship_code": "AEGS_Gladius",
+     "loadout_name": "PvE Setup",
+     "hardpoints": [
+       { "hardpoint_key": "hardpoint_weapon_gun_left", "component_key": "behr_laser_repeater_s3" },
+       { "hardpoint_key": "hardpoint_shield", "component_key": "shield_generator_s1_gurdian" }
+     ]
+   }
+   ```
+4. This would require coordination with erkul (DavidErkul), SPViewer maintainer, and HubCitizen — none of whom currently have open interchange formats
+
+### What We Should NOT Do
+- **Don't reverse-engineer erkul/spviewer URL formats** — they're proprietary, server-side, and would break on updates
+- **Don't build a "generate erkul link" feature** — not possible without their API
+- **Don't block on a community standard** — it doesn't exist yet and may not materialize
+
+## Sources
+- [Erkul.games](https://www.erkul.games/loadout)
+- [DavidErkul GitHub](https://github.com/DavidErkul)
+- [SC-Open GitHub](https://github.com/SC-Open)
+- [Hangar Transfer Format](https://docs.starcitizen.fans/)
+- [SPViewer HangarSync (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/spviewer-hangarsync/)
+- [SC-Open hangarlink-hangarexport](https://github.com/SC-Open/hangarlink-hangarexport)
+- [HubCitizen Ship Loadout Manager](https://hubcitizen.com/ships)
+- [FleetYards Issue #461](https://github.com/fleetyards/app/issues/461)

--- a/docs/exec-plans/vehicle-loadouts.md
+++ b/docs/exec-plans/vehicle-loadouts.md
@@ -1,0 +1,282 @@
+# Vehicle Loadout System
+
+## Context
+
+Fleetyards tracks ships and their hardpoints from Star Citizen game data, but weapon stats are not extracted (commented out since implementation) and there's no way for users to store custom loadout configurations on their vehicles. The mission builder needs loadout data to let organizers specify equipment requirements and members to show what they're bringing.
+
+This feature has three parts: enable missing component stats, add per-vehicle loadout storage, and integrate with erkul.games/spviewer.eu.
+
+Resolves #3792.
+
+## Current State
+
+### What Exists
+- **945 weapon components** in DB — but `type_data` is nil (parsing commented out at `items_parser.rb:380`)
+- **735 turret components** — `type_data` nil (commented out at line 388)
+- **0 missile components** — not being imported
+- **ModelHardpointLoadout** — stores alternative component options per hardpoint on a model template (admin-managed)
+- **Vehicle** model has `vehicle_modules` and `vehicle_upgrades` (RSI pledge modules) but no hardpoint-level loadout storage
+- **erkul_identifier** field on Model — used for deep-linking to `erkul.games/ship/{id}`
+- **Hardpoint** detail views link out to erkul and spviewer
+
+### What's Missing
+- Weapon/missile/turret/armor stats in `type_data`
+- Per-vehicle loadout storage (component selections per hardpoint)
+- Loadout management API and UI
+- Erkul/spviewer loadout URL storage
+- Component stat summaries (DPS, shield HP, etc.)
+
+## Phase 1 — Enable Weapon & Component Stats
+
+### Uncomment and Implement Stats Extraction
+
+In `app/lib/sc_data/parser/items_parser.rb`, uncomment and structure the following:
+
+**Weapons** (line 380):
+```ruby
+if values.dig("Components", "SCItemWeaponComponentParams")
+  weapon_data = values.dig("Components", "SCItemWeaponComponentParams")
+  fire_actions = weapon_data.dig("fireActions", "SWeaponActionFireSingleParams") ||
+                 weapon_data.dig("fireActions", "SWeaponActionSequenceParams")
+  fire_actions = fire_actions.is_a?(Array) ? fire_actions.first : fire_actions
+
+  item[:type_data] = {
+    weapon_class: weapon_data["weaponClass"],
+    fire_rate: fire_actions&.dig("fireRate")&.to_f,
+    heat_per_shot: fire_actions&.dig("heatPerShot")&.to_f,
+    damage_per_shot: extract_weapon_damage(fire_actions),
+    pellets_per_shot: fire_actions&.dig("launchParams", "SProjectileLauncher", "pelletCount")&.to_i,
+    speed: fire_actions&.dig("launchParams", "SProjectileLauncher", "speed")&.to_f,
+    range: fire_actions&.dig("launchParams", "SProjectileLauncher", "lifetime")&.to_f,
+    ammo_cost: fire_actions&.dig("launchParams", "SProjectileLauncher", "ammoCost")&.to_i
+  }.compact
+end
+```
+
+**Missiles** (line 376):
+```ruby
+if values.dig("Components", "SCItemMissileParams")
+  missile_data = values.dig("Components", "SCItemMissileParams")
+  item[:type_data] = {
+    damage: missile_data.dig("explosionParams", "damage")&.to_f,
+    radius: missile_data.dig("explosionParams", "radius")&.to_f,
+    lock_time: missile_data.dig("targetingParams", "lockTime")&.to_f,
+    lock_range: missile_data.dig("targetingParams", "lockRange")&.to_f,
+    tracking_signal: missile_data.dig("targetingParams", "trackingSignalType"),
+    speed: missile_data.dig("GCSParams", "linearSpeed")&.to_f
+  }.compact
+end
+```
+
+**Vehicle Armor** (line 384):
+```ruby
+if values.dig("Components", "SCItemVehicleArmorParams")
+  armor_data = values.dig("Components", "SCItemVehicleArmorParams")
+  item[:type_data] = {
+    damage_physical: armor_data.dig("damageMultiplier", "DamageInfo", "DamagePhysical")&.to_f,
+    damage_energy: armor_data.dig("damageMultiplier", "DamageInfo", "DamageEnergy")&.to_f,
+    damage_distortion: armor_data.dig("damageMultiplier", "DamageInfo", "DamageDistortion")&.to_f,
+    damage_thermal: armor_data.dig("damageMultiplier", "DamageInfo", "DamageThermal")&.to_f,
+    damage_biochemical: armor_data.dig("damageMultiplier", "DamageInfo", "DamageBiochemical")&.to_f,
+    damage_stun: armor_data.dig("damageMultiplier", "DamageInfo", "DamageStun")&.to_f,
+    signal_infrared: armor_data.dig("signalCrossSection", "SItemSignalEmission", "Infrared")&.to_f,
+    signal_electromagnetic: armor_data.dig("signalCrossSection", "SItemSignalEmission", "Electromagnetic")&.to_f,
+    signal_cross_section: armor_data.dig("signalCrossSection", "SItemSignalEmission", "CrossSection")&.to_f
+  }.compact
+end
+```
+
+**Note:** The exact JSON paths need verification against actual SC data files. The above is derived from the game data structure — first implementation should log the raw data and adjust paths.
+
+### MaintenanceTask
+
+`Maintenance::ReimportComponentStatsTask` — re-runs the items import to populate weapon/missile/armor type_data for existing components.
+
+### Verification
+- `Component.where(category: 'weapons').where.not(type_data: nil).count` should equal `Component.where(category: 'weapons').count` (or close)
+- Spot-check: CF-227 Badger should have fire_rate, damage_per_shot, speed values
+
+## Phase 2 — Vehicle Loadout Storage
+
+### Data Model
+
+```
+vehicle_loadouts
+  id              :uuid PK
+  vehicle_id      :uuid FK → vehicles, NOT NULL
+  name            :string NOT NULL ("PvE Setup", "Mining Escort")
+  active          :boolean default: false
+  erkul_url       :string (erkul.games share URL, nullable)
+  spviewer_url    :string (spviewer share URL, nullable)
+  timestamps
+
+  Indexes: (vehicle_id), (vehicle_id, name) unique
+
+vehicle_loadout_hardpoints
+  id                  :uuid PK
+  vehicle_loadout_id  :uuid FK → vehicle_loadouts, NOT NULL
+  model_hardpoint_id  :uuid FK → model_hardpoints, NOT NULL
+  component_id        :uuid FK → components (nullable — empty slot)
+  timestamps
+
+  Indexes: (vehicle_loadout_id), (vehicle_loadout_id, model_hardpoint_id) unique
+```
+
+### Models
+
+**VehicleLoadout**
+- `belongs_to :vehicle`
+- `has_many :vehicle_loadout_hardpoints, dependent: :destroy`
+- `accepts_nested_attributes_for :vehicle_loadout_hardpoints`
+- `validates :name, presence: true, uniqueness: { scope: :vehicle_id }`
+- Scope: `active` — `where(active: true)`
+
+**VehicleLoadoutHardpoint**
+- `belongs_to :vehicle_loadout`
+- `belongs_to :model_hardpoint`
+- `belongs_to :component, optional: true`
+- `validates :model_hardpoint_id, uniqueness: { scope: :vehicle_loadout_id }`
+
+### "Create from Default" Flow
+
+When a user creates a loadout, pre-populate with the model's default components:
+```ruby
+def create_from_defaults!
+  vehicle.model.model_hardpoints.each do |mh|
+    vehicle_loadout_hardpoints.find_or_create_by!(model_hardpoint_id: mh.id) do |vlh|
+      vlh.component_id = mh.component_id
+    end
+  end
+end
+```
+
+### API
+
+- `GET /vehicles/:id/loadouts` — list loadouts for a vehicle
+- `POST /vehicles/:id/loadouts` — create loadout (optionally from defaults)
+- `GET /vehicles/:id/loadouts/:id` — show loadout with hardpoint details
+- `PUT /vehicles/:id/loadouts/:id` — update loadout
+- `DELETE /vehicles/:id/loadouts/:id` — delete loadout
+- `PUT /vehicles/:id/loadouts/:id/activate` — set as active loadout
+
+## Phase 3 — Erkul/SPViewer Integration
+
+### Link-Based (Phase 3a)
+
+Store erkul and spviewer URLs on `VehicleLoadout`:
+- Users paste their erkul loadout URL (`erkul.games/loadout/{code}`)
+- Users paste their spviewer URL
+- Display links on loadout detail and fleet vehicle views
+
+### Deep-Link Generation (Phase 3b — investigation needed)
+
+Research whether we can generate erkul/spviewer links from our loadout data:
+- Erkul loadout codes — what format? Can we reverse-engineer?
+- SPViewer HangarSync extension — can we provide data in their format?
+- SC-Open.dev community standard — JSON-based hangar/loadout exchange format
+
+**This phase requires hands-on investigation.** Create a research spike:
+1. Visit erkul.games, create a loadout, examine the URL and any export options
+2. Check if erkul has an API or documented import format
+3. Check SPViewer docs for import mechanisms
+4. Review SC-Open.dev spec at `docs.starcitizen.fans`
+
+### Future: Import (Phase 3c)
+
+If erkul/spviewer formats are parseable:
+- "Import from Erkul" button — paste URL, parse component selections, populate loadout
+- "Import from SPViewer" — same flow
+- This is explicitly future work pending the Phase 3b research
+
+## Phase 4 — Component Stats Display
+
+### Loadout Summary
+
+Calculate and display per-loadout:
+- **Total DPS** = Σ(weapon.damage_per_shot × weapon.fire_rate) across all weapon hardpoints
+- **Burst DPS** = DPS accounting for magazine/heat limits
+- **Shield HP** = Σ(shield.max_health) across shield hardpoints
+- **Shield Regen** = Σ(shield.max_regen)
+- **Power Draw** = total power consumption (from power connection data)
+- **Cooling Capacity** = total cooling (from cooler type_data)
+- **Quantum Range** = from QD type_data + fuel capacity
+
+### Component Detail View
+
+On ship detail page and loadout editor:
+- Show component stats inline per hardpoint
+- Weapon hardpoints: damage, fire rate, DPS
+- Shield: HP, regen
+- Power plants: output
+- Coolers: cooling rate
+- QD: speed, range, fuel consumption
+
+### Note
+
+This is NOT a full DPS calculator — erkul does that much better. We provide a quick summary so users can compare loadouts at a glance and mission creators can assess what members are bringing.
+
+## Phase 5 — Frontend
+
+### Hangar: Loadout Management
+
+On vehicle detail (hangar page):
+- "Loadouts" tab/section
+- Create/rename/delete loadouts
+- Set active loadout
+- Paste erkul/spviewer URLs
+- Per-hardpoint component selector (dropdown of compatible components)
+- Stat summary per loadout
+
+### Ship Detail: Component Stats
+
+Extend hardpoint display to show:
+- Default component stats (damage, fire rate, etc.)
+- Link to erkul/spviewer for full analysis
+
+### Fleet Vehicle View
+
+Extend fleet vehicle cards to show:
+- Active loadout name
+- Erkul/spviewer links if set
+- Quick stat summary
+
+## Implementation Order
+
+1. **Phase 1** — Weapon stats import (~2 days)
+2. **Phase 2** — Loadout storage + API (~3 days)
+3. **Phase 4** — Component stats display on ship detail (~2 days)
+4. **Phase 5a** — Loadout management UI in hangar (~3 days)
+5. **Phase 3a** — Erkul/spviewer URL storage + links (~1 day)
+6. **Phase 3b** — Research spike for deeper integration (~investigation)
+7. **Phase 5b** — Fleet vehicle loadout display (~1 day)
+
+## Files to Create/Modify
+
+**Create:**
+- `db/migrate/xxx_create_vehicle_loadouts.rb`
+- `app/models/vehicle_loadout.rb`
+- `app/models/vehicle_loadout_hardpoint.rb`
+- `app/controllers/api/v1/vehicle_loadouts_controller.rb`
+- `app/policies/vehicle_loadout_policy.rb`
+- `app/views/api/v1/vehicle_loadouts/`
+- `app/api_components/v1/schemas/vehicles/vehicle_loadout.rb`
+- `spec/requests/api/v1/vehicle_loadouts/`
+- `spec/factories/vehicle_loadouts.rb`
+- `app/tasks/maintenance/reimport_component_stats_task.rb`
+- Frontend: loadout components + management UI
+
+**Modify:**
+- `app/lib/sc_data/parser/items_parser.rb` — uncomment weapon/missile/armor/turret stats
+- `app/models/vehicle.rb` — add `has_many :vehicle_loadouts`
+- `app/views/api/v1/components/_base.jbuilder` — ensure type_data is exposed
+- `app/frontend/frontend/components/Models/Hardpoints/` — add stat display
+- Routes for vehicle loadouts
+
+## Verification
+
+1. SC data import → weapon components have type_data with damage/fire_rate
+2. `POST /vehicles/:id/loadouts` → creates loadout with default components
+3. `PUT /vehicles/:id/loadouts/:id` → swap a weapon component, DPS changes
+4. Ship detail page shows weapon stats per hardpoint
+5. Hangar: create loadout, select components, paste erkul URL, see stat summary
+6. Fleet vehicle view shows active loadout name + erkul link

--- a/spec/factories/vehicle_loadout_hardpoints.rb
+++ b/spec/factories/vehicle_loadout_hardpoints.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicle_loadout_hardpoints
+#
+#  id                 :uuid             not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  component_id       :uuid
+#  model_hardpoint_id :uuid             not null
+#  vehicle_loadout_id :uuid             not null
+#
+# Indexes
+#
+#  idx_vehicle_loadout_hardpoints_unique                   (vehicle_loadout_id,model_hardpoint_id) UNIQUE
+#  index_vehicle_loadout_hardpoints_on_vehicle_loadout_id  (vehicle_loadout_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (component_id => components.id)
+#  fk_rails_...  (model_hardpoint_id => model_hardpoints.id)
+#  fk_rails_...  (vehicle_loadout_id => vehicle_loadouts.id)
+#
+FactoryBot.define do
+  factory :vehicle_loadout_hardpoint do
+    vehicle_loadout
+    model_hardpoint
+    component { nil }
+  end
+end

--- a/spec/factories/vehicle_loadouts.rb
+++ b/spec/factories/vehicle_loadouts.rb
@@ -24,14 +24,11 @@
 FactoryBot.define do
   factory :vehicle_loadout do
     name { Faker::Lorem.word }
+    url { "https://erkul.games/loadout/#{SecureRandom.hex(8)}" }
     vehicle
 
     trait :active do
       active { true }
-    end
-
-    trait :with_url do
-      url { "https://erkul.games/loadout/#{SecureRandom.hex(8)}" }
     end
   end
 end

--- a/spec/factories/vehicle_loadouts.rb
+++ b/spec/factories/vehicle_loadouts.rb
@@ -4,14 +4,13 @@
 #
 # Table name: vehicle_loadouts
 #
-#  id           :uuid             not null, primary key
-#  active       :boolean          default(FALSE), not null
-#  erkul_url    :string
-#  name         :string           not null
-#  spviewer_url :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  vehicle_id   :uuid             not null
+#  id         :uuid             not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  name       :string           not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  vehicle_id :uuid             not null
 #
 # Indexes
 #
@@ -31,12 +30,8 @@ FactoryBot.define do
       active { true }
     end
 
-    trait :with_erkul_url do
-      erkul_url { "https://erkul.games/loadout/#{SecureRandom.hex(8)}" }
-    end
-
-    trait :with_spviewer_url do
-      spviewer_url { "https://spviewer.eu/loadout/#{SecureRandom.hex(8)}" }
+    trait :with_url do
+      url { "https://erkul.games/loadout/#{SecureRandom.hex(8)}" }
     end
   end
 end

--- a/spec/factories/vehicle_loadouts.rb
+++ b/spec/factories/vehicle_loadouts.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicle_loadouts
+#
+#  id           :uuid             not null, primary key
+#  active       :boolean          default(FALSE), not null
+#  erkul_url    :string
+#  name         :string           not null
+#  spviewer_url :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  vehicle_id   :uuid             not null
+#
+# Indexes
+#
+#  index_vehicle_loadouts_on_vehicle_id           (vehicle_id)
+#  index_vehicle_loadouts_on_vehicle_id_and_name  (vehicle_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vehicle_id => vehicles.id)
+#
+FactoryBot.define do
+  factory :vehicle_loadout do
+    name { Faker::Lorem.word }
+    vehicle
+
+    trait :active do
+      active { true }
+    end
+
+    trait :with_erkul_url do
+      erkul_url { "https://erkul.games/loadout/#{SecureRandom.hex(8)}" }
+    end
+
+    trait :with_spviewer_url do
+      spviewer_url { "https://spviewer.eu/loadout/#{SecureRandom.hex(8)}" }
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/activate_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/activate_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+  let(:vehicle_loadout) { create(:vehicle_loadout, vehicle: vehicle) }
+  let(:id) { vehicle_loadout.id }
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:write"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts/{id}/activate" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
+
+    put("Activate Vehicle Loadout") do
+      operationId "activateVehicleLoadout"
+      tags "VehicleLoadouts"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:write"]},
+        {OpenId: ["hangar", "hangar:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["active"]).to be(true)
+        end
+      end
+
+      response(200, "deactivates other loadouts") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        let!(:other_loadout) { create(:vehicle_loadout, :active, vehicle: vehicle, name: "Other") }
+
+        run_test! do
+          expect(other_loadout.reload.active).to be(false)
+        end
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/activate_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/activate_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts/{id}/activate" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
     parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
 
     put("Activate Vehicle Loadout") do

--- a/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   let(:vehicle_id) { vehicle.id }
   let(:input) do
     {
-      name: "PvE Setup"
+      url: "https://erkul.games/loadout/abc123"
     }
   end
 
@@ -55,7 +55,8 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data["name"]).to eq("PvE Setup")
+          expect(data["url"]).to eq("https://erkul.games/loadout/abc123")
+          expect(data["name"]).to eq("Erkul Loadout")
         end
       end
 
@@ -64,7 +65,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
 
         let(:input) do
           {
-            name: "Default Loadout",
+            url: "https://erkul.games/loadout/def456",
             fromDefaults: true
           }
         end

--- a/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+  let(:input) do
+    {
+      name: "PvE Setup"
+    }
+  end
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:write"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+
+    post("Create Vehicle Loadout") do
+      operationId "createVehicleLoadout"
+      tags "VehicleLoadouts"
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :input, in: :body, schema: {"$ref": "#/components/schemas/VehicleLoadoutInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:write"]},
+        {OpenId: ["hangar", "hangar:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["name"]).to eq("PvE Setup")
+        end
+      end
+
+      response(201, "successful with from_defaults") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        let(:input) do
+          {
+            name: "Default Loadout",
+            fromDefaults: true
+          }
+        end
+
+        run_test!
+      end
+
+      include_examples "oauth_auth", success_status: 201
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:vehicle_id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/create_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
 
     post("Create Vehicle Loadout") do
       operationId "createVehicleLoadout"

--- a/spec/requests/api/v1/vehicle_loadouts/destroy_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/destroy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts/{id}" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
     parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
 
     delete("Delete Vehicle Loadout") do

--- a/spec/requests/api/v1/vehicle_loadouts/destroy_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/destroy_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+  let(:vehicle_loadout) { create(:vehicle_loadout, vehicle: vehicle) }
+  let(:id) { vehicle_loadout.id }
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:write"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts/{id}" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
+
+    delete("Delete Vehicle Loadout") do
+      operationId "destroyVehicleLoadout"
+      tags "VehicleLoadouts"
+      consumes "application/json"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:write"]},
+        {OpenId: ["hangar", "hangar:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        run_test!
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/index_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/index_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:read"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+
+    get("List Vehicle Loadouts") do
+      operationId "vehicleLoadouts"
+      tags "VehicleLoadouts"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:read"]},
+        {OpenId: ["hangar", "hangar:read"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :array, items: {"$ref": "#/components/schemas/VehicleLoadout"}
+
+        before do
+          create(:vehicle_loadout, vehicle: vehicle)
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.count).to eq(1)
+        end
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:vehicle_id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/index_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/index_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
 
     get("List Vehicle Loadouts") do
       operationId "vehicleLoadouts"

--- a/spec/requests/api/v1/vehicle_loadouts/show_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/show_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+  let(:vehicle_loadout) { create(:vehicle_loadout, vehicle: vehicle) }
+  let(:id) { vehicle_loadout.id }
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:read"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts/{id}" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
+
+    get("Show Vehicle Loadout") do
+      operationId "vehicleLoadout"
+      tags "VehicleLoadouts"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:read"]},
+        {OpenId: ["hangar", "hangar:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        run_test!
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/show_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts/{id}" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
     parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
 
     get("Show Vehicle Loadout") do

--- a/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   let(:id) { vehicle_loadout.id }
   let(:input) do
     {
-      name: "Updated Loadout"
+      name: "Updated Loadout",
+      url: "https://erkul.games/loadout/updated123"
     }
   end
 

--- a/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:vehicle_id) { vehicle.id }
+  let(:vehicle_loadout) { create(:vehicle_loadout, vehicle: vehicle) }
+  let(:id) { vehicle_loadout.id }
+  let(:input) do
+    {
+      name: "Updated Loadout"
+    }
+  end
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:write"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{vehicle_id}/loadouts/{id}" do
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
+
+    put("Update Vehicle Loadout") do
+      operationId "updateVehicleLoadout"
+      tags "VehicleLoadouts"
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :input, in: :body, schema: {"$ref": "#/components/schemas/VehicleLoadoutInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:write"]},
+        {OpenId: ["hangar", "hangar:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/VehicleLoadout"
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["name"]).to eq("Updated Loadout")
+        end
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
+++ b/spec/requests/api/v1/vehicle_loadouts/update_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "api/v1/vehicle_loadouts", type: :request, swagger_doc: "v1/schem
   end
 
   path "/vehicles/{vehicle_id}/loadouts/{id}" do
-    parameter name: "vehicle_id", in: :path, description: "Vehicle id", schema: {type: :string, format: :uuid}
+    parameter name: "vehicle_id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
     parameter name: "id", in: :path, description: "Loadout id", schema: {type: :string, format: :uuid}
 
     put("Update Vehicle Loadout") do

--- a/spec/requests/api/v1/vehicles/destroy_spec.rb
+++ b/spec/requests/api/v1/vehicles/destroy_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
   end
 
   path "/vehicles/{id}" do
-    parameter name: "id", in: :path, description: "id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
 
     delete("Delete Vehicle") do
       operationId "destroyVehicle"

--- a/spec/requests/api/v1/vehicles/show_spec.rb
+++ b/spec/requests/api/v1/vehicles/show_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" do
+  let(:author) { create(:user) }
+  let(:user) { author }
+  let(:vehicle) { create(:vehicle, user: author) }
+  let(:other_vehicle) { create(:vehicle) }
+  let(:id) { vehicle.id }
+
+  let(:Authorization) { nil }
+  let(:oauth_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["hangar", "hangar:read"]
+    )
+  end
+  let(:wrong_scope_access_token) do
+    create(
+      :oauth_access_token,
+      resource_owner_id: author.id,
+      scopes: ["public"]
+    )
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/vehicles/{id}" do
+    parameter name: "id", in: :path, description: "id", schema: {type: :string, format: :uuid}
+
+    get("Show Vehicle") do
+      operationId "showVehicle"
+      tags "Vehicles"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:read"]},
+        {OpenId: ["hangar", "hangar:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/Vehicle"
+
+        run_test!
+      end
+
+      include_examples "oauth_auth"
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { SecureRandom.uuid }
+
+        run_test!
+      end
+
+      response(404, "not found for other user") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { other_vehicle.id }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/vehicles/show_spec.rb
+++ b/spec/requests/api/v1/vehicles/show_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
   end
 
   path "/vehicles/{id}" do
-    parameter name: "id", in: :path, description: "id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
 
     get("Show Vehicle") do
       operationId "showVehicle"

--- a/spec/requests/api/v1/vehicles/update_spec.rb
+++ b/spec/requests/api/v1/vehicles/update_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "api/v1/vehicles", type: :request, swagger_doc: "v1/schema.yaml" 
   end
 
   path "/vehicles/{id}" do
-    parameter name: "id", in: :path, description: "id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Vehicle id or serial", schema: {type: :string}
 
     put("Update Vehicle") do
       operationId "updateVehicle"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5173,6 +5173,10 @@ components:
           - "$ref": "#/components/schemas/CargoHold"
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
+          - "$ref": "#/components/schemas/ComponentWeapon"
+          - "$ref": "#/components/schemas/ComponentShield"
+          - "$ref": "#/components/schemas/ComponentCooler"
+          - "$ref": "#/components/schemas/ComponentPowerPlant"
         hardpoints:
           type: array
           items:
@@ -5209,6 +5213,15 @@ components:
       - RSI_PROPULSION
       - RSI_THRUSTER
       title: ComponentClassEnum
+    ComponentCooler:
+      type: object
+      properties:
+        coolingRate:
+          type: number
+      additionalProperties: false
+      required:
+      - coolingRate
+      title: ComponentCooler
     ComponentItemClassEnum:
       type: string
       enum:
@@ -5224,6 +5237,15 @@ components:
       - MILITARY
       - COMPETITION
       title: ComponentItemClassEnum
+    ComponentPowerPlant:
+      type: object
+      properties:
+        powerBase:
+          type: number
+        powerDraw:
+          type: number
+      additionalProperties: false
+      title: ComponentPowerPlant
     ComponentQuantumDrive:
       type: object
       properties:
@@ -5263,6 +5285,24 @@ components:
       - spoolUpTime
       - cooldown
       title: ComponentQuantumDriveJump
+    ComponentShield:
+      type: object
+      properties:
+        maxHealth:
+          type: number
+        maxRegen:
+          type: number
+        decayRatio:
+          type: number
+        downedRegenDelay:
+          type: number
+        damagedRegenDelay:
+          type: number
+      additionalProperties: false
+      required:
+      - maxHealth
+      - maxRegen
+      title: ComponentShield
     ComponentSortEnum:
       type: string
       enum:
@@ -5444,6 +5484,41 @@ components:
       - SALVAGE_FIELD_SUPPORTER
       - SALVAGE_INTERNAL_STORAGE
       title: ComponentTypeEnum
+    ComponentWeapon:
+      type: object
+      properties:
+        weaponClass:
+          type: string
+        fireRate:
+          type: number
+        heatPerShot:
+          type: number
+        damagePerShot:
+          type: object
+          properties:
+            physical:
+              type: number
+            energy:
+              type: number
+            distortion:
+              type: number
+            thermal:
+              type: number
+            biochemical:
+              type: number
+            stun:
+              type: number
+          additionalProperties: false
+        pelletsPerShot:
+          type: integer
+        speed:
+          type: number
+        range:
+          type: number
+        ammoCost:
+          type: integer
+      additionalProperties: false
+      title: ComponentWeapon
     Components:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11173,6 +11173,9 @@ components:
       properties:
         name:
           type: string
+        url:
+          type: string
+          description: Auto-detected as erkul or spviewer URL
         erkulUrl:
           type: string
           nullable: true
@@ -11199,8 +11202,6 @@ components:
               _destroy:
                 type: boolean
       additionalProperties: false
-      required:
-      - name
       title: VehicleLoadoutInput
     VehicleLoadoutMinimal:
       type: object

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -6033,6 +6033,10 @@ components:
           - "$ref": "#/components/schemas/CargoHold"
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
+          - "$ref": "#/components/schemas/ComponentWeapon"
+          - "$ref": "#/components/schemas/ComponentShield"
+          - "$ref": "#/components/schemas/ComponentCooler"
+          - "$ref": "#/components/schemas/ComponentPowerPlant"
         hardpoints:
           type: array
           items:
@@ -6069,6 +6073,15 @@ components:
       - RSI_PROPULSION
       - RSI_THRUSTER
       title: ComponentClassEnum
+    ComponentCooler:
+      type: object
+      properties:
+        coolingRate:
+          type: number
+      additionalProperties: false
+      required:
+      - coolingRate
+      title: ComponentCooler
     ComponentItemClassEnum:
       type: string
       enum:
@@ -6084,6 +6097,15 @@ components:
       - MILITARY
       - COMPETITION
       title: ComponentItemClassEnum
+    ComponentPowerPlant:
+      type: object
+      properties:
+        powerBase:
+          type: number
+        powerDraw:
+          type: number
+      additionalProperties: false
+      title: ComponentPowerPlant
     ComponentQuantumDrive:
       type: object
       properties:
@@ -6123,6 +6145,24 @@ components:
       - spoolUpTime
       - cooldown
       title: ComponentQuantumDriveJump
+    ComponentShield:
+      type: object
+      properties:
+        maxHealth:
+          type: number
+        maxRegen:
+          type: number
+        decayRatio:
+          type: number
+        downedRegenDelay:
+          type: number
+        damagedRegenDelay:
+          type: number
+      additionalProperties: false
+      required:
+      - maxHealth
+      - maxRegen
+      title: ComponentShield
     ComponentSortEnum:
       type: string
       enum:
@@ -6304,6 +6344,41 @@ components:
       - SALVAGE_FIELD_SUPPORTER
       - SALVAGE_INTERNAL_STORAGE
       title: ComponentTypeEnum
+    ComponentWeapon:
+      type: object
+      properties:
+        weaponClass:
+          type: string
+        fireRate:
+          type: number
+        heatPerShot:
+          type: number
+        damagePerShot:
+          type: object
+          properties:
+            physical:
+              type: number
+            energy:
+              type: number
+            distortion:
+              type: number
+            thermal:
+              type: number
+            biochemical:
+              type: number
+            stun:
+              type: number
+          additionalProperties: false
+        pelletsPerShot:
+          type: integer
+        speed:
+          type: number
+        range:
+          type: number
+        ammoCost:
+          type: integer
+      additionalProperties: false
+      title: ComponentWeapon
     Components:
       type: object
       properties:
@@ -10827,6 +10902,8 @@ components:
           "$ref": "#/components/schemas/ModelUpgrade"
         wanted:
           type: boolean
+        activeLoadout:
+          "$ref": "#/components/schemas/VehicleLoadoutMinimal"
         createdAt:
           type: string
           format: date-time
@@ -11093,6 +11170,25 @@ components:
       required:
       - name
       title: VehicleLoadoutInput
+    VehicleLoadoutMinimal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        erkulUrl:
+          type: string
+          nullable: true
+        spviewerUrl:
+          type: string
+          nullable: true
+      additionalProperties: false
+      required:
+      - id
+      - name
+      title: VehicleLoadoutMinimal
     VehiclePublic:
       type: object
       properties:
@@ -11141,6 +11237,8 @@ components:
           "$ref": "#/components/schemas/ModelUpgrade"
         paint:
           "$ref": "#/components/schemas/ModelPaint"
+        activeLoadout:
+          "$ref": "#/components/schemas/VehicleLoadoutMinimal"
         createdAt:
           type: string
           format: date-time

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -5130,10 +5130,9 @@ paths:
     parameters:
     - name: vehicle_id
       in: path
-      description: Vehicle id
+      description: Vehicle id or serial
       schema:
         type: string
-        format: uuid
       required: true
     - name: id
       in: path
@@ -5178,10 +5177,9 @@ paths:
     parameters:
     - name: vehicle_id
       in: path
-      description: Vehicle id
+      description: Vehicle id or serial
       schema:
         type: string
-        format: uuid
       required: true
     post:
       summary: Create Vehicle Loadout
@@ -5260,10 +5258,9 @@ paths:
     parameters:
     - name: vehicle_id
       in: path
-      description: Vehicle id
+      description: Vehicle id or serial
       schema:
         type: string
-        format: uuid
       required: true
     - name: id
       in: path
@@ -5559,10 +5556,9 @@ paths:
     parameters:
     - name: id
       in: path
-      description: id
+      description: Vehicle id or serial
       schema:
         type: string
-        format: uuid
       required: true
     delete:
       summary: Delete Vehicle

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -5126,6 +5126,255 @@ paths:
             schema:
               "$ref": "#/components/schemas/AccountUpdateInput"
         required: true
+  "/vehicles/{vehicle_id}/loadouts/{id}/activate":
+    parameters:
+    - name: vehicle_id
+      in: path
+      description: Vehicle id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Loadout id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    put:
+      summary: Activate Vehicle Loadout
+      operationId: activateVehicleLoadout
+      tags:
+      - VehicleLoadouts
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:write
+      - OpenId:
+        - hangar
+        - hangar:write
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/vehicles/{vehicle_id}/loadouts":
+    parameters:
+    - name: vehicle_id
+      in: path
+      description: Vehicle id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Create Vehicle Loadout
+      operationId: createVehicleLoadout
+      tags:
+      - VehicleLoadouts
+      parameters: []
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:write
+      - OpenId:
+        - hangar
+        - hangar:write
+      responses:
+        '201':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/VehicleLoadoutInput"
+        required: true
+    get:
+      summary: List Vehicle Loadouts
+      operationId: vehicleLoadouts
+      tags:
+      - VehicleLoadouts
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:read
+      - OpenId:
+        - hangar
+        - hangar:read
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/vehicles/{vehicle_id}/loadouts/{id}":
+    parameters:
+    - name: vehicle_id
+      in: path
+      description: Vehicle id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Loadout id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    delete:
+      summary: Delete Vehicle Loadout
+      operationId: destroyVehicleLoadout
+      tags:
+      - VehicleLoadouts
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:write
+      - OpenId:
+        - hangar
+        - hangar:write
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    get:
+      summary: Show Vehicle Loadout
+      operationId: vehicleLoadout
+      tags:
+      - VehicleLoadouts
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:read
+      - OpenId:
+        - hangar
+        - hangar:read
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    put:
+      summary: Update Vehicle Loadout
+      operationId: updateVehicleLoadout
+      tags:
+      - VehicleLoadouts
+      parameters: []
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:write
+      - OpenId:
+        - hangar
+        - hangar:write
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/VehicleLoadout"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/VehicleLoadoutInput"
+        required: true
   "/vehicles/check-serial":
     post:
       summary: Check Vehicle Serial
@@ -10764,6 +11013,86 @@ components:
       - modules
       - upgrades
       title: VehicleExport
+    VehicleLoadout:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        active:
+          type: boolean
+        erkulUrl:
+          type: string
+          nullable: true
+        spviewerUrl:
+          type: string
+          nullable: true
+        hardpoints:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              modelHardpointId:
+                type: string
+                format: uuid
+              hardpoint:
+                "$ref": "#/components/schemas/ModelHardpoint"
+              component:
+                "$ref": "#/components/schemas/Component"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - active
+      - hardpoints
+      - createdAt
+      - updatedAt
+      title: VehicleLoadout
+    VehicleLoadoutInput:
+      type: object
+      properties:
+        name:
+          type: string
+        erkulUrl:
+          type: string
+          nullable: true
+        spviewerUrl:
+          type: string
+          nullable: true
+        fromDefaults:
+          type: boolean
+        vehicleLoadoutHardpointsAttributes:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              modelHardpointId:
+                type: string
+                format: uuid
+              componentId:
+                type: string
+                format: uuid
+                nullable: true
+              _destroy:
+                type: boolean
+      additionalProperties: false
+      required:
+      - name
+      title: VehicleLoadoutInput
     VehiclePublic:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11128,10 +11128,10 @@ components:
           type: string
         active:
           type: boolean
-        erkulUrl:
+        url:
           type: string
           nullable: true
-        spviewerUrl:
+        urlSource:
           type: string
           nullable: true
         hardpoints:
@@ -11171,12 +11171,6 @@ components:
           type: string
         url:
           type: string
-          description: Auto-detected as erkul or spviewer URL
-        erkulUrl:
-          type: string
-          nullable: true
-        spviewerUrl:
-          type: string
           nullable: true
         fromDefaults:
           type: boolean
@@ -11207,10 +11201,7 @@ components:
           format: uuid
         name:
           type: string
-        erkulUrl:
-          type: string
-          nullable: true
-        spviewerUrl:
+        url:
           type: string
           nullable: true
       additionalProperties: false

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -5596,6 +5596,38 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+    get:
+      summary: Show Vehicle
+      operationId: showVehicle
+      tags:
+      - Vehicles
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:read
+      - OpenId:
+        - hangar
+        - hangar:read
+      responses:
+        '200':
+          description: successful with OAuth token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Vehicle"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found for other user
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
     put:
       summary: Update Vehicle
       operationId: updateVehicle

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11130,10 +11130,8 @@ components:
           type: boolean
         url:
           type: string
-          nullable: true
         urlSource:
           type: string
-          nullable: true
         hardpoints:
           type: array
           items:
@@ -11158,8 +11156,8 @@ components:
       additionalProperties: false
       required:
       - id
-      - name
       - active
+      - url
       - hardpoints
       - createdAt
       - updatedAt
@@ -11169,9 +11167,9 @@ components:
       properties:
         name:
           type: string
+          nullable: true
         url:
           type: string
-          nullable: true
         fromDefaults:
           type: boolean
         vehicleLoadoutHardpointsAttributes:
@@ -11203,11 +11201,13 @@ components:
           type: string
         url:
           type: string
-          nullable: true
+        urlSource:
+          type: string
       additionalProperties: false
       required:
       - id
       - name
+      - url
       title: VehicleLoadoutMinimal
     VehiclePublic:
       type: object


### PR DESCRIPTION
## Summary
- Enable weapon/missile/armor/turret stats extraction from SC game data (Phase 1)
- Add per-vehicle loadout storage with full CRUD API nested under `/vehicles/:id/loadouts` (Phase 2)
- Add component stats display (DPS, shield HP, cooling rate, etc.) to hardpoint views (Phase 4)
- Add dedicated loadout management page at `/hangar/:serial/loadouts` with fleet-settings-style layout (Phase 5)
- Show active loadout name + erkul/spviewer links on vehicle and fleet vehicle panels
- Backend auto-detects erkul.games/spviewer.eu URLs and assigns them to the correct field
- Vehicle API endpoints accept serial number as alternative to UUID for cleaner URLs
- Research confirms no standard loadout interchange format exists in the SC community (Phase 3b)

## Test plan
- [x] Create a loadout via the hangar context menu → "Manage Loadouts"
- [x] Paste an erkul.games URL → loadout created with auto-detected source and default name
- [x] Edit loadout name and URL
- [x] Activate a loadout → others deactivated, active badge visible
- [x] Delete a loadout
- [x] Verify active loadout shows on vehicle panel in hangar and fleet views
- [x] Verify serial number works in URL (e.g., `/hangar/L8-4261-HA/loadouts`)
- [ ] After next SC data import: verify weapon/shield/cooler stats appear on ship detail hardpoints
- [x] Run `rspec spec/requests/api/v1/vehicle_loadouts/` — 32 tests pass
- [x] Run `rspec spec/requests/api/v1/vehicles/` — 47 tests pass

Resolves #3792

🤖 Generated with [Claude Code](https://claude.com/claude-code)