### PR TITLE
fix(appsignal): route Rails logs to AppSignal logging UI

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -3,7 +3,6 @@ production:
   name: "Fleetyards"
   active: true
   working_directory_path: "/tmp/appsignal"
-  enable_logging: true
   ignore_errors:
       - ActiveRecord::RecordNotFound
       - ActionController::RoutingError
@@ -14,7 +13,6 @@ staging:
   name: "fleetyards"
   active: true
   working_directory_path: "/tmp/appsignal"
-  enable_logging: true
   log_level: "debug"
   ignore_errors:
       - ActiveRecord::RecordNotFound

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,10 +72,17 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-    .tap { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  # Log to STDOUT and broadcast to AppSignal so log lines reach the AppSignal logging UI.
+  config.logger = begin
+    stdout_logger = ActiveSupport::Logger.new($stdout)
+    stdout_logger.formatter = ::Logger::Formatter.new
+
+    appsignal_logger = Appsignal::Logger.new("rails")
+
+    ActiveSupport::TaggedLogging.new(
+      ActiveSupport::BroadcastLogger.new(stdout_logger, appsignal_logger)
+    )
+  end
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -123,12 +130,6 @@ Rails.application.configure do
   config.action_mailer.postmark_settings = {
     api_token: Rails.application.credentials.postmark_api_token
   }
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   config.action_cable.url = endpoints.cable_endpoint
   config.action_cable.allowed_request_origins = [


### PR DESCRIPTION
## Problem

AppSignal showed no logs. Errors and performance traces worked, but the **Logging** view was empty.

## Root cause

Nothing in the app forwarded log lines to AppSignal:

1. The production logger (`config/environments/production.rb`) only wrote to `$stdout` — there was no `Appsignal::Logger` anywhere in the codebase.
2. `enable_logging: true` in `config/appsignal.yml` is **not a real AppSignal config option** — it's absent from the gem's `DEFAULT_CONFIG` (`appsignal-4.8.5`) and was silently ignored. The Ruby gem does not auto-capture Rails logs.
3. A second logger block guarded by `RAILS_LOG_TO_STDOUT` (set to `"1"` in `config/deploy.yml`) would also have clobbered any broadcast logger.

## Fix

- Broadcast the production logger to an `Appsignal::Logger` via `ActiveSupport::BroadcastLogger`, so lines still go to STDOUT **and** now stream to AppSignal.
- Remove the redundant `RAILS_LOG_TO_STDOUT` override (the main logger already writes to STDOUT).
- Drop the dead `enable_logging` keys from `appsignal.yml`.

Staging inherits production, so it's covered too.

## Verification

- `standardrb config/environments/production.rb` passes.
- Verified the logger composition at runtime — `TaggedLogging` + `BroadcastLogger` + `Appsignal::Logger` compose correctly, `request_id` tagging still applies, and both sinks receive the line.

🤖