### PR TITLE
chore(test): refresh model schema annotations

### DIFF
--- a/test/models/compare_image_test.rb
+++ b/test/models/compare_image_test.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: compare_images
+#
+#  id         :uuid             not null, primary key
+#  share_key  :string
+#  short_code :string
+#  slug_set   :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_compare_images_on_share_key   (share_key) UNIQUE WHERE (share_key IS NOT NULL)
+#  index_compare_images_on_short_code  (short_code) UNIQUE WHERE (short_code IS NOT NULL)
+#  index_compare_images_on_slug_set    (slug_set) UNIQUE
+#
 require "test_helper"
 
 class CompareImageTest < ActiveSupport::TestCase

--- a/test/models/fleet_membership_test.rb
+++ b/test/models/fleet_membership_test.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: fleet_memberships
+#
+#  id                :uuid             not null, primary key
+#  aasm_state        :string
+#  accepted_at       :datetime
+#  declined_at       :datetime
+#  hide_ships        :boolean          default(FALSE)
+#  invited_at        :datetime
+#  invited_by        :uuid
+#  primary           :boolean          default(FALSE)
+#  requested_at      :datetime
+#  ships_filter      :integer          default("all")
+#  used_invite_token :string
+#  verified          :boolean          default(FALSE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  fleet_id          :uuid
+#  fleet_role_id     :uuid
+#  hangar_group_id   :uuid
+#  user_id           :uuid
+#
+# Indexes
+#
+#  index_fleet_memberships_on_fleet_role_id         (fleet_role_id)
+#  index_fleet_memberships_on_user_id_and_fleet_id  (user_id,fleet_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_role_id => fleet_roles.id)
+#
 require "test_helper"
 
 class FleetMembershipTest < ActiveSupport::TestCase

--- a/test/models/fleet_role_test.rb
+++ b/test/models/fleet_role_test.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: fleet_roles
+#
+#  id              :uuid             not null, primary key
+#  name            :string
+#  permanent       :boolean
+#  rank            :text
+#  resource_access :text
+#  slug            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  fleet_id        :uuid             not null
+#
+# Indexes
+#
+#  index_fleet_roles_on_fleet_id_and_rank  (fleet_id,rank) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_id => fleets.id)
+#
 require "test_helper"
 
 class FleetRoleTest < ActiveSupport::TestCase

--- a/test/models/fleet_test.rb
+++ b/test/models/fleet_test.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: fleets
+#
+#  id                 :uuid             not null, primary key
+#  created_by         :uuid
+#  description        :text
+#  discord            :string
+#  fid                :string
+#  guilded            :string
+#  homepage           :string
+#  name               :string
+#  normalized_fid     :string
+#  public_fleet       :boolean          default(FALSE)
+#  public_fleet_stats :boolean          default(FALSE)
+#  rsi_sid            :string
+#  sid                :string
+#  slug               :string
+#  ts                 :string
+#  twitch             :string
+#  youtube            :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_fleets_on_fid  (fid) UNIQUE
+#
 require "test_helper"
 
 class FleetTest < ActiveSupport::TestCase

--- a/test/models/fleet_vehicle_test.rb
+++ b/test/models/fleet_vehicle_test.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: fleet_vehicles
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  fleet_id   :uuid
+#  vehicle_id :uuid
+#
+# Indexes
+#
+#  index_fleet_vehicles_on_fleet_id_and_vehicle_id  (fleet_id,vehicle_id) UNIQUE
+#  index_fleet_vehicles_on_vehicle_id               (vehicle_id)
+#
 require "test_helper"
 
 class FleetVehicleTest < ActiveSupport::TestCase

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,5 +1,35 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                :uuid             not null, primary key
+#  body              :text
+#  expires_at        :datetime         not null
+#  icon              :string
+#  link              :string
+#  notification_type :string           not null
+#  read_at           :datetime
+#  record_type       :string
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  record_id         :uuid
+#  user_id           :uuid             not null
+#
+# Indexes
+#
+#  index_notifications_on_expires_at              (expires_at)
+#  index_notifications_on_notification_type       (notification_type)
+#  index_notifications_on_record                  (record_type,record_id)
+#  index_notifications_on_user_id_and_created_at  (user_id,created_at DESC)
+#  index_notifications_on_user_id_and_read_at     (user_id,read_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "test_helper"
 
 class NotificationTest < ActiveSupport::TestCase

--- a/test/models/omniauth_connection_test.rb
+++ b/test/models/omniauth_connection_test.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: omniauth_connections
+#
+#  id           :uuid             not null, primary key
+#  auth_payload :jsonb
+#  provider     :integer          not null
+#  uid          :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :uuid             not null
+#
+# Indexes
+#
+#  index_omniauth_connections_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "test_helper"
 
 class OmniauthConnectionTest < ActiveSupport::TestCase

--- a/test/models/task_force_test.rb
+++ b/test/models/task_force_test.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: task_forces
+#
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  hangar_group_id :uuid
+#  vehicle_id      :uuid
+#
+# Indexes
+#
+#  index_task_forces_on_hangar_group_id  (hangar_group_id)
+#  index_task_forces_on_vehicle_id       (vehicle_id)
+#
 require "test_helper"
 
 class TaskForceTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,5 +1,75 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                        :uuid             not null, primary key
+#  confirmation_sent_at      :datetime
+#  confirmation_token        :string(255)
+#  confirmed_at              :datetime
+#  consumed_timestep         :integer
+#  current_sign_in_at        :datetime
+#  current_sign_in_ip        :string(255)
+#  current_system            :string
+#  current_system_code       :string
+#  discord                   :string
+#  email                     :string(255)      default(""), not null
+#  encrypted_otp_secret      :string
+#  encrypted_otp_secret_iv   :string
+#  encrypted_otp_secret_salt :string
+#  encrypted_password        :string(255)      default(""), not null
+#  failed_attempts           :integer          default(0), not null
+#  guilded                   :string
+#  hangar_updated_at         :datetime
+#  hide_owner                :boolean          default(FALSE), not null
+#  homepage                  :string
+#  last_active_at            :datetime
+#  last_sign_in_at           :datetime
+#  last_sign_in_ip           :string(255)
+#  latitude                  :decimal(10, 6)
+#  locale                    :string(255)
+#  location                  :string
+#  locked_at                 :datetime
+#  longitude                 :decimal(10, 6)
+#  normalized_email          :string
+#  normalized_username       :string
+#  otp_backup_codes          :string           is an Array
+#  otp_required_for_login    :boolean
+#  otp_secret                :string
+#  password_set_manually     :boolean          default(FALSE), not null
+#  public_hangar             :boolean          default(TRUE)
+#  public_hangar_loaners     :boolean          default(FALSE)
+#  public_hangar_stats       :boolean          default(FALSE)
+#  public_wishlist           :boolean          default(FALSE)
+#  purchased_vehicles_count  :integer          default(0), not null
+#  remember_created_at       :datetime
+#  reset_password_sent_at    :datetime
+#  reset_password_token      :string(255)
+#  rsi_handle                :string
+#  rsi_handle_verified       :boolean          default(FALSE), not null
+#  sale_notify               :boolean          default(FALSE)
+#  sign_in_count             :integer          default(0), not null
+#  tester                    :boolean          default(FALSE)
+#  tracking                  :boolean          default(TRUE)
+#  twitch                    :string
+#  unconfirmed_email         :string(255)
+#  unlock_token              :string(255)
+#  username                  :string(255)      default(""), not null
+#  wanted_vehicles_count     :integer          default(0), not null
+#  youtube                   :string
+#  created_at                :datetime
+#  updated_at                :datetime
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_normalized_username   (normalized_username)
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
+#  index_users_on_username              (username) UNIQUE
+#
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -1,5 +1,42 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: vehicles
+#
+#  id                   :uuid             not null, primary key
+#  alternative_names    :string
+#  bought_via           :integer          default("pledge_store")
+#  bundled              :boolean          default(FALSE), not null
+#  flagship             :boolean          default(FALSE)
+#  hidden               :boolean          default(FALSE)
+#  loaner               :boolean          default(FALSE)
+#  name                 :string(255)
+#  name_visible         :boolean          default(FALSE)
+#  notify               :boolean          default(TRUE)
+#  public               :boolean          default(FALSE)
+#  rsi_pledge_synced_at :datetime
+#  sale_notify          :boolean          default(FALSE)
+#  serial               :string
+#  slug                 :string
+#  wanted               :boolean          default(FALSE)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  model_id             :uuid
+#  model_paint_id       :uuid
+#  module_package_id    :uuid
+#  rsi_pledge_id        :string
+#  user_id              :uuid
+#  vehicle_id           :uuid
+#
+# Indexes
+#
+#  index_vehicles_on_hidden_and_loaner       (hidden,loaner)
+#  index_vehicles_on_model_id_and_id         (model_id,id)
+#  index_vehicles_on_serial_and_user_id      (serial,user_id) UNIQUE
+#  index_vehicles_on_user_id                 (user_id)
+#  index_vehicles_on_vehicle_id_and_bundled  (vehicle_id,bundled)
+#
 require "test_helper"
 
 class VehicleTest < ActiveSupport::TestCase

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: videos
+#
+#  id         :uuid             not null, primary key
+#  url        :string
+#  video_type :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  model_id   :uuid
+#
+# Indexes
+#
+#  index_videos_on_model_id  (model_id)
+#
 require "test_helper"
 
 class VideoTest < ActiveSupport::TestCase


### PR DESCRIPTION
## Summary

- Schema-info comment blocks regenerated by annotate_models on 11 model tests (compare_image, fleets, notification, omniauth_connection, task_force, user, vehicle, video). No logic changes.
- Picked up automatically when db:migrate ran while shipping #4147; carved out here to keep that PR under greptile's 100-file review limit.

## Test plan

- [x] No behavioral changes — comment-only diffs.

🤖