### PR TITLE
chore(deps): bump bundler 2.7.1 → 4.0.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -962,7 +962,7 @@ DEPENDENCIES
   with_advisory_lock
 
 RUBY VERSION
-   ruby 4.0.5
+  ruby 4.0.5
 
 BUNDLED WITH
-   2.7.1
+  4.0.14


### PR DESCRIPTION
## Summary
- Bumps bundler from **2.7.1** to **4.0.14** (latest) — major version jump
- Only `Gemfile.lock` changes: `BUNDLED WITH` line + an indentation tweak on `RUBY VERSION` (bundler 4.x normalizes leading spaces)
- No gem versions change; `bundle check` confirms dependencies are still satisfied

## Why now
Local environment was already on bundler 4.x while the lockfile pinned 2.7.1, causing drift between local and CI/Docker. Aligning the lockfile removes the warning and ensures everyone (CI included) resolves with the same bundler.

## CI / Docker impact
- CI uses `ruby/setup-ruby` with `bundler-cache: true`, which reads `BUNDLED WITH` from the lockfile — no workflow changes needed.
- `Dockerfile` doesn't pin a bundler version, so the base image's default will be used. Worth keeping an eye on the next image build, but no edit required.

## Test plan
- [x] `bundle check` passes locally
- [x] CI green (ruby-tests, ruby-lint, api-schema, e2e, tsc, build)
- [x] Confirm Docker image builds successfully

🤖