### PR TITLE
chore: readd chore section to release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
-        {"type": "refactor", "section": "Refactorings"}
+        {"type": "refactor", "section": "Refactorings"},
+        {"type": "chore", "section": "Chores"}
       ],
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

- Reverts 641c2320f, which dropped the `chore` entry from `release-please-config.json`'s changelog sections.
- Chore commits (CI changes, dependency bumps, infra tweaks) reappear in the generated changelog under their own "Chores" section instead of being silently filtered out.

## Test plan

- [ ] Next release-please PR includes a "Chores" section if any `chore:` commits landed since last release
- [ ] Existing `feat`/`fix`/`refactor` sections still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)