### PR TITLE
fix(fleet-logistics): gate fleet inventory endpoints on the fleet actor

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -66,8 +66,8 @@ module Api
       @current_ability ||= Ability.new(current_resource_owner)
     end
 
-    def feature_enabled?(feature)
-      Flipper.enabled?(feature, current_resource_owner)
+    def feature_enabled?(feature, *actors)
+      Flipper.enabled?(feature, current_resource_owner, *actors)
     end
 
     def access_confirmed?

--- a/app/controllers/api/v1/fleet_all_inventory_items_controller.rb
+++ b/app/controllers/api/v1/fleet_all_inventory_items_controller.rb
@@ -9,8 +9,8 @@ module Api
       before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
         unless: :user_signed_in?
 
-      before_action :check_fleet_logistics_feature
       before_action :set_fleet
+      before_action :check_fleet_logistics_feature
 
       def index
         authorize! with: FleetInventoryItemPolicy, context: {fleet: @fleet}
@@ -39,7 +39,7 @@ module Api
       end
 
       private def check_fleet_logistics_feature
-        return if feature_enabled?("fleet_logistics")
+        return if feature_enabled?("fleet_logistics", @fleet)
 
         render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
       end

--- a/app/controllers/api/v1/fleet_all_inventory_stock_controller.rb
+++ b/app/controllers/api/v1/fleet_all_inventory_stock_controller.rb
@@ -7,8 +7,8 @@ module Api
       before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
         unless: :user_signed_in?
 
-      before_action :check_fleet_logistics_feature
       before_action :set_fleet
+      before_action :check_fleet_logistics_feature
 
       def index
         authorize! with: FleetInventoryItemPolicy, context: {fleet: @fleet}
@@ -48,7 +48,7 @@ module Api
       end
 
       private def check_fleet_logistics_feature
-        return if feature_enabled?("fleet_logistics")
+        return if feature_enabled?("fleet_logistics", @fleet)
 
         render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
       end

--- a/app/controllers/api/v1/fleet_inventories_controller.rb
+++ b/app/controllers/api/v1/fleet_inventories_controller.rb
@@ -13,8 +13,8 @@ module Api
         unless: :user_signed_in?,
         only: %i[create update destroy]
 
-      before_action :check_fleet_logistics_feature
       before_action :set_fleet
+      before_action :check_fleet_logistics_feature
       before_action :set_fleet_inventory, only: %i[show update destroy]
 
       def index
@@ -81,7 +81,7 @@ module Api
       end
 
       private def check_fleet_logistics_feature
-        return if feature_enabled?("fleet_logistics")
+        return if feature_enabled?("fleet_logistics", @fleet)
 
         render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
       end

--- a/app/controllers/api/v1/fleet_inventory_items_controller.rb
+++ b/app/controllers/api/v1/fleet_inventory_items_controller.rb
@@ -13,8 +13,8 @@ module Api
         unless: :user_signed_in?,
         only: %i[create update destroy]
 
-      before_action :check_fleet_logistics_feature
       before_action :set_fleet
+      before_action :check_fleet_logistics_feature
       before_action :set_fleet_inventory
       before_action :set_fleet_inventory_item, only: %i[update destroy]
 
@@ -94,7 +94,7 @@ module Api
       end
 
       private def check_fleet_logistics_feature
-        return if feature_enabled?("fleet_logistics")
+        return if feature_enabled?("fleet_logistics", @fleet)
 
         render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
       end

--- a/app/controllers/api/v1/fleet_inventory_stock_controller.rb
+++ b/app/controllers/api/v1/fleet_inventory_stock_controller.rb
@@ -7,8 +7,8 @@ module Api
       before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
         unless: :user_signed_in?
 
-      before_action :check_fleet_logistics_feature
       before_action :set_fleet
+      before_action :check_fleet_logistics_feature
       before_action :set_fleet_inventory
 
       def index
@@ -28,7 +28,7 @@ module Api
       end
 
       private def check_fleet_logistics_feature
-        return if feature_enabled?("fleet_logistics")
+        return if feature_enabled?("fleet_logistics", @fleet)
 
         render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
       end

--- a/test/integration/api/v1/fleets_inventories_index_test.rb
+++ b/test/integration/api/v1/fleets_inventories_index_test.rb
@@ -63,6 +63,37 @@ class Api::V1::FleetsInventoriesIndexTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /fleets/:slug/inventories is allowed when fleet_logistics is enabled for the fleet actor" do
+    Flipper.disable("fleet_logistics")
+    Flipper.enable_actor("fleet_logistics", @fleet)
+    create_list(:fleet_inventory, 3, fleet: @fleet)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /fleets/:slug/inventories is allowed when fleet_logistics is enabled for the user actor" do
+    Flipper.disable("fleet_logistics")
+    Flipper.enable_actor("fleet_logistics", @admin)
+    create_list(:fleet_inventory, 3, fleet: @fleet)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /fleets/:slug/inventories is forbidden when fleet_logistics is disabled for both user and fleet" do
+    Flipper.disable("fleet_logistics")
+    sign_in @admin
+
+    get "/api/v1/fleets/#{@fleet.slug}/inventories"
+
+    assert_response :forbidden
+  end
+
   test "GET /fleets/:slug/inventories returns 404 for unknown fleet" do
     sign_in @admin
 


### PR DESCRIPTION
## Problem

`fleet_logistics` is a fleet-scoped feature, but its guard in the five fleet inventory controllers checked only the **user** actor (`feature_enabled?` → `Flipper.enabled?(feature, current_resource_owner)`) — and ran **before** `set_fleet`, so `@fleet` was `nil` anyway. Enabling the feature for a `Fleet` in the admin UI had no effect; the endpoints only opened via a global enable.

## Fix

- `feature_enabled?` now forwards extra actors: `Flipper.enabled?(feature, current_resource_owner, *actors)`. Existing user-only callers (`hardpoints-v2`, `oauth-applications`) are unaffected.
- The five `fleet_*` inventory controllers now pass `@fleet`, and `set_fleet` is reordered to run **before** the guard.
- Gating is now "enabled globally, for the user, **or** for this fleet" — consistent with the user+fleet feature-list endpoints.

## Tests

Added three cases to `fleets_inventories_index_test.rb`: enabled via the **fleet actor** (200, the core regression guard), via the **user actor** (200), and fully disabled (403). The existing tests only used a global enable, which masked the actor bug. Verified the fleet-actor test fails against the old helper.

`bin/rails test` on the fleet inventory suite: green. `standardrb` clean.

🤖