### PR TITLE
perf(storage): emit WebP image variants to cut CDN bandwidth

### DIFF
--- a/app/models/concerns/active_storage_variants.rb
+++ b/app/models/concerns/active_storage_variants.rb
@@ -4,10 +4,10 @@ module ActiveStorageVariants
   extend ActiveSupport::Concern
 
   REPRESENTATION_SIZES = {
-    small: {resize_to_limit: [500, 500], saver: {quality: 80}},
-    medium: {resize_to_limit: [1000, 1000], saver: {quality: 90}},
-    large: {resize_to_limit: [2000, 2000], saver: {quality: 90}},
-    xlarge: {resize_to_limit: [3000, 3000]}
+    small: {format: :webp, resize_to_limit: [500, 500], saver: {quality: 80}},
+    medium: {format: :webp, resize_to_limit: [1000, 1000], saver: {quality: 82}},
+    large: {format: :webp, resize_to_limit: [2000, 2000], saver: {quality: 82}},
+    xlarge: {format: :webp, resize_to_limit: [3000, 3000], saver: {quality: 82}}
   }.freeze
 
   included do


### PR DESCRIPTION
## Summary

Converts all Active Storage representation sizes (`small`/`medium`/`large`/`xlarge`) from original-format JPEG to **WebP** at quality 80–82. WebP is ~25–45% smaller at equivalent visual quality, reducing BunnyCDN egress for every image request — with **no URL or API contract changes**.

This is the byte-side half of a CDN cost reduction; the BunnyCDN pull zone has separately been moved to the Volume pricing tier (cuts price-per-GB). The two stack: fewer GB × cheaper per-GB.

## Changes

- `app/models/concerns/active_storage_variants.rb`: add `format: :webp` to each entry in `REPRESENTATION_SIZES`; normalize quality to 80–82.

The shared `REPRESENTATION_SIZES` constant feeds the API (`app/views/api/v1/shared/_file.jbuilder`) and the mailer views, so the change propagates everywhere automatically. Originals are untouched — only derived variants change.

## Rollout notes

- Changing the transform changes each variant's digest, so variants regenerate with **new keys**. Warm them after deploy via the preprocess-representations maintenance task / `PreprocessRepresentationsJob` so users don't hit cold generation. Until warmed, old JPEG variants keep serving (no savings yet, but no breakage).
- Old JPEG variants become **orphaned** in object storage (wasted storage, not bandwidth). Clean up later via the existing unattached-blob flow.

## Caveats

- Any animated GIFs would flatten to a static frame (unlikely for ship imagery; possible for a rare avatar).
- Variant URLs remain extensionless — cosmetic only, unrelated to the byte savings.

## Verification

- `standardrb` passes on the changed file.
- No specs pin `REPRESENTATION_SIZES`.
- Confirmed processor is `vips` (default) and the deploy image ships `libvips42` (built with libwebp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)