### PR TITLE
Declare ruby-vips explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem "after_commit_everywhere"
 
 gem "image_processing", "~> 1.0"
 gem "mini_magick"
-gem "ruby-vips"
+gem "ruby-vips", require: false
 
 gem "geocoder"
 

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem "after_commit_everywhere"
 
 gem "image_processing", "~> 1.0"
 gem "mini_magick"
+gem "ruby-vips"
 
 gem "geocoder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -976,6 +976,7 @@ DEPENDENCIES
   rollups
   rqrcode
   rspec-rails
+  ruby-vips
   shoulda-matchers
   sidekiq (~> 8.1)
   sidekiq-failures

--- a/app/controllers/frontend/base_controller.rb
+++ b/app/controllers/frontend/base_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "image_processing/mini_magick"
+require "image_processing/vips"
 
 module Frontend
   class BaseController < ApplicationController
@@ -190,19 +190,19 @@ module Frontend
         tempfile.binmode
         model.store_image.download { |chunk| tempfile.write(chunk) }
         tempfile.rewind
-        image = MiniMagick::Image.new(tempfile.path)
-        image.write(Rails.root.join("tmp", model.slug))
-        image.write(Rails.root.join("tmp", "#{filename_base}-base")) if index.zero?
+        image = Vips::Image.new_from_file(tempfile.path)
+        image.write_to_file(Rails.root.join("tmp", "#{model.slug}.jpg").to_s)
+        image.write_to_file(Rails.root.join("tmp", "#{filename_base}-base.jpg").to_s) if index.zero?
         tempfile.close!
       end
 
-      base_image = MiniMagick::Image.new(Rails.root.join("tmp", "#{filename_base}-base"))
-      base_image_pipeline = ImageProcessing::MiniMagick.source(Rails.root.join("tmp", "#{filename_base}-base"))
+      base_image = Vips::Image.new_from_file(Rails.root.join("tmp", "#{filename_base}-base.jpg").to_s)
+      base_image_pipeline = ImageProcessing::Vips.source(Rails.root.join("tmp", "#{filename_base}-base.jpg"))
 
       images = models.map do |model|
-        image = MiniMagick::Image.new(Rails.root.join("tmp", model.slug))
-        ImageProcessing::MiniMagick
-          .source(Rails.root.join("tmp", model.slug))
+        image = Vips::Image.new_from_file(Rails.root.join("tmp", "#{model.slug}.jpg").to_s)
+        ImageProcessing::Vips
+          .source(Rails.root.join("tmp", "#{model.slug}.jpg"))
           .resize_to_fill!(image.width / models.size, image.height)
       end
 
@@ -218,9 +218,9 @@ module Frontend
 
       File.chmod(0o644, path)
 
-      FileUtils.rm(Rails.root.join("tmp", "#{filename_base}-base"))
+      FileUtils.rm(Rails.root.join("tmp", "#{filename_base}-base.jpg"))
       models.each do |model|
-        FileUtils.rm(Rails.root.join("tmp", model.slug))
+        FileUtils.rm(Rails.root.join("tmp", "#{model.slug}.jpg"))
       end
 
       "https://fleetyards.net/compare/#{filename}"

--- a/app/controllers/frontend/base_controller.rb
+++ b/app/controllers/frontend/base_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "image_processing/vips"
+require "image_processing/mini_magick"
 
 module Frontend
   class BaseController < ApplicationController
@@ -190,19 +190,19 @@ module Frontend
         tempfile.binmode
         model.store_image.download { |chunk| tempfile.write(chunk) }
         tempfile.rewind
-        image = Vips::Image.new_from_file(tempfile.path)
-        image.write_to_file(Rails.root.join("tmp", "#{model.slug}.jpg").to_s)
-        image.write_to_file(Rails.root.join("tmp", "#{filename_base}-base.jpg").to_s) if index.zero?
+        image = MiniMagick::Image.new(tempfile.path)
+        image.write(Rails.root.join("tmp", model.slug))
+        image.write(Rails.root.join("tmp", "#{filename_base}-base")) if index.zero?
         tempfile.close!
       end
 
-      base_image = Vips::Image.new_from_file(Rails.root.join("tmp", "#{filename_base}-base.jpg").to_s)
-      base_image_pipeline = ImageProcessing::Vips.source(Rails.root.join("tmp", "#{filename_base}-base.jpg"))
+      base_image = MiniMagick::Image.new(Rails.root.join("tmp", "#{filename_base}-base"))
+      base_image_pipeline = ImageProcessing::MiniMagick.source(Rails.root.join("tmp", "#{filename_base}-base"))
 
       images = models.map do |model|
-        image = Vips::Image.new_from_file(Rails.root.join("tmp", "#{model.slug}.jpg").to_s)
-        ImageProcessing::Vips
-          .source(Rails.root.join("tmp", "#{model.slug}.jpg"))
+        image = MiniMagick::Image.new(Rails.root.join("tmp", model.slug))
+        ImageProcessing::MiniMagick
+          .source(Rails.root.join("tmp", model.slug))
           .resize_to_fill!(image.width / models.size, image.height)
       end
 
@@ -218,9 +218,9 @@ module Frontend
 
       File.chmod(0o644, path)
 
-      FileUtils.rm(Rails.root.join("tmp", "#{filename_base}-base.jpg"))
+      FileUtils.rm(Rails.root.join("tmp", "#{filename_base}-base"))
       models.each do |model|
-        FileUtils.rm(Rails.root.join("tmp", "#{model.slug}.jpg"))
+        FileUtils.rm(Rails.root.join("tmp", model.slug))
       end
 
       "https://fleetyards.net/compare/#{filename}"


### PR DESCRIPTION
## Summary
- Declares `gem \"ruby-vips\"` (with `require: false`) directly in the Gemfile. It's currently only a transitive dep of `image_processing` 1.x; #3983 upgrades that to 2.0, which makes `ruby-vips` a soft dependency.
- Required for #3983 to merge safely: Rails 8.1's default `config.active_storage.variant_processor` is `:vips`, so every `blob.representation(...).processed` path (PreprocessRepresentationsJob, redirect controller, maintenance task) relies on it.
- `require: false` keeps Bundler from dlopening libvips at boot for CI jobs that don't install the system package (libvips is present in the production Dockerfile and e2e workflow).

A separate PR will handle the `compare_image` rewrite (stateless, ActiveStorage-backed).

## Test plan
- [x] CI green
- [x] After merging, rebase #3983 on top and confirm checks stay green