### PR TITLE
Expand sc_data coverage: 47 sc_keys, ATLS parser, Bengal carrier

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/model_create_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_create_input.rb
@@ -43,6 +43,7 @@ module Admin
               beam: {type: :number},
               height: {type: :number},
               onSale: {type: :boolean},
+              playerOwnable: {type: :boolean},
               storeUrl: {type: :string},
               salesPageUrl: {type: :string},
               price: {type: :number},

--- a/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
@@ -45,6 +45,7 @@ module Admin
               fleetchartOffsetLength: {type: :number, nullable: true},
               fleetchartOffsetBeam: {type: :number, nullable: true},
               onSale: {type: :boolean},
+              playerOwnable: {type: :boolean},
               storeUrl: {type: :string, nullable: true},
               salesPageUrl: {type: :string, nullable: true},
               price: {type: :number, nullable: true},

--- a/app/api_components/v1/schemas/models/model.rb
+++ b/app/api_components/v1/schemas/models/model.rb
@@ -127,6 +127,7 @@ module V1
             quantumFuelTanks: {type: :array, items: {"$ref": "#/components/schemas/FuelTank"}},
 
             onSale: {type: :boolean},
+            playerOwnable: {type: :boolean},
             pledgePrice: {type: :number},
             pledgePriceLabel: {type: :string},
             price: {type: :number},
@@ -167,7 +168,7 @@ module V1
           additionalProperties: false,
           required: %w[
             id name slug availability crew hasImages hasModules hasPaints hasUpgrades hasVideos
-            inGame loaners media metrics onSale speeds adiMap createdAt updatedAt
+            inGame loaners media metrics onSale playerOwnable speeds adiMap createdAt updatedAt
           ]
         })
       end

--- a/app/api_components/v1/schemas/queries/model_query.rb
+++ b/app/api_components/v1/schemas/queries/model_query.rb
@@ -28,6 +28,7 @@ module V1
             slugIn: {type: :array, items: {type: :string}},
             nameOrDescriptionCont: {type: :string},
             onSaleEq: {type: :boolean},
+            playerOwnableEq: {type: :boolean},
             pledgePriceGteq: {type: :number},
             pledgePriceLteq: {type: :number},
             pledgePriceIn: {type: :array, items: {type: :number}},

--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -160,7 +160,7 @@ module Admin
             :scm_speed, :scm_speed_boosted, :max_speed, :reverse_speed_boosted, :yaw, :yaw_boosted,
             :pitch, :pitch_boosted, :roll, :roll_boosted, :erkul_identifier, :sc_key,
             :manufacturer_id, :rsi_id, :base_model_id, :production_status, :production_note,
-            :classification, :focus, :size, :dock_size, :length, :beam, :height, :on_sale,
+            :classification, :focus, :size, :dock_size, :length, :beam, :height, :on_sale, :player_ownable,
             :store_url, :sales_page_url, :price, :pledge_price, :cargo, :fleetchart_offset_length,
             :fleetchart_offset_beam,
             :cargo_holds, :hydrogen_fuel_tank_size, :hydrogen_fuel_tanks, :quantum_fuel_tank_size,

--- a/app/frontend/admin/pages/models/[id]/edit/index.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/index.vue
@@ -37,6 +37,7 @@ const initialValues = ref<ModelUpdateInput>({
   description: props.model.description,
   hidden: props.model.hidden,
   active: props.model.active,
+  playerOwnable: props.model.playerOwnable,
   ground: props.model.metrics.isGroundVehicle,
   rsiId: props.model.rsiId,
   scKey: props.model.scKey,
@@ -65,6 +66,7 @@ const [name, nameProps] = defineField("name");
 const [description, descriptionProps] = defineField("description");
 const [hidden, hiddenProps] = defineField("hidden");
 const [active, activeProps] = defineField("active");
+const [playerOwnable, playerOwnableProps] = defineField("playerOwnable");
 const [ground, groundProps] = defineField("ground");
 const [rsiId, rsiIdProps] = defineField("rsiId");
 const [scKey, scKeyProps] = defineField("scKey");
@@ -138,6 +140,14 @@ const [holo, holoProps] = defineField("holo");
               translation-key="model.ground"
               v-bind="groundProps"
               name="ground"
+            />
+          </div>
+          <div class="col-12 col-md-4">
+            <FormToggle
+              v-model="playerOwnable"
+              translation-key="model.playerOwnable"
+              v-bind="playerOwnableProps"
+              name="playerOwnable"
             />
           </div>
         </div>

--- a/app/frontend/admin/pages/models/create.vue
+++ b/app/frontend/admin/pages/models/create.vue
@@ -43,6 +43,7 @@ const [name, nameProps] = defineField("name");
 const [description, descriptionProps] = defineField("description");
 const [hidden, hiddenProps] = defineField("hidden");
 const [active, activeProps] = defineField("active");
+const [playerOwnable, playerOwnableProps] = defineField("playerOwnable");
 const [ground, groundProps] = defineField("ground");
 const [rsiId, rsiIdProps] = defineField("rsiId");
 const [scKey, scKeyProps] = defineField("scKey");
@@ -138,6 +139,14 @@ const handleCancel = async () => {
               translation-key="model.ground"
               v-bind="groundProps"
               name="ground"
+            />
+          </div>
+          <div class="col-12 col-md-4">
+            <FormToggle
+              v-model="playerOwnable"
+              translation-key="model.playerOwnable"
+              v-bind="playerOwnableProps"
+              name="playerOwnable"
             />
           </div>
         </div>

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -454,6 +454,7 @@
         "topView": "Top View",
         "topViewColored": "Top View Colored",
         "onSale": "On Sale",
+        "playerOwnable": "Player Ownable?",
         "salesPage": "Sales Page",
         "addons": "Modules & Upgrade-Kits",
         "storeImage": "Store Image",

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -4,6 +4,7 @@ module ScData
       def all
         parse_ships
         parse_vehicles
+        parse_powersuits
       end
 
       private def parse_ships
@@ -102,6 +103,57 @@ module ScData
         end
 
         save_items(vehicles, folder: "models")
+      end
+
+      private def parse_powersuits
+        powersuits = load_data("actor/actors").filter_map do |item|
+          key = item[:key]
+          values = item[:values]
+
+          actor_params = values.dig("Components", "SActorComponentParams")
+          next unless actor_params&.dig("actorType") == "Transport"
+
+          display_params = values.dig("StaticEntityClassData", "SEntityInsuranceProperties", "displayParams")
+          name_key = display_params&.dig("name")
+          next if name_key.blank? || name_key == "@LOC_UNINITIALIZED"
+
+          loadout = (values.dig(
+            "Components",
+            "SEntityComponentDefaultLoadoutParams",
+            "loadout",
+            "SItemPortLoadoutManualParams",
+            "entries",
+            "SItemPortLoadoutEntryParams"
+          ) || []).filter_map do |entry|
+            extract_loadout(entry)
+          end
+
+          loadout = merge_module_ports(values, loadout)
+
+          insurance_params = values.dig("StaticEntityClassData", "SEntityInsuranceProperties", "shipInsuranceParams")
+
+          {
+            key:,
+            ground: true,
+            movement_class: nil,
+            gravlev: nil,
+            min_crew: display_params&.dig("crewSize"),
+            name: translate(name_key),
+            description: nil,
+            career: translate(display_params&.dig("career")),
+            role: translate(display_params&.dig("role")),
+            insurance: {
+              base_wait_time_minutes: insurance_params&.dig("baseWaitTimeMinutes"),
+              mandatory_wait_time_minutes: insurance_params&.dig("mandatoryWaitTimeMinutes"),
+              base_expediting_fee: insurance_params&.dig("baseExpeditingFee")
+            },
+            mass: values.dig("Components", "SSCActorPhysicsControllerComponentParams", "physType", "SEntityActorPhysicsControllerParams", "Mass")&.to_f,
+            metrics: {x: 0.0, y: 0.0, z: 0.0},
+            loadout:
+          }
+        end
+
+        save_items(powersuits, folder: "models")
       end
 
       private def merge_module_ports(values, loadout)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -47,6 +47,7 @@
 #  on_sale                  :boolean          default(FALSE)
 #  pitch                    :decimal(15, 2)
 #  pitch_boosted            :decimal(15, 2)
+#  player_ownable           :boolean          default(TRUE), not null
 #  pledge_price             :decimal(15, 2)
 #  positions_need_curation  :boolean          default(FALSE)
 #  price                    :decimal(15, 2)
@@ -271,7 +272,7 @@ class Model < ApplicationRecord
       "images_count", "last_updated_at", "length", "loaners_count",
       "manufacturer", "manufacturer_id", "mass", "max_crew", "max_speed", "max_speed_acceleration",
       "max_speed_decceleration", "min_crew", "model_paints_count", "module_hardpoints_count",
-      "name", "notified", "on_sale", "pitch", "pledge_price", "price", "production_note",
+      "name", "notified", "on_sale", "pitch", "player_ownable", "pledge_price", "price", "production_note",
       "production_status", "quantum_fuel_tank_size", "quantum_fuel_tanks", "roll", "rsi_beam",
       "rsi_cargo", "rsi_chassis_id", "rsi_classification", "rsi_description", "rsi_focus",
       "rsi_height", "rsi_id", "rsi_length", "rsi_mass", "rsi_max_crew", "rsi_max_speed",

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -70,6 +70,7 @@ class Vehicle < ApplicationRecord
   has_many :model_upgrades, through: :vehicle_upgrades
 
   validates :serial, uniqueness: {scope: :user_id}, allow_nil: true
+  validate :model_must_be_player_ownable
 
   NULL_ATTRS = %w[name serial].freeze
 
@@ -342,5 +343,12 @@ class Vehicle < ApplicationRecord
 
   protected def nil_if_blank
     NULL_ATTRS.each { |attr| self[attr] = nil if self[attr].blank? }
+  end
+
+  private def model_must_be_player_ownable
+    return if model.blank?
+    return if model.player_ownable?
+
+    errors.add(:model, :not_player_ownable)
   end
 end

--- a/app/views/admin/api/v1/models/_base.jbuilder
+++ b/app/views/admin/api/v1/models/_base.jbuilder
@@ -131,6 +131,7 @@ json.hydrogen_fuel_tanks model.hydrogen_fuel_tanks
 json.quantum_fuel_tanks model.quantum_fuel_tanks
 
 json.on_sale model.on_sale
+json.player_ownable model.player_ownable
 json.pledge_price((model.pledge_price.to_f if model.pledge_price.present?))
 json.pledge_price_label model.pledge_price_label
 json.price((model.price.to_f if model.price.present?))

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -122,6 +122,7 @@ json.hydrogen_fuel_tanks model.hydrogen_fuel_tanks
 json.quantum_fuel_tanks model.quantum_fuel_tanks
 
 json.on_sale model.on_sale
+json.player_ownable model.player_ownable
 json.pledge_price(model.pledge_price.to_f) if model.pledge_price.present?
 json.pledge_price_label model.pledge_price_label
 json.price((model.price.to_f if model.price.present?))

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -253,6 +253,10 @@ en:
               cannot_destroy_from_permanent_role: Cannot remove member of Fleet from permanent role
             user_id:
               taken: already present or has a pending invite
+        vehicle:
+          attributes:
+            model:
+              not_player_ownable: cannot be added to a hangar (not player ownable)
         user:
           attributes:
             base:

--- a/data/sc_data/parsed/live/models/argo_atls.json
+++ b/data/sc_data/parsed/live/models/argo_atls.json
@@ -1,0 +1,89 @@
+{
+  "key": "ARGO_ATLS",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS",
+  "description": null,
+  "career": "Ground",
+  "role": "Cargo",
+  "insurance": {
+    "base_wait_time_minutes": "2.5",
+    "mandatory_wait_time_minutes": "0.63",
+    "base_expediting_fee": "850"
+  },
+  "mass": 1440.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "ad9758a5-9dfc-4f16-8b8e-f4ec12394a24",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "83b3857b-d7d5-40bd-b79c-058026f29ec6",
+      "key": null
+    },
+    {
+      "name": "salvage_controller",
+      "ref": "99b1d580-8fd8-4716-af13-c2e4287977f1",
+      "key": null
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "de9491ea-a5ef-463c-bf3f-252d74c54da1",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_geo.json
+++ b/data/sc_data/parsed/live/models/argo_atls_geo.json
@@ -1,0 +1,137 @@
+{
+  "key": "ARGO_ATLS_GEO",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS GEO",
+  "description": null,
+  "career": "Ground",
+  "role": "Mining",
+  "insurance": {
+    "base_wait_time_minutes": "3",
+    "mandatory_wait_time_minutes": "1",
+    "base_expediting_fee": "1020"
+  },
+  "mass": 2100.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "e069e960-816f-42a1-8711-7e46b94dea4e",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "40bd6a85-5695-409c-9d6c-ae1babde416a",
+      "key": null
+    },
+    {
+      "name": "mining_controller",
+      "ref": "976ec585-d102-4ba0-8fca-19f457167b2c",
+      "key": null,
+      "loadout": []
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "3f53c75f-524e-4a33-bcc4-dfd2719800ad",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "053ec62a-2472-447d-9737-263fac538d37",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_mining_tool",
+      "ref": "7c718ef7-251f-4ccf-aec5-02c44253e011",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad01.json
+++ b/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad01.json
@@ -1,0 +1,137 @@
+{
+  "key": "ARGO_ATLS_GEO_Collector_Grad01",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS GEO",
+  "description": null,
+  "career": "Ground",
+  "role": "Mining",
+  "insurance": {
+    "base_wait_time_minutes": "3",
+    "mandatory_wait_time_minutes": "1",
+    "base_expediting_fee": "1020"
+  },
+  "mass": 2100.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "e069e960-816f-42a1-8711-7e46b94dea4e",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "40bd6a85-5695-409c-9d6c-ae1babde416a",
+      "key": null
+    },
+    {
+      "name": "mining_controller",
+      "ref": "976ec585-d102-4ba0-8fca-19f457167b2c",
+      "key": null,
+      "loadout": []
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "3f53c75f-524e-4a33-bcc4-dfd2719800ad",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "053ec62a-2472-447d-9737-263fac538d37",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_mining_tool",
+      "ref": "7c718ef7-251f-4ccf-aec5-02c44253e011",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad02.json
+++ b/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad02.json
@@ -1,0 +1,137 @@
+{
+  "key": "ARGO_ATLS_GEO_Collector_Grad02",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS GEO",
+  "description": null,
+  "career": "Ground",
+  "role": "Mining",
+  "insurance": {
+    "base_wait_time_minutes": "3",
+    "mandatory_wait_time_minutes": "1",
+    "base_expediting_fee": "1020"
+  },
+  "mass": 2100.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "e069e960-816f-42a1-8711-7e46b94dea4e",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "40bd6a85-5695-409c-9d6c-ae1babde416a",
+      "key": null
+    },
+    {
+      "name": "mining_controller",
+      "ref": "976ec585-d102-4ba0-8fca-19f457167b2c",
+      "key": null,
+      "loadout": []
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "3f53c75f-524e-4a33-bcc4-dfd2719800ad",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "053ec62a-2472-447d-9737-263fac538d37",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_mining_tool",
+      "ref": "7c718ef7-251f-4ccf-aec5-02c44253e011",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad03.json
+++ b/data/sc_data/parsed/live/models/argo_atls_geo_collector_grad03.json
@@ -1,0 +1,137 @@
+{
+  "key": "ARGO_ATLS_GEO_Collector_Grad03",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS GEO",
+  "description": null,
+  "career": "Ground",
+  "role": "Mining",
+  "insurance": {
+    "base_wait_time_minutes": "3",
+    "mandatory_wait_time_minutes": "1",
+    "base_expediting_fee": "1020"
+  },
+  "mass": 2100.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "e069e960-816f-42a1-8711-7e46b94dea4e",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "40bd6a85-5695-409c-9d6c-ae1babde416a",
+      "key": null
+    },
+    {
+      "name": "mining_controller",
+      "ref": "976ec585-d102-4ba0-8fca-19f457167b2c",
+      "key": null,
+      "loadout": []
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "3f53c75f-524e-4a33-bcc4-dfd2719800ad",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "053ec62a-2472-447d-9737-263fac538d37",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_mining_tool",
+      "ref": "7c718ef7-251f-4ccf-aec5-02c44253e011",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_geo_ikti.json
+++ b/data/sc_data/parsed/live/models/argo_atls_geo_ikti.json
@@ -1,0 +1,141 @@
+{
+  "key": "ARGO_ATLS_GEO_IKTI",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS GEO IKTI",
+  "description": null,
+  "career": "Ground",
+  "role": "<= PLACEHOLDER =>",
+  "insurance": {
+    "base_wait_time_minutes": "7.5",
+    "mandatory_wait_time_minutes": "2.5",
+    "base_expediting_fee": "1520"
+  },
+  "mass": 2300.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "6921c36d-68dd-453b-ad41-dd3bc3b2ca07",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "weapon_controller",
+      "ref": "9316c060-265a-44c1-acd0-bdeca41f3548",
+      "key": null
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "f996eda3-731d-4d00-a333-5b9913e4de9b",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "30f37405-de4b-41b2-8743-58564f256163",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "291d8082-98ad-426e-b159-5dce406dacba",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_left",
+      "ref": "a7ca3a05-5a19-41a8-82fb-b4223b223e2f",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_right",
+      "ref": "30423c72-12c4-4ce7-b9c1-dabc2ce1161b",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_ikti.json
+++ b/data/sc_data/parsed/live/models/argo_atls_ikti.json
@@ -1,0 +1,104 @@
+{
+  "key": "ARGO_ATLS_IKTI",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "Argo ATLS IKTI",
+  "description": null,
+  "career": "Ground",
+  "role": "Combat",
+  "insurance": {
+    "base_wait_time_minutes": "3",
+    "mandatory_wait_time_minutes": "1",
+    "base_expediting_fee": "1020"
+  },
+  "mass": 1800.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "6921c36d-68dd-453b-ad41-dd3bc3b2ca07",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "weapon_controller",
+      "ref": "9316c060-265a-44c1-acd0-bdeca41f3548",
+      "key": null
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "de9491ea-a5ef-463c-bf3f-252d74c54da1",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_left",
+      "ref": "a7ca3a05-5a19-41a8-82fb-b4223b223e2f",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_right",
+      "ref": "30423c72-12c4-4ce7-b9c1-dabc2ce1161b",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/models/argo_atls_ikti_argos.json
+++ b/data/sc_data/parsed/live/models/argo_atls_ikti_argos.json
@@ -1,0 +1,151 @@
+{
+  "key": "ARGO_ATLS_IKTI_ARGOS",
+  "ground": true,
+  "movement_class": null,
+  "gravlev": null,
+  "min_crew": "1",
+  "name": "ATLS IKTI Rad",
+  "description": null,
+  "career": "Ground",
+  "role": "Combat",
+  "insurance": {
+    "base_wait_time_minutes": "7.5",
+    "mandatory_wait_time_minutes": "2.5",
+    "base_expediting_fee": "1520"
+  },
+  "mass": 2300.0,
+  "metrics": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "loadout": [
+    {
+      "name": "Seat_ItemPort",
+      "ref": "6921c36d-68dd-453b-ad41-dd3bc3b2ca07",
+      "key": null
+    },
+    {
+      "name": "LeftHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "RightHandWeapon_ItemPort",
+      "ref": "ba8c9920-9fd0-4253-a349-de32079edce2",
+      "key": null
+    },
+    {
+      "name": "weapon_controller",
+      "ref": "9316c060-265a-44c1-acd0-bdeca41f3548",
+      "key": null
+    },
+    {
+      "name": "hardpoint_paint",
+      "ref": null,
+      "key": null
+    },
+    {
+      "name": "hardpoint_battery_storage",
+      "ref": "6e4d388b-d3bf-40ec-9686-aa9cec5cda47",
+      "key": null
+    },
+    {
+      "name": "hardpoint_headlight",
+      "ref": "a116f5c9-f391-4281-8fac-c4515ba3db5a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_leg_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_right",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_01_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_arm_02_left",
+      "ref": "0d2f54bb-a5fd-42f5-8cd1-fbff2ddbb3af",
+      "key": null
+    },
+    {
+      "name": "hardpoint_backpack",
+      "ref": "41ca0b46-321d-47e3-a93c-e00b8c19c282",
+      "key": null,
+      "loadout": [
+        {
+          "name": "$IP_hardpoint_container",
+          "ref": "d867b41f-23ad-44dc-b0ea-686d287b1f9a",
+          "key": null
+        }
+      ]
+    },
+    {
+      "name": "hardpoint_multitool_storage",
+      "ref": "30f37405-de4b-41b2-8743-58564f256163",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_left",
+      "ref": "f5a2e579-3521-42b3-be80-4fc3025fb84a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_a_right",
+      "ref": "f5a2e579-3521-42b3-be80-4fc3025fb84a",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_left",
+      "ref": "7cb43dc5-2993-4796-ad9f-dbbfd068a301",
+      "key": null
+    },
+    {
+      "name": "hardpoint_thruster_backpack_b_right",
+      "ref": "7cb43dc5-2993-4796-ad9f-dbbfd068a301",
+      "key": null
+    },
+    {
+      "name": "hardpoint_Radar",
+      "ref": "e5bccaed-85de-483b-b4b8-dfb62f085b43",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_left",
+      "ref": "a7ca3a05-5a19-41a8-82fb-b4223b223e2f",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shield_right",
+      "ref": "30423c72-12c4-4ce7-b9c1-dabc2ce1161b",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shoulder_shield_left",
+      "ref": "b4e901ff-d2a0-4d34-b96d-1860449dd1b1",
+      "key": null
+    },
+    {
+      "name": "hardpoint_shoulder_shield_right",
+      "ref": "e78389c9-14ab-4dab-84a0-68e3a58b94b4",
+      "key": null
+    }
+  ]
+}

--- a/data/sc_data/parsed/live/version.json
+++ b/data/sc_data/parsed/live/version.json
@@ -1,5 +1,5 @@
 {
   "version": "4.7.1-live.11638371",
   "environment": "live",
-  "parsed_at": "2026-04-28T19:50:33Z"
+  "parsed_at": "2026-05-04T18:00:35Z"
 }

--- a/db/migrate/20260504120000_set_sc_keys_for_known_models.rb
+++ b/db/migrate/20260504120000_set_sc_keys_for_known_models.rb
@@ -1,0 +1,67 @@
+class SetScKeysForKnownModels < ActiveRecord::Migration[7.1]
+  MAPPING = {
+    "orig-890-jump" => "orig_890jump",
+    "orig-600i-explorer" => "orig_600i",
+    "crus-a1-spirit" => "crus_spirit_a1",
+    "crus-c1-spirit" => "crus_spirit_c1",
+    "crus-a2-hercules" => "crus_starlifter_a2",
+    "crus-c2-hercules" => "crus_starlifter_c2",
+    "crus-m2-hercules" => "crus_starlifter_m2",
+    "rsi-aurora-mk-i-cl" => "rsi_aurora_gs_cl",
+    "rsi-aurora-mk-i-es" => "rsi_aurora_gs_es",
+    "rsi-aurora-mk-i-ln" => "rsi_aurora_gs_ln",
+    "rsi-aurora-mk-i-lx" => "rsi_aurora_gs_lx",
+    "rsi-aurora-mk-i-mr" => "rsi_aurora_gs_mr",
+    "rsi-aurora-mk-i-se" => "rsi_aurora_gs_se",
+    "rsi-zeus-mk-ii-cl" => "rsi_zeus_cl",
+    "rsi-zeus-mk-ii-es" => "rsi_zeus_es",
+    "aegs-vanguard-warden" => "aegs_vanguard",
+    "aegs-gladius-pirate-edition" => "aegs_gladius_pir",
+    "misc-reliant-kore" => "misc_reliant",
+    "rsi-ursa" => "rsi_ursa_rover",
+    "rsi-ursa-fortuna" => "rsi_ursa_rover_emerald",
+    "krig-l-21-wolf" => "krig_l21_wolf",
+    "krig-l-22-alpha-wolf" => "krig_l22_alphawolf",
+    "krig-p-52-merlin" => "krig_p52_merlin",
+    "krig-p-72-archimedes" => "krig_p72_archimedes",
+    "xnaa-san-tok-yai" => "xnaa_santokyai",
+    "drak-dragonfly-black" => "drak_dragonfly",
+    "drak-dragonfly-yellowjacket" => "drak_dragonfly_yellow",
+    "drak-dragonfly-star-kitten-edition" => "drak_dragonfly_pink",
+    "argo-csv-sm" => "argo_csv_cargo",
+    "argo-mpuv-cargo" => "argo_mpuv",
+    "argo-mpuv-personnel" => "argo_mpuv_transport",
+    "argo-mpuv-tractor" => "argo_mpuv_1t",
+    "crus-mercury-star-runner" => "crus_star_runner",
+    "crus-ares-inferno" => "crus_starfighter_inferno",
+    "crus-ares-ion" => "crus_starfighter_ion",
+    "espr-blade" => "vncl_blade",
+    "espr-glaive" => "vncl_glaive",
+    "espr-stinger" => "vncl_stinger",
+    "mrai-razor" => "misc_razor",
+    "mrai-razor-ex" => "misc_razor_ex",
+    "mrai-razor-lx" => "misc_razor_lx",
+    "xnaa-khartu-al" => "xian_scout",
+    "xnaa-nox" => "xian_nox",
+    "xnaa-nox-kue" => "xian_nox_kue",
+    "grey-shiv" => "glsn_shiv",
+    "anvl-f8c-lightning" => "anvl_lightning_f8c",
+    "anvl-f8c-lightning-executive-edition" => "anvl_lightning_f8c_exec"
+  }.freeze
+
+  def up
+    MAPPING.each do |slug, sc_key|
+      execute ActiveRecord::Base.sanitize_sql_array(
+        ["UPDATE models SET sc_key = ? WHERE slug = ?", sc_key, slug]
+      )
+    end
+  end
+
+  def down
+    MAPPING.each_key do |slug|
+      execute ActiveRecord::Base.sanitize_sql_array(
+        ["UPDATE models SET sc_key = NULL WHERE slug = ?", slug]
+      )
+    end
+  end
+end

--- a/db/migrate/20260504130000_add_player_ownable_to_models.rb
+++ b/db/migrate/20260504130000_add_player_ownable_to_models.rb
@@ -1,0 +1,5 @@
+class AddPlayerOwnableToModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :models, :player_ownable, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260504130001_add_bengal_carrier.rb
+++ b/db/migrate/20260504130001_add_bengal_carrier.rb
@@ -1,0 +1,34 @@
+class AddBengalCarrier < ActiveRecord::Migration[8.1]
+  def up
+    rsi = Manufacturer.find_by(slug: "roberts-space-industries")
+    return if rsi.blank?
+    return if Model.exists?(slug: "rsi-bengal")
+
+    Model.create!(
+      name: "Bengal",
+      slug: "rsi-bengal",
+      manufacturer: rsi,
+      classification: "combat",
+      focus: "Carrier",
+      size: "capital",
+      length: 1000.0,
+      beam: 287.0,
+      height: 190.0,
+      sc_key: "rsi_bengal_pu_ai_uee_fleetweek_2021",
+      in_game: true,
+      production_status: "flight-ready",
+      player_ownable: false,
+      hidden: false,
+      active: true
+    )
+  end
+
+  def down
+    Model.where(slug: "rsi-bengal").find_each do |model|
+      # model_positions reference hardpoints via FK; destroy them first so
+      # the dependent: :destroy cascade on hardpoints doesn't trip the FK.
+      model.model_positions.destroy_all
+      model.destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_195601) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_130001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -690,6 +690,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_120000) do
     t.boolean "on_sale", default: false
     t.decimal "pitch", precision: 15, scale: 2
     t.decimal "pitch_boosted", precision: 15, scale: 2
+    t.boolean "player_ownable", default: true, null: false
     t.decimal "pledge_price", precision: 15, scale: 2
     t.boolean "positions_need_curation", default: false
     t.decimal "price", precision: 15, scale: 2

--- a/spec/factories/models.rb
+++ b/spec/factories/models.rb
@@ -45,6 +45,7 @@
 #  on_sale                  :boolean          default(FALSE)
 #  pitch                    :decimal(15, 2)
 #  pitch_boosted            :decimal(15, 2)
+#  player_ownable           :boolean          default(TRUE), not null
 #  pledge_price             :decimal(15, 2)
 #  positions_need_curation  :boolean          default(FALSE)
 #  price                    :decimal(15, 2)

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8443,6 +8443,8 @@ components:
           type: number
         onSale:
           type: boolean
+        playerOwnable:
+          type: boolean
         storeUrl:
           type: string
         salesPageUrl:
@@ -9991,6 +9993,8 @@ components:
           type: number
           nullable: true
         onSale:
+          type: boolean
+        playerOwnable:
           type: boolean
         storeUrl:
           type: string

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8269,6 +8269,8 @@ components:
             "$ref": "#/components/schemas/FuelTank"
         onSale:
           type: boolean
+        playerOwnable:
+          type: boolean
         pledgePrice:
           type: number
         pledgePriceLabel:
@@ -8362,6 +8364,7 @@ components:
       - media
       - metrics
       - onSale
+      - playerOwnable
       - speeds
       - adiMap
       - createdAt
@@ -8642,6 +8645,8 @@ components:
             "$ref": "#/components/schemas/FuelTank"
         onSale:
           type: boolean
+        playerOwnable:
+          type: boolean
         pledgePrice:
           type: number
         pledgePriceLabel:
@@ -8742,6 +8747,7 @@ components:
       - media
       - metrics
       - onSale
+      - playerOwnable
       - speeds
       - adiMap
       - createdAt

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10369,6 +10369,8 @@ components:
             "$ref": "#/components/schemas/FuelTank"
         onSale:
           type: boolean
+        playerOwnable:
+          type: boolean
         pledgePrice:
           type: number
         pledgePriceLabel:
@@ -10448,6 +10450,7 @@ components:
       - media
       - metrics
       - onSale
+      - playerOwnable
       - speeds
       - adiMap
       - createdAt
@@ -10629,6 +10632,8 @@ components:
             "$ref": "#/components/schemas/FuelTank"
         onSale:
           type: boolean
+        playerOwnable:
+          type: boolean
         pledgePrice:
           type: number
         pledgePriceLabel:
@@ -10712,6 +10717,7 @@ components:
       - media
       - metrics
       - onSale
+      - playerOwnable
       - speeds
       - adiMap
       - createdAt
@@ -11328,6 +11334,8 @@ components:
         nameOrDescriptionCont:
           type: string
         onSaleEq:
+          type: boolean
+        playerOwnableEq:
           type: boolean
         pledgePriceGteq:
           type: number


### PR DESCRIPTION
## Summary

- Set `sc_key` for 47 ships whose slug-derived identifier doesn't match CIG's game-data filenames (Mk I/Mk II suffixes, internal codenames like `crus_starlifter`/`crus_starfighter`, prefix swaps like `xnaa→xian`, `mrai→misc`, `espr→vncl`). Aurora Mk I variants point at the GS files since CIG labels those "Aurora Mk I"; SE only exists as `gs_se`.
- Add `parse_powersuits` to `ModelsParser` so ATLS-class entities under `entities/actor/actors` (currently outside the parser's scan path) get JSONs that the loader can match against. Mass comes from `SSCActorPhysicsControllerComponentParams`; metrics zeroed since CIG's actor schema has no bounding box (display dimensions live in separate manually-set columns).
- Add Bengal as the first non-player-ownable ship: new `models.player_ownable` boolean (default true), Vehicle validation rejects creation when the model is non-ownable, ransack filter `playerOwnableEq` exposed for the hangar picker, `playerOwnable` exposed on the Model API response. Bengal seeded with RSI manufacturer, capital/combat/Carrier classification, hand-set dimensions (~1000×287×190 m since CIG's data has zeros), pointing at `rsi_bengal_pu_ai_uee_fleetweek_2021` for its sc_data.
- Expected outcome: 47 ships flip to `inGame=true` on next sc_data loader run; ATLS / ATLS GEO ditto once the parser runs against fresh raw data; Bengal appears in browse but is hidden from hangar add (frontend filter pending) and can never be added even via direct API call.

## Test plan

- [x] `bundle exec rails db:migrate` applies cleanly on a current main snapshot
- [x] `bundle exec rails db:rollback STEP=2` reverts the Bengal record + the `player_ownable` column without FK violations
- [x] `bundle exec rspec spec/models/ spec/loaders/sc_data/models_loader_spec.rb` — all green
- [x] After running the sc_data loader: previously not-in-game ships (e.g. `rsi-aurora-mk-i-cl`, `aegs-vanguard-warden`, `crus-a2-hercules`) flip to `inGame=true`
- [x] `Vehicle.create!(model: Model.find_by(slug: "rsi-bengal"), user: some_user)` raises with "cannot be added to a hangar"
- [x] `Vehicle.create!(model: Model.find_by(slug: "rsi-aurora-mk-i-cl"), user: some_user)` still works
- [x] GET `/v1/models?q[playerOwnableEq]=true` excludes the Bengal
- [x] GET `/v1/models?q[searchCont]=bengal` returns the Bengal with `playerOwnable: false`

## Follow-ups (out of scope)

- Frontend: filter the hangar add picker by `q[playerOwnableEq]=true`
- Aurora Gold Standard variants — six new ship records (CL/ES/LN/LX/MR/SE GS) pointing at `rsi_aurora_gs_*` files
- Production sc_data refresh to pick up the Hornet variants (already have correct `sc_key`s, just stale data on prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)