### PR TITLE
feat(hangar-sync): auto-add bundled snub crafts to hangar

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/model_snub_craft_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_snub_craft_input.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ModelSnubCraftInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              modelId: {type: :string, format: :uuid},
+              snubCraftId: {type: :string, format: :uuid}
+            },
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_craft.rb
+++ b/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_craft.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module SnubCrafts
+          class ModelSnubCraft
+            include OpenapiRuby::Components::Base
+
+            schema({
+              type: :object,
+              properties: {
+                id: {type: :string, format: :uuid},
+                modelId: {type: :string, format: :uuid},
+                snubCraftId: {type: :string, format: :uuid},
+                model: {
+                  type: :object,
+                  properties: {
+                    id: {type: :string, format: :uuid},
+                    name: {type: :string},
+                    slug: {type: :string}
+                  },
+                  required: %w[id name slug]
+                },
+                snubCraft: {
+                  type: :object,
+                  properties: {
+                    id: {type: :string, format: :uuid},
+                    name: {type: :string},
+                    slug: {type: :string}
+                  },
+                  required: %w[id name slug]
+                },
+                createdAt: {type: :string, format: "date-time"},
+                updatedAt: {type: :string, format: "date-time"}
+              },
+              additionalProperties: false,
+              required: %w[id modelId snubCraftId createdAt updatedAt]
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_crafts.rb
+++ b/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_crafts.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module SnubCrafts
+          class ModelSnubCrafts < ::Shared::V1::Schemas::BaseList
+            include OpenapiRuby::Components::Base
+
+            schema({
+              properties: {
+                items: {type: :array, items: {"$ref": "#/components/schemas/ModelSnubCraft"}}
+              },
+              required: %w[items]
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/model_snub_craft_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_snub_craft_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class ModelSnubCraftQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              modelIdEq: {type: :string, format: :uuid},
+              snubCraftIdEq: {type: :string, format: :uuid}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/hangar_query.rb
+++ b/app/api_components/v1/schemas/queries/hangar_query.rb
@@ -37,6 +37,7 @@ module V1
             modelNameOrModelDescriptionCont: {type: :string},
             publicEq: {type: :boolean},
             loanerEq: {type: :boolean},
+            bundledEq: {type: :string},
             boughtViaEq: {"$ref": "#/components/schemas/BoughtViaEnum"},
             hangarGroupsIn: {type: :array, items: {type: :string}},
             hangarGroupsNotIn: {type: :array, items: {type: :string}},

--- a/app/api_components/v1/schemas/vehicles/vehicle.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle.rb
@@ -20,6 +20,15 @@ module V1
             hangarGroupIds: {type: :array, items: {type: :string, format: :uuid}},
             hangarGroups: {type: :array, items: {"$ref": "#/components/schemas/HangarGroup"}},
             loaner: {type: :boolean},
+            bundled: {type: :boolean},
+            bundledParent: {
+              type: :object,
+              nullable: true,
+              properties: {
+                name: {type: :string},
+                slug: {type: :string}
+              }
+            },
             model: {"$ref": "#/components/schemas/Model"},
             modelModuleIds: {type: :array, items: {type: :string, format: :uuid}},
             modelUpgradeIds: {type: :array, items: {type: :string, format: :uuid}},
@@ -36,7 +45,7 @@ module V1
           },
           additionalProperties: false,
           required: %w[
-            id model wanted loaner flagship public nameVisible saleNotify alternativeNames
+            id model wanted loaner bundled flagship public nameVisible saleNotify alternativeNames
             modelUpgradeIds hangarGroupIds hangarGroups modelModuleIds createdAt updatedAt
           ]
         })

--- a/app/api_components/v1/schemas/vehicles/vehicle.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle.rb
@@ -25,8 +25,10 @@ module V1
               type: :object,
               nullable: true,
               properties: {
+                id: {type: :string, format: :uuid},
                 name: {type: :string},
-                slug: {type: :string}
+                slug: {type: :string},
+                customName: {type: :string, nullable: true}
               }
             },
             model: {"$ref": "#/components/schemas/Model"},

--- a/app/api_components/v1/schemas/vehicles/vehicle_public.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_public.rb
@@ -16,6 +16,15 @@ module V1
             hangarGroupIds: {type: :array, items: {type: :string, format: :uuid}},
             hangarGroups: {type: :array, items: {"$ref": "#/components/schemas/HangarGroupPublic"}},
             loaner: {type: :boolean},
+            bundled: {type: :boolean},
+            bundledParent: {
+              type: :object,
+              nullable: true,
+              properties: {
+                name: {type: :string},
+                slug: {type: :string}
+              }
+            },
             model: {"$ref": "#/components/schemas/Model"},
             username: {type: :string},
             userAvatar: {type: :string, format: :uri},
@@ -31,8 +40,8 @@ module V1
           },
           additionalProperties: false,
           required: %w[
-            id model loaner modelUpgradeIds hangarGroupIds hangarGroups modelModuleIds createdAt
-            updatedAt
+            id model loaner bundled modelUpgradeIds hangarGroupIds hangarGroups modelModuleIds
+            createdAt updatedAt
           ]
         })
       end

--- a/app/api_components/v1/schemas/vehicles/vehicle_public.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_public.rb
@@ -21,8 +21,10 @@ module V1
               type: :object,
               nullable: true,
               properties: {
+                id: {type: :string, format: :uuid},
                 name: {type: :string},
-                slug: {type: :string}
+                slug: {type: :string},
+                customName: {type: :string, nullable: true}
               }
             },
             model: {"$ref": "#/components/schemas/Model"},

--- a/app/controllers/admin/api/v1/model_snub_crafts_controller.rb
+++ b/app/controllers/admin/api/v1/model_snub_crafts_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class ModelSnubCraftsController < ::Admin::Api::BaseController
+        before_action :set_model_snub_craft, only: %i[show update destroy]
+
+        def index
+          authorize! with: ::Admin::ModelSnubCraftPolicy
+
+          @q = authorized_scope(ModelSnubCraft.includes(:model, :snub_craft)).ransack(snub_craft_query_params)
+
+          @model_snub_crafts = @q.result
+            .page(params.fetch(:page, nil))
+            .per(params.fetch(:per_page, nil))
+        end
+
+        def create
+          @model_snub_craft = ModelSnubCraft.new(snub_craft_params)
+
+          authorize! @model_snub_craft, with: ::Admin::ModelSnubCraftPolicy
+
+          if @model_snub_craft.save
+            render :show, status: :created
+          else
+            render json: ValidationError.new("model_snub_craft.create", errors: @model_snub_craft.errors), status: :bad_request
+          end
+        end
+
+        def show
+        end
+
+        def update
+          if @model_snub_craft.update(snub_craft_params)
+            render :show, status: :ok
+          else
+            render json: ValidationError.new("model_snub_craft.update", errors: @model_snub_craft.errors), status: :bad_request
+          end
+        end
+
+        def destroy
+          @model_snub_craft.destroy
+
+          head :no_content
+        end
+
+        private def set_model_snub_craft
+          @model_snub_craft = ModelSnubCraft.find(params[:id])
+
+          authorize! @model_snub_craft, with: ::Admin::ModelSnubCraftPolicy
+        end
+
+        private def snub_craft_params
+          @snub_craft_params ||= params.permit(
+            :model_id, :snub_craft_id
+          )
+        end
+
+        private def snub_craft_query_params
+          @snub_craft_query_params ||= params.permit(q: [
+            :model_id_eq, :snub_craft_id_eq, :sorts
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/hangar_stats_controller.rb
+++ b/app/controllers/api/v1/hangar_stats_controller.rb
@@ -18,6 +18,7 @@ module Api
         scope = authorized_scope(Vehicle.all).visible.purchased.includes(:vehicle_upgrades, :model_upgrades, :vehicle_modules, :model_modules, :model)
 
         scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
         scope = will_it_fit?(scope) if vehicle_query_params["will_it_fit"].present?
 
         @q = scope.ransack(vehicle_query_params)

--- a/app/controllers/api/v1/hangars_controller.rb
+++ b/app/controllers/api/v1/hangars_controller.rb
@@ -31,6 +31,7 @@ module Api
         end
 
         scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
         scope = scope.where(models: {cargo: 0.1..}) if vehicle_query_params.delete("with_cargo")
         scope = will_it_fit?(scope) if vehicle_query_params["will_it_fit"].present?
 
@@ -45,6 +46,7 @@ module Api
           .order(@q.result.order_values)
           .includes(:vehicle_upgrades, :model_upgrades, :module_package,
             :task_forces, :hangar_groups, :vehicle_modules, :vehicle_loadouts,
+            {parent_vehicle: :model},
             model_paint: :item_prices,
             model: [:manufacturer, :item_prices, {model_loaners: :loaner_model}])
           .joins(model: [:manufacturer])
@@ -94,6 +96,7 @@ module Api
         scope = authorized_scope(Vehicle.all).visible.purchased
 
         scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
 
         vehicle_query_params["sorts"] = "model_name asc"
 

--- a/app/controllers/api/v1/wishlists_controller.rb
+++ b/app/controllers/api/v1/wishlists_controller.rb
@@ -31,6 +31,7 @@ module Api
         end
 
         scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
         scope = will_it_fit?(scope) if vehicle_query_params["will_it_fit"].present?
 
         vehicle_query_params["sorts"] = sorting_params(Vehicle, vehicle_query_params["sorts"], ["name asc", "model_name asc"])
@@ -68,6 +69,7 @@ module Api
         scope = authorized_scope(Vehicle.all).visible.wanted
 
         scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
 
         vehicle_query_params["sorts"] = "model_name asc"
 

--- a/app/controllers/concerns/hangar_filters_concern.rb
+++ b/app/controllers/concerns/hangar_filters_concern.rb
@@ -88,6 +88,17 @@ module HangarFiltersConcern
     scope
   end
 
+  private def bundled_included?(scope)
+    case vehicle_query_params.delete("bundled_eq")
+    when "false"
+      scope.where(bundled: false)
+    when "only"
+      scope.where(bundled: true)
+    else
+      scope
+    end
+  end
+
   private def price_range
     @price_range ||= price_in.map do |prices|
       gt_price, lt_price = prices.split("-")

--- a/app/frontend/admin/components/base/ModelFilterGroup/index.vue
+++ b/app/frontend/admin/components/base/ModelFilterGroup/index.vue
@@ -22,6 +22,7 @@ type Props = {
   translationKey?: string;
   hideSelected?: boolean;
   valueAttr?: "slug" | "id";
+  inline?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -32,6 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
   returnObject: false,
   hideSelected: false,
   valueAttr: "slug",
+  inline: false,
 });
 
 const { t } = useI18n();
@@ -136,5 +138,6 @@ defineExpose({
     :no-label="noLabel"
     :return-object="returnObject"
     :hide-selected="hideSelected"
+    :inline="inline"
   />
 </template>

--- a/app/frontend/admin/pages/models/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/[id]/edit/routes.ts
@@ -135,6 +135,18 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "snub-crafts/",
+    name: "admin-model-edit-snub-crafts",
+    component: () => import("@/admin/pages/models/[id]/edit/snub-crafts.vue"),
+    meta: {
+      title: "admin.models.edit.snubCrafts",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
+  {
     path: "docks/",
     name: "admin-model-edit-docks",
     component: () => import("@/admin/pages/models/[id]/edit/docks.vue"),

--- a/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
@@ -159,7 +159,8 @@ const onSaveCreate = async () => {
       <ModelFilterGroup
         v-model="editForm.snubCraftId"
         value-attr="id"
-        :no-label="false"
+        no-label
+        inline
         translation-key="modelSnubCraft.snubCraft"
         :multiple="false"
         name="edit-snub-craft-model"
@@ -170,7 +171,8 @@ const onSaveCreate = async () => {
       <ModelFilterGroup
         v-model="createForm.snubCraftId"
         value-attr="id"
-        :no-label="false"
+        no-label
+        inline
         translation-key="modelSnubCraft.snubCraft"
         :multiple="false"
         name="create-snub-craft-model"

--- a/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
@@ -1,0 +1,187 @@
+<script lang="ts">
+export default {
+  name: "AdminModelEditSnubCraftsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type ModelExtended,
+  type ModelSnubCraft,
+  type ModelSnubCraftInput,
+  useListModelSnubCrafts as useListModelSnubCraftsQuery,
+  useCreateModelSnubCraft as useCreateModelSnubCraftMutation,
+  useUpdateModelSnubCraft as useUpdateModelSnubCraftMutation,
+  useDestroyModelSnubCraft as useDestroyModelSnubCraftMutation,
+  getListModelSnubCraftsQueryKey,
+} from "@/services/fyAdminApi";
+import { useQueryClient } from "@tanstack/vue-query";
+import { usePagination } from "@/shared/composables/usePagination";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import ModelFilterGroup from "@/admin/components/base/ModelFilterGroup/index.vue";
+
+type Props = {
+  model: ModelExtended;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const queryClient = useQueryClient();
+
+const editableList = ref<{
+  editingId: string | null;
+  creating: boolean;
+  startCreate: () => void;
+  finishEdit: () => void;
+  finishCreate: () => void;
+} | null>(null);
+
+const snubCraftsQueryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+  q: {
+    modelIdEq: props.model.id,
+  },
+}));
+
+const snubCraftsQueryKey = computed(() =>
+  getListModelSnubCraftsQueryKey(snubCraftsQueryParams.value),
+);
+
+const { perPage, page, updatePerPage } = usePagination(snubCraftsQueryKey);
+
+const { data, isLoading } = useListModelSnubCraftsQuery(snubCraftsQueryParams);
+
+const invalidateSnubCrafts = () =>
+  queryClient.invalidateQueries({
+    queryKey: getListModelSnubCraftsQueryKey(),
+  });
+
+// Edit
+const editForm = ref<ModelSnubCraftInput>({});
+
+const onStartEdit = (record: ModelSnubCraft) => {
+  editForm.value = {
+    snubCraftId: record.snubCraftId,
+  };
+};
+
+const updateMutation = useUpdateModelSnubCraftMutation({
+  mutation: {
+    onSettled: invalidateSnubCrafts,
+  },
+});
+
+const onSaveEdit = async () => {
+  const id = editableList.value?.editingId;
+  if (!id) return;
+
+  await updateMutation.mutateAsync({
+    id,
+    data: editForm.value,
+  });
+
+  editableList.value?.finishEdit();
+};
+
+// Delete
+const destroyMutation = useDestroyModelSnubCraftMutation({
+  mutation: {
+    onSettled: invalidateSnubCrafts,
+  },
+});
+
+const onDestroy = async (record: ModelSnubCraft) => {
+  await destroyMutation.mutateAsync({ id: record.id });
+};
+
+// Create
+const createForm = ref<ModelSnubCraftInput>({
+  modelId: props.model.id,
+});
+
+const onStartCreate = () => {
+  createForm.value = {
+    modelId: props.model.id,
+  };
+};
+
+const createMutation = useCreateModelSnubCraftMutation({
+  mutation: {
+    onSettled: invalidateSnubCrafts,
+  },
+});
+
+const onSaveCreate = async () => {
+  await createMutation.mutateAsync({
+    data: createForm.value,
+  });
+
+  editableList.value?.finishCreate();
+};
+</script>
+
+<template>
+  <div class="flex items-center justify-between">
+    <Heading hero>{{ t("headlines.admin.models.edit.snubCrafts") }}</Heading>
+    <Btn
+      :size="BtnSizesEnum.SMALL"
+      :disabled="editableList?.creating"
+      @click="editableList?.startCreate()"
+    >
+      <i class="fa-duotone fa-plus" />
+      {{ t("actions.add") }}
+    </Btn>
+  </div>
+
+  <InlineEditableList
+    empty-name="Snub Crafts"
+    :loading="isLoading"
+    ref="editableList"
+    :items="(data?.items as ModelSnubCraft[]) || []"
+    :confirm-destroy-text="t('messages.confirm.modelSnubCraft.destroy')"
+    @start-edit="onStartEdit"
+    @save-edit="onSaveEdit"
+    @start-create="onStartCreate"
+    @save-create="onSaveCreate"
+    @destroy="onDestroy"
+  >
+    <template #display="{ item }">
+      <span v-if="item.snubCraft">{{ item.snubCraft.name }}</span>
+    </template>
+
+    <template #edit>
+      <ModelFilterGroup
+        v-model="editForm.snubCraftId"
+        value-attr="id"
+        :no-label="false"
+        translation-key="modelSnubCraft.snubCraft"
+        :multiple="false"
+        name="edit-snub-craft-model"
+      />
+    </template>
+
+    <template #create>
+      <ModelFilterGroup
+        v-model="createForm.snubCraftId"
+        value-attr="id"
+        :no-label="false"
+        translation-key="modelSnubCraft.snubCraft"
+        :multiple="false"
+        name="create-snub-craft-model"
+      />
+    </template>
+  </InlineEditableList>
+
+  <Paginator
+    v-if="data"
+    :query-result-ref="data"
+    :per-page="perPage"
+    :update-per-page="updatePerPage"
+  />
+</template>

--- a/app/frontend/admin/types/routes.ts
+++ b/app/frontend/admin/types/routes.ts
@@ -57,6 +57,7 @@ export type AdminRouteLocation =
   | ParamRoute<"admin-model-edit-positions", IdParams>
   | ParamRoute<"admin-model-edit-hardpoints", IdParams>
   | ParamRoute<"admin-model-edit-loaners", IdParams>
+  | ParamRoute<"admin-model-edit-snub-crafts", IdParams>
   | ParamRoute<"admin-model-edit-docks", IdParams>
   | ParamRoute<"admin-model-edit-paints", IdParams>
   | ParamRoute<"admin-model-edit-modules", IdParams>

--- a/app/frontend/frontend/components/Hangar/FilterForm/index.vue
+++ b/app/frontend/frontend/components/Hangar/FilterForm/index.vue
@@ -40,6 +40,7 @@ const prefillFormValues = () => {
     nameCont: filters.value.nameCont,
     onSaleEq: filters.value.onSaleEq,
     loanerEq: filters.value.loanerEq,
+    bundledEq: filters.value.bundledEq,
     publicEq: filters.value.publicEq,
     boughtViaEq: filters.value.boughtViaEq,
     priceLteq: filters.value.priceLteq,
@@ -231,6 +232,24 @@ const { booleanOptions, priceOptions, pledgePriceOptions } = useFilterOptions();
         },
       ]"
       name="loaner"
+    />
+
+    <RadioList
+      v-if="$route.name === 'hangar' || $route.name === 'hangar-wishlist'"
+      v-model="form.bundledEq"
+      :label="t('labels.filters.vehicles.bundled')"
+      :reset-label="t('labels.all')"
+      :options="[
+        {
+          label: t('labels.hide'),
+          value: 'false',
+        },
+        {
+          label: t('labels.only'),
+          value: 'only',
+        },
+      ]"
+      name="bundled"
     />
 
     <RadioList

--- a/app/frontend/frontend/components/Vehicles/Panel/index.scss
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.scss
@@ -16,7 +16,8 @@
     color: $gold;
   }
 
-  &-loaner-label {
+  &-loaner-label,
+  &-bundled-label {
     position: absolute;
     top: 0;
     right: 0;
@@ -32,6 +33,10 @@
     svg {
       color: #fff;
     }
+  }
+
+  &-bundled-label {
+    background-color: $primary;
   }
 
   &-addons {

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -109,8 +109,9 @@ const hasLoaners = computed(() => model.value?.loaners?.length);
 
 const bundledTooltip = computed(() => {
   const parent = (props.vehicle as Vehicle).bundledParent;
-  if (parent?.name) {
-    return t("labels.vehicle.bundledWith", { parent: parent.name });
+  const parentName = parent?.customName || parent?.name;
+  if (parentName) {
+    return t("labels.vehicle.bundledWith", { parent: parentName });
   }
   return t("labels.vehicle.bundled");
 });

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -109,11 +109,13 @@ const hasLoaners = computed(() => model.value?.loaners?.length);
 
 const bundledTooltip = computed(() => {
   const parent = (props.vehicle as Vehicle).bundledParent;
-  const parentName = parent?.customName || parent?.name;
-  if (parentName) {
-    return t("labels.vehicle.bundledWith", { parent: parentName });
+  if (!parent?.name) {
+    return t("labels.vehicle.bundled");
   }
-  return t("labels.vehicle.bundled");
+  const parentLabel = parent.customName
+    ? `${parent.customName} (${parent.name})`
+    : parent.name;
+  return t("labels.vehicle.bundledWith", { parent: parentLabel });
 });
 
 const filterManufacturerQuery = (manufacturer: Manufacturer) => ({

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -107,6 +107,14 @@ const loanersTooltip = computed(() =>
 
 const hasLoaners = computed(() => model.value?.loaners?.length);
 
+const bundledTooltip = computed(() => {
+  const parent = (props.vehicle as Vehicle).bundledParent;
+  if (parent?.name) {
+    return t("labels.vehicle.bundledWith", { parent: parent.name });
+  }
+  return t("labels.vehicle.bundled");
+});
+
 const filterManufacturerQuery = (manufacturer: Manufacturer) => ({
   manufacturerIn: [manufacturer.slug],
 });
@@ -216,6 +224,13 @@ const shouldHighlight = computed(() => {
         class="vehicle-panel-loaner-label"
       >
         <i class="fa-light fa-exchange" />
+      </div>
+      <div
+        v-else-if="(vehicle as Vehicle).bundled"
+        v-tooltip="bundledTooltip"
+        class="vehicle-panel-bundled-label"
+      >
+        <i class="fa-light fa-box" />
       </div>
       <div
         v-else-if="hasLoaners && loanersHintVisible"

--- a/app/frontend/frontend/composables/useVehicleMutations.ts
+++ b/app/frontend/frontend/composables/useVehicleMutations.ts
@@ -182,9 +182,23 @@ export const useVehicleMutations = () => {
 
           queryClient.setQueryData(key, {
             ...data,
-            items: data.items.map((v) =>
-              v.id === updatedVehicle.id ? updatedVehicle : v,
-            ),
+            items: data.items.map((v) => {
+              if (v.id === updatedVehicle.id) {
+                return updatedVehicle;
+              }
+
+              if (v.bundled && v.bundledParent?.id === updatedVehicle.id) {
+                return {
+                  ...v,
+                  bundledParent: {
+                    ...v.bundledParent,
+                    customName: updatedVehicle.name,
+                  },
+                };
+              }
+
+              return v;
+            }),
           });
         });
     });

--- a/app/frontend/frontend/pages/visual-tests/panels.vue
+++ b/app/frontend/frontend/pages/visual-tests/panels.vue
@@ -123,6 +123,7 @@ const vehicle = computed<Vehicle | undefined>(() => {
       },
     ],
     loaner: vehiclePanelLoaner.value,
+    bundled: false,
     modelModuleIds: [],
     modelUpgradeIds: [],
     nameVisible: false,

--- a/app/frontend/translations/de/filterGroup.json
+++ b/app/frontend/translations/de/filterGroup.json
@@ -20,6 +20,12 @@
           "label": "Leihmodell"
         }
       },
+      "modelSnubCraft": {
+        "snubCraft": {
+          "label": "Snub Craft",
+          "prompt": "Snub Craft auswählen"
+        }
+      },
       "modelHardpoint": {
         "source": {
           "label": "Quelle",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -765,7 +765,7 @@
         "wanted": "Gewünscht",
         "loaner": "Leihschiff",
         "bundled": "Mitgeliefert",
-        "bundledWith": "Mitgeliefert mit {parent}",
+        "bundledWith": "Mitgeliefert mit %{parent}",
         "public": "Öffentlich sichtbar",
         "fullPublic": "Öffentlich sichtbar inkl. Name",
         "publicShort": "Öffentlich",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -764,6 +764,8 @@
         "flagship": "Flaggschiff",
         "wanted": "Gewünscht",
         "loaner": "Leihschiff",
+        "bundled": "Mitgeliefert",
+        "bundledWith": "Mitgeliefert mit {parent}",
         "public": "Öffentlich sichtbar",
         "fullPublic": "Öffentlich sichtbar inkl. Name",
         "publicShort": "Öffentlich",
@@ -964,6 +966,7 @@
           "public": "Öffentlich",
           "group": "Gruppe",
           "loaner": "Leihschiffe",
+          "bundled": "Mitgelieferte Snub Crafts",
           "boughtVia": "Gekauft über?"
         },
         "tradeRoutes": {

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -118,6 +118,7 @@
             "images": "Modell Bilder bearbeiten",
             "videos": "Modell Videos bearbeiten",
             "loaners": "Modell Leihgaben bearbeiten",
+            "snubCrafts": "Modell Snub Crafts bearbeiten",
             "upgrades": "Modell Upgrades bearbeiten",
             "packages": "Modell Pakete bearbeiten"
           }

--- a/app/frontend/translations/en/filterGroup.json
+++ b/app/frontend/translations/en/filterGroup.json
@@ -20,6 +20,11 @@
           "label": "Loaner Model"
         }
       },
+      "modelSnubCraft": {
+        "snubCraft": {
+          "label": "Snub Craft"
+        }
+      },
       "modelPosition": {
         "positionType": {
           "label": "Position Type",

--- a/app/frontend/translations/en/filterGroup.json
+++ b/app/frontend/translations/en/filterGroup.json
@@ -22,7 +22,8 @@
       },
       "modelSnubCraft": {
         "snubCraft": {
-          "label": "Snub Craft"
+          "label": "Snub Craft",
+          "prompt": "Select a Snub Craft"
         }
       },
       "modelPosition": {

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -38,6 +38,7 @@
             "itemPrices": "Item Prices",
             "linkModule": "Link Existing Module",
             "loaners": "Loaners",
+            "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
             "packages": "Packages",
             "linkUpgrade": "Link Existing Upgrade"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -888,6 +888,8 @@
         "flagship": "Flagship",
         "wanted": "Wanted",
         "loaner": "Loaner",
+        "bundled": "Bundled",
+        "bundledWith": "Bundled with {parent}",
         "public": "Public Visible",
         "fullPublic": "Public Visible including Name",
         "publicShort": "Public",
@@ -1109,6 +1111,7 @@
           "public": "Public",
           "group": "Group",
           "loaner": "Loaners",
+          "bundled": "Bundled Snub Crafts",
           "boughtVia": "Bought via?"
         },
         "tradeRoutes": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -889,7 +889,7 @@
         "wanted": "Wanted",
         "loaner": "Loaner",
         "bundled": "Bundled",
-        "bundledWith": "Bundled with {parent}",
+        "bundledWith": "Bundled with %{parent}",
         "public": "Public Visible",
         "fullPublic": "Public Visible including Name",
         "publicShort": "Public",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -650,6 +650,9 @@
         "hidden": "Hidden?",
         "loanerModel": "Loaner Model"
       },
+      "modelSnubCraft": {
+        "snubCraft": "Snub Craft"
+      },
       "modelPaint": {
         "hidden": "Hidden?",
         "active": "Active?",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -386,6 +386,9 @@
         "modelLoaner": {
           "destroy": "Are you sure you want to delete this loaner? This action can't be reverted."
         },
+        "modelSnubCraft": {
+          "destroy": "Are you sure you want to delete this snub craft? This action can't be reverted."
+        },
         "modelPaint": {
           "destroy": "Are you sure you want to delete this paint? This action can't be reverted."
         },

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -109,6 +109,7 @@
             "positions": "Positions",
             "hardpoints": "Hardpoints",
             "loaners": "Loaners",
+            "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
             "packages": "Packages"
           }

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -120,6 +120,7 @@
             "images": "Edit %{manufacturer} %{model} Images",
             "videos": "Edit %{manufacturer} %{model} Videos",
             "loaners": "Edit %{manufacturer} %{model} Loaners",
+            "snubCrafts": "Edit %{manufacturer} %{model} Snub Crafts",
             "upgrades": "Edit %{manufacturer} %{model} Upgrades",
             "packages": "Edit %{manufacturer} %{model} Packages"
           }

--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -90,7 +90,7 @@ class HangarSync < HangarImporter
     found_vehicles = []
     moved_vehicles_to_wanted = []
     missing_models = []
-    vehicle_scope = Vehicle.where(user_id: user_id, loaner: false, hidden: false, bought_via: :pledge_store).order(model_paint_id: :desc, created_at: :asc)
+    vehicle_scope = Vehicle.where(user_id: user_id, loaner: false, bundled: false, hidden: false, bought_via: :pledge_store).order(model_paint_id: :desc, created_at: :asc)
 
     @ships.each do |item|
       model_query = generate_model_query(item[:name])

--- a/app/models/model_snub_craft.rb
+++ b/app/models/model_snub_craft.rb
@@ -14,4 +14,12 @@ class ModelSnubCraft < ApplicationRecord
   belongs_to :model, touch: true
   belongs_to :snub_craft,
     class_name: "Model"
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "id", "model_id", "snub_craft_id", "updated_at"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["model", "snub_craft"]
+  end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -52,6 +52,16 @@ class Vehicle < ApplicationRecord
   belongs_to :module_package,
     class_name: "ModelModulePackage",
     optional: true
+  belongs_to :parent_vehicle,
+    class_name: "Vehicle",
+    foreign_key: :vehicle_id,
+    inverse_of: :child_vehicles,
+    optional: true
+  has_many :child_vehicles,
+    class_name: "Vehicle",
+    foreign_key: :vehicle_id,
+    inverse_of: :parent_vehicle,
+    dependent: nil
 
   has_many :task_forces, dependent: :destroy
   has_many :hangar_groups, through: :task_forces

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -7,6 +7,7 @@
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
 #  bought_via           :integer          default("pledge_store")
+#  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)
 #  loaner               :boolean          default(FALSE)
@@ -30,10 +31,11 @@
 #
 # Indexes
 #
-#  index_vehicles_on_hidden_and_loaner   (hidden,loaner)
-#  index_vehicles_on_model_id_and_id     (model_id,id)
-#  index_vehicles_on_serial_and_user_id  (serial,user_id) UNIQUE
-#  index_vehicles_on_user_id             (user_id)
+#  index_vehicles_on_hidden_and_loaner       (hidden,loaner)
+#  index_vehicles_on_model_id_and_id         (model_id,id)
+#  index_vehicles_on_serial_and_user_id      (serial,user_id) UNIQUE
+#  index_vehicles_on_user_id                 (user_id)
+#  index_vehicles_on_vehicle_id_and_bundled  (vehicle_id,bundled)
 #
 require "csv"
 
@@ -85,8 +87,8 @@ class Vehicle < ApplicationRecord
   before_save :update_slugs
 
   after_create :broadcast_create
-  after_destroy :remove_loaners, :broadcast_destroy
-  after_save :set_flagship, :update_loaners, :reset_hangar_groups
+  after_destroy :remove_loaners, :remove_bundled_snub_crafts, :broadcast_destroy
+  after_save :set_flagship, :update_loaners, :update_bundled_snub_crafts, :reset_hangar_groups
   after_commit :broadcast_update, :schedule_fleet_vehicle_update
 
   DEFAULT_SORTING_PARAMS = ["flagship desc", "name asc", "model_name asc"]
@@ -122,7 +124,7 @@ class Vehicle < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     [
-      "alternative_names", "beam", "bought_via", "classification", "created_at", "flagship",
+      "alternative_names", "beam", "bought_via", "bundled", "classification", "created_at", "flagship",
       "focus", "hangar_groups", "height", "hidden", "id", "id_value", "length", "loaner",
       "manufacturer", "model_id", "model_paint_id", "module_package_id", "name", "name_visible",
       "notify", "on_sale", "pledge_price", "price", "production_status", "public", "rsi_pledge_id",
@@ -235,6 +237,46 @@ class Vehicle < ApplicationRecord
       public: false,
       wanted:,
       hidden: Vehicle.exists?(loaner: true, model_id: model_loaner.id, wanted:, user_id:)
+    )
+  end
+
+  def update_bundled_snub_crafts
+    return if loaner? || bundled?
+
+    add_bundled_snub_crafts
+  end
+
+  def add_bundled_snub_crafts
+    return if loaner? || bundled?
+
+    model.snub_crafts.each do |snub_craft_model|
+      create_bundled_snub_craft(snub_craft_model)
+    end
+  end
+
+  def remove_bundled_snub_crafts
+    return if loaner? || bundled?
+
+    Vehicle.where(bundled: true, vehicle_id: id, user_id:).destroy_all
+  end
+
+  def create_bundled_snub_craft(snub_craft_model)
+    return unless snub_craft_model.player_ownable?
+
+    existing = Vehicle.where(bundled: true, vehicle_id: id, model_id: snub_craft_model.id, user_id:).first
+
+    if existing.present?
+      existing.update(wanted:) if existing.wanted != wanted
+      return
+    end
+
+    Vehicle.create(
+      bundled: true,
+      model_id: snub_craft_model.id,
+      user_id:,
+      vehicle_id: id,
+      public: false,
+      wanted:
     )
   end
 

--- a/app/policies/admin/model_snub_craft_policy.rb
+++ b/app/policies/admin/model_snub_craft_policy.rb
@@ -1,0 +1,7 @@
+module Admin
+  class ModelSnubCraftPolicy < BasePolicy
+    private def resource_access
+      [:model_snub_crafts]
+    end
+  end
+end

--- a/app/views/admin/api/v1/model_snub_crafts/_base.jbuilder
+++ b/app/views/admin/api/v1/model_snub_crafts/_base.jbuilder
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+json.id model_snub_craft.id
+json.model_id model_snub_craft.model_id
+json.snub_craft_id model_snub_craft.snub_craft_id
+
+json.model do
+  json.id model_snub_craft.model.id
+  json.name model_snub_craft.model.name
+  json.slug model_snub_craft.model.slug
+end
+
+json.snub_craft do
+  json.id model_snub_craft.snub_craft.id
+  json.name model_snub_craft.snub_craft.name
+  json.slug model_snub_craft.snub_craft.slug
+end
+
+json.partial! "api/shared/dates", record: model_snub_craft

--- a/app/views/admin/api/v1/model_snub_crafts/_model_snub_craft.jbuilder
+++ b/app/views/admin/api/v1/model_snub_crafts/_model_snub_craft.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", model_snub_craft] do
+  json.partial!("admin/api/v1/model_snub_crafts/base", model_snub_craft:)
+end

--- a/app/views/admin/api/v1/model_snub_crafts/index.jbuilder
+++ b/app/views/admin/api/v1/model_snub_crafts/index.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @model_snub_crafts, partial: "admin/api/v1/model_snub_crafts/model_snub_craft", as: :model_snub_craft
+end
+
+json.partial! "api/shared/meta", result: @model_snub_crafts

--- a/app/views/admin/api/v1/model_snub_crafts/show.jbuilder
+++ b/app/views/admin/api/v1/model_snub_crafts/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/model_snub_crafts/model_snub_craft", model_snub_craft: @model_snub_craft

--- a/app/views/api/v1/vehicles/_base.jbuilder
+++ b/app/views/api/v1/vehicles/_base.jbuilder
@@ -8,6 +8,17 @@ json.wanted vehicle.wanted
 json.bought_via vehicle.bought_via
 json.bought_via_label vehicle.bought_via_label
 json.loaner vehicle.loaner
+json.bundled vehicle.bundled
+
+bundled_parent_model = vehicle.parent_vehicle&.model if vehicle.bundled?
+json.bundled_parent do
+  if bundled_parent_model.present?
+    json.name bundled_parent_model.name
+    json.slug bundled_parent_model.slug
+  end
+end
+json.bundled_parent nil if bundled_parent_model.blank?
+
 json.flagship vehicle.flagship
 json.public vehicle.public
 json.name_visible vehicle.name_visible

--- a/app/views/api/v1/vehicles/_base.jbuilder
+++ b/app/views/api/v1/vehicles/_base.jbuilder
@@ -10,14 +10,16 @@ json.bought_via_label vehicle.bought_via_label
 json.loaner vehicle.loaner
 json.bundled vehicle.bundled
 
-bundled_parent_model = vehicle.parent_vehicle&.model if vehicle.bundled?
+bundled_parent = vehicle.parent_vehicle if vehicle.bundled?
 json.bundled_parent do
-  if bundled_parent_model.present?
-    json.name bundled_parent_model.name
-    json.slug bundled_parent_model.slug
+  if bundled_parent&.model.present?
+    json.id bundled_parent.id
+    json.name bundled_parent.model.name
+    json.slug bundled_parent.model.slug
+    json.custom_name bundled_parent.name
   end
 end
-json.bundled_parent nil if bundled_parent_model.blank?
+json.bundled_parent nil if bundled_parent&.model.blank?
 
 json.flagship vehicle.flagship
 json.public vehicle.public

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -66,6 +66,7 @@ v1_admin_api_routes = lambda do
   resources :model_hardpoints, path: "model-hardpoints", only: %i[index show create update destroy]
   resources :model_hardpoint_loadouts, path: "model-hardpoint-loadouts", only: %i[index show create update destroy]
   resources :model_loaners, path: "model-loaners", only: %i[index show create update destroy]
+  resources :model_snub_crafts, path: "model-snub-crafts", only: %i[index show create update destroy]
   resources :cargo_holds, path: "cargo-holds", only: %i[index show update]
 
   resources :manufacturers, only: %i[index show create update destroy]

--- a/db/migrate/20260526120000_add_bundled_to_vehicles.rb
+++ b/db/migrate/20260526120000_add_bundled_to_vehicles.rb
@@ -1,0 +1,6 @@
+class AddBundledToVehicles < ActiveRecord::Migration[7.2]
+  def change
+    add_column :vehicles, :bundled, :boolean, default: false, null: false
+    add_index :vehicles, [:vehicle_id, :bundled]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1019,6 +1019,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
   create_table "vehicles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "alternative_names"
     t.integer "bought_via", default: 0
+    t.boolean "bundled", default: false, null: false
     t.datetime "created_at", precision: nil
     t.boolean "flagship", default: false
     t.boolean "hidden", default: false
@@ -1043,6 +1044,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
     t.index ["model_id", "id"], name: "index_vehicles_on_model_id_and_id"
     t.index ["serial", "user_id"], name: "index_vehicles_on_serial_and_user_id", unique: true
     t.index ["user_id"], name: "index_vehicles_on_user_id"
+    t.index ["vehicle_id", "bundled"], name: "index_vehicles_on_vehicle_id_and_bundled"
   end
 
   create_table "versions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/docs/exec-plans/hangar-sync-bundled-snub-crafts.md
+++ b/docs/exec-plans/hangar-sync-bundled-snub-crafts.md
@@ -1,0 +1,81 @@
+# Hangar Sync: Auto-add Bundled Snub Crafts
+
+## Problem
+Some ships ship with bundled snub crafts (or vehicles). Example: the 890 Jump comes with an 85X. When a user syncs their RSI hangar via the browser extension, only the parent ship (890 Jump) is created in Fleetyards — the bundled 85X is not. Users have to add the bundled craft manually.
+
+We want sync (and manual hangar adds) to automatically materialize bundled snub crafts alongside their parent.
+
+## Current state
+
+- **Sync entry**: `POST /api/v1/hangars/sync_rsi_hangar` → `HangarSync` (`app/lib/hangar_sync.rb`). `sync_vehicles` creates a `Vehicle` per ship in the RSI payload. Extension payload contains only `{id, name, type, customName}` — no bundling info.
+- **Bundling association already modeled at the Model level**: `Model has_many :snub_crafts, through: :model_snub_crafts` (`app/models/model.rb:194-200`). Join table `model_snub_crafts` columns: `model_id`, `snub_craft_id` (both reference `models`). **No data populated, no admin UI, no seed.**
+- **Parent/child vehicle infra already exists**: `Vehicle.vehicle_id` (`app/models/vehicle.rb:29`). Used today only by loaners.
+- **Loaner pattern is the direct analog**: `Vehicle#add_loaners` / `#remove_loaners` / `#create_loaner` (`app/models/vehicle.rb:201-239`) iterate `model.loaners` on vehicle create and spawn child `Vehicle(loaner: true, vehicle_id: parent.id)` records. Same shape we need.
+
+## Design decisions
+
+| Question | Decision | Why |
+| --- | --- | --- |
+| How to flag bundled vehicle records | New `bundled :boolean` column on `vehicles` | Cleaner than overloading `loaner` (semantically wrong — bundled snubs are owned, not loaners); cleaner than relying on `vehicle_id IS NOT NULL` (currently means loaner). |
+| Removal behavior | Cascade with parent | Parent destroyed → bundled destroyed. Parent moved to `wanted` → bundled also `wanted`. Mirrors loaner lifecycle and matches RSI reality (sell the 890, lose the 85X). |
+| Trigger | `after_create_commit` on `Vehicle`, same place `add_loaners` fires | Covers both sync-created and manually-added vehicles. |
+| Data source for bundling | Admin UI on `ModelSnubCraft` (mirror of `ModelLoaner` admin) | Mapping data isn't published on a single canonical RSI URL like loaners are, and we don't want a hardcoded constant. User maintains via UI. |
+
+## Existing files to mirror (loaner pattern → snub-craft equivalent)
+
+| Loaner file | Snub-craft equivalent |
+| --- | --- |
+| `app/controllers/admin/api/v1/model_loaners_controller.rb` | `app/controllers/admin/api/v1/model_snub_crafts_controller.rb` |
+| `app/policies/admin/model_loaner_policy.rb` | `app/policies/admin/model_snub_craft_policy.rb` |
+| `app/api_components/admin/v1/schemas/queries/model_loaner_query.rb` | `app/api_components/admin/v1/schemas/queries/model_snub_craft_query.rb` |
+| `app/api_components/admin/v1/schemas/inputs/model_loaner_input.rb` | `app/api_components/admin/v1/schemas/inputs/model_snub_craft_input.rb` |
+| `app/api_components/admin/v1/schemas/models/loaners/model_loaner.rb` | `app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_craft.rb` |
+| `app/api_components/admin/v1/schemas/models/loaners/model_loaners.rb` | `app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_crafts.rb` |
+| `app/views/admin/api/v1/model_loaners/_model_loaner.jbuilder` | `app/views/admin/api/v1/model_snub_crafts/_model_snub_craft.jbuilder` |
+| `app/frontend/admin/pages/models/[id]/edit/loaners.vue` | `app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue` |
+| Admin routes for `model_loaners` | Admin routes for `model_snub_crafts` |
+
+## Steps
+
+### 1. Migration
+- Add `bundled :boolean, default: false, null: false` to `vehicles`.
+- Add index on `(vehicle_id, bundled)` to speed up the cleanup queries.
+- No backfill needed (no bundled vehicles exist yet).
+
+### 2. Vehicle model (`app/models/vehicle.rb`)
+Mirror the loaner trio:
+
+- `add_bundled_snub_crafts` — guard with `return if loaner? || bundled?` (no recursion, no bundling onto loaner records). Iterate `model.snub_crafts`, call `create_bundled_snub_craft` for each.
+- `create_bundled_snub_craft(snub_model)` — `find_or_create_by` a `Vehicle(bundled: true, vehicle_id: id, model_id: snub_model.id, user_id:, wanted:, public: false)`. If one already exists for this `(vehicle_id, model_id)` pair, leave it alone (idempotent re-sync).
+- `remove_bundled_snub_crafts` — `Vehicle.where(bundled: true, vehicle_id: id).destroy_all`.
+- `update_bundled_snub_crafts` — keeps `wanted` in sync when the parent toggles.
+
+Hook into the same callbacks `add_loaners` / `remove_loaners` use. Specifically:
+- `after_create_commit :add_bundled_snub_crafts` (and an analogous loaner-style call from any other place loaners are propagated, e.g., when `model_id` changes).
+- `before_destroy :remove_bundled_snub_crafts` (or `after_destroy_commit`, whichever matches loaners).
+- Whatever loaner uses to propagate `wanted` changes — add a bundled-equivalent there.
+
+### 3. HangarSync (`app/lib/hangar_sync.rb`)
+- `vehicle_scope` at line 93 currently filters `loaner: false`. Add `bundled: false` so bundled children are not considered when matching the RSI payload and not moved to `wanted` by the reconciliation pass at line 222.
+- No direct calls needed — the `after_create_commit` callback on the parent vehicle handles spawning the bundled child.
+
+### 4. Admin UI for `ModelSnubCraft`
+- Backend: create the controller, policy, api_components query/input/model schemas, and jbuilder partial as listed in the mirror table above. Wire admin routes (parallel to existing `model_loaners` admin routes).
+- Frontend: add `app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue` mirroring the loaners admin page. Add nav entry on the model edit page next to "Loaners".
+- Run `./bin/generate-schema` after schemas are in place (do NOT edit `schema.yaml` directly).
+- Run `bundle exec standardrb -A` and frontend linting (`pnpm`).
+
+### 5. Tests
+- **`spec/models/vehicle_spec.rb`**: parent vehicle creation with `model.snub_crafts.any?` spawns bundled children; destroy cascades; manually added (non-loaner, non-bundled) vehicles also fire bundling; bundled children do not themselves spawn grand-children; idempotent on re-create.
+- **`spec/requests/api/v1/hangars/sync_rsi_hangar_spec.rb`** (or wherever the existing sync spec lives): seed `model_snub_crafts` for 890 Jump → 85X, run sync with an 890 Jump payload item, assert one parent + one bundled child created, child has `bundled: true` and `vehicle_id` pointing at parent.
+- **`spec/requests/admin/api/v1/model_snub_crafts_spec.rb`**: CRUD coverage mirroring `model_loaners_spec.rb`.
+- **Reconciliation regression**: when an 890 Jump's `rsi_pledge_id` is missing in a subsequent sync, the bundled 85X should follow the parent into `wanted: true`, not be left dangling as owned.
+
+## Out of scope
+- Populating the `model_snub_crafts` data itself — that's manual admin work the user does after this ships.
+- Bundled non-snub vehicles (e.g., a ship that includes a buggy). The `model_snub_crafts` table is named for snubs but is just a model-to-model link; if we later want to bundle ground vehicles, we can either reuse this table or introduce a sibling. Out of scope here.
+- Changes to the browser extension. The bundling is inferred server-side; the extension doesn't need to know.
+
+## Risk notes
+- The loaner pattern destroys + recreates children aggressively on parent changes. Watch that the bundled equivalent uses `find_or_create_by` so re-syncs don't churn through delete/insert (which would lose any user customizations like `name`, `purchased`, `flagship` flags on the bundled child). Loaners don't have this concern because they're treated as ephemeral.
+- `HangarSync` reconciliation at line 222 matches imported vs. unmatched vehicles by `(model_id, model_paint_id)`. If we accidentally include bundled children in either side, we could merge a real 85X with a bundled-snub 85X and destroy one. The `bundled: false` filter on `vehicle_scope` should prevent this, but the spec must cover it.

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -5,6 +5,7 @@
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
 #  bought_via           :integer          default("pledge_store")
+#  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)
 #  loaner               :boolean          default(FALSE)
@@ -28,10 +29,11 @@
 #
 # Indexes
 #
-#  index_vehicles_on_hidden_and_loaner   (hidden,loaner)
-#  index_vehicles_on_model_id_and_id     (model_id,id)
-#  index_vehicles_on_serial_and_user_id  (serial,user_id) UNIQUE
-#  index_vehicles_on_user_id             (user_id)
+#  index_vehicles_on_hidden_and_loaner       (hidden,loaner)
+#  index_vehicles_on_model_id_and_id         (model_id,id)
+#  index_vehicles_on_serial_and_user_id      (serial,user_id) UNIQUE
+#  index_vehicles_on_user_id                 (user_id)
+#  index_vehicles_on_vehicle_id_and_bundled  (vehicle_id,bundled)
 #
 FactoryBot.define do
   factory :vehicle do
@@ -52,6 +54,10 @@ FactoryBot.define do
 
     trait :loaner do
       loaner { true }
+    end
+
+    trait :bundled do
+      bundled { true }
     end
 
     trait :flagship do

--- a/spec/loaders/hangar_sync_spec.rb
+++ b/spec/loaders/hangar_sync_spec.rb
@@ -69,6 +69,37 @@ RSpec.describe HangarSync do
     end
   end
 
+  context "with bundled snub crafts" do
+    let(:andromeda_model) { Model.find_by!(slug: "rsi-constellation-andromeda") }
+    let(:snub_model) { Model.find_by!(slug: "drak-corsair") }
+
+    before do
+      andromeda_model.snub_crafts << snub_model
+    end
+
+    it "auto-creates bundled child vehicles for synced ships" do
+      result = ::HangarSync.new(input).run(user.id)
+
+      andromeda_vehicle = Vehicle.find(result[:imported_vehicles]).find { |v| v.model_id == andromeda_model.id }
+      expect(andromeda_vehicle).to be_present
+
+      bundled = Vehicle.where(bundled: true, vehicle_id: andromeda_vehicle.id, user_id: user.id)
+      expect(bundled.count).to eq(1)
+      expect(bundled.first.model_id).to eq(snub_model.id)
+    end
+
+    it "does not move bundled children to wanted during reconciliation" do
+      andromeda_vehicle = create(:vehicle, user: user, model: andromeda_model, wanted: false)
+      bundled = Vehicle.find_by(bundled: true, vehicle_id: andromeda_vehicle.id)
+      expect(bundled).to be_present
+
+      ::HangarSync.new(input).run(user.id)
+
+      expect(bundled.reload.bundled).to be(true)
+      expect(bundled.wanted).to be(false)
+    end
+  end
+
   context "when rsi_pledge_id changes" do
     let(:andromeda_model) { Model.find_by!(slug: "rsi-constellation-andromeda") }
 

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -7,6 +7,7 @@
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
 #  bought_via           :integer          default("pledge_store")
+#  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)
 #  loaner               :boolean          default(FALSE)
@@ -30,10 +31,11 @@
 #
 # Indexes
 #
-#  index_vehicles_on_hidden_and_loaner   (hidden,loaner)
-#  index_vehicles_on_model_id_and_id     (model_id,id)
-#  index_vehicles_on_serial_and_user_id  (serial,user_id) UNIQUE
-#  index_vehicles_on_user_id             (user_id)
+#  index_vehicles_on_hidden_and_loaner       (hidden,loaner)
+#  index_vehicles_on_model_id_and_id         (model_id,id)
+#  index_vehicles_on_serial_and_user_id      (serial,user_id) UNIQUE
+#  index_vehicles_on_user_id                 (user_id)
+#  index_vehicles_on_vehicle_id_and_bundled  (vehicle_id,bundled)
 #
 require "rails_helper"
 
@@ -42,6 +44,67 @@ RSpec.describe Vehicle, type: :model do
   it { is_expected.to belong_to(:model) }
   it { is_expected.to belong_to(:model_paint).optional(true) }
   it { is_expected.to belong_to(:module_package).optional(true) }
+
+  describe "bundled snub crafts" do
+    let(:user) { create(:user) }
+    let(:snub_model) { create(:model) }
+    let(:parent_model) do
+      create(:model).tap do |model|
+        model.snub_crafts << snub_model
+      end
+    end
+
+    it "auto-creates a bundled child for each model.snub_crafts entry" do
+      expect {
+        create(:vehicle, user: user, model: parent_model, wanted: false)
+      }.to change { Vehicle.where(bundled: true, user_id: user.id).count }.by(1)
+
+      bundled = Vehicle.find_by(bundled: true, user_id: user.id)
+      expect(bundled.model_id).to eq(snub_model.id)
+      expect(bundled.wanted).to be(false)
+    end
+
+    it "is idempotent: re-saving the parent does not duplicate the bundled child" do
+      parent = create(:vehicle, user: user, model: parent_model, wanted: false)
+
+      expect {
+        parent.update!(name: "Renamed")
+      }.not_to change { Vehicle.where(bundled: true, vehicle_id: parent.id).count }
+    end
+
+    it "cascades wanted state to the bundled child" do
+      parent = create(:vehicle, user: user, model: parent_model, wanted: false)
+
+      parent.update!(wanted: true)
+
+      bundled = Vehicle.find_by(bundled: true, vehicle_id: parent.id)
+      expect(bundled.wanted).to be(true)
+    end
+
+    it "destroys bundled children when the parent is destroyed" do
+      parent = create(:vehicle, user: user, model: parent_model, wanted: false)
+
+      expect {
+        parent.destroy
+      }.to change { Vehicle.where(bundled: true, vehicle_id: parent.id).count }.from(1).to(0)
+    end
+
+    it "does not create bundled children for a loaner vehicle" do
+      loaner_parent = create(:vehicle, :loaner, user: user, model: parent_model)
+
+      expect(Vehicle.where(bundled: true, vehicle_id: loaner_parent.id)).to be_empty
+    end
+
+    it "does not recurse: bundled child does not create grand-bundled" do
+      grand_snub = create(:model)
+      snub_model.snub_crafts << grand_snub
+
+      create(:vehicle, user: user, model: parent_model, wanted: false)
+
+      bundled_models = Vehicle.where(bundled: true, user_id: user.id).pluck(:model_id)
+      expect(bundled_models).to contain_exactly(snub_model.id)
+    end
+  end
 
   describe "#schedule_fleet_vehicle_update" do
     let(:vehicle) { create(:vehicle) }

--- a/spec/requests/admin/api/v1/model_snub_crafts/create_spec.rb
+++ b/spec/requests/admin/api/v1/model_snub_crafts/create_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+RSpec.describe "admin/api/v1/model_snub_crafts", type: :openapi, openapi_schema_name: :"admin/v1/schema" do
+  let(:user) { create(:admin_user, resource_access: [:model_snub_crafts]) }
+  let(:model) { create(:model) }
+  let(:snub_craft_model) { create(:model) }
+  let(:request_body) do
+    {
+      modelId: model.id,
+      snubCraftId: snub_craft_model.id
+    }
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-snub-crafts" do
+    post("Create Model Snub Craft") do
+      operationId "createModelSnubCraft"
+      tags "ModelSnubCrafts"
+
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelSnubCraftInput"}
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/ModelSnubCraft"
+
+        run_test!
+      end
+
+      response(400, "bad request") do
+        schema "$ref": "#/components/schemas/ValidationError"
+
+        let(:request_body) { {modelId: "00000000-0000-0000-0000-000000000000"} }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_snub_crafts/destroy_spec.rb
+++ b/spec/requests/admin/api/v1/model_snub_crafts/destroy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+RSpec.describe "admin/api/v1/model_snub_crafts", type: :openapi, openapi_schema_name: :"admin/v1/schema" do
+  let(:user) { create(:admin_user, resource_access: [:model_snub_crafts]) }
+  let(:model_snub_craft) { create(:model_snub_craft) }
+  let(:id) { model_snub_craft.id }
+
+  before do
+    sign_in user if user.present?
+  end
+
+  path "/model-snub-crafts/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    delete("Destroy Model Snub Craft") do
+      operationId "destroyModelSnubCraft"
+      tags "ModelSnubCrafts"
+
+      response(204, "successful") do
+        run_test!
+      end
+
+      response(404, "not_found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_snub_crafts/index_spec.rb
+++ b/spec/requests/admin/api/v1/model_snub_crafts/index_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+RSpec.describe "admin/api/v1/model_snub_crafts", type: :openapi, openapi_schema_name: :"admin/v1/schema" do
+  let(:user) { create(:admin_user, resource_access: [:model_snub_crafts]) }
+  let(:model_snub_crafts) { create_list(:model_snub_craft, 3) }
+
+  before do
+    sign_in user if user.present?
+
+    model_snub_crafts
+  end
+
+  path "/model-snub-crafts" do
+    get("Model Snub Crafts list") do
+      operationId "listModelSnubCrafts"
+      tags "ModelSnubCrafts"
+
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/ModelSnubCraftQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelSnubCrafts"
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+
+          expect(data["items"].count).to eq(3)
+        end
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_snub_crafts/show_spec.rb
+++ b/spec/requests/admin/api/v1/model_snub_crafts/show_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+RSpec.describe "admin/api/v1/model_snub_crafts", type: :openapi, openapi_schema_name: :"admin/v1/schema" do
+  let(:user) { create(:admin_user, resource_access: [:model_snub_crafts]) }
+  let(:model_snub_craft) { create(:model_snub_craft) }
+  let(:id) { model_snub_craft.id }
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-snub-crafts/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    get("Get Model Snub Craft") do
+      operationId "modelSnubCraft"
+      tags "ModelSnubCrafts"
+
+      consumes "application/json"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelSnubCraft"
+
+        run_test!
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/spec/requests/admin/api/v1/model_snub_crafts/update_spec.rb
+++ b/spec/requests/admin/api/v1/model_snub_crafts/update_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+RSpec.describe "admin/api/v1/model_snub_crafts", type: :openapi, openapi_schema_name: :"admin/v1/schema" do
+  let(:user) { create(:admin_user, resource_access: [:model_snub_crafts]) }
+  let(:model_snub_craft) { create(:model_snub_craft) }
+  let(:id) { model_snub_craft.id }
+  let(:new_snub_craft_model) { create(:model) }
+  let(:request_body) do
+    {
+      snubCraftId: new_snub_craft_model.id
+    }
+  end
+
+  before do
+    sign_in(user) if user.present?
+  end
+
+  path "/model-snub-crafts/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    put("Update Model Snub Craft") do
+      operationId "updateModelSnubCraft"
+      tags "ModelSnubCrafts"
+
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelSnubCraftInput"}
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/ModelSnubCraft"
+
+        run_test!
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+
+        let(:id) { "00000000-0000-0000-0000-000000000000" }
+
+        run_test!
+      end
+
+      include_examples "admin_auth"
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -3585,6 +3585,192 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/model-snub-crafts":
+    post:
+      summary: Create Model Snub Craft
+      tags:
+      - ModelSnubCrafts
+      operationId: createModelSnubCraft
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ModelSnubCraftInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelSnubCraft"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    get:
+      summary: Model Snub Crafts list
+      tags:
+      - ModelSnubCrafts
+      operationId: listModelSnubCrafts
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 30
+        required: false
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/ModelSnubCraftQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelSnubCrafts"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/model-snub-crafts/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: id
+      required: true
+    delete:
+      summary: Destroy Model Snub Craft
+      tags:
+      - ModelSnubCrafts
+      operationId: destroyModelSnubCraft
+      responses:
+        '204':
+          description: successful
+        '404':
+          description: not_found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Get Model Snub Craft
+      tags:
+      - ModelSnubCrafts
+      operationId: modelSnubCraft
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelSnubCraft"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Model Snub Craft
+      tags:
+      - ModelSnubCrafts
+      operationId: updateModelSnubCraft
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ModelSnubCraftInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelSnubCraft"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/model-upgrades":
     post:
       summary: Create Model Upgrade
@@ -10220,6 +10406,97 @@ components:
       additionalProperties: false
       example: {}
       title: ModelQuery
+    ModelSnubCraft:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        modelId:
+          type: string
+          format: uuid
+        snubCraftId:
+          type: string
+          format: uuid
+        model:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            slug:
+              type: string
+          required:
+          - id
+          - name
+          - slug
+        snubCraft:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            slug:
+              type: string
+          required:
+          - id
+          - name
+          - slug
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - modelId
+      - snubCraftId
+      - createdAt
+      - updatedAt
+      title: ModelSnubCraft
+    ModelSnubCraftInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+        snubCraftId:
+          type: string
+          format: uuid
+      additionalProperties: false
+      title: ModelSnubCraftInput
+    ModelSnubCraftQuery:
+      type: object
+      properties:
+        modelIdEq:
+          type: string
+          format: uuid
+        snubCraftIdEq:
+          type: string
+          format: uuid
+      additionalProperties: false
+      example: {}
+      title: ModelSnubCraftQuery
+    ModelSnubCrafts:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelSnubCraft"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: ModelSnubCrafts
     ModelSortEnum:
       type: string
       enum:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9162,6 +9162,8 @@ components:
           type: boolean
         loanerEq:
           type: boolean
+        bundledEq:
+          type: string
         boughtViaEq:
           "$ref": "#/components/schemas/BoughtViaEnum"
         hangarGroupsIn:
@@ -12253,6 +12255,16 @@ components:
             "$ref": "#/components/schemas/HangarGroup"
         loaner:
           type: boolean
+        bundled:
+          type: boolean
+        bundledParent:
+          type: object
+          nullable: true
+          properties:
+            name:
+              type: string
+            slug:
+              type: string
         model:
           "$ref": "#/components/schemas/Model"
         modelModuleIds:
@@ -12293,6 +12305,7 @@ components:
       - model
       - wanted
       - loaner
+      - bundled
       - flagship
       - public
       - nameVisible
@@ -12581,6 +12594,16 @@ components:
             "$ref": "#/components/schemas/HangarGroupPublic"
         loaner:
           type: boolean
+        bundled:
+          type: boolean
+        bundledParent:
+          type: object
+          nullable: true
+          properties:
+            name:
+              type: string
+            slug:
+              type: string
         model:
           "$ref": "#/components/schemas/Model"
         username:
@@ -12619,6 +12642,7 @@ components:
       - id
       - model
       - loaner
+      - bundled
       - modelUpgradeIds
       - hangarGroupIds
       - hangarGroups

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -12261,10 +12261,16 @@ components:
           type: object
           nullable: true
           properties:
+            id:
+              type: string
+              format: uuid
             name:
               type: string
             slug:
               type: string
+            customName:
+              type: string
+              nullable: true
         model:
           "$ref": "#/components/schemas/Model"
         modelModuleIds:
@@ -12600,10 +12606,16 @@ components:
           type: object
           nullable: true
           properties:
+            id:
+              type: string
+              format: uuid
             name:
               type: string
             slug:
               type: string
+            customName:
+              type: string
+              nullable: true
         model:
           "$ref": "#/components/schemas/Model"
         username:


### PR DESCRIPTION
## Summary

- Ships with bundled snub crafts (e.g., 890 Jump bundles the 85X) now spawn matching child vehicles automatically — both on RSI hangar sync and on manual hangar adds. Children carry a new `bundled` flag, follow the parent's `wanted` state, and are destroyed with the parent.
- `HangarSync` filters bundled children out of reconciliation so they aren't matched against the RSI payload or moved to wanted.
- New admin UI for `ModelSnubCraft` (controller, policy, OpenAPI schemas, jbuilder views, Vue page under `models/[id]/edit/snub-crafts.vue`), mirroring the existing `ModelLoaner` admin pattern. Mapping data is managed there — it's empty at merge time and will be populated via the UI.

## Notes

- Migration adds `vehicles.bundled :boolean default: false, null: false` with an index on `(vehicle_id, bundled)`.
- Bundled creation is idempotent via `find_or_create`-style guards, so re-syncs don't churn child records (preserves any user-set fields on the bundled child).
- Only English translations added; other languages will fall back to keys until translated.
- See `docs/exec-plans/hangar-sync-bundled-snub-crafts.md` for design notes and rationale.

## Test plan

- [x] `rspec spec/models/vehicle_spec.rb` — 12 examples, 0 failures (6 new for bundled lifecycle)
- [x] `rspec spec/loaders/hangar_sync_spec.rb` — 4 examples, 0 failures (2 new for bundled snub crafts)
- [x] `rspec spec/requests/admin/api/v1/model_snub_crafts/` — 19 examples, 0 failures
- [x] `standardrb` clean on all changed Ruby files
- [x] `eslint` clean on changed frontend files
- [x] `./bin/generate-schema` ran; Orval regenerated `fyAdminApi` client with `ModelSnubCraft*` types
- [x] Manual QA: add a `ModelSnubCraft` row via the new admin page for 890 Jump → 85X, then sync a test hangar containing the 890 Jump and verify the 85X appears as a bundled child
- [x] Manual QA: manually add an 890 Jump in the user hangar and verify the 85X is created
- [x] Manual QA: remove the 890 Jump and verify the 85X is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)