### PR TITLE
chore(lint): apply standardrb 1.55 autofixes

### DIFF
--- a/app/controllers/admin/api/v1/stats_controller.rb
+++ b/app/controllers/admin/api/v1/stats_controller.rb
@@ -38,11 +38,11 @@ module Admin
           visits_per_day = Ahoy::Visit.without_users(tracking_blocklist).one_month
             .group_by_day(:started_at).count
             .map do |created_at, count|
-              {
-                label: I18n.l(created_at.to_date, format: :day_month_short),
-                count:,
-                tooltip: I18n.l(created_at.to_date, format: :day_month)
-              }
+            {
+              label: I18n.l(created_at.to_date, format: :day_month_short),
+              count:,
+              tooltip: I18n.l(created_at.to_date, format: :day_month)
+            }
           end
 
           render json: visits_per_day.to_json

--- a/app/models/classification_count.rb
+++ b/app/models/classification_count.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-ClassificationCount = Struct.new(:classification_count, :name, :label, keyword_init: true)
+ClassificationCount = Struct.new(:classification_count, :name, :label)

--- a/app/models/dock_count.rb
+++ b/app/models/dock_count.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DockCount = Struct.new(:dock_size, :dock_type, :dock_type_label, :dock_count, keyword_init: true)
+DockCount = Struct.new(:dock_size, :dock_type, :dock_type_label, :dock_count)

--- a/app/models/hangar_group_count.rb
+++ b/app/models/hangar_group_count.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-HangarGroupCount = Struct.new(:group_count, :id, :slug, keyword_init: true)
+HangarGroupCount = Struct.new(:group_count, :id, :slug)

--- a/app/models/quick_stats.rb
+++ b/app/models/quick_stats.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-QuickStats = Struct.new(:total, :wishlist_total, :classifications, :groups, :metrics, keyword_init: true)
+QuickStats = Struct.new(:total, :wishlist_total, :classifications, :groups, :metrics)

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -357,7 +357,7 @@ class Vehicle < ApplicationRecord
     Vehicle.where(user_id:, flagship: true)
       .where.not(id:)
       .find_each do |vehicle|
-        vehicle.update(flagship: false)
+      vehicle.update(flagship: false)
     end
   end
 


### PR DESCRIPTION
## Summary
- Pre-applies the lint changes required by standard 1.55 so #4095 can land cleanly.
- Removes redundant `keyword_init: true` from 4 Structs (Ruby 3.2+ accepts kwargs by default — and call sites already use kwargs).
- Adjusts indentation in two chained `.map`/`.find_each` block bodies per the new `Layout/IndentationWidth` interpretation.

## Test plan
- [x] `bundle exec standardrb` is clean locally with standard 1.55.0.
- [ ] CI green.

🤖