### PR TITLE
chore(filter-group): drop unused returnObject prop

### DIFF
--- a/app/frontend/admin/components/base/FleetFilterGroup/index.vue
+++ b/app/frontend/admin/components/base/FleetFilterGroup/index.vue
@@ -21,14 +21,12 @@ type Props = {
   modelValue?: string | string[];
   multiple?: boolean;
   noLabel?: boolean;
-  returnObject?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   multiple: false,
   noLabel: true,
-  returnObject: false,
 });
 
 const { t } = useI18n();

--- a/app/frontend/admin/components/base/ModelFilterGroup/index.vue
+++ b/app/frontend/admin/components/base/ModelFilterGroup/index.vue
@@ -6,13 +6,8 @@ export default {
 
 <script lang="ts" setup>
 import { ComponentExposed } from "vue-component-type-helpers";
+import { modelOptions as fetchModelOptions } from "@/services/fyApi";
 import {
-  models as fetchModels,
-  modelOptions as fetchModelOptions,
-} from "@/services/fyApi";
-import {
-  type Models,
-  type Model,
   type ModelQuery,
   type ModelOptions,
   type ModelOption,
@@ -27,7 +22,6 @@ type Props = {
   modelValue?: string | string[];
   multiple?: boolean;
   noLabel?: boolean;
-  returnObject?: boolean;
   translationKey?: string;
   hideSelected?: boolean;
   valueAttr?: "slug" | "id";
@@ -39,7 +33,6 @@ const props = withDefaults(defineProps<Props>(), {
   translationKey: undefined,
   multiple: false,
   noLabel: true,
-  returnObject: false,
   hideSelected: false,
   valueAttr: "slug",
   inline: false,
@@ -71,8 +64,8 @@ watch(
   },
 );
 
-const formatter = (response: Models | ModelOptions) => {
-  return response.items.map((model: Model | ModelOption) => {
+const formatter = (response: ModelOptions) => {
+  return response.items.map((model) => {
     return {
       label: model.name,
       value: model[props.valueAttr],
@@ -80,7 +73,7 @@ const formatter = (response: Models | ModelOptions) => {
   });
 };
 
-const fetch = async (params: FilterGroupParams<Model>) => {
+const fetch = async (params: FilterGroupParams<ModelOption>) => {
   const q: ModelQuery = {};
 
   if (params.search) {
@@ -103,13 +96,7 @@ const fetch = async (params: FilterGroupParams<Model>) => {
     }
   }
 
-  const page = String(params.page || 1);
-
-  if (props.returnObject) {
-    return fetchModels({ page, q });
-  }
-
-  return fetchModelOptions({ page, q });
+  return fetchModelOptions({ page: String(params.page || 1), q });
 };
 
 const clear = () => {
@@ -148,7 +135,6 @@ defineExpose({
     :searchable="true"
     :multiple="multiple"
     :no-label="noLabel"
-    :return-object="returnObject"
     :hide-selected="hideSelected"
     :inline="inline"
   />

--- a/app/frontend/admin/components/base/UserFilterGroup/index.vue
+++ b/app/frontend/admin/components/base/UserFilterGroup/index.vue
@@ -21,14 +21,12 @@ type Props = {
   modelValue?: string | string[];
   multiple?: boolean;
   noLabel?: boolean;
-  returnObject?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   multiple: false,
   noLabel: true,
-  returnObject: false,
 });
 
 const { t } = useI18n();

--- a/app/frontend/frontend/components/base/ModelFilterGroup/index.vue
+++ b/app/frontend/frontend/components/base/ModelFilterGroup/index.vue
@@ -9,8 +9,6 @@ import { ComponentExposed } from "vue-component-type-helpers";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   type ModelQuery,
-  type Models,
-  type Model,
   type ModelOptions,
   type ModelOption,
 } from "@/services/fyApi";
@@ -18,29 +16,24 @@ import FilterGroup, {
   type FilterGroupParams,
   type ValueType,
 } from "@/shared/components/base/FilterGroup/index.vue";
-import {
-  models as fetchModels,
-  modelOptions as fetchModelOptions,
-} from "@/services/fyApi";
+import { modelOptions as fetchModelOptions } from "@/services/fyApi";
 
 type Props = {
   name: string;
-  modelValue?: ValueType<Model>;
+  modelValue?: ValueType<ModelOption>;
   multiple?: boolean;
   noLabel?: boolean;
-  returnObject?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   multiple: false,
   noLabel: true,
-  returnObject: false,
 });
 
 const { t } = useI18n();
 
-const internalValue = ref<ValueType<Model> | undefined>(props.modelValue);
+const internalValue = ref<ValueType<ModelOption> | undefined>(props.modelValue);
 
 onMounted(() => {
   internalValue.value = props.modelValue;
@@ -62,8 +55,8 @@ watch(
   },
 );
 
-const formatter = (response: Models | ModelOptions) => {
-  return response.items.map((model: Model | ModelOption) => {
+const formatter = (response: ModelOptions) => {
+  return response.items.map((model) => {
     return {
       label: model.name,
       value: model.slug,
@@ -72,7 +65,7 @@ const formatter = (response: Models | ModelOptions) => {
   });
 };
 
-const fetch = async (params: FilterGroupParams<Model>) => {
+const fetch = async (params: FilterGroupParams<ModelOption>) => {
   const q: ModelQuery = {};
 
   if (params.search) {
@@ -87,13 +80,7 @@ const fetch = async (params: FilterGroupParams<Model>) => {
     }
   }
 
-  const page = String(params.page || 1);
-
-  if (props.returnObject) {
-    return fetchModels({ page, q });
-  }
-
-  return fetchModelOptions({ page, q });
+  return fetchModelOptions({ page: String(params.page || 1), q });
 };
 
 const filterGroup = ref<ComponentExposed<typeof FilterGroup>>();
@@ -133,6 +120,5 @@ defineExpose({
     :searchable="true"
     :multiple="multiple"
     :no-label="noLabel"
-    :return-object="returnObject"
   />
 </template>

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -61,7 +61,6 @@ type Props = {
   multiple?: boolean;
   disabled?: boolean;
   searchable?: boolean;
-  returnObject?: boolean;
   nullable?: boolean;
   paginated?: boolean;
   noLabel?: boolean;
@@ -84,7 +83,6 @@ const props = withDefaults(defineProps<Props>(), {
   multiple: false,
   disabled: false,
   searchable: false,
-  returnObject: false,
   nullable: true,
   paginated: false,
   noLabel: false,
@@ -400,27 +398,11 @@ const select = async (optionValue: FilterOptionValue) => {
 
     values.push(optionValue);
 
-    if (props.returnObject) {
-      emits(
-        "update:modelValue",
-        values.map((value) => {
-          return internalOptions.value.find((item) => item.value === value);
-        }),
-      );
-    } else {
-      emits("update:modelValue", values);
-    }
+    emits("update:modelValue", values);
 
     await focusSearch();
   } else {
-    if (props.returnObject) {
-      emits(
-        "update:modelValue",
-        internalOptions.value.find((item) => item.value === optionValue),
-      );
-    } else {
-      emits("update:modelValue", optionValue);
-    }
+    emits("update:modelValue", optionValue);
 
     await toggle();
   }


### PR DESCRIPTION
## Summary
- Removed `returnObject` from the shared `FilterGroup` and its four wrappers (`ModelFilterGroup` ×2, `UserFilterGroup`, `FleetFilterGroup`).
- No call site in the codebase sets `return-object`, so the object-emit branches in `FilterGroup` and the fallback to the heavy `fetchModels` endpoint in `ModelFilterGroup` were dead.
- Inlined `fetchModelOptions` as the only fetch path in both `ModelFilterGroup` variants, dropping the unused `fetchModels` / `Models` / `Model` imports.

## Test plan
- [x] `pnpm run lint:ts` (vue-tsc + tsc) — clean
- [x] `pnpm run lint:js` — clean
- [x] `pnpm run format` — clean
- [ ] Smoke-test pickers that use `ModelFilterGroup`: compare-models form, admin vehicles filter, admin model edit (base model / snub crafts / loaners), admin model-modules link, admin model-paints copy modal.
- [ ] Smoke-test admin filters using `UserFilterGroup` / `FleetFilterGroup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)