### PR TITLE
feat(supporters): funding goals, supporter contributions, public progress widget

### DIFF
--- a/app/api_components/admin/v1/schemas/funding_goal.rb
+++ b/app/api_components/admin/v1/schemas/funding_goal.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FundingGoal
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            title: {type: :string},
+            description: {type: :string},
+            amountCents: {type: :integer},
+            currency: {type: :string},
+            effectiveFrom: {type: :string, format: :date},
+            endedAt: {type: :string, format: :date},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id title amountCents currency effectiveFrom createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/funding_goals.rb
+++ b/app/api_components/admin/v1/schemas/funding_goals.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FundingGoals < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/FundingGoal"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/funding_goal_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/funding_goal_input.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class FundingGoalInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              title: {type: :string},
+              description: {type: :string},
+              amountCents: {type: :integer},
+              currency: {type: :string},
+              effectiveFrom: {type: :string, format: :date},
+              endedAt: {type: :string, format: :date}
+            },
+            additionalProperties: false,
+            required: %w[title amountCents effectiveFrom]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/supporter_contribution_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/supporter_contribution_input.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class SupporterContributionInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              name: {type: :string},
+              amountCents: {type: :integer},
+              currency: {type: :string},
+              anonymous: {type: :boolean},
+              recurring: {type: :boolean},
+              startedAt: {type: :string, format: :date},
+              endedAt: {type: :string, format: :date},
+              note: {type: :string}
+            },
+            additionalProperties: false,
+            required: %w[amountCents startedAt]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/funding_goal_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/funding_goal_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class FundingGoalQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              titleCont: {type: :string},
+              effectiveFromGteq: {type: :string, format: :date},
+              effectiveFromLteq: {type: :string, format: :date},
+              sorts: {anyOf: [{
+                type: :array, items: {"$ref": "#/components/schemas/FundingGoalSortEnum"}
+              }, {
+                "$ref": "#/components/schemas/FundingGoalSortEnum"
+              }]}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class SupporterContributionQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              nameCont: {type: :string},
+              nameEq: {type: :string},
+              recurringEq: {type: :boolean},
+              anonymousEq: {type: :boolean},
+              startedAtGteq: {type: :string, format: :date},
+              startedAtLteq: {type: :string, format: :date},
+              endedAtGteq: {type: :string, format: :date},
+              endedAtLteq: {type: :string, format: :date},
+              sorts: {anyOf: [{
+                type: :array, items: {"$ref": "#/components/schemas/SupporterContributionSortEnum"}
+              }, {
+                "$ref": "#/components/schemas/SupporterContributionSortEnum"
+              }]}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/supporter_contribution.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class SupporterContribution
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            amountCents: {type: :integer},
+            currency: {type: :string},
+            anonymous: {type: :boolean},
+            recurring: {type: :boolean},
+            startedAt: {type: :string, format: :date},
+            endedAt: {type: :string, format: :date},
+            note: {type: :string},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id amountCents currency anonymous recurring startedAt createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/supporter_contribution_stats.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution_stats.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class SupporterContributionStats
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            totalAmountCents: {type: :integer},
+            currency: {type: :string},
+            totalCount: {type: :integer},
+            recurringCount: {type: :integer},
+            anonymousCount: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[totalAmountCents currency totalCount recurringCount anonymousCount]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/supporter_contributions.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contributions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class SupporterContributions < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/SupporterContribution"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/sorts/funding_goal_sort_enum.rb
+++ b/app/api_components/shared/v1/schemas/sorts/funding_goal_sort_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Sorts
+        class FundingGoalSortEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::FundingGoal::ALLOWED_SORTING_PARAMS,
+            "x-enumNames": ::FundingGoal::ALLOWED_SORTING_PARAMS.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/sorts/supporter_contribution_sort_enum.rb
+++ b/app/api_components/shared/v1/schemas/sorts/supporter_contribution_sort_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Sorts
+        class SupporterContributionSortEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::SupporterContribution::ALLOWED_SORTING_PARAMS,
+            "x-enumNames": ::SupporterContribution::ALLOWED_SORTING_PARAMS.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/support_progress.rb
+++ b/app/api_components/v1/schemas/support_progress.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SupportProgress
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          goal: {
+            type: :object,
+            properties: {
+              amountCents: {type: :integer},
+              currency: {type: :string},
+              items: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    title: {type: :string},
+                    description: {type: :string},
+                    amountCents: {type: :integer},
+                    currency: {type: :string}
+                  },
+                  additionalProperties: false,
+                  required: %w[title amountCents currency]
+                }
+              }
+            },
+            additionalProperties: false,
+            required: %w[amountCents currency items]
+          },
+          monthlyTotal: {
+            type: :object,
+            properties: {
+              amountCents: {type: :integer},
+              currency: {type: :string}
+            },
+            additionalProperties: false,
+            required: %w[amountCents currency]
+          },
+          contributions: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                displayName: {type: :string},
+                amountCents: {type: :integer},
+                currency: {type: :string},
+                recurring: {type: :boolean}
+              },
+              additionalProperties: false,
+              required: %w[displayName amountCents currency recurring]
+            }
+          }
+        },
+        additionalProperties: false,
+        required: %w[monthlyTotal contributions]
+      })
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/funding_goals_controller.rb
+++ b/app/controllers/admin/api/v1/funding_goals_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class FundingGoalsController < ::Admin::Api::BaseController
+        before_action :set_funding_goal, only: %i[show update destroy]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.funding_goal"))
+        end
+
+        def index
+          authorize! with: ::Admin::FundingGoalPolicy
+
+          funding_goal_query_params["sorts"] = sorting_params(FundingGoal, funding_goal_query_params[:sorts])
+
+          q = FundingGoal.ransack(funding_goal_query_params)
+
+          @funding_goals = q.result(distinct: true)
+            .page(params[:page])
+            .per(per_page(FundingGoal))
+        end
+
+        def show
+        end
+
+        def create
+          @funding_goal = FundingGoal.new(funding_goal_params)
+
+          authorize! @funding_goal, with: ::Admin::FundingGoalPolicy
+
+          return if @funding_goal.save
+
+          render json: ValidationError.new("funding_goal.create", errors: @funding_goal.errors), status: :bad_request
+        end
+
+        def update
+          return if @funding_goal.update(funding_goal_params)
+
+          render json: ValidationError.new("funding_goal.update", errors: @funding_goal.errors), status: :bad_request
+        end
+
+        def destroy
+          return if @funding_goal.destroy
+
+          render json: ValidationError.new("funding_goal.destroy", errors: @funding_goal.errors), status: :bad_request
+        end
+
+        private def set_funding_goal
+          @funding_goal = FundingGoal.find(params[:id])
+
+          authorize! @funding_goal, with: ::Admin::FundingGoalPolicy
+        end
+
+        private def funding_goal_params
+          @funding_goal_params ||= params.permit(
+            :title, :description, :amount_cents, :currency, :effective_from, :ended_at
+          )
+        end
+
+        private def funding_goal_query_params
+          @funding_goal_query_params ||= params.permit(q: [
+            :title_cont,
+            :amount_cents_eq, :amount_cents_gteq, :amount_cents_lteq,
+            :effective_from_eq, :effective_from_gteq, :effective_from_lteq,
+            :sorts, sorts: []
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/supporter_contributions_controller.rb
+++ b/app/controllers/admin/api/v1/supporter_contributions_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class SupporterContributionsController < ::Admin::Api::BaseController
+        before_action :set_supporter_contribution, only: %i[show update destroy]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.supporter_contribution"))
+        end
+
+        def index
+          authorize! with: ::Admin::SupporterContributionPolicy
+
+          supporter_contribution_query_params["sorts"] = sorting_params(SupporterContribution, supporter_contribution_query_params[:sorts])
+
+          q = SupporterContribution.ransack(supporter_contribution_query_params)
+
+          @supporter_contributions = q.result(distinct: true)
+            .page(params[:page])
+            .per(per_page(SupporterContribution))
+        end
+
+        def stats
+          authorize! with: ::Admin::SupporterContributionPolicy
+
+          q = SupporterContribution.ransack(supporter_contribution_query_params.except("sorts"))
+          @stats_scope = q.result(distinct: true)
+        end
+
+        def show
+        end
+
+        def create
+          @supporter_contribution = SupporterContribution.new(supporter_contribution_params)
+
+          authorize! @supporter_contribution, with: ::Admin::SupporterContributionPolicy
+
+          return if @supporter_contribution.save
+
+          render json: ValidationError.new("supporter_contribution.create", errors: @supporter_contribution.errors), status: :bad_request
+        end
+
+        def update
+          return if @supporter_contribution.update(supporter_contribution_params)
+
+          render json: ValidationError.new("supporter_contribution.update", errors: @supporter_contribution.errors), status: :bad_request
+        end
+
+        def destroy
+          return if @supporter_contribution.destroy
+
+          render json: ValidationError.new("supporter_contribution.destroy", errors: @supporter_contribution.errors), status: :bad_request
+        end
+
+        private def set_supporter_contribution
+          @supporter_contribution = SupporterContribution.find(params[:id])
+
+          authorize! @supporter_contribution, with: ::Admin::SupporterContributionPolicy
+        end
+
+        private def supporter_contribution_params
+          @supporter_contribution_params ||= params.permit(
+            :name, :amount_cents, :currency, :anonymous, :recurring,
+            :started_at, :ended_at, :note
+          )
+        end
+
+        private def supporter_contribution_query_params
+          @supporter_contribution_query_params ||= params.permit(q: [
+            :name_cont, :name_eq, :recurring_eq, :anonymous_eq,
+            :started_at_gteq, :started_at_lteq, :ended_at_gteq, :ended_at_lteq,
+            :sorts, sorts: []
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/supporter_contributions_controller.rb
+++ b/app/controllers/admin/api/v1/supporter_contributions_controller.rb
@@ -26,7 +26,13 @@ module Admin
           authorize! with: ::Admin::SupporterContributionPolicy
 
           q = SupporterContribution.ransack(supporter_contribution_query_params.except("sorts"))
-          @stats_scope = q.result(distinct: true)
+          @stats = q.result(distinct: true).pick(
+            Arel.sql("COALESCE(SUM(amount_cents), 0)"),
+            Arel.sql("MAX(currency)"),
+            Arel.sql("COUNT(*)"),
+            Arel.sql("COUNT(*) FILTER (WHERE recurring)"),
+            Arel.sql("COUNT(*) FILTER (WHERE anonymous)")
+          )
         end
 
         def show

--- a/app/controllers/api/v1/supporters_controller.rb
+++ b/app/controllers/api/v1/supporters_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SupportersController < ::Api::BaseController
+      skip_verify_authorized
+
+      before_action :authenticate_user!, only: []
+
+      def progress
+        today = Date.current
+        @goals = FundingGoal.active_for_month(today)
+        @monthly_total = SupporterContribution.monthly_total(today)
+        @contributions = SupporterContribution.active_in(today.beginning_of_month, today.end_of_month)
+          .order(started_at: :desc, created_at: :desc)
+      end
+    end
+  end
+end

--- a/app/frontend/admin/components/FundingGoals/Actions/Items.vue
+++ b/app/frontend/admin/components/FundingGoals/Actions/Items.vue
@@ -1,0 +1,81 @@
+<script lang="ts">
+export default {
+  name: "FundingGoalActionItems",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  type FundingGoal,
+  useDestroyFundingGoal,
+  getFundingGoalsQueryKey,
+} from "@/services/fyAdminApi";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  fundingGoal: FundingGoal;
+  withLabels?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  withLabels: false,
+});
+
+const { t } = useI18n();
+const { displayConfirm, displaySuccess } = useAppNotifications();
+const queryClient = useQueryClient();
+
+const invalidate = () =>
+  queryClient.invalidateQueries({
+    queryKey: getFundingGoalsQueryKey(),
+  });
+
+const destroyMutation = useDestroyFundingGoal({
+  mutation: {
+    onSettled: invalidate,
+  },
+});
+
+const destroy = () => {
+  if (!props.fundingGoal.id) return;
+
+  displayConfirm({
+    text: t("messages.confirm.fundingGoal.destroy"),
+    onConfirm: async () => {
+      await destroyMutation.mutateAsync({ id: props.fundingGoal.id! });
+      displaySuccess({
+        text: t("messages.fundingGoal.destroyed"),
+      });
+    },
+  });
+};
+</script>
+
+<template>
+  <Btn
+    v-tooltip="!withLabels && t('actions.edit')"
+    :size="BtnSizesEnum.SMALL"
+    :to="{
+      name: 'admin-funding-goal-edit',
+      params: { id: props.fundingGoal.id },
+    }"
+  >
+    <i class="fa-duotone fa-pen-to-square" />
+    <span v-if="withLabels">{{ t("actions.edit") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.delete')"
+    :size="BtnSizesEnum.SMALL"
+    :variant="BtnVariantsEnum.DANGER"
+    @click="destroy"
+  >
+    <i class="fa-duotone fa-trash" />
+    <span v-if="withLabels">{{ t("actions.delete") }}</span>
+  </Btn>
+</template>

--- a/app/frontend/admin/components/FundingGoals/Actions/index.vue
+++ b/app/frontend/admin/components/FundingGoals/Actions/index.vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+export default {
+  name: "FundingGoalActions",
+};
+</script>
+
+<script lang="ts" setup>
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import Items from "@/admin/components/FundingGoals/Actions/Items.vue";
+import { useMobile } from "@/shared/composables/useMobile";
+import { type FundingGoal } from "@/services/fyAdminApi";
+
+type Props = {
+  fundingGoal: FundingGoal;
+};
+
+const props = defineProps<Props>();
+
+const mobile = useMobile();
+</script>
+
+<template>
+  <BtnDropdown v-if="mobile" :size="BtnSizesEnum.SMALL" inline>
+    <Items :funding-goal="props.fundingGoal" with-labels />
+  </BtnDropdown>
+  <BtnGroup v-else inline>
+    <Items :funding-goal="props.fundingGoal" />
+  </BtnGroup>
+</template>

--- a/app/frontend/admin/components/SupporterContributions/Actions/Items.vue
+++ b/app/frontend/admin/components/SupporterContributions/Actions/Items.vue
@@ -1,0 +1,83 @@
+<script lang="ts">
+export default {
+  name: "SupporterContributionActionItems",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  type SupporterContribution,
+  useDestroySupporterContribution,
+  getSupporterContributionsQueryKey,
+} from "@/services/fyAdminApi";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  supporterContribution: SupporterContribution;
+  withLabels?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  withLabels: false,
+});
+
+const { t } = useI18n();
+const { displayConfirm, displaySuccess } = useAppNotifications();
+const queryClient = useQueryClient();
+
+const invalidate = () =>
+  queryClient.invalidateQueries({
+    queryKey: getSupporterContributionsQueryKey(),
+  });
+
+const destroyMutation = useDestroySupporterContribution({
+  mutation: {
+    onSettled: invalidate,
+  },
+});
+
+const destroy = () => {
+  if (!props.supporterContribution.id) return;
+
+  displayConfirm({
+    text: t("messages.confirm.supporterContribution.destroy"),
+    onConfirm: async () => {
+      await destroyMutation.mutateAsync({
+        id: props.supporterContribution.id!,
+      });
+      displaySuccess({
+        text: t("messages.supporterContribution.destroyed"),
+      });
+    },
+  });
+};
+</script>
+
+<template>
+  <Btn
+    v-tooltip="!withLabels && t('actions.edit')"
+    :size="BtnSizesEnum.SMALL"
+    :to="{
+      name: 'admin-supporter-contribution-edit',
+      params: { id: props.supporterContribution.id },
+    }"
+  >
+    <i class="fa-duotone fa-pen-to-square" />
+    <span v-if="withLabels">{{ t("actions.edit") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.delete')"
+    :size="BtnSizesEnum.SMALL"
+    :variant="BtnVariantsEnum.DANGER"
+    @click="destroy"
+  >
+    <i class="fa-duotone fa-trash" />
+    <span v-if="withLabels">{{ t("actions.delete") }}</span>
+  </Btn>
+</template>

--- a/app/frontend/admin/components/SupporterContributions/Actions/index.vue
+++ b/app/frontend/admin/components/SupporterContributions/Actions/index.vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+export default {
+  name: "SupporterContributionActions",
+};
+</script>
+
+<script lang="ts" setup>
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import Items from "@/admin/components/SupporterContributions/Actions/Items.vue";
+import { useMobile } from "@/shared/composables/useMobile";
+import { type SupporterContribution } from "@/services/fyAdminApi";
+
+type Props = {
+  supporterContribution: SupporterContribution;
+};
+
+const props = defineProps<Props>();
+
+const mobile = useMobile();
+</script>
+
+<template>
+  <BtnDropdown v-if="mobile" :size="BtnSizesEnum.SMALL" inline>
+    <Items :supporter-contribution="props.supporterContribution" with-labels />
+  </BtnDropdown>
+  <BtnGroup v-else inline>
+    <Items :supporter-contribution="props.supporterContribution" />
+  </BtnGroup>
+</template>

--- a/app/frontend/admin/components/SupporterContributions/FilterForm/index.vue
+++ b/app/frontend/admin/components/SupporterContributions/FilterForm/index.vue
@@ -1,0 +1,100 @@
+<script lang="ts">
+export default {
+  name: "SupporterContributionsFilterForm",
+};
+</script>
+
+<script lang="ts" setup>
+import RadioList from "@/shared/components/base/RadioList/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { type SupporterContributionQuery } from "@/services/fyAdminApi";
+import { useSupporterContributionFilters } from "@/admin/composables/useSupporterContributionFilters";
+import { useFilterOptions } from "@/shared/composables/useFilterOptions";
+
+const { booleanOptions } = useFilterOptions();
+
+const { t } = useI18n();
+
+const prefillFormValues = () => {
+  return {
+    nameCont: filters.value.nameCont,
+    recurringEq: filters.value.recurringEq,
+    anonymousEq: filters.value.anonymousEq,
+    startedAtGteq: filters.value.startedAtGteq,
+    startedAtLteq: filters.value.startedAtLteq,
+  };
+};
+
+const setupForm = () => {
+  form.value = prefillFormValues();
+};
+
+const { filter, resetFilter, isFilterSelected, filters } =
+  useSupporterContributionFilters(setupForm);
+
+const handleSubmit = () => {
+  filter(form.value);
+};
+
+const form = ref<SupporterContributionQuery>(prefillFormValues());
+
+watch(
+  () => form.value,
+  () => {
+    filter(form.value);
+  },
+  { deep: true },
+);
+</script>
+
+<template>
+  <form @submit.prevent="handleSubmit">
+    <Teleport to="#header-left">
+      <FormInput
+        v-model="form.nameCont"
+        name="search"
+        translation-key="filters.supporterContributions.name"
+        no-label
+        clearable
+        inline
+      />
+    </Teleport>
+
+    <RadioList
+      v-model="form.recurringEq"
+      :label="t('labels.filters.supporterContributions.recurring')"
+      :reset-label="t('labels.all')"
+      :options="booleanOptions"
+      name="recurringEq"
+    />
+
+    <RadioList
+      v-model="form.anonymousEq"
+      :label="t('labels.filters.supporterContributions.anonymous')"
+      :reset-label="t('labels.all')"
+      :options="booleanOptions"
+      name="anonymousEq"
+    />
+
+    <FormDatePicker
+      v-model="form.startedAtGteq"
+      translation-key="filters.supporterContributions.startedAtGteq"
+      name="startedAtGteq"
+    />
+
+    <FormDatePicker
+      v-model="form.startedAtLteq"
+      translation-key="filters.supporterContributions.startedAtLteq"
+      name="startedAtLteq"
+    />
+
+    <br />
+    <Btn :disabled="!isFilterSelected" :block="true" @click="resetFilter">
+      <i class="fa-light fa-times" />
+      {{ t("actions.resetFilter") }}
+    </Btn>
+  </form>
+</template>

--- a/app/frontend/admin/components/SupporterContributions/Stats/index.vue
+++ b/app/frontend/admin/components/SupporterContributions/Stats/index.vue
@@ -1,0 +1,95 @@
+<script lang="ts">
+export default {
+  name: "SupporterContributionsStats",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  useSupporterContributionsStats,
+  type SupporterContributionsStatsParams,
+} from "@/services/fyAdminApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useCurrencyFormat } from "@/shared/composables/useCurrencyFormat";
+import type { MaybeRef } from "vue";
+
+type Props = {
+  params?: MaybeRef<SupporterContributionsStatsParams>;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const { formatCents } = useCurrencyFormat();
+
+const queryParams = computed(
+  () => unref(props.params) as SupporterContributionsStatsParams,
+);
+
+const { data: stats } = useSupporterContributionsStats(queryParams);
+</script>
+
+<template>
+  <div v-if="stats" class="supporter-contributions-stats">
+    <div class="supporter-contributions-stats__entry">
+      <span class="supporter-contributions-stats__label">
+        {{ t("labels.supporterContribution.stats.total") }}
+      </span>
+      <span class="supporter-contributions-stats__value">
+        {{ formatCents(stats.totalAmountCents, stats.currency) }}
+      </span>
+    </div>
+    <div class="supporter-contributions-stats__entry">
+      <span class="supporter-contributions-stats__label">
+        {{ t("labels.supporterContribution.stats.count") }}
+      </span>
+      <span class="supporter-contributions-stats__value">{{
+        stats.totalCount
+      }}</span>
+    </div>
+    <div class="supporter-contributions-stats__entry">
+      <span class="supporter-contributions-stats__label">
+        {{ t("labels.supporterContribution.stats.recurringCount") }}
+      </span>
+      <span class="supporter-contributions-stats__value">{{
+        stats.recurringCount
+      }}</span>
+    </div>
+    <div class="supporter-contributions-stats__entry">
+      <span class="supporter-contributions-stats__label">
+        {{ t("labels.supporterContribution.stats.anonymousCount") }}
+      </span>
+      <span class="supporter-contributions-stats__value">{{
+        stats.anonymousCount
+      }}</span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.supporter-contributions-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 4px;
+
+  &__entry {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__label {
+    font-size: 0.85rem;
+    opacity: 0.7;
+  }
+
+  &__value {
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+}
+</style>

--- a/app/frontend/admin/composables/useFundingGoalFilters.ts
+++ b/app/frontend/admin/composables/useFundingGoalFilters.ts
@@ -1,0 +1,10 @@
+import { type FundingGoalQuery } from "@/services/fyAdminApi";
+import { useFilters } from "@/shared/composables/useFilters";
+
+export const useFundingGoalFilters = (
+  updateCallback?: (() => void) | (() => Promise<void>),
+) => {
+  return useFilters<FundingGoalQuery>({
+    updateCallback,
+  });
+};

--- a/app/frontend/admin/composables/useSupporterContributionFilters.ts
+++ b/app/frontend/admin/composables/useSupporterContributionFilters.ts
@@ -1,0 +1,10 @@
+import { type SupporterContributionQuery } from "@/services/fyAdminApi";
+import { useFilters } from "@/shared/composables/useFilters";
+
+export const useSupporterContributionFilters = (
+  updateCallback?: (() => void) | (() => Promise<void>),
+) => {
+  return useFilters<SupporterContributionQuery>({
+    updateCallback,
+  });
+};

--- a/app/frontend/admin/pages/routes.ts
+++ b/app/frontend/admin/pages/routes.ts
@@ -7,6 +7,7 @@ import { routes as adminsRoutes } from "@/admin/pages/admins/routes";
 import { routes as oauthApplicationsRoutes } from "@/admin/pages/oauth-applications/routes";
 import { routes as maintenanceRoutes } from "@/admin/pages/maintenance/routes";
 import { routes as usersRoutes } from "@/admin/pages/users/routes";
+import { routes as supporterContributionsRoutes } from "@/admin/pages/supporter-contributions/routes";
 import { RouteRecordRaw } from "vue-router";
 
 export const routes: RouteRecordRaw[] = [
@@ -118,6 +119,18 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
       icon: "fa-duotone fa-user-group-crown",
       access: ["admins"],
+    },
+  },
+  {
+    path: "/supporter-contributions/",
+    component: () => import("@/admin/pages/supporter-contributions.vue"),
+    children: supporterContributionsRoutes,
+    redirect: { name: supporterContributionsRoutes[0].name },
+    meta: {
+      title: "admin.supporterContributions.index",
+      needsAuthentication: true,
+      icon: "fa-duotone fa-hand-holding-heart",
+      access: ["supporters"],
     },
   },
   {

--- a/app/frontend/admin/pages/supporter-contributions.vue
+++ b/app/frontend/admin/pages/supporter-contributions.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/[id].vue
+++ b/app/frontend/admin/pages/supporter-contributions/[id].vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { useSupporterContribution as useSupporterContributionQuery } from "@/services/fyAdminApi";
+import AsyncData from "@/shared/components/AsyncData.vue";
+
+const route = useRoute();
+
+const { data: supporterContribution, ...asyncStatus } =
+  useSupporterContributionQuery(route.params.id as string);
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <router-view :supporter-contribution="supporterContribution" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
+++ b/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
@@ -23,6 +23,7 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { toCents } from "@/shared/utils/currencyHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 type Props = {
@@ -101,7 +102,7 @@ const onSubmit = handleSubmit(async (values) => {
 
   const payload: SupporterContributionInput = {
     name: values.name || undefined,
-    amountCents: Math.round(Number(values.amount) * 100),
+    amountCents: toCents(values.amount),
     startedAt: values.startedAt,
     endedAt: (values.recurring && values.endedAt) || undefined,
     recurring: values.recurring,

--- a/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
+++ b/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
@@ -1,0 +1,204 @@
+<script lang="ts">
+export default {
+  name: "AdminSupporterContributionEditPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import {
+  type SupporterContribution,
+  type SupporterContributionInput,
+  useUpdateSupporterContribution,
+  getSupporterContributionsQueryKey,
+  getSupporterContributionQueryKey,
+} from "@/services/fyAdminApi";
+import { useForm } from "vee-validate";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import FormToggle from "@/shared/components/base/FormToggle/index.vue";
+import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  supporterContribution: SupporterContribution;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const router = useRouter();
+const { extend } = useBreadCrumbs();
+const { displaySuccess, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
+
+type FormValues = {
+  name?: string;
+  amount: number;
+  startedAt: string;
+  endedAt?: string;
+  recurring: boolean;
+  anonymous: boolean;
+  note?: string;
+  currency?: string;
+};
+
+const initialValues = ref<FormValues>({
+  name: props.supporterContribution.name,
+  amount: props.supporterContribution.amountCents / 100,
+  startedAt: props.supporterContribution.startedAt,
+  endedAt: props.supporterContribution.endedAt,
+  recurring: props.supporterContribution.recurring,
+  anonymous: props.supporterContribution.anonymous,
+  note: props.supporterContribution.note,
+  currency: props.supporterContribution.currency,
+});
+
+const validationSchema = {
+  amount: "required",
+  startedAt: "required",
+};
+
+const { defineField, handleSubmit, meta } = useForm<FormValues>({
+  initialValues: initialValues.value,
+  validationSchema,
+});
+
+const [name, nameProps] = defineField("name");
+const [amount, amountProps] = defineField("amount");
+const [startedAt, startedAtProps] = defineField("startedAt");
+const [endedAt, endedAtProps] = defineField("endedAt");
+const [recurring, recurringProps] = defineField("recurring");
+const [anonymous, anonymousProps] = defineField("anonymous");
+const [note, noteProps] = defineField("note");
+
+const submitting = ref(false);
+
+const updateMutation = useUpdateSupporterContribution({
+  mutation: {
+    onSettled: () => {
+      void Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: getSupporterContributionsQueryKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getSupporterContributionQueryKey(
+            props.supporterContribution.id,
+          ),
+        }),
+      ]);
+    },
+  },
+});
+
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  const payload: SupporterContributionInput = {
+    name: values.name || undefined,
+    amountCents: Math.round(Number(values.amount) * 100),
+    startedAt: values.startedAt,
+    endedAt: (values.recurring && values.endedAt) || undefined,
+    recurring: values.recurring,
+    anonymous: values.anonymous,
+    note: values.note || undefined,
+    currency: values.currency,
+  };
+
+  await updateMutation
+    .mutateAsync({
+      id: props.supporterContribution.id,
+      data: payload,
+    })
+    .then(() => {
+      displaySuccess({
+        text: t("messages.supporterContribution.updated"),
+      });
+    })
+    .catch((error) => {
+      console.error("Error updating supporter contribution:", error);
+      displayAlert({ text: t("messages.supporterContribution.updateFailed") });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+
+const handleCancel = async () => {
+  await router.push(
+    extend({
+      name: "admin-supporter-contributions",
+      hash: `#${props.supporterContribution.id}`,
+    }),
+  );
+};
+</script>
+
+<template>
+  <Heading hero>{{ t("headlines.admin.supporterContributions.edit") }}</Heading>
+  <form id="admin-supporter-contribution-edit-form" @submit.prevent="onSubmit">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <FormInput
+          v-model="name"
+          v-bind="nameProps"
+          translation-key="supporterContribution.name"
+          name="name"
+        />
+        <FormInput
+          v-model="amount"
+          v-bind="amountProps"
+          :type="InputTypesEnum.NUMBER"
+          :step="0.01"
+          translation-key="supporterContribution.amount"
+          name="amount"
+        />
+        <FormDatePicker
+          v-model="startedAt"
+          v-bind="startedAtProps"
+          translation-key="supporterContribution.startedAt"
+          name="startedAt"
+        />
+        <FormDatePicker
+          v-if="recurring"
+          v-model="endedAt"
+          v-bind="endedAtProps"
+          :min-date="startedAt || undefined"
+          translation-key="supporterContribution.endedAt"
+          name="endedAt"
+        />
+      </div>
+      <div class="col-12 col-md-6">
+        <FormToggle
+          v-model="recurring"
+          v-bind="recurringProps"
+          translation-key="supporterContribution.recurring"
+          name="recurring"
+        />
+        <FormToggle
+          v-model="anonymous"
+          v-bind="anonymousProps"
+          translation-key="supporterContribution.anonymous"
+          name="anonymous"
+        />
+        <FormTextarea
+          v-model="note"
+          v-bind="noteProps"
+          translation-key="supporterContribution.note"
+          name="note"
+        />
+      </div>
+    </div>
+    <FormActions
+      :submitting="submitting"
+      form-id="admin-supporter-contribution-edit-form"
+      :dirty="meta.dirty || meta.touched"
+      @cancel="handleCancel"
+    />
+  </form>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/[id]/routes.ts
+++ b/app/frontend/admin/pages/supporter-contributions/[id]/routes.ts
@@ -1,0 +1,15 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "edit",
+    name: "admin-supporter-contribution-edit",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/[id]/edit.vue"),
+    meta: {
+      title: "admin.supporterContributions.edit",
+      activeRoute: "admin-supporter-contributions",
+      needsAuthentication: true,
+    },
+  },
+];

--- a/app/frontend/admin/pages/supporter-contributions/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/create.vue
@@ -22,6 +22,7 @@ import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
+import { toCents } from "@/shared/utils/currencyHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 const { t } = useI18n();
@@ -83,7 +84,7 @@ const onSubmit = handleSubmit(async (values) => {
 
   const payload: SupporterContributionInput = {
     name: values.name || undefined,
-    amountCents: Math.round(Number(values.amount) * 100),
+    amountCents: toCents(values.amount),
     startedAt: values.startedAt,
     endedAt: (values.recurring && values.endedAt) || undefined,
     recurring: values.recurring,

--- a/app/frontend/admin/pages/supporter-contributions/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/create.vue
@@ -21,6 +21,7 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 const { t } = useI18n();
@@ -47,7 +48,7 @@ const validationSchema = {
 const initialValues = ref<FormValues>({
   name: "",
   amount: undefined,
-  startedAt: new Date().toISOString().slice(0, 10),
+  startedAt: todayIsoDateLocal(),
   recurring: false,
   anonymous: false,
 });

--- a/app/frontend/admin/pages/supporter-contributions/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/create.vue
@@ -1,0 +1,180 @@
+<script lang="ts">
+export default {
+  name: "AdminSupporterContributionCreatePage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import {
+  type SupporterContributionInput,
+  useCreateSupporterContribution,
+  getSupporterContributionsQueryKey,
+} from "@/services/fyAdminApi";
+import { useForm } from "vee-validate";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import FormToggle from "@/shared/components/base/FormToggle/index.vue";
+import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+const { t } = useI18n();
+const router = useRouter();
+const { extend } = useBreadCrumbs();
+const { displaySuccess, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
+
+type FormValues = {
+  name?: string;
+  amount?: number;
+  startedAt: string;
+  endedAt?: string;
+  recurring: boolean;
+  anonymous: boolean;
+  note?: string;
+};
+
+const validationSchema = {
+  amount: "required",
+  startedAt: "required",
+};
+
+const initialValues = ref<FormValues>({
+  name: "",
+  amount: undefined,
+  startedAt: new Date().toISOString().slice(0, 10),
+  recurring: false,
+  anonymous: false,
+});
+
+const { defineField, handleSubmit, meta } = useForm<FormValues>({
+  initialValues: initialValues.value,
+  validationSchema,
+});
+
+const [name, nameProps] = defineField("name");
+const [amount, amountProps] = defineField("amount");
+const [startedAt, startedAtProps] = defineField("startedAt");
+const [endedAt, endedAtProps] = defineField("endedAt");
+const [recurring, recurringProps] = defineField("recurring");
+const [anonymous, anonymousProps] = defineField("anonymous");
+const [note, noteProps] = defineField("note");
+
+const submitting = ref(false);
+
+const createMutation = useCreateSupporterContribution({
+  mutation: {
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getSupporterContributionsQueryKey(),
+      });
+    },
+  },
+});
+
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  const payload: SupporterContributionInput = {
+    name: values.name || undefined,
+    amountCents: Math.round(Number(values.amount) * 100),
+    startedAt: values.startedAt,
+    endedAt: (values.recurring && values.endedAt) || undefined,
+    recurring: values.recurring,
+    anonymous: values.anonymous,
+    note: values.note || undefined,
+  };
+
+  await createMutation
+    .mutateAsync({ data: payload })
+    .then(async () => {
+      displaySuccess({
+        text: t("messages.supporterContribution.created"),
+      });
+      await router.push(extend({ name: "admin-supporter-contributions" }));
+    })
+    .catch((error) => {
+      console.error("Error creating supporter contribution:", error);
+      displayAlert({ text: t("messages.supporterContribution.createFailed") });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+
+const handleCancel = async () => {
+  await router.push(extend({ name: "admin-supporter-contributions" }));
+};
+</script>
+
+<template>
+  <Heading hero>{{ t("headlines.admin.supporterContributions.new") }}</Heading>
+  <form
+    id="admin-supporter-contribution-create-form"
+    @submit.prevent="onSubmit"
+  >
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <FormInput
+          v-model="name"
+          v-bind="nameProps"
+          translation-key="supporterContribution.name"
+          name="name"
+        />
+        <FormInput
+          v-model="amount"
+          v-bind="amountProps"
+          :type="InputTypesEnum.NUMBER"
+          :step="0.01"
+          translation-key="supporterContribution.amount"
+          name="amount"
+        />
+        <FormDatePicker
+          v-model="startedAt"
+          v-bind="startedAtProps"
+          translation-key="supporterContribution.startedAt"
+          name="startedAt"
+        />
+        <FormDatePicker
+          v-if="recurring"
+          v-model="endedAt"
+          v-bind="endedAtProps"
+          :min-date="startedAt || undefined"
+          translation-key="supporterContribution.endedAt"
+          name="endedAt"
+        />
+      </div>
+      <div class="col-12 col-md-6">
+        <FormToggle
+          v-model="recurring"
+          v-bind="recurringProps"
+          translation-key="supporterContribution.recurring"
+          name="recurring"
+        />
+        <FormToggle
+          v-model="anonymous"
+          v-bind="anonymousProps"
+          translation-key="supporterContribution.anonymous"
+          name="anonymous"
+        />
+        <FormTextarea
+          v-model="note"
+          v-bind="noteProps"
+          translation-key="supporterContribution.note"
+          name="note"
+        />
+      </div>
+    </div>
+    <FormActions
+      :submitting="submitting"
+      form-id="admin-supporter-contribution-create-form"
+      :dirty="meta.dirty || meta.touched"
+      @cancel="handleCancel"
+    />
+  </form>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/[id].vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/[id].vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+import { useFundingGoal as useFundingGoalQuery } from "@/services/fyAdminApi";
+import AsyncData from "@/shared/components/AsyncData.vue";
+
+const route = useRoute();
+
+const { data: fundingGoal, ...asyncStatus } = useFundingGoalQuery(
+  route.params.id as string,
+);
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <router-view :funding-goal="fundingGoal" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/edit.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/edit.vue
@@ -1,0 +1,194 @@
+<script lang="ts">
+export default {
+  name: "AdminFundingGoalEditPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import {
+  type FundingGoal,
+  type FundingGoalInput,
+  useUpdateFundingGoal,
+  getFundingGoalsQueryKey,
+  getFundingGoalQueryKey,
+} from "@/services/fyAdminApi";
+import { useForm } from "vee-validate";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  fundingGoal: FundingGoal;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const router = useRouter();
+const { extend } = useBreadCrumbs();
+const { displaySuccess, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
+
+type FormValues = {
+  title: string;
+  description?: string;
+  amount: number;
+  effectiveFrom: string;
+  endedAt?: string;
+  currency: string;
+};
+
+const initialValues = ref<FormValues>({
+  title: props.fundingGoal.title,
+  description: props.fundingGoal.description,
+  amount: props.fundingGoal.amountCents / 100,
+  effectiveFrom: props.fundingGoal.effectiveFrom,
+  endedAt: props.fundingGoal.endedAt,
+  currency: props.fundingGoal.currency,
+});
+
+const validationSchema = {
+  title: "required",
+  amount: "required",
+  effectiveFrom: "required",
+};
+
+const { defineField, handleSubmit, meta } = useForm<FormValues>({
+  initialValues: initialValues.value,
+  validationSchema,
+});
+
+const [title, titleProps] = defineField("title");
+const [description, descriptionProps] = defineField("description");
+const [amount, amountProps] = defineField("amount");
+const [effectiveFrom, effectiveFromProps] = defineField("effectiveFrom");
+const [endedAt, endedAtProps] = defineField("endedAt");
+
+const submitting = ref(false);
+
+const updateMutation = useUpdateFundingGoal({
+  mutation: {
+    onSettled: () => {
+      void Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: getFundingGoalsQueryKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: getFundingGoalQueryKey(props.fundingGoal.id),
+        }),
+      ]);
+    },
+  },
+});
+
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  const payload: FundingGoalInput = {
+    title: values.title,
+    description: values.description || undefined,
+    amountCents: Math.round(Number(values.amount) * 100),
+    effectiveFrom: values.effectiveFrom,
+    endedAt: values.endedAt || undefined,
+    currency: values.currency,
+  };
+
+  await updateMutation
+    .mutateAsync({
+      id: props.fundingGoal.id,
+      data: payload,
+    })
+    .then(() => {
+      displaySuccess({
+        text: t("messages.fundingGoal.updated"),
+      });
+    })
+    .catch((error) => {
+      console.error("Error updating funding goal:", error);
+      displayAlert({ text: t("messages.fundingGoal.updateFailed") });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+
+const handleCancel = async () => {
+  await router.push(
+    extend({
+      name: "admin-funding-goals",
+      hash: `#${props.fundingGoal.id}`,
+    }),
+  );
+};
+</script>
+
+<template>
+  <BreadCrumbs
+    :crumbs="[
+      {
+        to: { name: 'admin-supporter-contributions' },
+        label: t('headlines.admin.supporterContributions.index'),
+      },
+      {
+        to: { name: 'admin-funding-goals' },
+        label: t('headlines.admin.fundingGoals.index'),
+      },
+    ]"
+  />
+  <Heading hero>{{ t("headlines.admin.fundingGoals.edit") }}</Heading>
+  <form id="admin-funding-goal-edit-form" @submit.prevent="onSubmit">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <FormInput
+          v-model="title"
+          v-bind="titleProps"
+          translation-key="fundingGoal.title"
+          name="title"
+        />
+        <FormInput
+          v-model="amount"
+          v-bind="amountProps"
+          :type="InputTypesEnum.NUMBER"
+          :step="0.01"
+          translation-key="fundingGoal.amount"
+          name="amount"
+        />
+        <FormDatePicker
+          v-model="effectiveFrom"
+          v-bind="effectiveFromProps"
+          translation-key="fundingGoal.effectiveFrom"
+          name="effectiveFrom"
+        />
+        <FormDatePicker
+          v-model="endedAt"
+          v-bind="endedAtProps"
+          :min-date="effectiveFrom || undefined"
+          translation-key="fundingGoal.endedAt"
+          name="endedAt"
+        />
+      </div>
+      <div class="col-12 col-md-6">
+        <FormTextarea
+          v-model="description"
+          v-bind="descriptionProps"
+          translation-key="fundingGoal.description"
+          name="description"
+        />
+      </div>
+    </div>
+    <FormActions
+      :submitting="submitting"
+      form-id="admin-funding-goal-edit-form"
+      :dirty="meta.dirty || meta.touched"
+      @cancel="handleCancel"
+    />
+  </form>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/edit.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/edit.vue
@@ -23,6 +23,7 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { toCents } from "@/shared/utils/currencyHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 type Props = {
@@ -95,7 +96,7 @@ const onSubmit = handleSubmit(async (values) => {
   const payload: FundingGoalInput = {
     title: values.title,
     description: values.description || undefined,
-    amountCents: Math.round(Number(values.amount) * 100),
+    amountCents: toCents(values.amount),
     effectiveFrom: values.effectiveFrom,
     endedAt: values.endedAt || undefined,
     currency: values.currency,

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/routes.ts
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/[id]/routes.ts
@@ -1,0 +1,15 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "edit",
+    name: "admin-funding-goal-edit",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/funding-goals/[id]/edit.vue"),
+    meta: {
+      title: "admin.fundingGoals.edit",
+      activeRoute: "admin-supporter-contributions",
+      needsAuthentication: true,
+    },
+  },
+];

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
@@ -22,6 +22,7 @@ import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
+import { toCents } from "@/shared/utils/currencyHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 const { t } = useI18n();
@@ -83,7 +84,7 @@ const onSubmit = handleSubmit(async (values) => {
   const payload: FundingGoalInput = {
     title: values.title,
     description: values.description || undefined,
-    amountCents: Math.round(Number(values.amount) * 100),
+    amountCents: toCents(values.amount),
     effectiveFrom: values.effectiveFrom,
     endedAt: values.endedAt || undefined,
     currency: values.currency,

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
@@ -21,6 +21,7 @@ import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
 import { useQueryClient } from "@tanstack/vue-query";
 
 const { t } = useI18n();
@@ -48,7 +49,7 @@ const initialValues = ref<FormValues>({
   title: "",
   description: undefined,
   amount: undefined,
-  effectiveFrom: new Date().toISOString().slice(0, 10),
+  effectiveFrom: todayIsoDateLocal(),
   endedAt: undefined,
   currency: "EUR",
 });

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/create.vue
@@ -1,0 +1,174 @@
+<script lang="ts">
+export default {
+  name: "AdminFundingGoalCreatePage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import {
+  type FundingGoalInput,
+  useCreateFundingGoal,
+  getFundingGoalsQueryKey,
+} from "@/services/fyAdminApi";
+import { useForm } from "vee-validate";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+const { t } = useI18n();
+const router = useRouter();
+const { extend } = useBreadCrumbs();
+const { displaySuccess, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
+
+type FormValues = {
+  title: string;
+  description?: string;
+  amount?: number;
+  effectiveFrom: string;
+  endedAt?: string;
+  currency: string;
+};
+
+const validationSchema = {
+  title: "required",
+  amount: "required",
+  effectiveFrom: "required",
+};
+
+const initialValues = ref<FormValues>({
+  title: "",
+  description: undefined,
+  amount: undefined,
+  effectiveFrom: new Date().toISOString().slice(0, 10),
+  endedAt: undefined,
+  currency: "EUR",
+});
+
+const { defineField, handleSubmit, meta } = useForm<FormValues>({
+  initialValues: initialValues.value,
+  validationSchema,
+});
+
+const [title, titleProps] = defineField("title");
+const [description, descriptionProps] = defineField("description");
+const [amount, amountProps] = defineField("amount");
+const [effectiveFrom, effectiveFromProps] = defineField("effectiveFrom");
+const [endedAt, endedAtProps] = defineField("endedAt");
+
+const submitting = ref(false);
+
+const createMutation = useCreateFundingGoal({
+  mutation: {
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getFundingGoalsQueryKey(),
+      });
+    },
+  },
+});
+
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  const payload: FundingGoalInput = {
+    title: values.title,
+    description: values.description || undefined,
+    amountCents: Math.round(Number(values.amount) * 100),
+    effectiveFrom: values.effectiveFrom,
+    endedAt: values.endedAt || undefined,
+    currency: values.currency,
+  };
+
+  await createMutation
+    .mutateAsync({ data: payload })
+    .then(async () => {
+      displaySuccess({
+        text: t("messages.fundingGoal.created"),
+      });
+      await router.push(extend({ name: "admin-funding-goals" }));
+    })
+    .catch((error) => {
+      console.error("Error creating funding goal:", error);
+      displayAlert({ text: t("messages.fundingGoal.createFailed") });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+
+const handleCancel = async () => {
+  await router.push(extend({ name: "admin-funding-goals" }));
+};
+</script>
+
+<template>
+  <BreadCrumbs
+    :crumbs="[
+      {
+        to: { name: 'admin-supporter-contributions' },
+        label: t('headlines.admin.supporterContributions.index'),
+      },
+      {
+        to: { name: 'admin-funding-goals' },
+        label: t('headlines.admin.fundingGoals.index'),
+      },
+    ]"
+  />
+  <Heading hero>{{ t("headlines.admin.fundingGoals.new") }}</Heading>
+  <form id="admin-funding-goal-create-form" @submit.prevent="onSubmit">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <FormInput
+          v-model="title"
+          v-bind="titleProps"
+          translation-key="fundingGoal.title"
+          name="title"
+        />
+        <FormInput
+          v-model="amount"
+          v-bind="amountProps"
+          :type="InputTypesEnum.NUMBER"
+          :step="0.01"
+          translation-key="fundingGoal.amount"
+          name="amount"
+        />
+        <FormDatePicker
+          v-model="effectiveFrom"
+          v-bind="effectiveFromProps"
+          translation-key="fundingGoal.effectiveFrom"
+          name="effectiveFrom"
+        />
+        <FormDatePicker
+          v-model="endedAt"
+          v-bind="endedAtProps"
+          :min-date="effectiveFrom || undefined"
+          translation-key="fundingGoal.endedAt"
+          name="endedAt"
+        />
+      </div>
+      <div class="col-12 col-md-6">
+        <FormTextarea
+          v-model="description"
+          v-bind="descriptionProps"
+          translation-key="fundingGoal.description"
+          name="description"
+        />
+      </div>
+    </div>
+    <FormActions
+      :submitting="submitting"
+      form-id="admin-funding-goal-create-form"
+      :dirty="meta.dirty || meta.touched"
+      @cancel="handleCancel"
+    />
+  </form>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
@@ -1,0 +1,209 @@
+<script lang="ts">
+export default {
+  name: "AdminFundingGoalsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Heading from "@/shared/components/base/Heading/index.vue";
+import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import FundingGoalActions from "@/admin/components/FundingGoals/Actions/index.vue";
+import {
+  useFundingGoals,
+  getFundingGoalsQueryKey,
+  type FundingGoal,
+  type FundingGoalSortEnum,
+} from "@/services/fyAdminApi";
+import { usePagination } from "@/shared/composables/usePagination";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useCurrencyFormat } from "@/shared/composables/useCurrencyFormat";
+import { useFundingGoalFilters } from "@/admin/composables/useFundingGoalFilters";
+
+const route = useRoute();
+
+const sorts = computed((): FundingGoalSortEnum[] => {
+  return route.query.s ? [route.query.s as FundingGoalSortEnum] : [];
+});
+
+watch(
+  () => sorts.value,
+  async () => {
+    await refetch();
+  },
+);
+
+const fundingGoalsQueryKey = computed(() => {
+  return getFundingGoalsQueryKey(fundingGoalsQueryParams.value);
+});
+
+const { perPage, page, updatePerPage } = usePagination(fundingGoalsQueryKey);
+
+const { filters, isFilterSelected } = useFundingGoalFilters(async () => {
+  await refetch();
+});
+
+const fundingGoalsQueryParams = computed(() => {
+  return {
+    page: page.value,
+    perPage: perPage.value,
+    q: {
+      ...filters.value,
+      sorts: sorts.value,
+    },
+  };
+});
+
+const {
+  data: fundingGoals,
+  refetch,
+  ...asyncStatus
+} = useFundingGoals(fundingGoalsQueryParams);
+
+const columns: BaseTableCol<FundingGoal>[] = [
+  {
+    name: "title",
+    label: "Title",
+    sortable: true,
+  },
+  {
+    name: "amount",
+    label: "Amount",
+    sortable: true,
+  },
+  {
+    name: "effectiveFrom",
+    label: "Effective from",
+    sortable: true,
+  },
+  {
+    name: "endedAt",
+    label: "Ended at",
+    mobile: false,
+    sortable: false,
+  },
+  {
+    name: "active",
+    label: "Active",
+    mobile: false,
+  },
+];
+
+const { t, l } = useI18n();
+const { formatCents } = useCurrencyFormat();
+</script>
+
+<template>
+  <BreadCrumbs
+    :crumbs="[
+      {
+        to: { name: 'admin-supporter-contributions' },
+        label: t('headlines.admin.supporterContributions.index'),
+      },
+    ]"
+  />
+  <Heading hero>
+    {{ t("headlines.admin.fundingGoals.index") }}
+    <HeadingSmall v-if="fundingGoals">
+      {{
+        t("headlines.pagination.count", {
+          current: fundingGoals?.items.length,
+          total: fundingGoals?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <Teleport to="#header-right">
+    <Btn
+      :to="{ name: 'admin-supporter-contributions' }"
+      :aria-label="t('headlines.admin.supporterContributions.index')"
+      mobile-icon-only
+    >
+      <i class="fa-duotone fa-hand-holding-heart" />
+      {{ t("headlines.admin.supporterContributions.index") }}
+    </Btn>
+    <Btn
+      :to="{ name: 'admin-funding-goal-create' }"
+      :aria-label="t('actions.create')"
+      mobile-icon-only
+    >
+      <i class="fa fa-plus" />
+      {{ t("actions.create") }}
+    </Btn>
+  </Teleport>
+
+  <FilteredList
+    name="admin-funding-goals"
+    :records="fundingGoals?.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+    :is-filter-selected="isFilterSelected"
+  >
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="fundingGoals?.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+        default-sort="effectiveFrom desc"
+        selectable
+      >
+        <template #col-title="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-funding-goal-edit',
+              params: { id: record.id },
+            }"
+          >
+            {{ record.title }}
+          </router-link>
+        </template>
+        <template #col-amount="{ record }">
+          {{ formatCents(record.amountCents, record.currency) }}
+        </template>
+        <template #col-effectiveFrom="{ record }">
+          {{ l(record.effectiveFrom, "datetime.formats.short") }}
+        </template>
+        <template #col-endedAt="{ record }">
+          <span v-if="record.endedAt">
+            {{ l(record.endedAt, "datetime.formats.short") }}
+          </span>
+          <span v-else>—</span>
+        </template>
+        <template #col-active="{ record }">
+          <i
+            v-if="!record.endedAt || record.endedAt >= new Date().toISOString().slice(0, 10)"
+            class="fa-duotone fa-circle-check"
+          />
+          <i v-else class="fa-duotone fa-circle-xmark" />
+        </template>
+        <template #actions="{ record }">
+          <FundingGoalActions :funding-goal="record" />
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-top>
+      <Paginator
+        v-if="fundingGoals"
+        :query-result-ref="fundingGoals"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="fundingGoals"
+        :query-result-ref="fundingGoals"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
@@ -22,6 +22,7 @@ import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useCurrencyFormat } from "@/shared/composables/useCurrencyFormat";
+import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
 import { useFundingGoalFilters } from "@/admin/composables/useFundingGoalFilters";
 
 const route = useRoute();
@@ -179,7 +180,7 @@ const { formatCents } = useCurrencyFormat();
         </template>
         <template #col-active="{ record }">
           <i
-            v-if="!record.endedAt || record.endedAt >= new Date().toISOString().slice(0, 10)"
+            v-if="!record.endedAt || record.endedAt >= todayIsoDateLocal()"
             class="fa-duotone fa-circle-check"
           />
           <i v-else class="fa-duotone fa-circle-xmark" />

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/routes.ts
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/routes.ts
@@ -1,0 +1,42 @@
+import type { RouteRecordRaw } from "vue-router";
+import { routes as fundingGoalRoutes } from "@/admin/pages/supporter-contributions/funding-goals/[id]/routes";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "",
+    name: "admin-funding-goals",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/funding-goals/index.vue"),
+    strict: true,
+    meta: {
+      title: "admin.fundingGoals.index",
+      needsAuthentication: true,
+      access: ["supporters"],
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+  {
+    path: "create/",
+    name: "admin-funding-goal-create",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/funding-goals/create.vue"),
+    meta: {
+      title: "admin.fundingGoals.new",
+      needsAuthentication: true,
+      nav: "hidden",
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+  {
+    path: ":id/",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/funding-goals/[id].vue"),
+    children: fundingGoalRoutes,
+    redirect: { name: fundingGoalRoutes[0].name },
+    meta: {
+      needsAuthentication: true,
+      nav: "hidden",
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+];

--- a/app/frontend/admin/pages/supporter-contributions/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/index.vue
@@ -1,0 +1,227 @@
+<script lang="ts">
+export default {
+  name: "AdminSupporterContributionsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Heading from "@/shared/components/base/Heading/index.vue";
+import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import SupporterContributionActions from "@/admin/components/SupporterContributions/Actions/index.vue";
+import FilterForm from "@/admin/components/SupporterContributions/FilterForm/index.vue";
+import Stats from "@/admin/components/SupporterContributions/Stats/index.vue";
+import {
+  useSupporterContributions,
+  getSupporterContributionsQueryKey,
+  type SupporterContribution,
+  type SupporterContributionSortEnum,
+} from "@/services/fyAdminApi";
+import { usePagination } from "@/shared/composables/usePagination";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useCurrencyFormat } from "@/shared/composables/useCurrencyFormat";
+import { useSupporterContributionFilters } from "@/admin/composables/useSupporterContributionFilters";
+
+const route = useRoute();
+
+const sorts = computed((): SupporterContributionSortEnum[] => {
+  return route.query.s ? [route.query.s as SupporterContributionSortEnum] : [];
+});
+
+watch(
+  () => sorts.value,
+  async () => {
+    await refetch();
+  },
+);
+
+const supporterContributionsQueryKey = computed(() => {
+  return getSupporterContributionsQueryKey(
+    supporterContributionsQueryParams.value,
+  );
+});
+
+const { perPage, page, updatePerPage } = usePagination(
+  supporterContributionsQueryKey,
+);
+
+const { filters, isFilterSelected } = useSupporterContributionFilters(
+  async () => {
+    await refetch();
+  },
+);
+
+const supporterContributionsQueryParams = computed(() => {
+  return {
+    page: page.value,
+    perPage: perPage.value,
+    q: {
+      ...filters.value,
+      sorts: sorts.value,
+    },
+  };
+});
+
+const statsQueryParams = computed(() => {
+  return {
+    q: {
+      ...filters.value,
+    },
+  };
+});
+
+const {
+  data: supporterContributions,
+  refetch,
+  ...asyncStatus
+} = useSupporterContributions(supporterContributionsQueryParams);
+
+const columns: BaseTableCol<SupporterContribution>[] = [
+  {
+    name: "name",
+    label: "Name",
+    sortable: true,
+  },
+  {
+    name: "amount",
+    label: "Amount",
+    sortable: false,
+  },
+  {
+    name: "startedAt",
+    label: "Started at",
+    sortable: true,
+  },
+  {
+    name: "endedAt",
+    label: "Ended at",
+    mobile: false,
+    sortable: true,
+  },
+  {
+    name: "recurring",
+    label: "Recurring",
+    mobile: false,
+  },
+  {
+    name: "anonymous",
+    label: "Anonymous",
+    mobile: false,
+  },
+];
+
+const { t, l } = useI18n();
+const { formatCents } = useCurrencyFormat();
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.supporterContributions.index") }}
+    <HeadingSmall v-if="supporterContributions">
+      {{
+        t("headlines.pagination.count", {
+          current: supporterContributions?.items.length,
+          total: supporterContributions?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <Teleport to="#header-right">
+    <Btn
+      :to="{ name: 'admin-funding-goals' }"
+      :aria-label="t('headlines.admin.fundingGoals.index')"
+      mobile-icon-only
+    >
+      <i class="fa-duotone fa-bullseye-arrow" />
+      {{ t("headlines.admin.fundingGoals.index") }}
+    </Btn>
+    <Btn
+      :to="{ name: 'admin-supporter-contribution-create' }"
+      :aria-label="t('actions.create')"
+      mobile-icon-only
+    >
+      <i class="fa fa-plus" />
+      {{ t("actions.create") }}
+    </Btn>
+  </Teleport>
+
+  <FilteredList
+    name="admin-supporter-contributions"
+    :records="supporterContributions?.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+    :is-filter-selected="isFilterSelected"
+  >
+    <template #filter>
+      <FilterForm />
+    </template>
+    <template #header>
+      <Stats :params="statsQueryParams" />
+    </template>
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="supporterContributions?.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+        default-sort="startedAt desc"
+        selectable
+      >
+        <template #col-name="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-supporter-contribution-edit',
+              params: { id: record.id },
+            }"
+          >
+            <span v-if="record.name">{{ record.name }}</span>
+            <em v-else>—</em>
+          </router-link>
+        </template>
+        <template #col-amount="{ record }">
+          {{ formatCents(record.amountCents, record.currency) }}
+        </template>
+        <template #col-startedAt="{ record }">
+          {{ l(record.startedAt, "datetime.formats.short") }}
+        </template>
+        <template #col-endedAt="{ record }">
+          <span v-if="record.endedAt">
+            {{ l(record.endedAt, "datetime.formats.short") }}
+          </span>
+          <span v-else>—</span>
+        </template>
+        <template #col-recurring="{ record }">
+          <i v-if="record.recurring" class="fa-duotone fa-arrows-rotate" />
+        </template>
+        <template #col-anonymous="{ record }">
+          <i v-if="record.anonymous" class="fa-duotone fa-user-secret" />
+        </template>
+        <template #actions="{ record }">
+          <SupporterContributionActions :supporter-contribution="record" />
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-top>
+      <Paginator
+        v-if="supporterContributions"
+        :query-result-ref="supporterContributions"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="supporterContributions"
+        :query-result-ref="supporterContributions"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>

--- a/app/frontend/admin/pages/supporter-contributions/routes.ts
+++ b/app/frontend/admin/pages/supporter-contributions/routes.ts
@@ -1,0 +1,51 @@
+import type { RouteRecordRaw } from "vue-router";
+import { routes as supporterContributionRoutes } from "@/admin/pages/supporter-contributions/[id]/routes";
+import { routes as fundingGoalsRoutes } from "@/admin/pages/supporter-contributions/funding-goals/routes";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "",
+    name: "admin-supporter-contributions",
+    component: () => import("@/admin/pages/supporter-contributions/index.vue"),
+    strict: true,
+    meta: {
+      title: "admin.supporterContributions.index",
+      needsAuthentication: true,
+      access: ["supporters"],
+    },
+  },
+  {
+    path: "create/",
+    name: "admin-supporter-contribution-create",
+    component: () => import("@/admin/pages/supporter-contributions/create.vue"),
+    meta: {
+      title: "admin.supporterContributions.new",
+      needsAuthentication: true,
+      nav: "hidden",
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+  {
+    path: "funding-goals/",
+    component: () =>
+      import("@/admin/pages/supporter-contributions/funding-goals.vue"),
+    children: fundingGoalsRoutes,
+    redirect: { name: fundingGoalsRoutes[0].name },
+    meta: {
+      needsAuthentication: true,
+      access: ["supporters"],
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+  {
+    path: ":id/",
+    component: () => import("@/admin/pages/supporter-contributions/[id].vue"),
+    children: supporterContributionRoutes,
+    redirect: { name: supporterContributionRoutes[0].name },
+    meta: {
+      needsAuthentication: true,
+      nav: "hidden",
+      activeRoute: "admin-supporter-contributions",
+    },
+  },
+];

--- a/app/frontend/frontend/components/SupportBtn/Modal/index.vue
+++ b/app/frontend/frontend/components/SupportBtn/Modal/index.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
+import SupportProgress from "@/frontend/components/SupportProgress/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import kofiIcon from "@/images/icons/kofi_s_logo_nolabel.png";
 
@@ -16,6 +17,12 @@ const { t } = useI18n();
 <template>
   <Modal :title="t('headlines.support')">
     <div class="support-body">
+      <br />
+      <div class="row">
+        <div class="col-12">
+          <SupportProgress show-breakdown />
+        </div>
+      </div>
       <br />
       <div class="row">
         <div class="col-12">

--- a/app/frontend/frontend/components/SupportProgress/index.scss
+++ b/app/frontend/frontend/components/SupportProgress/index.scss
@@ -1,0 +1,68 @@
+.support-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  &__header {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: 1.1rem;
+  }
+
+  &__total {
+    font-weight: 600;
+  }
+
+  &__goal {
+    opacity: 0.7;
+  }
+
+  &__caption {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.7;
+  }
+
+  &__breakdown {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__breakdown-entry {
+    padding: 6px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__breakdown-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  &__breakdown-amount {
+    font-weight: 600;
+    opacity: 0.85;
+  }
+
+  &__breakdown-desc {
+    margin: 2px 0 0;
+    font-size: 0.85rem;
+    opacity: 0.7;
+  }
+
+  &--compact {
+    .support-progress__header {
+      font-size: 1rem;
+    }
+  }
+}

--- a/app/frontend/frontend/components/SupportProgress/index.vue
+++ b/app/frontend/frontend/components/SupportProgress/index.vue
@@ -1,0 +1,96 @@
+<script lang="ts">
+export default {
+  name: "SupportProgress",
+};
+</script>
+
+<script lang="ts" setup>
+import { useSupportersProgress } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useCurrencyFormat } from "@/shared/composables/useCurrencyFormat";
+import ProgressBar from "@/shared/components/ProgressBar/index.vue";
+
+type Props = {
+  compact?: boolean;
+  showBreakdown?: boolean;
+};
+
+withDefaults(defineProps<Props>(), {
+  compact: false,
+  showBreakdown: false,
+});
+
+const { t } = useI18n();
+const { formatCents } = useCurrencyFormat();
+
+const { data: progress } = useSupportersProgress();
+
+const goalAmount = computed(() => progress.value?.goal?.amountCents ?? 0);
+const totalAmount = computed(
+  () => progress.value?.monthlyTotal.amountCents ?? 0,
+);
+const currency = computed(
+  () =>
+    progress.value?.goal?.currency ??
+    progress.value?.monthlyTotal.currency ??
+    "EUR",
+);
+
+const percent = computed(() => {
+  if (!goalAmount.value) return 0;
+  return Math.min(
+    100,
+    Math.round((totalAmount.value / goalAmount.value) * 100),
+  );
+});
+
+const formattedTotal = computed(() =>
+  formatCents(totalAmount.value, currency.value),
+);
+
+const formattedGoal = computed(() =>
+  formatCents(goalAmount.value, currency.value),
+);
+</script>
+
+<template>
+  <div
+    class="support-progress"
+    :class="{ 'support-progress--compact': compact }"
+  >
+    <div class="support-progress__header">
+      <span class="support-progress__total">{{ formattedTotal }}</span>
+      <span v-if="progress?.goal" class="support-progress__goal">
+        / {{ formattedGoal }}
+      </span>
+    </div>
+    <ProgressBar :progress="percent" />
+    <p v-if="!compact && progress?.goal" class="support-progress__caption">
+      {{ t("texts.support.thisMonth") }}
+    </p>
+    <ul
+      v-if="showBreakdown && progress?.goal?.items?.length"
+      class="support-progress__breakdown"
+    >
+      <li
+        v-for="(item, index) in progress.goal.items"
+        :key="index"
+        class="support-progress__breakdown-entry"
+      >
+        <div class="support-progress__breakdown-title">
+          <strong>{{ item.title }}</strong>
+          <span class="support-progress__breakdown-amount">
+            {{ formatCents(item.amountCents, item.currency) }}
+          </span>
+        </div>
+        <p v-if="item.description" class="support-progress__breakdown-desc">
+          {{ item.description }}
+        </p>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "./index.scss";
+</style>

--- a/app/frontend/shared/components/base/FormDatePicker/index.vue
+++ b/app/frontend/shared/components/base/FormDatePicker/index.vue
@@ -1,0 +1,275 @@
+<script lang="ts">
+export default {
+  name: "FormDatePicker",
+};
+</script>
+
+<script lang="ts" setup>
+import { useField, type RuleExpression } from "vee-validate";
+import { v4 as uuidv4 } from "uuid";
+import { useI18n } from "@/shared/composables/useI18n";
+import { VueDatePicker } from "@vuepic/vue-datepicker";
+import "@vuepic/vue-datepicker/dist/main.css";
+import type { MaybeRef } from "vue";
+
+type Props = {
+  id?: string;
+  name: string;
+  rules?: MaybeRef<RuleExpression<string | null>>;
+  icon?: string;
+  modelValue?: string | null;
+  translationKey?: string;
+  label?: string;
+  noLabel?: boolean;
+  placeholder?: string;
+  noPlaceholder?: boolean;
+  clearable?: boolean;
+  disabled?: boolean;
+  withTime?: boolean;
+  minDate?: string | Date;
+  maxDate?: string | Date;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  id: undefined,
+  rules: undefined,
+  icon: undefined,
+  modelValue: undefined,
+  translationKey: undefined,
+  label: undefined,
+  noLabel: false,
+  placeholder: undefined,
+  noPlaceholder: false,
+  clearable: true,
+  disabled: false,
+  withTime: false,
+  minDate: undefined,
+  maxDate: undefined,
+});
+
+const emit = defineEmits(["update:modelValue", "clear"]);
+
+const { t } = useI18n();
+
+const internalId = ref(`${props.name}-${uuidv4()}`);
+
+const innerLabel = computed(() => {
+  if (props.label) return props.label;
+  if (props.translationKey) return t(`labels.${props.translationKey}`);
+  return t(`labels.${props.name}`);
+});
+
+const innerPlaceholder = computed(() => {
+  if (props.noPlaceholder) return undefined;
+  if (props.placeholder) return props.placeholder;
+  if (props.translationKey) return t(`placeholders.${props.translationKey}`);
+  return t(`placeholders.${props.name}`);
+});
+
+const {
+  value: fieldValue,
+  errorMessage,
+  errors,
+  handleChange,
+  handleReset,
+  resetField,
+} = useField<string | null>(props.name, props.rules, {
+  initialValue: props.modelValue ?? null,
+  label: innerLabel.value,
+});
+
+const hasErrors = computed(() => errors.value.length > 0);
+
+const pickerValue = computed<Date | null>({
+  get: () => (fieldValue.value ? new Date(fieldValue.value) : null),
+  set: (next) => {
+    const serialized = next
+      ? props.withTime
+        ? next.toISOString()
+        : toIsoDate(next)
+      : null;
+    handleChange(serialized);
+    emit("update:modelValue", serialized);
+  },
+});
+
+const toIsoDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const inputFormat = computed(() =>
+  props.withTime ? "d MMM yyyy HH:mm" : "d MMM yyyy",
+);
+
+const timeConfig = computed(() => ({
+  enableTimePicker: props.withTime,
+  timePickerInline: props.withTime,
+}));
+
+watch(
+  () => props.modelValue,
+  (next) => {
+    resetField({
+      value: next ?? null,
+    });
+  },
+);
+
+const clear = () => {
+  handleReset();
+  emit("update:modelValue", undefined);
+  emit("clear");
+};
+
+onMounted(() => {
+  if (props.id) {
+    internalId.value = props.id;
+  } else {
+    internalId.value = `${props.name}-${uuidv4()}`;
+  }
+});
+
+defineExpose({ clear });
+</script>
+
+<template>
+  <div
+    :key="internalId"
+    class="base-input form-date-picker"
+    :class="{
+      'base-input--with-error': hasErrors,
+      'base-input--disabled': disabled,
+    }"
+    :data-test="`input-wrapper-${name}`"
+  >
+    <label v-if="innerLabel && !noLabel" :for="internalId">
+      <i v-if="icon" :class="icon" />
+      {{ innerLabel }}
+    </label>
+    <div class="base-input__wrapper">
+      <VueDatePicker
+        v-model="pickerValue"
+        v-tooltip.right="hasErrors && errorMessage"
+        :uid="internalId"
+        :name="name"
+        :placeholder="innerPlaceholder"
+        :clearable="clearable"
+        :disabled="disabled"
+        :time-config="timeConfig"
+        :formats="{ input: inputFormat, preview: inputFormat }"
+        auto-apply
+        :min-date="minDate"
+        :max-date="maxDate"
+        dark
+        :data-test="`input-${name}`"
+        @cleared="clear"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+// Calendar popup palette — vue-datepicker teleports the menu to body
+// so this block intentionally lives outside any scoped wrapper.
+.dp--theme-dark {
+  --dp-font-family: inherit;
+  --dp-background-color: #{$input-bg};
+  --dp-text-color: #{$input-color};
+  --dp-hover-color: #{color.adjust($input-bg, $lightness: 5%)};
+  --dp-hover-text-color: #{$input-color};
+  --dp-primary-color: #{$primary};
+  --dp-primary-text-color: #fff;
+  --dp-secondary-color: #{$gray-light};
+  --dp-border-color: #{$input-border};
+  --dp-menu-border-color: #{$input-border};
+  --dp-border-color-hover: #{color.adjust($input-border, $lightness: 8%)};
+  --dp-border-color-focus: #{$primary};
+  --dp-icon-color: #{$gray-light};
+  --dp-disabled-color: #{$input-bg};
+  --dp-disabled-color-text: #{color.adjust($input-color, $lightness: -10%)};
+  --dp-border-radius: 3px;
+  --dp-font-size: 16px;
+  --dp-success-color: #{$success};
+  --dp-danger-color: #{$danger};
+}
+</style>
+
+<style lang="scss" scoped>
+.form-date-picker {
+  margin-bottom: 1rem;
+
+  :deep(.dp--main),
+  :deep(.dp--input-wrap) {
+    width: 100%;
+  }
+
+  // Tighten the icon-container padding (default is 6px 12px) so the visible
+  // calendar glyph sits inside the input's 36px left padding cleanly.
+  :deep(.dp--input-icons) {
+    padding: 0;
+  }
+
+  // Match `.base-input__wrapper input` from FormInput exactly.
+  :deep(.dp--input) {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    height: 43px;
+    padding: 6px 12px 6px 36px; // 36px left padding leaves room for the calendar icon
+    margin: 0;
+    color: $input-color;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.42857;
+    font-family: inherit;
+    text-overflow: ellipsis;
+    background-color: $input-bg;
+    background-image: none;
+    border: 1px solid $input-border;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    transition: none;
+    cursor: pointer;
+
+    &::placeholder {
+      color: $input-placerholder;
+      opacity: 1;
+    }
+
+    &:focus {
+      outline: none;
+      border-color: $input-border;
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    }
+  }
+
+  // Calendar icon on the left + clear button on the right inherit the
+  // FormInput muted-gray tone.
+  :deep(.dp--input-icon),
+  :deep(.dp--clear-btn) {
+    color: $gray-light;
+    fill: $gray-light;
+  }
+
+  :deep(.dp--input-icon) {
+    inset-inline-start: 14px;
+  }
+
+  :deep(.dp--clear-btn) {
+    inset-inline-end: 14px;
+  }
+
+  &.base-input--with-error :deep(.dp--input) {
+    border-color: color.adjust($danger, $lightness: -15%);
+  }
+
+  &.base-input--disabled :deep(.dp--input) {
+    color: color.adjust($input-color, $lightness: -10%);
+    cursor: not-allowed;
+    opacity: 0.9;
+  }
+}
+</style>

--- a/app/frontend/shared/components/base/FormDatePicker/index.vue
+++ b/app/frontend/shared/components/base/FormDatePicker/index.vue
@@ -68,7 +68,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const internalId = ref(`${props.name}-${uuidv4()}`);
+const internalId = ref(props.id ?? `${props.name}-${uuidv4()}`);
 
 const innerLabel = computed(() => {
   if (props.label) return props.label;
@@ -133,14 +133,6 @@ const clear = () => {
   emit("update:modelValue", undefined);
   emit("clear");
 };
-
-onMounted(() => {
-  if (props.id) {
-    internalId.value = props.id;
-  } else {
-    internalId.value = `${props.name}-${uuidv4()}`;
-  }
-});
 
 defineExpose({ clear });
 </script>

--- a/app/frontend/shared/components/base/FormDatePicker/index.vue
+++ b/app/frontend/shared/components/base/FormDatePicker/index.vue
@@ -8,9 +8,23 @@ export default {
 import { useField, type RuleExpression } from "vee-validate";
 import { v4 as uuidv4 } from "uuid";
 import { useI18n } from "@/shared/composables/useI18n";
+import { toLocalIsoDate } from "@/shared/utils/dateHelpers";
 import { VueDatePicker } from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import type { MaybeRef } from "vue";
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// `new Date('YYYY-MM-DD')` parses as UTC midnight; for users west of UTC
+// the resulting Date falls on the previous local day. Parse as local
+// midnight instead when the value is a date-only string.
+const parseLocal = (value: string): Date => {
+  if (DATE_ONLY_RE.test(value)) {
+    const [year, month, day] = value.split("-").map(Number);
+    return new Date(year, month - 1, day);
+  }
+  return new Date(value);
+};
 
 type Props = {
   id?: string;
@@ -47,7 +61,10 @@ const props = withDefaults(defineProps<Props>(), {
   maxDate: undefined,
 });
 
-const emit = defineEmits(["update:modelValue", "clear"]);
+const emit = defineEmits<{
+  "update:modelValue": [value: string | null | undefined];
+  clear: [];
+}>();
 
 const { t } = useI18n();
 
@@ -81,24 +98,17 @@ const {
 const hasErrors = computed(() => errors.value.length > 0);
 
 const pickerValue = computed<Date | null>({
-  get: () => (fieldValue.value ? new Date(fieldValue.value) : null),
+  get: () => (fieldValue.value ? parseLocal(fieldValue.value) : null),
   set: (next) => {
     const serialized = next
       ? props.withTime
         ? next.toISOString()
-        : toIsoDate(next)
+        : toLocalIsoDate(next)
       : null;
     handleChange(serialized);
     emit("update:modelValue", serialized);
   },
 });
-
-const toIsoDate = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
 
 const inputFormat = computed(() =>
   props.withTime ? "d MMM yyyy HH:mm" : "d MMM yyyy",

--- a/app/frontend/shared/composables/useCurrencyFormat.ts
+++ b/app/frontend/shared/composables/useCurrencyFormat.ts
@@ -1,0 +1,15 @@
+import { useI18nStore } from "@/shared/stores/i18n";
+
+export const useCurrencyFormat = () => {
+  const i18nStore = useI18nStore();
+
+  const formatCents = (amountCents: number, currency = "EUR") => {
+    const locale = i18nStore.locale || "en";
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+    }).format(amountCents / 100);
+  };
+
+  return { formatCents };
+};

--- a/app/frontend/shared/utils/currencyHelpers.ts
+++ b/app/frontend/shared/utils/currencyHelpers.ts
@@ -1,0 +1,18 @@
+// Convert a decimal amount string/number ("12.34") into integer cents.
+// Avoids the IEEE-754 trap where `Math.round(2.675 * 100)` returns 267 —
+// we operate on the integer + fractional parts of the string directly so
+// no float multiplication is involved.
+export const toCents = (value: number | string | undefined | null): number => {
+  if (value === undefined || value === null || value === "") return 0;
+
+  const str = String(value).trim().replace(",", ".");
+  const negative = str.startsWith("-");
+  const unsigned = negative ? str.slice(1) : str;
+
+  const [intPart, fracPart = ""] = unsigned.split(".");
+  const fracPadded = (fracPart + "00").slice(0, 2);
+
+  const cents = Number(intPart || "0") * 100 + Number(fracPadded || "0");
+
+  return negative ? -cents : cents;
+};

--- a/app/frontend/shared/utils/dateHelpers.ts
+++ b/app/frontend/shared/utils/dateHelpers.ts
@@ -1,0 +1,8 @@
+export const toLocalIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const todayIsoDateLocal = (): string => toLocalIsoDate(new Date());

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -71,6 +71,16 @@
           "new": "Neuer Hersteller",
           "edit": "Hersteller bearbeiten"
         },
+        "supporterContributions": {
+          "index": "Unterstützer-Beiträge",
+          "new": "Neuer Beitrag",
+          "edit": "Beitrag bearbeiten"
+        },
+        "fundingGoals": {
+          "index": "Finanzierungsziele",
+          "new": "Neues Finanzierungsziel",
+          "edit": "Finanzierungsziel bearbeiten"
+        },
         "users": {
           "index": "Benutzer",
           "edit": "Benutzer bearbeiten",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -540,6 +540,30 @@
         "logo": "Logo",
         "scRef": "SC Ref"
       },
+      "fundingGoal": {
+        "title": "Titel",
+        "description": "Beschreibung",
+        "amount": "Betrag",
+        "currency": "Währung",
+        "effectiveFrom": "Gültig ab",
+        "endedAt": "Beendet am"
+      },
+      "supporterContribution": {
+        "name": "Unterstützer-Name",
+        "amount": "Betrag",
+        "currency": "Währung",
+        "anonymous": "Anonym",
+        "recurring": "Wiederkehrend",
+        "startedAt": "Beginnt am",
+        "endedAt": "Endet am",
+        "note": "Interne Notiz",
+        "stats": {
+          "total": "Gesamt",
+          "count": "Beiträge",
+          "recurringCount": "Wiederkehrend",
+          "anonymousCount": "Anonym"
+        }
+      },
       "itemPrice": {
         "price": "Preis",
         "location": "Standort",
@@ -1021,6 +1045,13 @@
           "name": "Name",
           "withModels": "Mit Modellen",
           "logoBlank": "Ohne Logo"
+        },
+        "supporterContributions": {
+          "name": "Nach Name suchen",
+          "recurring": "Wiederkehrend",
+          "anonymous": "Anonym",
+          "startedAtGteq": "Beginnt ab",
+          "startedAtLteq": "Beginnt bis"
         },
         "images": {
           "station": "Station",

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -150,6 +150,20 @@
         "syncMatrixStarted": "Matrix-Synchronisation gestartet. Du wirst benachrichtigt, wenn sie abgeschlossen ist.",
         "syncScDataStarted": "SC-Daten-Synchronisation gestartet. Du wirst benachrichtigt, wenn sie abgeschlossen ist."
       },
+      "fundingGoal": {
+        "created": "Finanzierungsziel angelegt.",
+        "updated": "Finanzierungsziel aktualisiert.",
+        "destroyed": "Finanzierungsziel gelöscht.",
+        "createFailed": "Finanzierungsziel konnte nicht angelegt werden.",
+        "updateFailed": "Finanzierungsziel konnte nicht aktualisiert werden."
+      },
+      "supporterContribution": {
+        "created": "Unterstützer-Beitrag angelegt.",
+        "updated": "Unterstützer-Beitrag aktualisiert.",
+        "destroyed": "Unterstützer-Beitrag gelöscht.",
+        "createFailed": "Unterstützer-Beitrag konnte nicht angelegt werden.",
+        "updateFailed": "Unterstützer-Beitrag konnte nicht aktualisiert werden."
+      },
       "notification": {
         "granted": "Willkommen bei FleetYards.net Benachrichtigungen!"
       },
@@ -361,6 +375,12 @@
         },
         "manufacturer": {
           "destroy": "Bist du sicher, dass du diesen Hersteller löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "fundingGoal": {
+          "destroy": "Bist du sicher, dass du dieses Finanzierungsziel löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "supporterContribution": {
+          "destroy": "Bist du sicher, dass du diesen Unterstützer-Beitrag löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden."
         },
         "modelHardpoint": {
           "destroy": "Sind Sie sicher, dass Sie diesen Aufhängungspunkt löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."

--- a/app/frontend/translations/de/placeholders.json
+++ b/app/frontend/translations/de/placeholders.json
@@ -97,6 +97,22 @@
         "code": "Code",
         "scRef": "SC Ref"
       },
+      "fundingGoal": {
+        "title": "Serverkosten, Domain, Discord...",
+        "description": "Optionaler öffentlicher Kontext",
+        "amount": "100,00",
+        "currency": "EUR",
+        "effectiveFrom": "2026-01-01",
+        "endedAt": "leer lassen, wenn laufend"
+      },
+      "supporterContribution": {
+        "name": "Öffentlich angezeigter Name",
+        "amount": "5,00",
+        "currency": "EUR",
+        "startedAt": "2026-01-01",
+        "endedAt": "2026-12-31",
+        "note": "Optionale interne Notiz"
+      },
       "component": {
         "componentClass": "Komponentenklasse",
         "componentType": "Komponententyp",
@@ -198,6 +214,11 @@
         },
         "manufacturers": {
           "name": "Origin, Robert Space Industries, Aegis..."
+        },
+        "supporterContributions": {
+          "name": "Alice, Bob...",
+          "startedAtGteq": "2026-01-01",
+          "startedAtLteq": "2026-12-31"
         },
         "users": {
           "search": "Benutzername oder E-Mail",

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -7,7 +7,8 @@
       "support": {
         "info": "If you like FleetYards.net and want to support the further development and maintenance of this project please upvote our <a href=\"https://robertsspaceindustries.com/spectrum/community/SC/forum/57219/thread/fleetyards-net\" target=\"_blank\" rel=\"noopener\"><b>Spectrum Post</b></a> and our Post on the <a href=\"https://robertsspaceindustries.com/community/deep-space-radar/1730-FleetYardsnet\" target=\"_blank\" rel=\"noopener\"><b>Deep Space Radar</b></a>.",
         "code": "Additionally you can get 5000 UEC starting money by using the following Recruitment Code <a href=\"https://robertsspaceindustries.com/enlist?referral=%{code}\" target=\"_blank\" rel=\"noopener\"><b>\"%{code}\"</b></a> when you buy Star Citizen or you can:",
-        "subline": "oder Sie können uns direkt unterstützen über:"
+        "subline": "oder Sie können uns direkt unterstützen über:",
+        "thisMonth": "Diesen Monat eingegangen"
       },
       "supportHint": {
         "hangarSync": "Background-Syncs sind der größte Posten unserer Hosting-Rechnung. FleetYards läuft auf Spendenbasis — jeder Beitrag hilft.",

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -139,6 +139,16 @@
           "new": "Neuer Hersteller",
           "edit": "Hersteller bearbeiten"
         },
+        "supporterContributions": {
+          "index": "Unterstützer-Beiträge",
+          "new": "Neuer Beitrag",
+          "edit": "Beitrag bearbeiten"
+        },
+        "fundingGoals": {
+          "index": "Finanzierungsziele",
+          "new": "Neues Finanzierungsziel",
+          "edit": "Finanzierungsziel bearbeiten"
+        },
         "users": {
           "index": "Benutzer",
           "edit": "Benutzer bearbeiten"

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -77,6 +77,16 @@
           "new": "New Manufacturer",
           "edit": "Edit Manufacturer"
         },
+        "supporterContributions": {
+          "index": "Supporter Contributions",
+          "new": "New Supporter Contribution",
+          "edit": "Edit Supporter Contribution"
+        },
+        "fundingGoals": {
+          "index": "Funding Goals",
+          "new": "New Funding Goal",
+          "edit": "Edit Funding Goal"
+        },
         "users": {
           "index": "Users",
           "edit": "Edit User",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -577,6 +577,30 @@
         "logo": "Logo",
         "scRef": "SC Ref"
       },
+      "fundingGoal": {
+        "title": "Title",
+        "description": "Description",
+        "amount": "Amount",
+        "currency": "Currency",
+        "effectiveFrom": "Effective from",
+        "endedAt": "Ended at"
+      },
+      "supporterContribution": {
+        "name": "Supporter Name",
+        "amount": "Amount",
+        "currency": "Currency",
+        "anonymous": "Anonymous",
+        "recurring": "Recurring",
+        "startedAt": "Started at",
+        "endedAt": "Ended at",
+        "note": "Internal note",
+        "stats": {
+          "total": "Total",
+          "count": "Contributions",
+          "recurringCount": "Recurring",
+          "anonymousCount": "Anonymous"
+        }
+      },
       "itemPrice": {
         "price": "Price",
         "location": "Location",
@@ -1167,6 +1191,13 @@
           "name": "Name",
           "withModels": "With Models",
           "logoBlank": "Without Logo"
+        },
+        "supporterContributions": {
+          "name": "Search by name",
+          "recurring": "Recurring",
+          "anonymous": "Anonymous",
+          "startedAtGteq": "Started from",
+          "startedAtLteq": "Started until"
         },
         "images": {
           "station": "Station",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -149,6 +149,20 @@
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes."
       },
+      "fundingGoal": {
+        "created": "Funding goal created.",
+        "updated": "Funding goal updated.",
+        "destroyed": "Funding goal deleted.",
+        "createFailed": "Could not create funding goal.",
+        "updateFailed": "Could not update funding goal."
+      },
+      "supporterContribution": {
+        "created": "Supporter contribution created.",
+        "updated": "Supporter contribution updated.",
+        "destroyed": "Supporter contribution deleted.",
+        "createFailed": "Could not create supporter contribution.",
+        "updateFailed": "Could not update supporter contribution."
+      },
       "notification": {
         "granted": "Welcome to FleetYards.net Notifications!"
       },
@@ -373,6 +387,12 @@
         },
         "manufacturer": {
           "destroy": "Are you sure you want to delete this manufacturer? This action can't be reverted."
+        },
+        "fundingGoal": {
+          "destroy": "Are you sure you want to delete this funding goal? This action can't be reverted."
+        },
+        "supporterContribution": {
+          "destroy": "Are you sure you want to delete this supporter contribution? This action can't be reverted."
         },
         "modelHardpoint": {
           "destroy": "Are you sure you want to delete this hardpoint? This action can't be reverted."

--- a/app/frontend/translations/en/placeholders.json
+++ b/app/frontend/translations/en/placeholders.json
@@ -97,6 +97,22 @@
         "code": "Code",
         "scRef": "SC Ref"
       },
+      "fundingGoal": {
+        "title": "Server costs, Domain, Discord...",
+        "description": "Optional context shown publicly",
+        "amount": "100.00",
+        "currency": "EUR",
+        "effectiveFrom": "2026-01-01",
+        "endedAt": "leave blank for ongoing"
+      },
+      "supporterContribution": {
+        "name": "Supporter name shown publicly",
+        "amount": "5.00",
+        "currency": "EUR",
+        "startedAt": "2026-01-01",
+        "endedAt": "2026-12-31",
+        "note": "Optional internal note"
+      },
       "component": {
         "componentClass": "Component Class",
         "componentType": "Component Type",
@@ -202,6 +218,11 @@
         },
         "manufacturers": {
           "name": "Origin, Robert Space Industries, Aegis..."
+        },
+        "supporterContributions": {
+          "name": "Alice, Bob...",
+          "startedAtGteq": "2026-01-01",
+          "startedAtLteq": "2026-12-31"
         },
         "users": {
           "search": "Username or Email",

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -7,7 +7,8 @@
       "support": {
         "info": "If you like FleetYards.net and want to support the further development and maintenance<br>of this project please upvote our <a href=\"https://robertsspaceindustries.com/spectrum/community/SC/forum/57219/thread/fleetyards-net\" target=\"_blank\" rel=\"noopener\"><b>Spectrum Post</b></a>.",
         "code": "Additionally you can get 5000 UEC starting money by using the following Recruitment Code when you buy Star Citizen:",
-        "subline": "or you can support us directly via:"
+        "subline": "or you can support us directly via:",
+        "thisMonth": "Raised this month"
       },
       "supportHint": {
         "hangarSync": "Background syncs are the biggest item on our hosting bill. FleetYards runs on donations — if you'd like to chip in, every bit helps.",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -141,6 +141,16 @@
           "new": "New Manufacturer",
           "edit": "Edit Manufacturer"
         },
+        "supporterContributions": {
+          "index": "Supporter Contributions",
+          "new": "New Supporter Contribution",
+          "edit": "Edit Supporter Contribution"
+        },
+        "fundingGoals": {
+          "index": "Funding Goals",
+          "new": "New Funding Goal",
+          "edit": "Edit Funding Goal"
+        },
         "users": {
           "index": "Users",
           "edit": "Edit User"

--- a/app/models/funding_goal.rb
+++ b/app/models/funding_goal.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: funding_goals
+#
+#  id             :uuid             not null, primary key
+#  amount_cents   :integer          not null
+#  currency       :string           default("EUR"), not null
+#  description    :text
+#  effective_from :date             not null
+#  ended_at       :date
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_funding_goals_on_effective_from  (effective_from)
+#  index_funding_goals_on_ended_at        (ended_at)
+#
+class FundingGoal < ApplicationRecord
+  paginates_per 30
+
+  DEFAULT_SORTING_PARAMS = "effective_from desc"
+  ALLOWED_SORTING_PARAMS = [
+    "title asc", "title desc",
+    "effectiveFrom asc", "effectiveFrom desc",
+    "amountCents asc", "amountCents desc",
+    "createdAt asc", "createdAt desc"
+  ]
+
+  validates :title, presence: true
+  validates :amount_cents, presence: true, numericality: {greater_than: 0, only_integer: true}
+  validates :currency, presence: true
+  validates :effective_from, presence: true
+  validate :ended_at_after_effective_from
+
+  scope :active_on, ->(date) {
+    where("effective_from <= ?", date)
+      .where("ended_at IS NULL OR ended_at >= ?", date)
+  }
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["title", "amount_cents", "currency", "effective_from", "ended_at", "created_at", "updated_at", "id"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
+  def self.active_for_month(date = Date.current)
+    active_on(date).order(effective_from: :desc, created_at: :desc)
+  end
+
+  def self.monthly_total(date = Date.current)
+    active_on(date).sum(:amount_cents)
+  end
+
+  private def ended_at_after_effective_from
+    return if ended_at.blank? || effective_from.blank?
+    return if ended_at >= effective_from
+
+    errors.add(:ended_at, :must_be_after_effective_from)
+  end
+end

--- a/app/models/supporter_contribution.rb
+++ b/app/models/supporter_contribution.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: supporter_contributions
+#
+#  id           :uuid             not null, primary key
+#  amount_cents :integer          not null
+#  anonymous    :boolean          default(FALSE), not null
+#  currency     :string           default("EUR"), not null
+#  ended_at     :date
+#  name         :string
+#  note         :text
+#  recurring    :boolean          default(FALSE), not null
+#  started_at   :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
+#  index_supporter_contributions_on_started_at              (started_at)
+#
+class SupporterContribution < ApplicationRecord
+  paginates_per 30
+
+  DEFAULT_SORTING_PARAMS = "started_at desc"
+  ALLOWED_SORTING_PARAMS = [
+    "startedAt asc", "startedAt desc",
+    "endedAt asc", "endedAt desc",
+    "amountCents asc", "amountCents desc",
+    "name asc", "name desc",
+    "createdAt asc", "createdAt desc"
+  ]
+
+  validates :amount_cents, presence: true, numericality: {greater_than: 0, only_integer: true}
+  validates :currency, presence: true
+  validates :started_at, presence: true
+  validate :ended_at_after_started_at
+
+  before_validation :force_anonymous_when_name_blank
+
+  scope :active_in, ->(month_start, month_end) {
+    where(
+      "(recurring = ? AND started_at BETWEEN ? AND ?) OR " \
+      "(recurring = ? AND started_at <= ? AND (ended_at IS NULL OR ended_at >= ?))",
+      false, month_start, month_end,
+      true, month_end, month_start
+    )
+  }
+
+  def self.ransackable_attributes(auth_object = nil)
+    [
+      "name", "amount_cents", "currency", "anonymous", "recurring",
+      "started_at", "ended_at", "note", "created_at", "updated_at", "id"
+    ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
+  def self.monthly_total(date = Date.current)
+    month_start = date.beginning_of_month
+    month_end = date.end_of_month
+    active_in(month_start, month_end).sum(:amount_cents)
+  end
+
+  private def ended_at_after_started_at
+    return if ended_at.blank? || started_at.blank?
+    return if ended_at >= started_at
+
+    errors.add(:ended_at, :must_be_after_started_at)
+  end
+
+  private def force_anonymous_when_name_blank
+    self.anonymous = true if name.blank?
+  end
+end

--- a/app/policies/admin/funding_goal_policy.rb
+++ b/app/policies/admin/funding_goal_policy.rb
@@ -1,0 +1,7 @@
+module Admin
+  class FundingGoalPolicy < BasePolicy
+    private def resource_access
+      [:supporters]
+    end
+  end
+end

--- a/app/policies/admin/supporter_contribution_policy.rb
+++ b/app/policies/admin/supporter_contribution_policy.rb
@@ -1,0 +1,7 @@
+module Admin
+  class SupporterContributionPolicy < BasePolicy
+    private def resource_access
+      [:supporters]
+    end
+  end
+end

--- a/app/views/admin/api/v1/funding_goals/_base.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/_base.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.id funding_goal.id
+json.title funding_goal.title
+json.description funding_goal.description if funding_goal.description.present?
+json.amount_cents funding_goal.amount_cents
+json.currency funding_goal.currency
+json.effective_from funding_goal.effective_from.iso8601
+json.ended_at funding_goal.ended_at.iso8601 if funding_goal.ended_at.present?
+
+json.partial! "api/shared/dates", record: funding_goal

--- a/app/views/admin/api/v1/funding_goals/_funding_goal.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/_funding_goal.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", funding_goal] do
+  json.partial!("admin/api/v1/funding_goals/base", funding_goal:)
+end

--- a/app/views/admin/api/v1/funding_goals/create.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/create.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/funding_goals/funding_goal", funding_goal: @funding_goal

--- a/app/views/admin/api/v1/funding_goals/destroy.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/destroy.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/funding_goals/funding_goal", funding_goal: @funding_goal

--- a/app/views/admin/api/v1/funding_goals/index.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @funding_goals, partial: "admin/api/v1/funding_goals/funding_goal", as: :funding_goal
+end
+json.partial! "api/shared/meta", result: @funding_goals

--- a/app/views/admin/api/v1/funding_goals/show.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/funding_goals/funding_goal", funding_goal: @funding_goal

--- a/app/views/admin/api/v1/funding_goals/update.jbuilder
+++ b/app/views/admin/api/v1/funding_goals/update.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/funding_goals/funding_goal", funding_goal: @funding_goal

--- a/app/views/admin/api/v1/supporter_contributions/_base.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/_base.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+json.id supporter_contribution.id
+json.name supporter_contribution.name if supporter_contribution.name.present?
+json.amount_cents supporter_contribution.amount_cents
+json.currency supporter_contribution.currency
+json.anonymous supporter_contribution.anonymous
+json.recurring supporter_contribution.recurring
+json.started_at supporter_contribution.started_at.iso8601
+json.ended_at supporter_contribution.ended_at&.iso8601 if supporter_contribution.ended_at.present?
+json.note supporter_contribution.note if supporter_contribution.note.present?
+
+json.partial! "api/shared/dates", record: supporter_contribution

--- a/app/views/admin/api/v1/supporter_contributions/_supporter_contribution.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/_supporter_contribution.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", supporter_contribution] do
+  json.partial!("admin/api/v1/supporter_contributions/base", supporter_contribution:)
+end

--- a/app/views/admin/api/v1/supporter_contributions/create.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/create.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/supporter_contributions/supporter_contribution", supporter_contribution: @supporter_contribution

--- a/app/views/admin/api/v1/supporter_contributions/destroy.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/destroy.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/supporter_contributions/supporter_contribution", supporter_contribution: @supporter_contribution

--- a/app/views/admin/api/v1/supporter_contributions/index.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @supporter_contributions, partial: "admin/api/v1/supporter_contributions/supporter_contribution", as: :supporter_contribution
+end
+json.partial! "api/shared/meta", result: @supporter_contributions

--- a/app/views/admin/api/v1/supporter_contributions/show.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/supporter_contributions/supporter_contribution", supporter_contribution: @supporter_contribution

--- a/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.total_amount_cents @stats_scope.sum(:amount_cents)
+json.currency @stats_scope.pick(:currency) || "EUR"
+json.total_count @stats_scope.count
+json.recurring_count @stats_scope.where(recurring: true).count
+json.anonymous_count @stats_scope.where(anonymous: true).count

--- a/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-json.total_amount_cents @stats_scope.sum(:amount_cents)
-json.currency @stats_scope.pick(:currency) || "EUR"
-json.total_count @stats_scope.count
-json.recurring_count @stats_scope.where(recurring: true).count
-json.anonymous_count @stats_scope.where(anonymous: true).count
+total_amount_cents, currency, total_count, recurring_count, anonymous_count = @stats
+
+json.total_amount_cents total_amount_cents.to_i
+json.currency currency || "EUR"
+json.total_count total_count.to_i
+json.recurring_count recurring_count.to_i
+json.anonymous_count anonymous_count.to_i

--- a/app/views/admin/api/v1/supporter_contributions/update.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/update.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/supporter_contributions/supporter_contribution", supporter_contribution: @supporter_contribution

--- a/app/views/api/v1/supporters/progress.jbuilder
+++ b/app/views/api/v1/supporters/progress.jbuilder
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+goal_total = @goals.sum(&:amount_cents)
+goal_currency = @goals.first&.currency || "EUR"
+
+if @goals.any?
+  json.goal do
+    json.amount_cents goal_total
+    json.currency goal_currency
+    json.items @goals do |goal|
+      json.title goal.title
+      json.description goal.description if goal.description.present?
+      json.amount_cents goal.amount_cents
+      json.currency goal.currency
+    end
+  end
+end
+
+json.monthly_total do
+  json.amount_cents @monthly_total
+  json.currency goal_currency
+end
+
+json.contributions @contributions do |contribution|
+  json.display_name contribution.anonymous? ? "Anonymous" : contribution.name
+  json.amount_cents contribution.amount_cents
+  json.currency contribution.currency
+  json.recurring contribution.recurring
+end

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -117,6 +117,13 @@ v1_admin_api_routes = lambda do
 
   resources :imports, only: %i[index show]
 
+  resources :funding_goals, path: "funding-goals", only: %i[index show create update destroy]
+  resources :supporter_contributions, path: "supporter-contributions", only: %i[index show create update destroy] do
+    collection do
+      get :stats
+    end
+  end
+
   resources :oauth_applications, path: "oauth-applications", only: %i[index show create update destroy]
 
   resources :rsi_request_logs, path: "rsi-request-logs", only: %i[index] do

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -59,6 +59,8 @@ v1_api_routes = lambda do
     end
   end
 
+  get "supporters/progress", to: "supporters#progress"
+
   post "compare/share", to: "compare#share", as: :compare_share
 
   resources :images, only: %i[index] do

--- a/db/migrate/20260617120000_create_funding_goals.rb
+++ b/db/migrate/20260617120000_create_funding_goals.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateFundingGoals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :funding_goals, id: :uuid do |t|
+      t.integer :amount_cents, null: false
+      t.string :currency, null: false, default: "EUR"
+      t.date :effective_from, null: false
+
+      t.timestamps
+    end
+
+    add_index :funding_goals, :effective_from
+  end
+end

--- a/db/migrate/20260617120001_create_supporter_contributions.rb
+++ b/db/migrate/20260617120001_create_supporter_contributions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateSupporterContributions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :supporter_contributions, id: :uuid do |t|
+      t.string :name, null: false
+      t.integer :amount_cents, null: false
+      t.string :currency, null: false, default: "EUR"
+      t.boolean :anonymous, null: false, default: false
+      t.boolean :recurring, null: false, default: false
+      t.date :started_at, null: false
+      t.date :ended_at
+      t.text :note
+
+      t.timestamps
+    end
+
+    add_index :supporter_contributions, :started_at
+    add_index :supporter_contributions, [:recurring, :ended_at]
+  end
+end

--- a/db/migrate/20260620120000_make_supporter_contribution_name_nullable.rb
+++ b/db/migrate/20260620120000_make_supporter_contribution_name_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeSupporterContributionNameNullable < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :supporter_contributions, :name, true
+  end
+end

--- a/db/migrate/20260620120100_add_title_to_funding_goals.rb
+++ b/db/migrate/20260620120100_add_title_to_funding_goals.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddTitleToFundingGoals < ActiveRecord::Migration[8.1]
+  def change
+    add_column :funding_goals, :title, :string
+    add_column :funding_goals, :description, :text
+    add_column :funding_goals, :ended_at, :date
+
+    add_index :funding_goals, :ended_at
+  end
+end

--- a/db/migrate/20260621120000_seed_initial_funding_goals.rb
+++ b/db/migrate/20260621120000_seed_initial_funding_goals.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SeedInitialFundingGoals < ActiveRecord::Migration[8.1]
+  GOALS = [
+    {title: "Servers", amount_cents: 6_000, effective_from: Date.new(2026, 6, 17)},
+    {title: "Mail", amount_cents: 1_000, effective_from: Date.new(2026, 6, 20)},
+    {title: "Domains", amount_cents: 1_000, effective_from: Date.new(2026, 6, 20)},
+    {title: "CDN", amount_cents: 1_000, effective_from: Date.new(2026, 6, 20)},
+    {title: "Cloud Storage", amount_cents: 1_000, effective_from: Date.new(2026, 6, 20)}
+  ].freeze
+
+  def up
+    GOALS.each do |attrs|
+      FundingGoal.find_or_create_by!(title: attrs[:title]) do |goal|
+        goal.amount_cents = attrs[:amount_cents]
+        goal.currency = "EUR"
+        goal.effective_from = attrs[:effective_from]
+      end
+    end
+  end
+
+  def down
+    FundingGoal.where(title: GOALS.map { |g| g[:title] }).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_113905) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -382,6 +382,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_113905) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "funding_goals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.datetime "created_at", null: false
+    t.string "currency", default: "EUR", null: false
+    t.text "description"
+    t.date "effective_from", null: false
+    t.date "ended_at"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["effective_from"], name: "index_funding_goals_on_effective_from"
+    t.index ["ended_at"], name: "index_funding_goals_on_ended_at"
   end
 
   create_table "github_issue_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -899,6 +912,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_113905) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.string "url"
+  end
+
+  create_table "supporter_contributions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.boolean "anonymous", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "currency", default: "EUR", null: false
+    t.date "ended_at"
+    t.string "name"
+    t.text "note"
+    t.boolean "recurring", default: false, null: false
+    t.date "started_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recurring", "ended_at"], name: "index_supporter_contributions_on_recurring_and_ended_at"
+    t.index ["started_at"], name: "index_supporter_contributions_on_started_at"
   end
 
   create_table "task_forces", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/docs/exec-plans/supporter-payments.md
+++ b/docs/exec-plans/supporter-payments.md
@@ -1,0 +1,164 @@
+# Supporter Payments — Exec Plan
+
+A dedicated public page showing supporter contributions and progress toward a monthly funding goal, with admin UI to manage both the goal (with history) and contributions (free-text name, recurring or one-time, opt-out anonymous flag).
+
+## Decisions (from clarifying questions)
+
+- **Supporter identity**: free-text name (no User association). Add per-contribution `anonymous` flag so name can be hidden publicly.
+- **Funding goal**: history kept via `effective_from` dated rows; admin updates a new row when the goal changes, no monthly bookkeeping required. The active goal is the latest row with `effective_from <= today`.
+- **Public display**: shows names + amounts, except for entries flagged anonymous (still count toward total).
+- **Recurrence**: one-time and recurring (monthly) supported. Recurring rows are counted for every month between `started_at` and `ended_at` (null = ongoing).
+- **Currency**: single currency (EUR) — store cents as `integer`, currency column kept for future flexibility but UI is EUR-only for now.
+
+## Data model
+
+### Migration 1 — `funding_goals`
+- `id` uuid pk
+- `amount_cents` integer, not null
+- `currency` string, default "EUR", not null
+- `effective_from` date, not null
+- `created_at`, `updated_at`
+- index: `effective_from desc`
+
+### Migration 2 — `supporter_contributions`
+- `id` uuid pk
+- `name` string, not null
+- `amount_cents` integer, not null
+- `currency` string, default "EUR", not null
+- `anonymous` boolean, default false, not null
+- `recurring` boolean, default false, not null
+- `started_at` date, not null  ← first (or only) contribution date
+- `ended_at` date, nullable    ← only meaningful when `recurring`
+- `note` text, nullable        ← admin-internal note
+- `created_at`, `updated_at`
+- index: `started_at desc`, `(recurring, ended_at)`
+
+### Models
+
+`app/models/funding_goal.rb`
+- validates `amount_cents > 0`, `effective_from` present
+- scope `:current` → `where("effective_from <= ?", Date.current).order(effective_from: :desc).limit(1)`
+- class method `.for_month(date)` → latest row with `effective_from <= end_of_month(date)`
+
+`app/models/supporter_contribution.rb`
+- validates name, amount_cents > 0, started_at; `ended_at >= started_at` if present
+- scope `:active_in(month_start, month_end)`
+  - one-time: `recurring = false AND started_at BETWEEN month_start AND month_end`
+  - recurring: `recurring = true AND started_at <= month_end AND (ended_at IS NULL OR ended_at >= month_start)`
+- class method `.monthly_total(date = Date.current)` → sum of `amount_cents` for `active_in(month_start, month_end)`
+
+## Backend API
+
+### Admin routes (`config/routes/admin/api/v1_routes.rb`)
+```ruby
+resources :funding_goals, path: "funding-goals", only: %i[index show create update destroy]
+resources :supporter_contributions, path: "supporter-contributions", only: %i[index show create update destroy]
+```
+
+### Admin controllers (Ransack/pagination pattern matching `ManufacturersController`)
+- `app/controllers/admin/api/v1/funding_goals_controller.rb` — full CRUD
+- `app/controllers/admin/api/v1/supporter_contributions_controller.rb` — full CRUD
+
+### Admin policies + resource access
+Add a new resource access slug `:supporters` (shared by both policies — same admin domain). Admins must have `"supporters"` in their `resource_access` array to manage either goals or contributions.
+- `app/policies/admin/funding_goal_policy.rb` → `resource_access = [:supporters]`
+- `app/policies/admin/supporter_contribution_policy.rb` → `resource_access = [:supporters]`
+
+Wherever admin resource lists exist (admin user edit form, dashboard, etc. — locate by grepping for `"manufacturers"` as a string), add `"supporters"` to the available options.
+
+### Public route (`config/routes/api/v1_routes.rb`)
+```ruby
+get "supporters/progress" => "supporters#progress"
+```
+
+### Public controller
+- `app/controllers/api/v1/supporters_controller.rb` with `progress` action
+- Returns: current month's goal (amount/currency), current month total, list of contributions active this month (with name OR `Anonymous` placeholder based on `anonymous` flag; amount always included; `recurring` flag included).
+
+## OpenAPI schemas (`app/api_components/`)
+
+Never edit `swagger/*.yaml` directly — defined per `feedback_never_edit_schema_yaml`.
+
+### Admin schemas (`app/api_components/admin/v1/schemas/`)
+- `funding_goal.rb` — id, amountCents, currency, effectiveFrom, createdAt, updatedAt
+- `funding_goal_params.rb` — amountCents, currency (optional), effectiveFrom
+- `supporter_contribution.rb` — id, name, amountCents, currency, anonymous, recurring, startedAt, endedAt, note, createdAt, updatedAt
+- `supporter_contribution_params.rb` — same minus id/timestamps; ended_at/note optional
+
+### Public schema (`app/api_components/v1/schemas/`)
+- `support_progress.rb` — `goal: { amountCents, currency, effectiveFrom } | null`, `monthlyTotal: { amountCents, currency }`, `contributions: [{ displayName, amountCents, currency, recurring }]`
+- Per `feedback_response_never_nullable`: omit absent fields (e.g. `goal` only included if a goal row exists), exclude from `required`.
+
+### Regenerate schemas + Orval clients
+- `./bin/generate-schema` then standardrb + linter per `feedback_generate_schema`.
+- `pnpm orval` to regenerate Vue Query hooks under `app/frontend/services/fyAdminApi/` and the public API client.
+
+## Admin UI (`app/frontend/admin/pages/`)
+
+Follow the manufacturers pattern: `index.vue` (list, sortable, paginated), `create.vue`, `[id].vue` (edit/delete), with `routes.ts` and nested `[id]/routes.ts`.
+
+### Funding goals
+- `funding-goals/index.vue` — table: effective_from, amount, currency; sort by effective_from desc; row click → edit
+- `funding-goals/create.vue` — form: amount (EUR input), effective_from (date picker)
+- `funding-goals/[id].vue` — same form + delete
+
+### Supporter contributions
+- `supporter-contributions/index.vue` — table: name, amount, started_at, ended_at, recurring, anonymous; ransack filters (name_cont, recurring_eq, anonymous_eq)
+- `supporter-contributions/create.vue` — form: name, amount, started_at, ended_at (only when recurring=true), recurring switch, anonymous switch, note
+- `supporter-contributions/[id].vue` — edit/delete
+
+### Register pages in admin routes
+- `app/frontend/admin/pages/routes.ts` — add entries with `access: ["supporters"]` and `needsAuthentication: true` matching the existing pattern
+- Add nav entries in the admin sidebar component (locate sidebar/menu component and add `funding-goals` + `supporter-contributions` under a "Supporters" group, gated on `sessionStore.hasAccessTo("supporters")`)
+
+## Public page (`app/frontend/frontend/pages/`)
+
+- New page `support.vue` (route `/support`) showing:
+  - Goal progress bar (current month total vs. active goal)
+  - Live total and goal in EUR
+  - Contributor list — name + amount, anonymous entries shown as `Anonymous`, recurring entries marked with a recurring badge
+  - "How to contribute" section that re-uses links from existing `SupportBtn/Modal/index.vue`
+
+## Support button modal widget
+
+Extract a small shared `SupportProgress` component (`app/frontend/frontend/components/SupportProgress/index.vue`) that fetches `GET /api/v1/supporters/progress` and renders a compact progress bar with current total / monthly goal. Use it in two places:
+- Inside `SupportBtn/Modal/index.vue` at the top, above the existing PayPal/Patreon/etc. links — gives a live preview without leaving the modal.
+- On the new `/support` page (larger variant with the full contributor list below).
+The modal widget links through to `/support` for the detailed view.
+
+## i18n
+
+Add German + English translations for:
+- Page titles ("Supporter Funding", "Funding Goals", "Supporter Contributions")
+- Form labels, table headers, validation messages
+- Public page strings ("Goal", "This Month", "Anonymous", "Recurring", "One-time")
+
+## Testing
+
+Minitest (per project conventions):
+- `test/models/funding_goal_test.rb` — `.current`, `.for_month` boundary cases
+- `test/models/supporter_contribution_test.rb` — `.active_in` with one-time/recurring/edge dates, `.monthly_total`
+- `test/controllers/admin/api/v1/funding_goals_controller_test.rb` — CRUD + policy
+- `test/controllers/admin/api/v1/supporter_contributions_controller_test.rb` — CRUD + policy
+- `test/controllers/api/v1/supporters_controller_test.rb` — progress endpoint with/without active goal, anonymous masking, recurring counted across months
+
+## Resolved decisions
+
+1. Currency stays EUR-only for now (schema keeps `currency` column for future flexibility).
+2. Anonymous contributions: name hidden, amount still visible publicly.
+3. New `/support` page **plus** an embedded progress widget inside the existing `SupportBtn` modal (shared component).
+4. New `:supporters` resource_access slug — both policies require it; admins must be granted explicitly.
+
+## Commit slicing (one logical change per commit, per user prefs)
+
+1. `feat(db): add funding_goals and supporter_contributions tables`
+2. `feat(models): add FundingGoal and SupporterContribution models with scopes`
+3. `feat(api): add admin CRUD for funding goals`
+4. `feat(api): add admin CRUD for supporter contributions`
+5. `feat(api): add public supporters progress endpoint`
+6. `feat(admin-ui): funding goals CRUD pages`
+7. `feat(admin-ui): supporter contributions CRUD pages`
+8. `feat(frontend): shared SupportProgress widget`
+9. `feat(frontend): public /support page with goal progress and contributor list`
+10. `feat(frontend): embed SupportProgress widget in SupportBtn modal`
+11. `chore(i18n): add supporter funding translations`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tresjs/cientos": "^5.7.2",
     "@tresjs/core": "^5.8.1",
     "@vee-validate/rules": "^4.15.1",
+    "@vuepic/vue-datepicker": "^14.0.0",
     "@vueuse/core": "^14.3.0",
     "ahoy.js": "0.4.5",
     "axios": "1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@vee-validate/rules':
         specifier: ^4.15.1
         version: 4.15.1(vue@3.5.38(typescript@6.0.3))
+      '@vuepic/vue-datepicker':
+        specifier: ^14.0.0
+        version: 14.0.0(vue@3.5.38(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.3.0
         version: 14.3.0(vue@3.5.38(typescript@6.0.3))
@@ -1034,6 +1037,9 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
+
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
@@ -1257,6 +1263,18 @@ packages:
   '@faker-js/faker@10.4.0':
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -1497,48 +1515,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.133.0':
     resolution: {integrity: sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==}
@@ -1611,41 +1637,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -1696,36 +1730,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1811,36 +1851,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1951,66 +1997,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -2135,24 +2194,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2637,6 +2700,12 @@ packages:
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
+
+  '@vuepic/vue-datepicker@14.0.0':
+    resolution: {integrity: sha512-zDl1U2MRk+udu0gYA3pdY2f0O+ckqUPiKgWmp7qQV3D7CRgDKYvUXFpnt+rgMQ+uLydtlRqzy4eS6nvtVjNS4A==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      vue: '>=3.5.0'
 
   '@vueuse/core@13.9.0':
     resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
@@ -4176,24 +4245,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6734,6 +6807,8 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
+  '@date-fns/tz@1.5.0': {}
+
   '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/core@1.10.0':
@@ -6881,6 +6956,26 @@ snapshots:
   '@exodus/bytes@1.15.0': {}
 
   '@faker-js/faker@10.4.0': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/utils': 0.2.11
+      vue-demi: 0.14.10(vue@3.5.38(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
@@ -8249,6 +8344,16 @@ snapshots:
       vue-component-type-helpers: 3.3.4
     optionalDependencies:
       '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
+
+  '@vuepic/vue-datepicker@14.0.0(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.38(typescript@6.0.3))
+      date-fns: 4.4.0
+      vue: 3.5.38(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@vueuse/core@13.9.0(vue@3.5.38(typescript@6.0.3))':
     dependencies:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -1499,6 +1499,193 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/funding-goals":
+    post:
+      summary: Create Funding Goal
+      tags:
+      - FundingGoals
+      operationId: createFundingGoal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FundingGoalInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FundingGoal"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Funding Goals list
+      tags:
+      - FundingGoals
+      operationId: fundingGoals
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 30
+        required: false
+      - "$ref": "#/components/parameters/SortingParameter"
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/FundingGoalQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FundingGoals"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/funding-goals/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Funding Goal id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    delete:
+      summary: Destroy Funding Goal
+      tags:
+      - FundingGoals
+      operationId: destroyFundingGoal
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FundingGoal"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Funding Goal Detail
+      tags:
+      - FundingGoals
+      operationId: fundingGoal
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FundingGoal"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Funding Goal
+      tags:
+      - FundingGoals
+      operationId: updateFundingGoal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FundingGoalInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FundingGoal"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/images":
     post:
       summary: Image create
@@ -5055,6 +5242,229 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/supporter-contributions":
+    post:
+      summary: Create Supporter Contribution
+      tags:
+      - SupporterContributions
+      operationId: createSupporterContribution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SupporterContributionInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContribution"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Supporter Contributions list
+      tags:
+      - SupporterContributions
+      operationId: supporterContributions
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 30
+        required: false
+      - "$ref": "#/components/parameters/SortingParameter"
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/SupporterContributionQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContributions"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/supporter-contributions/stats":
+    get:
+      summary: Supporter Contributions Stats
+      tags:
+      - SupporterContributions
+      operationId: supporterContributionsStats
+      parameters:
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/SupporterContributionQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContributionStats"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/supporter-contributions/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Supporter Contribution id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    delete:
+      summary: Destroy Supporter Contribution
+      tags:
+      - SupporterContributions
+      operationId: destroySupporterContribution
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContribution"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Supporter Contribution Detail
+      tags:
+      - SupporterContributions
+      operationId: supporterContribution
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContribution"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Supporter Contribution
+      tags:
+      - SupporterContributions
+      operationId: updateSupporterContribution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SupporterContributionInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupporterContribution"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/users":
     get:
       summary: Users list
@@ -7595,6 +8005,120 @@ components:
       required:
       - capacity
       title: FuelTank
+    FundingGoal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        effectiveFrom:
+          type: string
+          format: date
+        endedAt:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - title
+      - amountCents
+      - currency
+      - effectiveFrom
+      - createdAt
+      - updatedAt
+      title: FundingGoal
+    FundingGoalInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        effectiveFrom:
+          type: string
+          format: date
+        endedAt:
+          type: string
+          format: date
+      additionalProperties: false
+      required:
+      - title
+      - amountCents
+      - effectiveFrom
+      title: FundingGoalInput
+    FundingGoalQuery:
+      type: object
+      properties:
+        titleCont:
+          type: string
+        effectiveFromGteq:
+          type: string
+          format: date
+        effectiveFromLteq:
+          type: string
+          format: date
+        sorts:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/FundingGoalSortEnum"
+          - "$ref": "#/components/schemas/FundingGoalSortEnum"
+      additionalProperties: false
+      example: {}
+      title: FundingGoalQuery
+    FundingGoalSortEnum:
+      type: string
+      enum:
+      - title asc
+      - title desc
+      - effectiveFrom asc
+      - effectiveFrom desc
+      - amountCents asc
+      - amountCents desc
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - TITLE_ASC
+      - TITLE_DESC
+      - EFFECTIVE_FROM_ASC
+      - EFFECTIVE_FROM_DESC
+      - AMOUNT_CENTS_ASC
+      - AMOUNT_CENTS_DESC
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: FundingGoalSortEnum
+    FundingGoals:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FundingGoal"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: FundingGoals
     Gallery:
       type: object
       properties:
@@ -11502,6 +12026,165 @@ components:
       - usersCountTotal
       - fleetsCountTotal
       title: Stats
+    SupporterContribution:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        anonymous:
+          type: boolean
+        recurring:
+          type: boolean
+        startedAt:
+          type: string
+          format: date
+        endedAt:
+          type: string
+          format: date
+        note:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - amountCents
+      - currency
+      - anonymous
+      - recurring
+      - startedAt
+      - createdAt
+      - updatedAt
+      title: SupporterContribution
+    SupporterContributionInput:
+      type: object
+      properties:
+        name:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        anonymous:
+          type: boolean
+        recurring:
+          type: boolean
+        startedAt:
+          type: string
+          format: date
+        endedAt:
+          type: string
+          format: date
+        note:
+          type: string
+      additionalProperties: false
+      required:
+      - amountCents
+      - startedAt
+      title: SupporterContributionInput
+    SupporterContributionQuery:
+      type: object
+      properties:
+        nameCont:
+          type: string
+        nameEq:
+          type: string
+        recurringEq:
+          type: boolean
+        anonymousEq:
+          type: boolean
+        startedAtGteq:
+          type: string
+          format: date
+        startedAtLteq:
+          type: string
+          format: date
+        endedAtGteq:
+          type: string
+          format: date
+        endedAtLteq:
+          type: string
+          format: date
+        sorts:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/SupporterContributionSortEnum"
+          - "$ref": "#/components/schemas/SupporterContributionSortEnum"
+      additionalProperties: false
+      example: {}
+      title: SupporterContributionQuery
+    SupporterContributionSortEnum:
+      type: string
+      enum:
+      - startedAt asc
+      - startedAt desc
+      - endedAt asc
+      - endedAt desc
+      - amountCents asc
+      - amountCents desc
+      - name asc
+      - name desc
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - STARTED_AT_ASC
+      - STARTED_AT_DESC
+      - ENDED_AT_ASC
+      - ENDED_AT_DESC
+      - AMOUNT_CENTS_ASC
+      - AMOUNT_CENTS_DESC
+      - NAME_ASC
+      - NAME_DESC
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: SupporterContributionSortEnum
+    SupporterContributionStats:
+      type: object
+      properties:
+        totalAmountCents:
+          type: integer
+        currency:
+          type: string
+        totalCount:
+          type: integer
+        recurringCount:
+          type: integer
+        anonymousCount:
+          type: integer
+      additionalProperties: false
+      required:
+      - totalAmountCents
+      - currency
+      - totalCount
+      - recurringCount
+      - anonymousCount
+      title: SupporterContributionStats
+    SupporterContributions:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SupporterContribution"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: SupporterContributions
     ThrusterClassEnum:
       type: string
       enum:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -5578,6 +5578,19 @@ paths:
                 type: array
                 items:
                   "$ref": "#/components/schemas/BarChartStats"
+  "/supporters/progress":
+    get:
+      summary: Public Supporters Progress
+      tags:
+      - Supporters
+      operationId: supportersProgress
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SupportProgress"
   "/user-features":
     get:
       summary: User Feature Flags
@@ -8907,6 +8920,27 @@ components:
       required:
       - capacity
       title: FuelTank
+    FundingGoalSortEnum:
+      type: string
+      enum:
+      - title asc
+      - title desc
+      - effectiveFrom asc
+      - effectiveFrom desc
+      - amountCents asc
+      - amountCents desc
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - TITLE_ASC
+      - TITLE_DESC
+      - EFFECTIVE_FROM_ASC
+      - EFFECTIVE_FROM_DESC
+      - AMOUNT_CENTS_ASC
+      - AMOUNT_CENTS_DESC
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: FundingGoalSortEnum
     Gallery:
       type: object
       properties:
@@ -12119,6 +12153,99 @@ components:
       - wishlistsCount
       - shipOfTheMonthCount
       title: Stats
+    SupportProgress:
+      type: object
+      properties:
+        goal:
+          type: object
+          properties:
+            amountCents:
+              type: integer
+            currency:
+              type: string
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  amountCents:
+                    type: integer
+                  currency:
+                    type: string
+                additionalProperties: false
+                required:
+                - title
+                - amountCents
+                - currency
+          additionalProperties: false
+          required:
+          - amountCents
+          - currency
+          - items
+        monthlyTotal:
+          type: object
+          properties:
+            amountCents:
+              type: integer
+            currency:
+              type: string
+          additionalProperties: false
+          required:
+          - amountCents
+          - currency
+        contributions:
+          type: array
+          items:
+            type: object
+            properties:
+              displayName:
+                type: string
+              amountCents:
+                type: integer
+              currency:
+                type: string
+              recurring:
+                type: boolean
+            additionalProperties: false
+            required:
+            - displayName
+            - amountCents
+            - currency
+            - recurring
+      additionalProperties: false
+      required:
+      - monthlyTotal
+      - contributions
+      title: SupportProgress
+    SupporterContributionSortEnum:
+      type: string
+      enum:
+      - startedAt asc
+      - startedAt desc
+      - endedAt asc
+      - endedAt desc
+      - amountCents asc
+      - amountCents desc
+      - name asc
+      - name desc
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - STARTED_AT_ASC
+      - STARTED_AT_DESC
+      - ENDED_AT_ASC
+      - ENDED_AT_DESC
+      - AMOUNT_CENTS_ASC
+      - AMOUNT_CENTS_DESC
+      - NAME_ASC
+      - NAME_DESC
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: SupporterContributionSortEnum
     SyncRsiHangarInput:
       type: object
       properties:

--- a/test/factories/funding_goals.rb
+++ b/test/factories/funding_goals.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: funding_goals
+#
+#  id             :uuid             not null, primary key
+#  amount_cents   :integer          not null
+#  currency       :string           default("EUR"), not null
+#  description    :text
+#  effective_from :date             not null
+#  ended_at       :date
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_funding_goals_on_effective_from  (effective_from)
+#  index_funding_goals_on_ended_at        (ended_at)
+#
+FactoryBot.define do
+  factory :funding_goal do
+    sequence(:title) { |n| "Funding goal ##{n}" }
+    amount_cents { 10_000 }
+    currency { "EUR" }
+    effective_from { Date.current }
+
+    trait :ended do
+      ended_at { Date.current }
+    end
+
+    trait :server_costs do
+      title { "Server costs" }
+      description { "VPS and database hosting" }
+    end
+  end
+end

--- a/test/factories/supporter_contributions.rb
+++ b/test/factories/supporter_contributions.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: supporter_contributions
+#
+#  id           :uuid             not null, primary key
+#  amount_cents :integer          not null
+#  anonymous    :boolean          default(FALSE), not null
+#  currency     :string           default("EUR"), not null
+#  ended_at     :date
+#  name         :string
+#  note         :text
+#  recurring    :boolean          default(FALSE), not null
+#  started_at   :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
+#  index_supporter_contributions_on_started_at              (started_at)
+#
+FactoryBot.define do
+  factory :supporter_contribution do
+    sequence(:name) { |n| "Supporter #{n}" }
+    amount_cents { 500 }
+    currency { "EUR" }
+    anonymous { false }
+    recurring { false }
+    started_at { Date.current }
+
+    trait :anonymous do
+      anonymous { true }
+    end
+
+    trait :recurring do
+      recurring { true }
+      ended_at { nil }
+    end
+  end
+end

--- a/test/integration/admin/api/v1/funding_goals_test.rb
+++ b/test/integration/admin/api/v1/funding_goals_test.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::FundingGoalsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/funding-goals" do
+    post("Create Funding Goal") do
+      operationId "createFundingGoal"
+      tags "FundingGoals"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FundingGoalInput"}
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FundingGoal"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    get("Funding Goals list") do
+      operationId "fundingGoals"
+      tags "FundingGoals"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string, default: FundingGoal.default_per_page}, required: false
+      parameter "$ref": "#/components/parameters/SortingParameter"
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/FundingGoalQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FundingGoals"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/funding-goals/{id}" do
+    parameter name: "id", in: :path, description: "Funding Goal id", schema: {type: :string, format: :uuid}
+
+    delete("Destroy Funding Goal") do
+      operationId "destroyFundingGoal"
+      tags "FundingGoals"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FundingGoal"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    get("Funding Goal Detail") do
+      operationId "fundingGoal"
+      tags "FundingGoals"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FundingGoal"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    put("Update Funding Goal") do
+      operationId "updateFundingGoal"
+      tags "FundingGoals"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FundingGoalInput"}
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FundingGoal"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:supporters])
+  end
+
+  test "POST /funding-goals creates a funding goal" do
+    sign_in @user
+
+    body = {title: "Server costs", amountCents: 25_000, effectiveFrom: Date.current.iso8601}
+
+    assert_api_response :post, 200, body: body do
+      assert_equal "Server costs", parsed_body["title"]
+      assert_equal 25_000, parsed_body["amountCents"]
+      assert_equal "EUR", parsed_body["currency"]
+    end
+  end
+
+  test "POST /funding-goals returns 401 when not signed in" do
+    assert_api_response :post, 401, body: {title: "Test", amountCents: 100, effectiveFrom: Date.current.iso8601}
+  end
+
+  test "POST /funding-goals returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :post, 403, body: {title: "Test", amountCents: 100, effectiveFrom: Date.current.iso8601}
+  end
+
+  test "GET /funding-goals lists funding goals" do
+    create_list(:funding_goal, 3)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /funding-goals returns 401 when not signed in" do
+    assert_api_response :get, 401
+  end
+
+  test "GET /funding-goals returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403
+  end
+
+  test "DELETE /funding-goals/:id destroys the funding goal" do
+    funding_goal = create(:funding_goal)
+    sign_in @user
+
+    assert_api_response :delete, 200, path_params: {id: funding_goal.id}
+  end
+
+  test "DELETE /funding-goals/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :delete, 404, path_params: {id: SecureRandom.uuid}
+  end
+
+  test "DELETE /funding-goals/:id returns 401 when not signed in" do
+    funding_goal = create(:funding_goal)
+
+    assert_api_response :delete, 401, path_params: {id: funding_goal.id}
+  end
+
+  test "DELETE /funding-goals/:id returns 403 for admin without access" do
+    funding_goal = create(:funding_goal)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :delete, 403, path_params: {id: funding_goal.id}
+  end
+
+  test "GET /funding-goals/:id returns the funding goal" do
+    funding_goal = create(:funding_goal)
+    sign_in @user
+
+    assert_api_response :get, 200, path_params: {id: funding_goal.id}
+  end
+
+  test "GET /funding-goals/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :get, 404, path_params: {id: SecureRandom.uuid}
+  end
+
+  test "GET /funding-goals/:id returns 401 when not signed in" do
+    funding_goal = create(:funding_goal)
+
+    assert_api_response :get, 401, path_params: {id: funding_goal.id}
+  end
+
+  test "GET /funding-goals/:id returns 403 for admin without access" do
+    funding_goal = create(:funding_goal)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, path_params: {id: funding_goal.id}
+  end
+
+  test "PUT /funding-goals/:id updates the funding goal" do
+    funding_goal = create(:funding_goal, amount_cents: 5_000)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: funding_goal.id}, body: {title: "Updated", amountCents: 12_000, effectiveFrom: Date.current.iso8601} do
+      assert_equal "Updated", parsed_body["title"]
+      assert_equal 12_000, parsed_body["amountCents"]
+    end
+  end
+
+  test "PUT /funding-goals/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, path_params: {id: SecureRandom.uuid}, body: {title: "Test", amountCents: 100, effectiveFrom: Date.current.iso8601}
+  end
+
+  test "PUT /funding-goals/:id returns 401 when not signed in" do
+    funding_goal = create(:funding_goal)
+
+    assert_api_response :put, 401, path_params: {id: funding_goal.id}, body: {title: "Test", amountCents: 100, effectiveFrom: Date.current.iso8601}
+  end
+
+  test "PUT /funding-goals/:id returns 403 for admin without access" do
+    funding_goal = create(:funding_goal)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, path_params: {id: funding_goal.id}, body: {title: "Test", amountCents: 100, effectiveFrom: Date.current.iso8601}
+  end
+end

--- a/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::SupporterContributionsStatsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/supporter-contributions/stats" do
+    get("Supporter Contributions Stats") do
+      operationId "supporterContributionsStats"
+      tags "SupporterContributions"
+      produces "application/json"
+
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/SupporterContributionQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContributionStats"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:supporters])
+  end
+
+  test "GET /supporter-contributions/stats returns aggregated stats" do
+    create(:supporter_contribution, amount_cents: 500)
+    create(:supporter_contribution, :recurring, amount_cents: 1_000)
+    create(:supporter_contribution, :anonymous, amount_cents: 250)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_equal 1_750, parsed_body["totalAmountCents"]
+      assert_equal 3, parsed_body["totalCount"]
+      assert_equal 1, parsed_body["recurringCount"]
+      assert_equal 1, parsed_body["anonymousCount"]
+    end
+  end
+
+  test "GET /supporter-contributions/stats respects ransack filters" do
+    create(:supporter_contribution, amount_cents: 500)
+    create(:supporter_contribution, :recurring, amount_cents: 1_000)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"recurringEq" => true}} do
+      assert_equal 1_000, parsed_body["totalAmountCents"]
+      assert_equal 1, parsed_body["totalCount"]
+    end
+  end
+
+  test "GET /supporter-contributions/stats returns 401 when not signed in" do
+    assert_api_response :get, 401
+  end
+
+  test "GET /supporter-contributions/stats returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403
+  end
+end

--- a/test/integration/admin/api/v1/supporter_contributions_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_test.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/supporter-contributions" do
+    post("Create Supporter Contribution") do
+      operationId "createSupporterContribution"
+      tags "SupporterContributions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/SupporterContributionInput"}
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContribution"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    get("Supporter Contributions list") do
+      operationId "supporterContributions"
+      tags "SupporterContributions"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string, default: SupporterContribution.default_per_page}, required: false
+      parameter "$ref": "#/components/parameters/SortingParameter"
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/SupporterContributionQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContributions"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/supporter-contributions/{id}" do
+    parameter name: "id", in: :path, description: "Supporter Contribution id", schema: {type: :string, format: :uuid}
+
+    delete("Destroy Supporter Contribution") do
+      operationId "destroySupporterContribution"
+      tags "SupporterContributions"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContribution"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    get("Supporter Contribution Detail") do
+      operationId "supporterContribution"
+      tags "SupporterContributions"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContribution"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    put("Update Supporter Contribution") do
+      operationId "updateSupporterContribution"
+      tags "SupporterContributions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/SupporterContributionInput"}
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupporterContribution"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:supporters])
+  end
+
+  test "POST /supporter-contributions creates a contribution" do
+    sign_in @user
+
+    body = {name: "Test Supporter", amountCents: 500, startedAt: Date.current.iso8601}
+
+    assert_api_response :post, 200, body: body do
+      assert_equal "Test Supporter", parsed_body["name"]
+      assert_equal 500, parsed_body["amountCents"]
+      assert_equal false, parsed_body["anonymous"]
+      assert_equal false, parsed_body["recurring"]
+    end
+  end
+
+  test "POST /supporter-contributions returns 401 when not signed in" do
+    assert_api_response :post, 401, body: {amountCents: 100, startedAt: Date.current.iso8601}
+  end
+
+  test "POST /supporter-contributions returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :post, 403, body: {amountCents: 100, startedAt: Date.current.iso8601}
+  end
+
+  test "GET /supporter-contributions lists contributions" do
+    create_list(:supporter_contribution, 3)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /supporter-contributions filters by recurringEq" do
+    create_list(:supporter_contribution, 2)
+    create_list(:supporter_contribution, 3, :recurring)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"recurringEq" => true}} do
+      assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /supporter-contributions returns 401 when not signed in" do
+    assert_api_response :get, 401
+  end
+
+  test "GET /supporter-contributions returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403
+  end
+
+  test "DELETE /supporter-contributions/:id destroys the contribution" do
+    contribution = create(:supporter_contribution)
+    sign_in @user
+
+    assert_api_response :delete, 200, path_params: {id: contribution.id}
+  end
+
+  test "DELETE /supporter-contributions/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :delete, 404, path_params: {id: SecureRandom.uuid}
+  end
+
+  test "DELETE /supporter-contributions/:id returns 401 when not signed in" do
+    contribution = create(:supporter_contribution)
+
+    assert_api_response :delete, 401, path_params: {id: contribution.id}
+  end
+
+  test "DELETE /supporter-contributions/:id returns 403 for admin without access" do
+    contribution = create(:supporter_contribution)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :delete, 403, path_params: {id: contribution.id}
+  end
+
+  test "GET /supporter-contributions/:id returns the contribution" do
+    contribution = create(:supporter_contribution)
+    sign_in @user
+
+    assert_api_response :get, 200, path_params: {id: contribution.id}
+  end
+
+  test "GET /supporter-contributions/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :get, 404, path_params: {id: SecureRandom.uuid}
+  end
+
+  test "GET /supporter-contributions/:id returns 401 when not signed in" do
+    contribution = create(:supporter_contribution)
+
+    assert_api_response :get, 401, path_params: {id: contribution.id}
+  end
+
+  test "GET /supporter-contributions/:id returns 403 for admin without access" do
+    contribution = create(:supporter_contribution)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, path_params: {id: contribution.id}
+  end
+
+  test "PUT /supporter-contributions/:id updates the contribution" do
+    contribution = create(:supporter_contribution)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: contribution.id}, body: {name: "Updated Name", amountCents: 999, startedAt: Date.current.iso8601} do
+      assert_equal "Updated Name", parsed_body["name"]
+    end
+  end
+
+  test "PUT /supporter-contributions/:id returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, path_params: {id: SecureRandom.uuid}, body: {amountCents: 100, startedAt: Date.current.iso8601}
+  end
+
+  test "PUT /supporter-contributions/:id returns 401 when not signed in" do
+    contribution = create(:supporter_contribution)
+
+    assert_api_response :put, 401, path_params: {id: contribution.id}, body: {amountCents: 100, startedAt: Date.current.iso8601}
+  end
+
+  test "PUT /supporter-contributions/:id returns 403 for admin without access" do
+    contribution = create(:supporter_contribution)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, path_params: {id: contribution.id}, body: {amountCents: 100, startedAt: Date.current.iso8601}
+  end
+end

--- a/test/integration/api/v1/supporters_progress_test.rb
+++ b/test/integration/api/v1/supporters_progress_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::SupportersProgressTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/supporters/progress" do
+    get("Public Supporters Progress") do
+      operationId "supportersProgress"
+      tags "Supporters"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/SupportProgress"
+      end
+    end
+  end
+
+  test "GET /supporters/progress returns 200 with summed goal and contributions" do
+    create(:funding_goal, title: "Server costs", amount_cents: 70_000, effective_from: 30.days.ago.to_date)
+    create(:funding_goal, title: "Discord", amount_cents: 30_000, effective_from: 30.days.ago.to_date, description: "Discord Nitro")
+    create(:funding_goal, title: "Retired", amount_cents: 99_999, effective_from: 90.days.ago.to_date, ended_at: 30.days.ago.to_date)
+    create(:supporter_contribution, name: "Alice", amount_cents: 1_000, started_at: Date.current)
+    create(:supporter_contribution, :anonymous, name: "Bob", amount_cents: 500, started_at: Date.current)
+    create(:supporter_contribution, :recurring, name: "Carla", amount_cents: 2_500, started_at: 90.days.ago.to_date)
+    create(:supporter_contribution, name: nil, amount_cents: 250, started_at: Date.current)
+
+    assert_api_response :get, 200 do
+      assert_equal 100_000, parsed_body["goal"]["amountCents"]
+      assert_equal "EUR", parsed_body["goal"]["currency"]
+      assert_equal 2, parsed_body["goal"]["items"].count
+      titles = parsed_body["goal"]["items"].map { |g| g["title"] }
+      assert_includes titles, "Server costs"
+      assert_includes titles, "Discord"
+      refute_includes titles, "Retired"
+      assert_equal 4_250, parsed_body["monthlyTotal"]["amountCents"]
+      assert_equal 4, parsed_body["contributions"].count
+
+      anonymous_entry = parsed_body["contributions"].find { |c| c["amountCents"] == 500 }
+      assert_equal "Anonymous", anonymous_entry["displayName"]
+
+      named_entry = parsed_body["contributions"].find { |c| c["amountCents"] == 1_000 }
+      assert_equal "Alice", named_entry["displayName"]
+
+      nameless_entry = parsed_body["contributions"].find { |c| c["amountCents"] == 250 }
+      assert_equal "Anonymous", nameless_entry["displayName"]
+    end
+  end
+
+  test "GET /supporters/progress works without an active goal" do
+    assert_api_response :get, 200 do
+      assert_nil parsed_body["goal"]
+      assert_equal 0, parsed_body["monthlyTotal"]["amountCents"]
+      assert_equal [], parsed_body["contributions"]
+    end
+  end
+
+  test "GET /supporters/progress counts recurring contributions in subsequent months" do
+    today = Date.current
+    create(:supporter_contribution, :recurring, name: "Carla", amount_cents: 2_500, started_at: 90.days.ago.to_date)
+
+    travel_to today.next_month do
+      assert_api_response :get, 200 do
+        assert_equal 2_500, parsed_body["monthlyTotal"]["amountCents"]
+        assert_equal 1, parsed_body["contributions"].count
+      end
+    end
+  end
+end

--- a/test/models/funding_goal_test.rb
+++ b/test/models/funding_goal_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: funding_goals
+#
+#  id             :uuid             not null, primary key
+#  amount_cents   :integer          not null
+#  currency       :string           default("EUR"), not null
+#  description    :text
+#  effective_from :date             not null
+#  ended_at       :date
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_funding_goals_on_effective_from  (effective_from)
+#  index_funding_goals_on_ended_at        (ended_at)
+#
+require "test_helper"
+
+class FundingGoalTest < ActiveSupport::TestCase
+  test "requires title, amount_cents > 0, effective_from" do
+    refute FundingGoal.new(amount_cents: 100, effective_from: Date.current).valid?
+    refute FundingGoal.new(title: "x", amount_cents: 0, effective_from: Date.current).valid?
+    refute FundingGoal.new(title: "x", amount_cents: -10, effective_from: Date.current).valid?
+    refute FundingGoal.new(title: "x", amount_cents: 100).valid?
+    assert FundingGoal.new(title: "x", amount_cents: 1, effective_from: Date.current).valid?
+  end
+
+  test "validates ended_at is on or after effective_from" do
+    record = FundingGoal.new(
+      title: "x", amount_cents: 100,
+      effective_from: Date.new(2026, 6, 1),
+      ended_at: Date.new(2026, 5, 1)
+    )
+
+    refute record.valid?
+    assert_includes record.errors[:ended_at], record.errors.generate_message(:ended_at, :must_be_after_effective_from)
+  end
+
+  test ".active_on includes goals where effective_from <= date and not yet ended" do
+    in_window = create(:funding_goal, effective_from: 30.days.ago.to_date, ended_at: nil)
+    future = create(:funding_goal, effective_from: 30.days.from_now.to_date)
+    ended_before = create(:funding_goal, effective_from: 90.days.ago.to_date, ended_at: 30.days.ago.to_date)
+    ends_today = create(:funding_goal, effective_from: 90.days.ago.to_date, ended_at: Date.current)
+
+    ids = FundingGoal.active_on(Date.current).pluck(:id)
+
+    assert_includes ids, in_window.id
+    assert_includes ids, ends_today.id
+    refute_includes ids, future.id
+    refute_includes ids, ended_before.id
+  end
+
+  test ".monthly_total sums amount_cents of all active goals" do
+    create(:funding_goal, amount_cents: 5_000, effective_from: 30.days.ago.to_date)
+    create(:funding_goal, amount_cents: 3_000, effective_from: 1.day.ago.to_date)
+    create(:funding_goal, amount_cents: 9_999, effective_from: 30.days.from_now.to_date)
+
+    assert_equal 8_000, FundingGoal.monthly_total
+  end
+
+  test ".active_for_month returns empty relation when no goals exist" do
+    assert_equal 0, FundingGoal.active_for_month.count
+  end
+end

--- a/test/models/supporter_contribution_test.rb
+++ b/test/models/supporter_contribution_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: supporter_contributions
+#
+#  id           :uuid             not null, primary key
+#  amount_cents :integer          not null
+#  anonymous    :boolean          default(FALSE), not null
+#  currency     :string           default("EUR"), not null
+#  ended_at     :date
+#  name         :string
+#  note         :text
+#  recurring    :boolean          default(FALSE), not null
+#  started_at   :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
+#  index_supporter_contributions_on_started_at              (started_at)
+#
+require "test_helper"
+
+class SupporterContributionTest < ActiveSupport::TestCase
+  test "requires amount_cents > 0 and started_at; name is optional" do
+    refute SupporterContribution.new(amount_cents: 0, started_at: Date.current).valid?
+    refute SupporterContribution.new(amount_cents: 100, started_at: nil).valid?
+    assert SupporterContribution.new(amount_cents: 100, started_at: Date.current).valid?
+    assert SupporterContribution.new(name: nil, amount_cents: 100, started_at: Date.current).valid?
+    assert SupporterContribution.new(name: "", amount_cents: 100, started_at: Date.current).valid?
+  end
+
+  test "auto-sets anonymous when name is blank" do
+    contribution = create(:supporter_contribution, name: nil, anonymous: false)
+    assert contribution.anonymous?
+
+    contribution = create(:supporter_contribution, name: "", anonymous: false)
+    assert contribution.anonymous?
+
+    contribution = create(:supporter_contribution, name: "Alice", anonymous: false)
+    refute contribution.anonymous?
+  end
+
+  test "validates ended_at is on or after started_at" do
+    record = SupporterContribution.new(
+      amount_cents: 100,
+      started_at: Date.new(2026, 6, 1),
+      ended_at: Date.new(2026, 5, 1)
+    )
+
+    refute record.valid?
+    assert_includes record.errors[:ended_at], record.errors.generate_message(:ended_at, :must_be_after_started_at)
+  end
+
+  test ".active_in includes one-time contributions whose started_at lands in the month" do
+    in_month = create(:supporter_contribution, started_at: Date.new(2026, 6, 10))
+    before_month = create(:supporter_contribution, started_at: Date.new(2026, 5, 28))
+    after_month = create(:supporter_contribution, started_at: Date.new(2026, 7, 1))
+
+    ids = SupporterContribution.active_in(Date.new(2026, 6, 1), Date.new(2026, 6, 30)).pluck(:id)
+
+    assert_includes ids, in_month.id
+    refute_includes ids, before_month.id
+    refute_includes ids, after_month.id
+  end
+
+  test ".active_in includes ongoing recurring contributions that overlap the month" do
+    ongoing = create(:supporter_contribution, :recurring, started_at: Date.new(2026, 1, 1))
+    ended_before = create(:supporter_contribution, :recurring, started_at: Date.new(2025, 1, 1), ended_at: Date.new(2026, 5, 31))
+    ended_during = create(:supporter_contribution, :recurring, started_at: Date.new(2025, 1, 1), ended_at: Date.new(2026, 6, 15))
+    starts_after = create(:supporter_contribution, :recurring, started_at: Date.new(2026, 7, 1))
+
+    ids = SupporterContribution.active_in(Date.new(2026, 6, 1), Date.new(2026, 6, 30)).pluck(:id)
+
+    assert_includes ids, ongoing.id
+    assert_includes ids, ended_during.id
+    refute_includes ids, ended_before.id
+    refute_includes ids, starts_after.id
+  end
+
+  test ".monthly_total sums amount_cents of active contributions" do
+    create(:supporter_contribution, amount_cents: 500, started_at: Date.new(2026, 6, 5))
+    create(:supporter_contribution, :recurring, amount_cents: 1_000, started_at: Date.new(2026, 1, 1))
+    create(:supporter_contribution, amount_cents: 9_999, started_at: Date.new(2026, 5, 28))
+
+    assert_equal 1_500, SupporterContribution.monthly_total(Date.new(2026, 6, 15))
+  end
+end


### PR DESCRIPTION
## Summary

- Two new tables, models and admin CRUD: `funding_goals` (title, description, amount, effective_from/ended_at window — multiple concurrent goals sum into the public target) and `supporter_contributions` (free-text name, recurring or one-time, anonymous flag auto-set when name is blank).
- Public `GET /api/v1/supporters/progress` returns the summed goal with per-line breakdown, current monthly total, and contributor list (anonymous entries surface as "Anonymous"). Embedded in the existing `SupportBtn` modal via a new `SupportProgress` widget that shows the breakdown of what each goal covers.
- Admin UI under a single Supporters nav entry: supporter-contributions index with filter-aware stats (count, recurring, anonymous, sum) + date range / name filters, funding-goals sub-page with breadcrumbs. Forms accept decimal amounts and constrain end dates to start dates. New shared `FormDatePicker` wrapping `@vuepic/vue-datepicker` styled to match `FormInput`, with optional inline time picker.
- Seed migration ships the initial five line-item goals (Servers, Mail, Domains, CDN, Cloud Storage) so production starts with the same data already in use locally.

Exec plan: `docs/exec-plans/supporter-payments.md`

## Test plan

- [x] Backend: 55 tests (model unit + admin CRUD + public progress + stats endpoint) — all green
- [x] `pnpm lint:ts` clean
- [x] `bundle exec standardrb` clean
- [x] Manual: create/edit/delete a funding goal in admin, confirm it shows up summed on the public modal
- [x] Manual: create one-time + recurring + anonymous + nameless contributions, confirm filter-aware stats update and contributor list displays correctly
- [x] Manual: confirm date picker styling matches FormInput in both pages and modal
- [x] Verify the seed migration is idempotent on the live DB

🤖