### PR TITLE
fix(test): use host! for short_domain routing in model_compare_share

### DIFF
--- a/test/integration/short/model_compare_share_test.rb
+++ b/test/integration/short/model_compare_share_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test_helper"
 
 class Short::ModelCompareShareTest < ActionDispatch::IntegrationTest
   setup do
-    @short_host = Rails.configuration.app.short_domain
+    host! Rails.configuration.app.short_domain
     @carrack = create_model_with_slug("anvil-carrack")
     @cutlass = create_model_with_slug("drake-cutlass-black")
   end
@@ -16,7 +16,7 @@ class Short::ModelCompareShareTest < ActionDispatch::IntegrationTest
       short_code: "abcd1234"
     )
 
-    get "/c/abcd1234", headers: {"Host" => @short_host}
+    get "/c/abcd1234"
 
     assert_response :found
     assert_includes response.location, "/compare"
@@ -25,7 +25,7 @@ class Short::ModelCompareShareTest < ActionDispatch::IntegrationTest
   end
 
   test "redirects unknown short_codes to the bare compare page" do
-    get "/c/zzzzzzzz", headers: {"Host" => @short_host}
+    get "/c/zzzzzzzz"
 
     assert_response :found
     assert_match(%r{/compare/?\z}, response.location)


### PR DESCRIPTION
## Summary

Fixes the failing Minitest job on main introduced by #4088. Rails IntegrationTest in Minitest doesn't honor a `Host` header passed via `headers:` for routing constraints — `/c/:short_code` is namespaced to `short_domain` via `host:` in routes.rb, so the request was falling through to `Frontend::BaseController#render_frontend` and trying to render the HTML layout, which fails in CI without Vite assets.

Switches both tests in `Short::ModelCompareShareTest` to the integration-test `host!` helper, which actually sets the request host for routing.

## Test plan

- [x] `bin/rails test test/integration/short/model_compare_share_test.rb` — 2 tests / 10 assertions
- [x] `bundle exec standardrb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)