### PR TITLE
Route /compare to compare_models so OG metadata renders

### DIFF
--- a/config/routes/frontend_routes.rb
+++ b/config/routes/frontend_routes.rb
@@ -9,7 +9,9 @@ frontend_options = {
 namespace :frontend, **frontend_options do
   get "ships/mercury", to: redirect("/ships/CRUS-mercury-star-runner")
   get "ships/compare", to: redirect("/compare/")
-  get "compare/ships", to: redirect("/compare/")
+  get "compare/ships", to: redirect(status: 301) { |_params, req|
+    req.query_string.empty? ? "/compare/" : "/compare/?#{req.query_string}"
+  }
 
   get "ships/:slug", to: "base#model", as: :model
   get "ships/:slug/images", to: "base#model_images", as: :model_images
@@ -21,7 +23,7 @@ namespace :frontend, **frontend_options do
   get "hangar/:username/stats", to: "hangar#public"
   get "hangar/:username/wishlist", to: "hangar#wishlist", as: :public_wishlist
 
-  get "compare/ships", to: "base#compare_models"
+  get "compare", to: "base#compare_models"
 
   get "fleets/invites", to: "base#index", as: :fleets_invites
   get "fleets/invites/:token", to: "fleets#invite", as: :fleet_invite


### PR DESCRIPTION
## Summary
The compare page has been silently rendering without any OG metadata (title, description, image). Two routing bugs in \`config/routes/frontend_routes.rb\`:

1. \`get \"compare/ships\", to: redirect(\"/compare/\")\` was declared **before** \`get \"compare/ships\", to: \"base#compare_models\"\`, so the redirect always won and the action was unreachable.
2. The Vue SPA route (\`app/frontend/frontend/pages/routes.ts:60\`) is \`/compare/\`, not \`/compare/ships\` — so even with the redirect removed, \`compare_models\` would have sat on a URL the user never visits.

Move \`compare_models\` to \`/compare\` to match the SPA, and keep \`/compare/ships\` as a 301 redirect with query-string preservation for backward compatibility.

After this lands, the compare page gets the \`og:title\`, \`og:description\` and \`og:image\` (first model's store image) that the action has been trying to set all along. #3992 (CompareImage composite) then replaces that single-image OG with the diagonal composite.

## Test plan
- [x] CI green
- [x] Manually visit \`/compare?models[]=rsi-aurora-mk-i-cl&models[]=crus-intrepid\` — confirm \`og:image\`, \`og:title\`, \`og:description\` are set in the HTML head.
- [x] Manually visit \`/compare/ships?models[]=...\` — confirm 301 redirect to \`/compare/?models[]=...\` (query string preserved).