### PR TITLE
fix(fleets): restore fleet owner as admin on purged restore

### DIFF
--- a/app/services/fleets/purged_fleet_restorer.rb
+++ b/app/services/fleets/purged_fleet_restorer.rb
@@ -84,15 +84,17 @@ module Fleets
 
     # Role assignment is best effort: FleetRole nullifies its memberships when
     # it is destroyed (roles cascade before memberships), so the destroy
-    # snapshot's fleet_role_id may already be nil. When the old role cannot be
-    # mapped, the member falls back to the default member role and the fleet
-    # owner is re-granted admin by setup_admin_user.
+    # snapshot's fleet_role_id is usually already nil and the old role cannot be
+    # mapped. The fleet owner is the exception: setup_admin_user (run on fleet
+    # save) already recreated their membership with the admin role, so we must
+    # keep any role the record already carries rather than downgrading it.
+    # Everyone else falls back to the default member role.
     def restore_memberships(fleet, role_map)
       child_destroy_versions("FleetMembership", "fleet_id", fleet.id).find_each do |version|
         membership = version.reify
         record = fleet.fleet_memberships.find_or_initialize_by(user_id: membership.user_id)
         record.assign_attributes(membership.attributes.slice(*MEMBERSHIP_COLUMNS))
-        record.fleet_role = role_map[membership.fleet_role_id] || fleet.default_member_role
+        record.fleet_role = role_map[membership.fleet_role_id] || record.fleet_role || fleet.default_member_role
         record.discarded_at = membership.discarded_at
         record.save!(validate: false)
       end

--- a/test/services/fleets/purged_fleet_restorer_test.rb
+++ b/test/services/fleets/purged_fleet_restorer_test.rb
@@ -14,7 +14,10 @@ class Fleets::PurgedFleetRestorerTest < ActiveSupport::TestCase
     inventory.fleet_inventory_items.create!(name: "Quantum Fuel", quantity: 5)
     fleet_id = fleet.id
 
-    fleet.destroy
+    # Load fresh before destroying so no membership is cached in memory with a
+    # stale fleet_role_id: this mirrors production, where the role-nullify on
+    # destroy leaves every membership's destroy snapshot with a nil role.
+    Fleet.find(fleet_id).destroy
     assert_not Fleet.exists?(fleet_id)
 
     restored = Fleets::PurgedFleetRestorer.new(fleet_id).call


### PR DESCRIPTION
## Problem

Restoring a purged (hard-deleted) fleet did not recreate member roles — every member, **including the user who created the fleet**, came back with the default Member role.

## Root cause

When a fleet is destroyed, `FleetRole` (declared before `FleetMembership` in `Fleet`) cascades first, and its `dependent: :nullify` strips `fleet_role_id` from every membership via `update_all` *before* the membership destroy snapshots are captured. PaperTrail never records that `update_all`, so each membership's destroy version stores `fleet_role_id: nil`. `PurgedFleetRestorer#restore_memberships` then reads it back, `role_map[nil]` is always `nil`, and everyone falls through to `default_member_role`.

The owner was hit even though `setup_admin_user` (an `after_create` that runs during the restore save) had *correctly* recreated their membership with the Admin role — `restore_memberships` then overwrote it with Member.

> The nullify-before-destroy ordering is load-bearing: `FleetMembership#check_if_can_be_destroyed` throws `:abort` for memberships on a `permanent?` role (Admin), so the role must be nullified before the membership is destroyed or the cascade is blocked. The fix therefore lives in the restorer, not in the association order.

## Fix

Keep any role the record already carries instead of downgrading it:

```ruby
record.fleet_role = role_map[membership.fleet_role_id] || record.fleet_role || fleet.default_member_role
```

The owner's membership already has Admin from `setup_admin_user`, so it's preserved; everyone else still falls back to Member (the documented best-effort behavior for non-owner roles).

## Test

The existing test was passing only by luck — it destroyed the in-memory `fleet`, whose owner membership was cached with a stale (non-nil) role. It now destroys a freshly-loaded fleet (`Fleet.find(fleet_id).destroy`), mirroring production. Confirmed the updated test fails without the fix (`Expected: "Admin"`) and passes with it.

## Caveat

This reliably restores the **owner** as Admin. Non-owner custom roles (e.g. an Officer) still can't be recovered from purge snapshots and will return as Member; already-purged fleets can't be improved retroactively.

🤖