### PR TITLE
fix(admin): hide supporter contributions sub-nav items

### DIFF
--- a/app/frontend/admin/pages/supporter-contributions/routes.ts
+++ b/app/frontend/admin/pages/supporter-contributions/routes.ts
@@ -34,6 +34,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       needsAuthentication: true,
       access: ["supporters"],
+      nav: "hidden",
       activeRoute: "admin-supporter-contributions",
     },
   },


### PR DESCRIPTION
## Summary

The admin nav for supporter contributions rendered a 2-item submenu (the contributions index + funding goals) when it should only expose a single top-level entry point.

The submenu appears because `AppNavigationItems` shows a submenu whenever a route has more than one main-nav child (`hasSubmenu` → `filteredChildRoutes(...).length > 1`). The `funding-goals/` child route was missing `nav: "hidden"`, so it counted as a second main-nav child alongside the index route.

## Fix

Add `nav: "hidden"` to the `funding-goals/` route, matching the existing `models/modules` route convention. Now only the index route counts as a main-nav child, so no submenu renders. Funding goals stays reachable via direct navigation / in-page links, with `activeRoute` keeping the parent entry highlighted.

🤖