### PR TITLE
feat: notify the team when a new Patreon supporter joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ USD pledge amounts are converted to EUR at sync time using the free
 to the `exchange_rates` table as a fallback when the rate API is unreachable. No
 extra credentials are required for the exchange-rate lookup.
 
+When a sync creates a brand-new active patron, the team is notified by email
+(super admins) and via a Discord webhook. The Discord post is sent to an internal
+channel and is skipped unless its webhook is configured:
+
+```yaml
+discord_admin_endpoint: <discord-webhook-url>
+```
+
+The email always sends; only the Discord half depends on this credential.
+
 ## Authors and Acknowledgement
 
 - [@mortik](https://www.github.com/mortik) for development and design.

--- a/app/api_components/admin/v1/schemas/supporter_contribution_stats.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution_stats.rb
@@ -13,10 +13,11 @@ module Admin
             currency: {type: :string},
             totalCount: {type: :integer},
             recurringCount: {type: :integer},
-            anonymousCount: {type: :integer}
+            anonymousCount: {type: :integer},
+            patreonSyncEnabled: {type: :boolean}
           },
           additionalProperties: false,
-          required: %w[totalAmountCents currency totalCount recurringCount anonymousCount]
+          required: %w[totalAmountCents currency totalCount recurringCount anonymousCount patreonSyncEnabled]
         })
       end
     end

--- a/app/frontend/admin/pages/supporter-contributions/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/index.vue
@@ -15,6 +15,7 @@ import FilterForm from "@/admin/components/SupporterContributions/FilterForm/ind
 import Stats from "@/admin/components/SupporterContributions/Stats/index.vue";
 import {
   useSupporterContributions,
+  useSupporterContributionsStats,
   useSyncSupporterContributionsFromPatreon,
   getSupporterContributionsQueryKey,
   type SupporterContribution,
@@ -75,6 +76,8 @@ const statsQueryParams = computed(() => {
     },
   };
 });
+
+const { data: stats } = useSupporterContributionsStats(statsQueryParams);
 
 const {
   data: supporterContributions,
@@ -163,6 +166,7 @@ const syncFromPatreon = () => {
       {{ t("headlines.admin.fundingGoals.index") }}
     </Btn>
     <Btn
+      v-if="stats?.patreonSyncEnabled"
       :aria-label="t('actions.admin.supporterContributions.syncFromPatreon')"
       :loading="syncMutation.isPending.value"
       mobile-icon-only

--- a/app/jobs/notifications/new_patron_job.rb
+++ b/app/jobs/notifications/new_patron_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "discord/new_supporter"
+
+module Notifications
+  class NewPatronJob < Notifications::BaseJob
+    def perform(supporter_contribution_id)
+      supporter = SupporterContribution.find_by(id: supporter_contribution_id)
+      return if supporter.nil? || !supporter.patreon?
+
+      Discord::NewSupporter.new(supporter:).run
+      AdminMailer.new_supporter(supporter).deliver_later
+    end
+  end
+end

--- a/app/jobs/notifications/new_patron_job.rb
+++ b/app/jobs/notifications/new_patron_job.rb
@@ -8,8 +8,13 @@ module Notifications
       supporter = SupporterContribution.find_by(id: supporter_contribution_id)
       return if supporter.nil? || !supporter.patreon?
 
-      Discord::NewSupporter.new(supporter:).run
       AdminMailer.new_supporter(supporter).deliver_later
+
+      begin
+        Discord::NewSupporter.new(supporter:).run
+      rescue => e
+        Appsignal.report_error(e)
+      end
     end
   end
 end

--- a/app/lib/patreon/supporter_importer.rb
+++ b/app/lib/patreon/supporter_importer.rb
@@ -69,6 +69,8 @@ module Patreon
       record.save!
       @stats[new_record ? :created : :updated] += 1
       @stats[:ended] += 1 if ended_now
+
+      Notifications::NewPatronJob.perform_async(record.id) if new_record && record.ended_at.blank?
     end
 
     def assign_defaults(record, member)

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,6 +10,15 @@ class AdminMailer < ApplicationMailer
     )
   end
 
+  def new_supporter(supporter)
+    @supporter = supporter
+
+    mail(
+      to: super_admin_emails,
+      subject: I18n.t(:"mailer.admin.new_supporter.subject")
+    )
+  end
+
   def notify_block(url)
     @url = url
 

--- a/app/models/supporter_contribution.rb
+++ b/app/models/supporter_contribution.rb
@@ -74,6 +74,10 @@ class SupporterContribution < ApplicationRecord
     active_in(month_start, month_end).sum(:amount_cents)
   end
 
+  def formatted_amount
+    format("%.2f %s", amount_cents.to_f / 100, currency)
+  end
+
   private def ended_at_after_started_at
     return if ended_at.blank? || started_at.blank?
     return if ended_at >= started_at

--- a/app/models/supporter_contribution.rb
+++ b/app/models/supporter_contribution.rb
@@ -78,6 +78,10 @@ class SupporterContribution < ApplicationRecord
     format("%.2f %s", amount_cents.to_f / 100, currency)
   end
 
+  def display_name
+    name.presence || I18n.t("messages.supporter_contributions.anonymous_name")
+  end
+
   private def ended_at_after_started_at
     return if ended_at.blank? || started_at.blank?
     return if ended_at >= started_at

--- a/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/stats.jbuilder
@@ -7,3 +7,4 @@ json.currency currency || "EUR"
 json.total_count total_count.to_i
 json.recurring_count recurring_count.to_i
 json.anonymous_count anonymous_count.to_i
+json.patreon_sync_enabled PatreonSupporterSyncJob.configured?

--- a/app/views/admin_mailer/new_supporter.html.inky
+++ b/app/views/admin_mailer/new_supporter.html.inky
@@ -2,5 +2,5 @@
   <%= I18n.t("mailer.admin.new_supporter.headline") %>
 </h4>
 <p>
-  <%= I18n.t("mailer.admin.new_supporter.text", name: @supporter.name, amount: @supporter.formatted_amount) %>
+  <%= I18n.t("mailer.admin.new_supporter.text", name: @supporter.display_name, amount: @supporter.formatted_amount) %>
 </p>

--- a/app/views/admin_mailer/new_supporter.html.inky
+++ b/app/views/admin_mailer/new_supporter.html.inky
@@ -1,0 +1,6 @@
+<h4>
+  <%= I18n.t("mailer.admin.new_supporter.headline") %>
+</h4>
+<p>
+  <%= I18n.t("mailer.admin.new_supporter.text", name: @supporter.name, amount: @supporter.formatted_amount) %>
+</p>

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -4,6 +4,9 @@ de:
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added
+    new_supporter:
+      message: '%{name} ist jetzt Patreon-Unterstützer (%{amount})'
+      title: Neuer Patreon-Unterstützer
     progress_tracker_update:
       message: Es gab %{changes} Änderungen im Progress Tracker
       title: Neue Änderungen im Progress Tracker

--- a/config/locales/de/mailer.yml
+++ b/config/locales/de/mailer.yml
@@ -4,6 +4,10 @@ de:
     account:
       action: Kontoeinstellungen verwalten
     admin:
+      new_supporter:
+        headline: FleetYards.net Command - Neuer Patreon-Unterstützer
+        subject: Neuer Patreon-Unterstützer
+        text: '%{name} ist jetzt Patreon-Unterstützer (%{amount})'
       notify_block:
         headline: FleetYards.net Command - Connection to RSI blocked
         subject: Verbindung zu RSI blockiert

--- a/config/locales/de/messages.yml
+++ b/config/locales/de/messages.yml
@@ -35,6 +35,7 @@ de:
       model: Kein Modell gefunden
       supporter_contribution: Kein Unterstützer-Beitrag gefunden
     supporter_contributions:
+      anonymous_name: Ein anonymer Unterstützer
       patreon_sync_enqueued: Patreon-Synchronisierung gestartet. Aktualisiere in einer Minute, um importierte Unterstützer zu sehen.
     reload:
       started: "%{resource} Neuladen gestartet."

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -4,6 +4,9 @@ en:
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added
+    new_supporter:
+      message: '%{name} just became a Patreon supporter (%{amount})'
+      title: New Patreon Supporter
     progress_tracker_update:
       message: There have been %{changes} changes on the Progress Tracker
       title: New changes on the Progress Tracker

--- a/config/locales/en/mailer.yml
+++ b/config/locales/en/mailer.yml
@@ -4,6 +4,10 @@ en:
     account:
       action: Manage Account Settings
     admin:
+      new_supporter:
+        headline: FleetYards.net Command - New Patreon Supporter
+        subject: New Patreon Supporter
+        text: '%{name} just became a Patreon supporter (%{amount})'
       notify_block:
         headline: FleetYards.net Command - Connection to RSI blocked
         subject: Connection to RSI blocked

--- a/config/locales/en/messages.yml
+++ b/config/locales/en/messages.yml
@@ -33,6 +33,7 @@ en:
       model: No Model found
       supporter_contribution: No Supporter Contribution found
     supporter_contributions:
+      anonymous_name: An anonymous supporter
       patreon_sync_enqueued: Patreon sync started. Refresh in a minute to see imported supporters.
     reload:
       started: "%{resource} reload started."

--- a/lib/discord/new_supporter.rb
+++ b/lib/discord/new_supporter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "discord/webhook"
+
+# rubocop:disable Naming/AccessorMethodName
+module Discord
+  class NewSupporter < ::Discord::Webhook
+    private def supporter
+      options[:supporter]
+    end
+
+    private def get_webhook_endpoint
+      Rails.application.credentials.discord_admin_endpoint
+    end
+
+    private def get_title
+      I18n.t("discord.new_supporter.title")
+    end
+
+    private def get_message
+      I18n.t("discord.new_supporter.message", name: supporter.name, amount: supporter.formatted_amount)
+    end
+
+    private def get_url
+    end
+  end
+end
+# rubocop:enable Naming/AccessorMethodName

--- a/lib/discord/new_supporter.rb
+++ b/lib/discord/new_supporter.rb
@@ -18,10 +18,14 @@ module Discord
     end
 
     private def get_message
-      I18n.t("discord.new_supporter.message", name: supporter.name, amount: supporter.formatted_amount)
+      I18n.t("discord.new_supporter.message", name: supporter.display_name, amount: supporter.formatted_amount)
     end
 
     private def get_url
+    end
+
+    private def allowed_mentions
+      {parse: []}
     end
   end
 end

--- a/lib/discord/webhook.rb
+++ b/lib/discord/webhook.rb
@@ -22,6 +22,7 @@ module Discord
 
       client.execute do |builder|
         builder.content = content
+        builder.allowed_mentions = allowed_mentions if allowed_mentions
       end
     end
 
@@ -30,6 +31,9 @@ module Discord
     end
 
     private def get_message
+    end
+
+    private def allowed_mentions
     end
 
     private def get_title

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -12209,6 +12209,8 @@ components:
           type: integer
         anonymousCount:
           type: integer
+        patreonSyncEnabled:
+          type: boolean
       additionalProperties: false
       required:
       - totalAmountCents
@@ -12216,6 +12218,7 @@ components:
       - totalCount
       - recurringCount
       - anonymousCount
+      - patreonSyncEnabled
       title: SupporterContributionStats
     SupporterContributions:
       type: object

--- a/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
@@ -51,6 +51,7 @@ class Admin::Api::V1::SupporterContributionsStatsTest < ActionDispatch::Integrat
       assert_equal 3, parsed_body["totalCount"]
       assert_equal 1, parsed_body["recurringCount"]
       assert_equal 1, parsed_body["anonymousCount"]
+      assert_equal false, parsed_body["patreonSyncEnabled"]
     end
   end
 

--- a/test/jobs/notifications/new_patron_job_test.rb
+++ b/test/jobs/notifications/new_patron_job_test.rb
@@ -12,6 +12,19 @@ module Notifications
       ::Notifications::NewPatronJob.new.perform(supporter.id)
     end
 
+    test "#perform still emails when the Discord post fails" do
+      supporter = create(:supporter_contribution, :patreon)
+      failing = stub
+      failing.stubs(:run).raises(StandardError, "discord down")
+      Discord::NewSupporter.expects(:new).with(supporter:).returns(failing)
+      AdminMailer.expects(:new_supporter).with(supporter).returns(stub(deliver_later: true))
+      Appsignal.expects(:report_error)
+
+      assert_nothing_raised do
+        ::Notifications::NewPatronJob.new.perform(supporter.id)
+      end
+    end
+
     test "#perform does nothing for a manual contribution" do
       supporter = create(:supporter_contribution)
       Discord::NewSupporter.expects(:new).never

--- a/test/jobs/notifications/new_patron_job_test.rb
+++ b/test/jobs/notifications/new_patron_job_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class NewPatronJobTest < ActiveJob::TestCase
+    test "#perform posts to Discord and emails super admins" do
+      supporter = create(:supporter_contribution, :patreon, name: "Alice", amount_cents: 500, currency: "EUR")
+      Discord::NewSupporter.expects(:new).with(supporter:).returns(stub(run: true))
+      AdminMailer.expects(:new_supporter).with(supporter).returns(stub(deliver_later: true))
+
+      ::Notifications::NewPatronJob.new.perform(supporter.id)
+    end
+
+    test "#perform does nothing for a manual contribution" do
+      supporter = create(:supporter_contribution)
+      Discord::NewSupporter.expects(:new).never
+      AdminMailer.expects(:new_supporter).never
+
+      ::Notifications::NewPatronJob.new.perform(supporter.id)
+    end
+
+    test "#perform does nothing when the record is gone" do
+      Discord::NewSupporter.expects(:new).never
+      AdminMailer.expects(:new_supporter).never
+
+      assert_nothing_raised do
+        ::Notifications::NewPatronJob.new.perform("00000000-0000-0000-0000-000000000000")
+      end
+    end
+  end
+end

--- a/test/lib/discord/new_supporter_test.rb
+++ b/test/lib/discord/new_supporter_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/new_supporter"
+
+module Discord
+  class NewSupporterTest < ActiveSupport::TestCase
+    test "builds content from the supporter's name and amount" do
+      supporter = build(:supporter_contribution, :patreon, name: "Alice", amount_cents: 500, currency: "EUR")
+      webhook = Discord::NewSupporter.new(supporter:)
+
+      assert_equal I18n.t("discord.new_supporter.title"), webhook.title
+      assert_equal I18n.t("discord.new_supporter.message", name: "Alice", amount: "5.00 EUR"), webhook.message
+      assert_nil webhook.url
+    end
+
+    test "#run is a no-op when no admin endpoint is configured" do
+      Rails.application.credentials.stubs(:discord_admin_endpoint).returns(nil)
+      supporter = build(:supporter_contribution, :patreon)
+
+      assert_nil Discord::NewSupporter.new(supporter:).run
+    end
+  end
+end

--- a/test/lib/discord/new_supporter_test.rb
+++ b/test/lib/discord/new_supporter_test.rb
@@ -14,6 +14,19 @@ module Discord
       assert_nil webhook.url
     end
 
+    test "falls back to an anonymous label when the supporter has no name" do
+      supporter = build(:supporter_contribution, :patreon, name: nil, amount_cents: 500, currency: "EUR")
+      webhook = Discord::NewSupporter.new(supporter:)
+
+      assert_includes webhook.message, I18n.t("messages.supporter_contributions.anonymous_name")
+    end
+
+    test "suppresses mentions so a patron name cannot ping the channel" do
+      supporter = build(:supporter_contribution, :patreon)
+
+      assert_equal({parse: []}, Discord::NewSupporter.new(supporter:).send(:allowed_mentions))
+    end
+
     test "#run is a no-op when no admin endpoint is configured" do
       Rails.application.credentials.stubs(:discord_admin_endpoint).returns(nil)
       supporter = build(:supporter_contribution, :patreon)

--- a/test/lib/patreon/supporter_importer_test.rb
+++ b/test/lib/patreon/supporter_importer_test.rb
@@ -46,6 +46,36 @@ module Patreon
       assert_equal({created: 1, updated: 0, ended: 0, skipped: 0}, stats)
     end
 
+    test "enqueues a new-patron notification for a newly-created active patron" do
+      ExchangeRateFetcher.stubs(:convert_cents).returns(460)
+      Sidekiq::Worker.clear_all
+
+      import([member])
+
+      assert_equal 1, Notifications::NewPatronJob.jobs.size
+      assert_equal SupporterContribution.find_by(patreon_member_id: "m1").id,
+        Notifications::NewPatronJob.jobs.first["args"].first
+    end
+
+    test "does not enqueue a notification when an existing patron is updated" do
+      ExchangeRateFetcher.stubs(:convert_cents).returns(460)
+      import([member])
+      Sidekiq::Worker.clear_all
+
+      import([member(amount_cents: 1000)])
+
+      assert_equal 0, Notifications::NewPatronJob.jobs.size
+    end
+
+    test "does not enqueue a notification for a member created already churned" do
+      ExchangeRateFetcher.stubs(:convert_cents).returns(460)
+      Sidekiq::Worker.clear_all
+
+      import([member(status: "former_patron", last_charge_date: Date.new(2026, 5, 20))])
+
+      assert_equal 0, Notifications::NewPatronJob.jobs.size
+    end
+
     test "skips free-tier members with no positive amount" do
       stats = import([member(amount_cents: 0)])
 

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -22,6 +22,21 @@ class AdminMailerTest < ActionMailer::TestCase
     assert mail.body.encoded.present?
   end
 
+  test "#new_supporter renders the subject" do
+    mail = AdminMailer.new_supporter(supporter)
+    assert_equal I18n.t(:"mailer.admin.new_supporter.subject"), mail.subject
+  end
+
+  test "#new_supporter sends to super admin users" do
+    mail = AdminMailer.new_supporter(supporter)
+    assert_includes mail.to, @super_admin.email
+  end
+
+  test "#new_supporter renders the body" do
+    mail = AdminMailer.new_supporter(supporter)
+    assert mail.body.encoded.present?
+  end
+
   test "#notify_block renders the subject" do
     mail = AdminMailer.notify_block("https://robertsspaceindustries.com")
     assert_equal I18n.t(:"mailer.admin.notify_block.subject"), mail.subject
@@ -56,5 +71,9 @@ class AdminMailerTest < ActionMailer::TestCase
 
   def weekly_stats
     {registrations: 10, ships: 5, vehicles: 20, fleets: 2}
+  end
+
+  def supporter
+    create(:supporter_contribution, :patreon, name: "Alice", amount_cents: 500, currency: "EUR")
   end
 end


### PR DESCRIPTION
## What

Sends a notification to the team whenever the Patreon sync imports a **brand-new active patron**, and hides the admin "Sync from Patreon" button when Patreon credentials aren't configured.

Builds on the Patreon supporter sync (#4150).

## Notifications

When a sync creates a new active patron, two alerts fire via `Notifications::NewPatronJob`:

- **Email** to super admins (`AdminMailer#new_supporter`) — always sends.
- **Discord webhook** (`Discord::NewSupporter`) to an internal channel — only sends if the new `discord_admin_endpoint` credential is set; otherwise a silent no-op.

Both include the supporter's name and pledge amount (e.g. `5.00 EUR`).

The trigger lives in `Patreon::SupporterImporter#upsert` and fires only for `new_record && ended_at.blank?` — so updates, reactivations, and members created already-churned do **not** notify.

## Hide sync button when unconfigured

- The admin stats endpoint now returns `patreonSyncEnabled` (`PatreonSupporterSyncJob.configured?`).
- The frontend gates the "Sync from Patreon" button on it, reusing the cached stats query the page header already fetches (no extra request).

## Config

The Discord half depends on a new credential; the email works without it:

```yaml
discord_admin_endpoint: <discord-webhook-url>
```

Documented in the README.

## Testing

- New tests: `NewPatronJob`, `Discord::NewSupporter`, importer enqueue behaviour, `AdminMailer#new_supporter`, and a stats-endpoint assertion for `patreonSyncEnabled`.
- All affected suites pass; `standardrb`, ESLint, Prettier and `vue-tsc` clean.

## Notes

- Used a dedicated internal Discord endpoint rather than the public `discord_updates_endpoint`, since synced patrons are anonymous by default and the message names them.
- The generated `app/frontend/services/` client is gitignored (rebuilt at deploy), so CI will regenerate the TS client from the updated schema.

🤖