### PR TITLE
feat: in-app DPS & survivability panels on the ship page

### DIFF
--- a/app/api_components/v1/schemas/models/model.rb
+++ b/app/api_components/v1/schemas/models/model.rb
@@ -131,6 +131,7 @@ module V1
                 lengthLabel: {type: :string},
                 mass: {type: :number},
                 massLabel: {type: :string},
+                hullHealth: {type: :number},
                 quantumFuelTankSize: {type: :number},
                 size: {type: :string},
                 sizeLabel: {type: :string},

--- a/app/api_components/v1/schemas/models/model.rb
+++ b/app/api_components/v1/schemas/models/model.rb
@@ -132,6 +132,19 @@ module V1
                 mass: {type: :number},
                 massLabel: {type: :string},
                 hullHealth: {type: :number},
+                hullParts: {
+                  type: :array,
+                  items: {
+                    type: :object,
+                    properties: {
+                      name: {type: :string},
+                      health: {type: :number},
+                      category: {type: :string, enum: %w[vital secondary breakable subpart]}
+                    },
+                    required: %w[name health category],
+                    additionalProperties: false
+                  }
+                },
                 quantumFuelTankSize: {type: :number},
                 size: {type: :string},
                 sizeLabel: {type: :string},

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -1,0 +1,488 @@
+<script lang="ts">
+export default {
+  name: "ModelCombatMetrics",
+};
+</script>
+
+<script lang="ts" setup>
+import type { Hardpoint } from "@/services/fyApi";
+import Collapsed from "@/shared/components/Collapsed.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useLoadoutStats,
+  type DamageBreakdown,
+} from "@/frontend/composables/useLoadoutStats";
+
+type Props = {
+  hardpoints?: Hardpoint[];
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  hardpoints: () => [],
+});
+
+const { t, toNumber } = useI18n();
+
+const stats = useLoadoutStats(() => props.hardpoints);
+
+const round = (value: number) => Math.round(value);
+
+const expanded = ref(false);
+const hoveredType = ref<string | null>(null);
+
+const damageTypes: { key: keyof DamageBreakdown; label: string }[] = [
+  { key: "physical", label: "labels.combat.damagePhysical" },
+  { key: "energy", label: "labels.combat.damageEnergy" },
+  { key: "distortion", label: "labels.combat.damageDistortion" },
+  { key: "thermal", label: "labels.combat.damageThermal" },
+];
+
+const composition = computed(() => {
+  const total = stats.value.dps.total;
+  if (!total) return [];
+
+  return damageTypes
+    .map(({ key, label }) => ({
+      key,
+      label,
+      value: stats.value.dps[key],
+      pct: (stats.value.dps[key] / total) * 100,
+    }))
+    .filter((entry) => entry.value > 0)
+    .sort((a, b) => b.value - a.value);
+});
+</script>
+
+<template>
+  <div v-if="stats.hasData" class="combat-panel">
+    <div class="combat-panel__head">
+      <span class="combat-panel__title">
+        <span class="combat-panel__dot" />
+        {{ t("labels.combat.title") }}
+      </span>
+    </div>
+
+    <div class="combat-panel__body">
+      <div class="combat-panel__hero">
+        <div class="tile tile--primary">
+          <div class="tile__label">{{ t("labels.combat.dps") }}</div>
+          <div class="tile__value">
+            {{ toNumber(round(stats.dps.total), "integer") }}
+            <span class="tile__unit">DPS</span>
+          </div>
+          <div class="tile__sub">{{ t("labels.combat.dpsSub") }}</div>
+        </div>
+        <div class="tile">
+          <div class="tile__label">{{ t("labels.combat.alpha") }}</div>
+          <div class="tile__value">
+            {{ toNumber(round(stats.alpha.total), "integer") }}
+            <span class="tile__unit">DMG</span>
+          </div>
+          <div class="tile__sub">{{ t("labels.combat.alphaSub") }}</div>
+        </div>
+        <div class="tile">
+          <div class="tile__label">{{ t("labels.combat.weapons") }}</div>
+          <div class="tile__value">
+            {{ toNumber(stats.weaponCount, "integer") }}
+          </div>
+        </div>
+      </div>
+
+      <div class="combat-panel__section-label">
+        {{ t("labels.combat.composition") }}
+      </div>
+      <div
+        class="compbar"
+        :class="{ 'compbar--dimmed': hoveredType }"
+      >
+        <div
+          v-for="seg in composition"
+          :key="seg.key"
+          class="compbar__seg"
+          :class="{ 'compbar__seg--active': hoveredType === seg.key }"
+          :data-type="seg.key"
+          :style="{ width: `${seg.pct}%` }"
+        />
+      </div>
+
+      <div class="legend">
+        <div
+          v-for="seg in composition"
+          :key="seg.key"
+          class="legend__row"
+          @mouseenter="hoveredType = seg.key"
+          @mouseleave="hoveredType = null"
+        >
+          <span class="legend__swatch" :data-type="seg.key" />
+          <span class="legend__label">{{ t(seg.label) }}</span>
+          <span class="legend__value">{{ toNumber(round(seg.value), "integer") }}</span>
+          <span class="legend__pct">{{ toNumber(round(seg.pct), "integer") }}%</span>
+        </div>
+      </div>
+
+      <Collapsed :visible="expanded" :duration="200">
+        <div class="combat-panel__divider" />
+        <table class="weapon-table">
+          <thead>
+            <tr>
+              <th>{{ t("labels.combat.weaponName") }}</th>
+              <th class="num">{{ t("labels.combat.size") }}</th>
+              <th class="num">{{ t("labels.combat.dps") }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="weapon in stats.weapons" :key="weapon.id">
+              <td class="weapon-table__name">{{ weapon.name }}</td>
+              <td class="num">
+                <span v-if="weapon.size">S{{ weapon.size }}</span>
+                <span v-else>—</span>
+              </td>
+              <td class="num">{{ toNumber(round(weapon.dps), "integer") }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </Collapsed>
+
+      <div class="combat-panel__footer">
+        <button
+          type="button"
+          class="combat-panel__toggle"
+          @click="expanded = !expanded"
+        >
+          {{
+            expanded
+              ? t("labels.combat.hideBreakdown")
+              : t("labels.combat.showBreakdown")
+          }}
+        </button>
+        <span class="combat-panel__hint">{{ t("labels.combat.hint") }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+$c-physical: $text-color;
+$c-energy: $primary;
+$c-distortion: $cyan;
+$c-thermal: $warning;
+
+.combat-panel {
+  position: relative;
+  margin: 15px 0 40px;
+  background: $panel-bg;
+  border: 2px solid rgba($gray-light, 0.5);
+  border-radius: 16px;
+  box-shadow: 0 6px 18px -12px rgba(#000, 0.8);
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    left: 34px;
+    right: 34px;
+    height: 3px;
+    background: #4a4f54;
+    border-radius: 1px;
+  }
+
+  &::before {
+    top: -2px;
+  }
+
+  &::after {
+    bottom: -2px;
+  }
+
+  &__head {
+    padding: 16px 18px 12px;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 15px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: lighten($text-color, 15%);
+  }
+
+  &__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: $gold;
+    box-shadow: 0 0 10px 1px rgba($gold, 0.55);
+  }
+
+  &__body {
+    padding: 4px 18px 18px;
+  }
+
+  &__hero {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr;
+    gap: 1px;
+    background: rgba($gray-light, 0.28);
+    border: 1px solid rgba($gray-light, 0.28);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+
+    @media (max-width: 576px) {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  &__section-label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: $gray-light;
+    margin: 4px 0 10px;
+  }
+
+  &__divider {
+    height: 1px;
+    background: rgba($gray-light, 0.28);
+    margin: 20px 0;
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-top: 16px;
+    flex-wrap: wrap;
+  }
+
+  &__toggle {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 6px 13px;
+    background: transparent;
+    color: $text-color;
+    border: 1px solid rgba($gray-light, 0.5);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      color: lighten($text-color, 15%);
+      border-color: $primary;
+    }
+  }
+
+  &__hint {
+    font-size: 11.5px;
+    color: $gray;
+  }
+}
+
+.tile {
+  position: relative;
+  background: $gray-black;
+  padding: 14px 16px;
+
+  &--primary {
+    grid-column: 1;
+
+    @media (max-width: 576px) {
+      grid-column: 1 / -1;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 12px;
+      bottom: 12px;
+      width: 3px;
+      background: linear-gradient($gold, rgba($gold, 0.15));
+      border-radius: 2px;
+    }
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: $gray-light;
+    margin-bottom: 7px;
+  }
+
+  &__value {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 1;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &--primary &__value {
+    font-size: 40px;
+    color: #fff;
+
+    @media (max-width: 576px) {
+      font-size: 32px;
+    }
+  }
+
+  &__unit {
+    font-family: "Open Sans", sans-serif;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    color: $gray-light;
+  }
+
+  &__sub {
+    margin-top: 6px;
+    font-size: 11px;
+    color: $gray;
+  }
+}
+
+.compbar {
+  display: flex;
+  height: 16px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: $gray-black;
+  border: 1px solid rgba($gray-light, 0.28);
+
+  &__seg {
+    height: 100%;
+    transition: opacity 0.18s ease;
+
+    &[data-type="physical"] {
+      background: $c-physical;
+    }
+    &[data-type="energy"] {
+      background: $c-energy;
+    }
+    &[data-type="distortion"] {
+      background: $c-distortion;
+    }
+    &[data-type="thermal"] {
+      background: $c-thermal;
+    }
+  }
+
+  &--dimmed &__seg:not(&__seg--active) {
+    opacity: 0.25;
+  }
+}
+
+.legend {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 22px;
+  margin-top: 16px;
+
+  @media (max-width: 576px) {
+    grid-template-columns: 1fr;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 9px;
+    padding: 5px 6px;
+    border-radius: 6px;
+    transition: background 0.15s ease;
+
+    &:hover {
+      background: rgba(#fff, 0.03);
+    }
+  }
+
+  &__swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+
+    &[data-type="physical"] {
+      background: $c-physical;
+    }
+    &[data-type="energy"] {
+      background: $c-energy;
+    }
+    &[data-type="distortion"] {
+      background: $c-distortion;
+    }
+    &[data-type="thermal"] {
+      background: $c-thermal;
+    }
+  }
+
+  &__label {
+    font-size: 13px;
+    color: $text-color;
+  }
+
+  &__value {
+    font-weight: 700;
+    font-size: 13px;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__pct {
+    font-size: 12px;
+    color: $gray-light;
+    min-width: 42px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.weapon-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-weight: 400;
+    font-size: 9.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray;
+    padding: 0 10px 8px 0;
+    border-bottom: 1px solid rgba($gray-light, 0.28);
+  }
+
+  td {
+    padding: 9px 10px 9px 0;
+    border-bottom: 1px solid rgba($gray-light, 0.28);
+    color: $text-color;
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+  }
+
+  .num {
+    text-align: right;
+    padding-right: 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__name {
+    color: lighten($text-color, 15%);
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -54,41 +54,41 @@ const composition = computed(() => {
 </script>
 
 <template>
-  <div v-if="stats.hasData" class="combat-panel">
-    <div class="combat-panel__head">
-      <span class="combat-panel__title">
-        <span class="combat-panel__dot" />
+  <div v-if="stats.hasData" class="metrics-card combat-panel">
+    <div class="metrics-card__head">
+      <span class="metrics-card__title">
+        <span class="metrics-card__dot" />
         {{ t("labels.combat.title") }}
       </span>
     </div>
 
-    <div class="combat-panel__body">
-      <div class="combat-panel__hero">
-        <div class="tile tile--primary">
-          <div class="tile__label">{{ t("labels.combat.dps") }}</div>
-          <div class="tile__value">
+    <div class="metrics-card__body">
+      <div class="metrics-card__hero">
+        <div class="metrics-card__tile metrics-card__tile--primary">
+          <div class="metrics-card__tile__label">{{ t("labels.combat.dps") }}</div>
+          <div class="metrics-card__tile__value">
             {{ toNumber(round(stats.dps.total), "integer") }}
-            <span class="tile__unit">DPS</span>
+            <span class="metrics-card__tile__unit">DPS</span>
           </div>
-          <div class="tile__sub">{{ t("labels.combat.dpsSub") }}</div>
+          <div class="metrics-card__tile__sub">{{ t("labels.combat.dpsSub") }}</div>
         </div>
-        <div class="tile">
-          <div class="tile__label">{{ t("labels.combat.alpha") }}</div>
-          <div class="tile__value">
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">{{ t("labels.combat.alpha") }}</div>
+          <div class="metrics-card__tile__value">
             {{ toNumber(round(stats.alpha.total), "integer") }}
-            <span class="tile__unit">DMG</span>
+            <span class="metrics-card__tile__unit">DMG</span>
           </div>
-          <div class="tile__sub">{{ t("labels.combat.alphaSub") }}</div>
+          <div class="metrics-card__tile__sub">{{ t("labels.combat.alphaSub") }}</div>
         </div>
-        <div class="tile">
-          <div class="tile__label">{{ t("labels.combat.weapons") }}</div>
-          <div class="tile__value">
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">{{ t("labels.combat.weapons") }}</div>
+          <div class="metrics-card__tile__value">
             {{ toNumber(stats.weaponCount, "integer") }}
           </div>
         </div>
       </div>
 
-      <div class="combat-panel__section-label">
+      <div class="metrics-card__section-label">
         {{ t("labels.combat.composition") }}
       </div>
       <div
@@ -121,7 +121,7 @@ const composition = computed(() => {
       </div>
 
       <Collapsed :visible="expanded" :duration="200">
-        <div class="combat-panel__divider" />
+        <div class="metrics-card__divider" />
         <table class="weapon-table">
           <thead>
             <tr>
@@ -143,10 +143,10 @@ const composition = computed(() => {
         </table>
       </Collapsed>
 
-      <div class="combat-panel__footer">
+      <div class="metrics-card__footer">
         <button
           type="button"
-          class="combat-panel__toggle"
+          class="metrics-card__toggle"
           @click="expanded = !expanded"
         >
           {{
@@ -155,203 +155,19 @@ const composition = computed(() => {
               : t("labels.combat.showBreakdown")
           }}
         </button>
-        <span class="combat-panel__hint">{{ t("labels.combat.hint") }}</span>
+        <span class="metrics-card__hint">{{ t("labels.combat.hint") }}</span>
       </div>
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
 $c-physical: $text-color;
 $c-energy: $primary;
 $c-distortion: $cyan;
 $c-thermal: $warning;
-
-.combat-panel {
-  position: relative;
-  margin: 15px 0 40px;
-  background: $panel-bg;
-  border: 2px solid rgba($gray-light, 0.5);
-  border-radius: 16px;
-  box-shadow: 0 6px 18px -12px rgba(#000, 0.8);
-
-  &::before,
-  &::after {
-    content: "";
-    position: absolute;
-    left: 34px;
-    right: 34px;
-    height: 3px;
-    background: #4a4f54;
-    border-radius: 1px;
-  }
-
-  &::before {
-    top: -2px;
-  }
-
-  &::after {
-    bottom: -2px;
-  }
-
-  &__head {
-    padding: 16px 18px 12px;
-  }
-
-  &__title {
-    display: flex;
-    align-items: center;
-    gap: 11px;
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 15px;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: lighten($text-color, 15%);
-  }
-
-  &__dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: $gold;
-    box-shadow: 0 0 10px 1px rgba($gold, 0.55);
-  }
-
-  &__body {
-    padding: 4px 18px 18px;
-  }
-
-  &__hero {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr 1fr;
-    gap: 1px;
-    background: rgba($gray-light, 0.28);
-    border: 1px solid rgba($gray-light, 0.28);
-    border-radius: 8px;
-    overflow: hidden;
-    margin-bottom: 20px;
-
-    @media (max-width: 576px) {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-
-  &__section-label {
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 10px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: $gray-light;
-    margin: 4px 0 10px;
-  }
-
-  &__divider {
-    height: 1px;
-    background: rgba($gray-light, 0.28);
-    margin: 20px 0;
-  }
-
-  &__footer {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    margin-top: 16px;
-    flex-wrap: wrap;
-  }
-
-  &__toggle {
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 10px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 6px 13px;
-    background: transparent;
-    color: $text-color;
-    border: 1px solid rgba($gray-light, 0.5);
-    border-radius: 999px;
-    cursor: pointer;
-    transition: all 0.15s ease;
-
-    &:hover {
-      color: lighten($text-color, 15%);
-      border-color: $primary;
-    }
-  }
-
-  &__hint {
-    font-size: 11.5px;
-    color: $gray;
-  }
-}
-
-.tile {
-  position: relative;
-  background: $gray-black;
-  padding: 14px 16px;
-
-  &--primary {
-    grid-column: 1;
-
-    @media (max-width: 576px) {
-      grid-column: 1 / -1;
-    }
-
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      top: 12px;
-      bottom: 12px;
-      width: 3px;
-      background: linear-gradient($gold, rgba($gold, 0.15));
-      border-radius: 2px;
-    }
-  }
-
-  &__label {
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 10px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: $gray-light;
-    margin-bottom: 7px;
-  }
-
-  &__value {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 1;
-    color: lighten($text-color, 15%);
-    font-variant-numeric: tabular-nums;
-  }
-
-  &--primary &__value {
-    font-size: 40px;
-    color: #fff;
-
-    @media (max-width: 576px) {
-      font-size: 32px;
-    }
-  }
-
-  &__unit {
-    font-family: "Open Sans", sans-serif;
-    font-weight: 600;
-    font-size: 12px;
-    letter-spacing: 0.08em;
-    color: $gray-light;
-  }
-
-  &__sub {
-    margin-top: 6px;
-    font-size: 11px;
-    color: $gray;
-  }
-}
 
 .compbar {
   display: flex;

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -31,13 +31,20 @@ const round = (value: number) => Math.round(value);
 const expanded = ref(false);
 const hoveredType = ref<string | null>(null);
 
-const damageTypes: { key: keyof DamageBreakdown; label: string; color: string }[] =
-  [
-    { key: "physical", label: "labels.combat.damagePhysical", color: "#c8c8c8" },
-    { key: "energy", label: "labels.combat.damageEnergy", color: "#428bca" },
-    { key: "distortion", label: "labels.combat.damageDistortion", color: "#38bec9" },
-    { key: "thermal", label: "labels.combat.damageThermal", color: "#fa6800" },
-  ];
+const damageTypes: {
+  key: keyof DamageBreakdown;
+  label: string;
+  color: string;
+}[] = [
+  { key: "physical", label: "labels.combat.damagePhysical", color: "#c8c8c8" },
+  { key: "energy", label: "labels.combat.damageEnergy", color: "#428bca" },
+  {
+    key: "distortion",
+    label: "labels.combat.damageDistortion",
+    color: "#38bec9",
+  },
+  { key: "thermal", label: "labels.combat.damageThermal", color: "#fa6800" },
+];
 
 const composition = computed(() =>
   damageTypes
@@ -68,23 +75,33 @@ const damageMeta = Object.fromEntries(
     <div class="metrics-card__body">
       <div class="metrics-card__hero">
         <div class="metrics-card__tile metrics-card__tile--primary">
-          <div class="metrics-card__tile__label">{{ t("labels.combat.dps") }}</div>
+          <div class="metrics-card__tile__label">
+            {{ t("labels.combat.dps") }}
+          </div>
           <div class="metrics-card__tile__value">
             {{ toNumber(round(stats.dps.total), "integer") }}
             <span class="metrics-card__tile__unit">DPS</span>
           </div>
-          <div class="metrics-card__tile__sub">{{ t("labels.combat.dpsSub") }}</div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.combat.dpsSub") }}
+          </div>
         </div>
         <div class="metrics-card__tile">
-          <div class="metrics-card__tile__label">{{ t("labels.combat.alpha") }}</div>
+          <div class="metrics-card__tile__label">
+            {{ t("labels.combat.alpha") }}
+          </div>
           <div class="metrics-card__tile__value">
             {{ toNumber(round(stats.alpha.total), "integer") }}
             <span class="metrics-card__tile__unit">DMG</span>
           </div>
-          <div class="metrics-card__tile__sub">{{ t("labels.combat.alphaSub") }}</div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.combat.alphaSub") }}
+          </div>
         </div>
         <div class="metrics-card__tile">
-          <div class="metrics-card__tile__label">{{ t("labels.combat.weapons") }}</div>
+          <div class="metrics-card__tile__label">
+            {{ t("labels.combat.weapons") }}
+          </div>
           <div class="metrics-card__tile__value">
             {{ toNumber(stats.weaponCount, "integer") }}
           </div>
@@ -118,29 +135,31 @@ const damageMeta = Object.fromEntries(
         <div class="metrics-card__breakdown">
           <table class="weapon-table">
             <thead>
-            <tr>
-              <th>{{ t("labels.combat.weaponName") }}</th>
-              <th class="num">{{ t("labels.combat.size") }}</th>
-              <th class="num">{{ t("labels.combat.dps") }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="weapon in stats.weapons" :key="weapon.id">
-              <td class="weapon-table__name">
-                <span
-                  class="weapon-table__type"
-                  :style="{ background: damageMeta[weapon.type]?.color }"
-                  :title="t(damageMeta[weapon.type]?.label)"
-                />
-                {{ weapon.name }}
-              </td>
-              <td class="num">
-                <span v-if="weapon.size">S{{ weapon.size }}</span>
-                <span v-else>—</span>
-              </td>
-              <td class="num">{{ toNumber(round(weapon.dps), "integer") }}</td>
-            </tr>
-          </tbody>
+              <tr>
+                <th>{{ t("labels.combat.weaponName") }}</th>
+                <th class="num">{{ t("labels.combat.size") }}</th>
+                <th class="num">{{ t("labels.combat.dps") }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="weapon in stats.weapons" :key="weapon.id">
+                <td class="weapon-table__name">
+                  <span
+                    class="weapon-table__type"
+                    :style="{ background: damageMeta[weapon.type]?.color }"
+                    :title="t(damageMeta[weapon.type]?.label)"
+                  />
+                  {{ weapon.name }}
+                </td>
+                <td class="num">
+                  <span v-if="weapon.size">S{{ weapon.size }}</span>
+                  <span v-else>—</span>
+                </td>
+                <td class="num">
+                  {{ toNumber(round(weapon.dps), "integer") }}
+                </td>
+              </tr>
+            </tbody>
           </table>
         </div>
       </Collapsed>

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import type { Hardpoint } from "@/services/fyApi";
 import Collapsed from "@/shared/components/Collapsed.vue";
+import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useLoadoutStats,
@@ -30,27 +31,29 @@ const round = (value: number) => Math.round(value);
 const expanded = ref(false);
 const hoveredType = ref<string | null>(null);
 
-const damageTypes: { key: keyof DamageBreakdown; label: string }[] = [
-  { key: "physical", label: "labels.combat.damagePhysical" },
-  { key: "energy", label: "labels.combat.damageEnergy" },
-  { key: "distortion", label: "labels.combat.damageDistortion" },
-  { key: "thermal", label: "labels.combat.damageThermal" },
-];
+const damageTypes: { key: keyof DamageBreakdown; label: string; color: string }[] =
+  [
+    { key: "physical", label: "labels.combat.damagePhysical", color: "#c8c8c8" },
+    { key: "energy", label: "labels.combat.damageEnergy", color: "#428bca" },
+    { key: "distortion", label: "labels.combat.damageDistortion", color: "#38bec9" },
+    { key: "thermal", label: "labels.combat.damageThermal", color: "#fa6800" },
+  ];
 
-const composition = computed(() => {
-  const total = stats.value.dps.total;
-  if (!total) return [];
-
-  return damageTypes
-    .map(({ key, label }) => ({
+const composition = computed(() =>
+  damageTypes
+    .map(({ key, label, color }) => ({
       key,
       label,
+      color,
       value: stats.value.dps[key],
-      pct: (stats.value.dps[key] / total) * 100,
     }))
     .filter((entry) => entry.value > 0)
-    .sort((a, b) => b.value - a.value);
-});
+    .sort((a, b) => b.value - a.value),
+);
+
+const damageMeta = Object.fromEntries(
+  damageTypes.map((entry) => [entry.key, entry]),
+);
 </script>
 
 <template>
@@ -91,59 +94,13 @@ const composition = computed(() => {
       <div class="metrics-card__section-label">
         {{ t("labels.combat.composition") }}
       </div>
-      <div
-        class="compbar"
-        :class="{ 'compbar--dimmed': hoveredType }"
-      >
-        <div
-          v-for="seg in composition"
-          :key="seg.key"
-          class="compbar__seg"
-          :class="{ 'compbar__seg--active': hoveredType === seg.key }"
-          :data-type="seg.key"
-          :style="{ width: `${seg.pct}%` }"
-        />
-      </div>
+      <CompositionBar
+        :segments="composition"
+        :highlighted="hoveredType"
+        @highlight="hoveredType = $event"
+      />
 
-      <div class="legend">
-        <div
-          v-for="seg in composition"
-          :key="seg.key"
-          class="legend__row"
-          @mouseenter="hoveredType = seg.key"
-          @mouseleave="hoveredType = null"
-        >
-          <span class="legend__swatch" :data-type="seg.key" />
-          <span class="legend__label">{{ t(seg.label) }}</span>
-          <span class="legend__value">{{ toNumber(round(seg.value), "integer") }}</span>
-          <span class="legend__pct">{{ toNumber(round(seg.pct), "integer") }}%</span>
-        </div>
-      </div>
-
-      <Collapsed :visible="expanded" :duration="200">
-        <div class="metrics-card__divider" />
-        <table class="weapon-table">
-          <thead>
-            <tr>
-              <th>{{ t("labels.combat.weaponName") }}</th>
-              <th class="num">{{ t("labels.combat.size") }}</th>
-              <th class="num">{{ t("labels.combat.dps") }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="weapon in stats.weapons" :key="weapon.id">
-              <td class="weapon-table__name">{{ weapon.name }}</td>
-              <td class="num">
-                <span v-if="weapon.size">S{{ weapon.size }}</span>
-                <span v-else>—</span>
-              </td>
-              <td class="num">{{ toNumber(round(weapon.dps), "integer") }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </Collapsed>
-
-      <div class="metrics-card__footer">
+      <div class="metrics-card__actions">
         <button
           type="button"
           class="metrics-card__toggle"
@@ -155,6 +112,40 @@ const composition = computed(() => {
               : t("labels.combat.showBreakdown")
           }}
         </button>
+      </div>
+
+      <Collapsed :visible="expanded" :duration="200">
+        <div class="metrics-card__breakdown">
+          <table class="weapon-table">
+            <thead>
+            <tr>
+              <th>{{ t("labels.combat.weaponName") }}</th>
+              <th class="num">{{ t("labels.combat.size") }}</th>
+              <th class="num">{{ t("labels.combat.dps") }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="weapon in stats.weapons" :key="weapon.id">
+              <td class="weapon-table__name">
+                <span
+                  class="weapon-table__type"
+                  :style="{ background: damageMeta[weapon.type]?.color }"
+                  :title="t(damageMeta[weapon.type]?.label)"
+                />
+                {{ weapon.name }}
+              </td>
+              <td class="num">
+                <span v-if="weapon.size">S{{ weapon.size }}</span>
+                <span v-else>—</span>
+              </td>
+              <td class="num">{{ toNumber(round(weapon.dps), "integer") }}</td>
+            </tr>
+          </tbody>
+          </table>
+        </div>
+      </Collapsed>
+
+      <div class="metrics-card__footer">
         <span class="metrics-card__hint">{{ t("labels.combat.hint") }}</span>
       </div>
     </div>
@@ -163,106 +154,6 @@ const composition = computed(() => {
 
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
-
-$c-physical: $text-color;
-$c-energy: $primary;
-$c-distortion: $cyan;
-$c-thermal: $warning;
-
-.compbar {
-  display: flex;
-  height: 16px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: $gray-black;
-  border: 1px solid rgba($gray-light, 0.28);
-
-  &__seg {
-    height: 100%;
-    transition: opacity 0.18s ease;
-
-    &[data-type="physical"] {
-      background: $c-physical;
-    }
-    &[data-type="energy"] {
-      background: $c-energy;
-    }
-    &[data-type="distortion"] {
-      background: $c-distortion;
-    }
-    &[data-type="thermal"] {
-      background: $c-thermal;
-    }
-  }
-
-  &--dimmed &__seg:not(&__seg--active) {
-    opacity: 0.25;
-  }
-}
-
-.legend {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px 22px;
-  margin-top: 16px;
-
-  @media (max-width: 576px) {
-    grid-template-columns: 1fr;
-  }
-
-  &__row {
-    display: grid;
-    grid-template-columns: auto 1fr auto auto;
-    align-items: center;
-    gap: 9px;
-    padding: 5px 6px;
-    border-radius: 6px;
-    transition: background 0.15s ease;
-
-    &:hover {
-      background: rgba(#fff, 0.03);
-    }
-  }
-
-  &__swatch {
-    width: 9px;
-    height: 9px;
-    border-radius: 2px;
-
-    &[data-type="physical"] {
-      background: $c-physical;
-    }
-    &[data-type="energy"] {
-      background: $c-energy;
-    }
-    &[data-type="distortion"] {
-      background: $c-distortion;
-    }
-    &[data-type="thermal"] {
-      background: $c-thermal;
-    }
-  }
-
-  &__label {
-    font-size: 13px;
-    color: $text-color;
-  }
-
-  &__value {
-    font-weight: 700;
-    font-size: 13px;
-    color: lighten($text-color, 15%);
-    font-variant-numeric: tabular-nums;
-  }
-
-  &__pct {
-    font-size: 12px;
-    color: $gray-light;
-    min-width: 42px;
-    text-align: right;
-    font-variant-numeric: tabular-nums;
-  }
-}
 
 .weapon-table {
   width: 100%;
@@ -299,6 +190,15 @@ $c-thermal: $warning;
 
   &__name {
     color: lighten($text-color, 15%);
+  }
+
+  &__type {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 8px;
+    border-radius: 2px;
+    vertical-align: middle;
   }
 }
 </style>

--- a/app/frontend/frontend/components/Models/CompositionBar/index.vue
+++ b/app/frontend/frontend/components/Models/CompositionBar/index.vue
@@ -1,0 +1,150 @@
+<script lang="ts">
+export default {
+  name: "CompositionBar",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Segment = {
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+};
+
+type Props = {
+  segments: Segment[];
+  format?: string;
+  highlighted?: string | null;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  format: "integer",
+  highlighted: null,
+});
+
+const emit = defineEmits<{ highlight: [key: string | null] }>();
+
+const { t, toNumber } = useI18n();
+
+const round = (value: number) => Math.round(value);
+
+const rows = computed(() => {
+  const total = props.segments.reduce((sum, segment) => sum + segment.value, 0);
+
+  return props.segments.map((segment) => ({
+    ...segment,
+    pct: total ? (segment.value / total) * 100 : 0,
+  }));
+});
+</script>
+
+<template>
+  <div class="composition">
+    <div
+      class="composition__bar"
+      :class="{ 'composition__bar--dimmed': highlighted }"
+    >
+      <div
+        v-for="row in rows"
+        :key="row.key"
+        class="composition__seg"
+        :class="{ 'composition__seg--active': highlighted === row.key }"
+        :style="{ width: `${row.pct}%`, background: row.color }"
+      />
+    </div>
+    <div class="composition__legend">
+      <div
+        v-for="row in rows"
+        :key="row.key"
+        class="composition__row"
+        @mouseenter="emit('highlight', row.key)"
+        @mouseleave="emit('highlight', null)"
+      >
+        <span class="composition__swatch" :style="{ background: row.color }" />
+        <span class="composition__label">{{ t(row.label) }}</span>
+        <span class="composition__value">
+          {{ toNumber(round(row.value), format) }}
+        </span>
+        <span class="composition__pct">
+          {{ toNumber(round(row.pct), "integer") }}%
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.composition {
+  &__bar {
+    display: flex;
+    height: 16px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: $gray-black;
+    border: 1px solid rgba($gray-light, 0.28);
+  }
+
+  &__seg {
+    height: 100%;
+    transition: opacity 0.18s ease;
+  }
+
+  &__bar--dimmed &__seg:not(&__seg--active) {
+    opacity: 0.25;
+  }
+
+  &__legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 22px;
+    margin-top: 16px;
+
+    @media (max-width: 576px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 9px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    transition: background 0.15s ease;
+
+    &:hover {
+      background: rgba(#fff, 0.03);
+    }
+  }
+
+  &__swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+  }
+
+  &__label {
+    font-size: 13px;
+    color: $text-color;
+  }
+
+  &__value {
+    font-weight: 700;
+    font-size: 13px;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__pct {
+    font-size: 12px;
+    color: $gray-light;
+    min-width: 42px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -10,9 +10,11 @@ import Loader from "@/shared/components/Loader/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
 import HardpointGroup from "./Group/index.vue";
 import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index.vue";
+import ModelSurvivabilityMetrics from "@/frontend/components/Models/SurvivabilityMetrics/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
+import { useShieldStats } from "@/frontend/composables/useShieldStats";
 import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
@@ -87,6 +89,10 @@ const {
 const combatStats = useLoadoutStats(
   () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
 );
+
+const shieldStats = useShieldStats(
+  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
+);
 </script>
 
 <template>
@@ -132,11 +138,16 @@ const combatStats = useLoadoutStats(
         </BtnGroup>
       </div>
       <ModelRefuelBoom :model="model" />
-      <div v-if="combatStats.hasData" class="row combat-row">
+      <div
+        v-if="combatStats.hasData || shieldStats.hasData"
+        class="row combat-row"
+      >
         <div class="col-12 col-lg-6">
           <ModelCombatMetrics :hardpoints="(hardpoints as Hardpoint[])" />
         </div>
-        <div class="col-12 col-lg-6" />
+        <div class="col-12 col-lg-6">
+          <ModelSurvivabilityMetrics :hardpoints="(hardpoints as Hardpoint[])" />
+        </div>
       </div>
       <div v-if="hardpoints?.length" class="row">
         <div class="col-12 col-md-6 col-lg-4">

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -9,8 +9,10 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
 import HardpointGroup from "./Group/index.vue";
+import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
 import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
@@ -81,6 +83,10 @@ const {
 } = useModelHardpointsQuery(props.model.slug, modelHardpointsQueryParams, {
   query: { enabled: !!props.model },
 });
+
+const combatStats = useLoadoutStats(
+  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
+);
 </script>
 
 <template>
@@ -126,6 +132,12 @@ const {
         </BtnGroup>
       </div>
       <ModelRefuelBoom :model="model" />
+      <div v-if="combatStats.hasData" class="row combat-row">
+        <div class="col-12 col-lg-6">
+          <ModelCombatMetrics :hardpoints="(hardpoints as Hardpoint[])" />
+        </div>
+        <div class="col-12 col-lg-6" />
+      </div>
       <div v-if="hardpoints?.length" class="row">
         <div class="col-12 col-md-6 col-lg-4">
           <HardpointGroup

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -139,14 +139,17 @@ const shieldStats = useShieldStats(
       </div>
       <ModelRefuelBoom :model="model" />
       <div
-        v-if="combatStats.hasData || shieldStats.hasData"
+        v-if="combatStats.hasData || shieldStats.hasData || model.metrics.hullHealth"
         class="row combat-row"
       >
         <div class="col-12 col-lg-6">
           <ModelCombatMetrics :hardpoints="(hardpoints as Hardpoint[])" />
         </div>
         <div class="col-12 col-lg-6">
-          <ModelSurvivabilityMetrics :hardpoints="(hardpoints as Hardpoint[])" />
+          <ModelSurvivabilityMetrics
+            :hardpoints="(hardpoints as Hardpoint[])"
+            :hull-health="model.metrics.hullHealth"
+          />
         </div>
       </div>
       <div v-if="hardpoints?.length" class="row">

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -149,6 +149,7 @@ const shieldStats = useShieldStats(
           <ModelSurvivabilityMetrics
             :hardpoints="(hardpoints as Hardpoint[])"
             :hull-health="model.metrics.hullHealth"
+            :hull-parts="model.metrics.hullParts"
           />
         </div>
       </div>

--- a/app/frontend/frontend/components/Models/Hardpoints/new.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/new.vue
@@ -139,15 +139,17 @@ const shieldStats = useShieldStats(
       </div>
       <ModelRefuelBoom :model="model" />
       <div
-        v-if="combatStats.hasData || shieldStats.hasData || model.metrics.hullHealth"
+        v-if="
+          combatStats.hasData || shieldStats.hasData || model.metrics.hullHealth
+        "
         class="row combat-row"
       >
         <div class="col-12 col-lg-6">
-          <ModelCombatMetrics :hardpoints="(hardpoints as Hardpoint[])" />
+          <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
         </div>
         <div class="col-12 col-lg-6">
           <ModelSurvivabilityMetrics
-            :hardpoints="(hardpoints as Hardpoint[])"
+            :hardpoints="hardpoints as Hardpoint[]"
             :hull-health="model.metrics.hullHealth"
             :hull-parts="model.metrics.hullParts"
           />

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -1,0 +1,163 @@
+<script lang="ts">
+export default {
+  name: "ModelSurvivabilityMetrics",
+};
+</script>
+
+<script lang="ts" setup>
+import type { Hardpoint } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useShieldStats } from "@/frontend/composables/useShieldStats";
+
+type Props = {
+  hardpoints?: Hardpoint[];
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  hardpoints: () => [],
+});
+
+const { t, toNumber } = useI18n();
+
+const stats = useShieldStats(() => props.hardpoints);
+
+const round = (value: number) => Math.round(value);
+</script>
+
+<template>
+  <div v-if="stats.hasData" class="metrics-card survivability-panel">
+    <div class="metrics-card__head">
+      <span class="metrics-card__title">
+        <span class="metrics-card__dot" />
+        {{ t("labels.survivability.title") }}
+      </span>
+    </div>
+
+    <div class="metrics-card__body">
+      <div class="metrics-card__hero">
+        <div class="metrics-card__tile metrics-card__tile--primary">
+          <div class="metrics-card__tile__label">
+            {{ t("labels.survivability.shieldHp") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(round(stats.totalHp), "integer") }}
+            <span class="metrics-card__tile__unit">HP</span>
+          </div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.survivability.shieldHpSub") }}
+          </div>
+        </div>
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">
+            {{ t("labels.survivability.regen") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(round(stats.totalRegen), "integer") }}
+            <span class="metrics-card__tile__unit">HP/s</span>
+          </div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.survivability.regenSub") }}
+          </div>
+        </div>
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">
+            {{ t("labels.survivability.shields") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(stats.shieldCount, "integer") }}
+          </div>
+        </div>
+      </div>
+
+      <template v-if="stats.resistances.length">
+        <div class="metrics-card__section-label">
+          {{ t("labels.survivability.resistances") }}
+        </div>
+        <div class="resist">
+          <div
+            v-for="resistance in stats.resistances"
+            :key="resistance.key"
+            class="resist__row"
+          >
+            <span class="resist__label">{{ t(resistance.label) }}</span>
+            <div class="resist__track">
+              <div
+                class="resist__fill"
+                :data-type="resistance.key"
+                :style="{ width: `${resistance.value * 100}%` }"
+              />
+            </div>
+            <span class="resist__value">
+              {{ toNumber(round(resistance.value * 100), "integer") }}%
+            </span>
+          </div>
+        </div>
+      </template>
+
+      <div class="metrics-card__footer">
+        <span class="metrics-card__hint">
+          {{ t("labels.survivability.hint") }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+$c-physical: $text-color;
+$c-energy: $primary;
+$c-distortion: $cyan;
+$c-thermal: $warning;
+
+.resist {
+  display: grid;
+  gap: 10px;
+
+  &__row {
+    display: grid;
+    grid-template-columns: 90px 1fr 48px;
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__label {
+    font-size: 13px;
+    color: $text-color;
+  }
+
+  &__track {
+    height: 8px;
+    border-radius: 999px;
+    background: $gray-black;
+    border: 1px solid rgba($gray-light, 0.28);
+    overflow: hidden;
+  }
+
+  &__fill {
+    height: 100%;
+    border-radius: 999px;
+
+    &[data-type="physical"] {
+      background: $c-physical;
+    }
+    &[data-type="energy"] {
+      background: $c-energy;
+    }
+    &[data-type="distortion"] {
+      background: $c-distortion;
+    }
+    &[data-type="thermal"] {
+      background: $c-thermal;
+    }
+  }
+
+  &__value {
+    font-size: 12px;
+    color: $gray-light;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -11,10 +11,12 @@ import { useShieldStats } from "@/frontend/composables/useShieldStats";
 
 type Props = {
   hardpoints?: Hardpoint[];
+  hullHealth?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   hardpoints: () => [],
+  hullHealth: undefined,
 });
 
 const { t, toNumber } = useI18n();
@@ -22,10 +24,13 @@ const { t, toNumber } = useI18n();
 const stats = useShieldStats(() => props.hardpoints);
 
 const round = (value: number) => Math.round(value);
+
+const hasHull = computed(() => (props.hullHealth ?? 0) > 0);
+const hasData = computed(() => stats.value.hasData || hasHull.value);
 </script>
 
 <template>
-  <div v-if="stats.hasData" class="metrics-card survivability-panel">
+  <div v-if="hasData" class="metrics-card survivability-panel">
     <div class="metrics-card__head">
       <span class="metrics-card__title">
         <span class="metrics-card__dot" />
@@ -35,7 +40,10 @@ const round = (value: number) => Math.round(value);
 
     <div class="metrics-card__body">
       <div class="metrics-card__hero">
-        <div class="metrics-card__tile metrics-card__tile--primary">
+        <div
+          v-if="stats.hasData"
+          class="metrics-card__tile metrics-card__tile--primary"
+        >
           <div class="metrics-card__tile__label">
             {{ t("labels.survivability.shieldHp") }}
           </div>
@@ -44,27 +52,24 @@ const round = (value: number) => Math.round(value);
             <span class="metrics-card__tile__unit">HP</span>
           </div>
           <div class="metrics-card__tile__sub">
-            {{ t("labels.survivability.shieldHpSub") }}
+            {{ toNumber(stats.totalRegen, "integer") }} HP/s ·
+            {{ toNumber(stats.shieldCount, "integer") }}×
           </div>
         </div>
-        <div class="metrics-card__tile">
+        <div
+          v-if="hasHull"
+          class="metrics-card__tile"
+          :class="{ 'metrics-card__tile--primary': !stats.hasData }"
+        >
           <div class="metrics-card__tile__label">
-            {{ t("labels.survivability.regen") }}
+            {{ t("labels.survivability.hullHp") }}
           </div>
           <div class="metrics-card__tile__value">
-            {{ toNumber(round(stats.totalRegen), "integer") }}
-            <span class="metrics-card__tile__unit">HP/s</span>
+            {{ toNumber(round(hullHealth ?? 0), "integer") }}
+            <span class="metrics-card__tile__unit">HP</span>
           </div>
           <div class="metrics-card__tile__sub">
-            {{ t("labels.survivability.regenSub") }}
-          </div>
-        </div>
-        <div class="metrics-card__tile">
-          <div class="metrics-card__tile__label">
-            {{ t("labels.survivability.shields") }}
-          </div>
-          <div class="metrics-card__tile__value">
-            {{ toNumber(stats.shieldCount, "integer") }}
+            {{ t("labels.survivability.hullHpSub") }}
           </div>
         </div>
       </div>
@@ -105,6 +110,14 @@ const round = (value: number) => Math.round(value);
 
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
+
+.metrics-card__hero {
+  grid-template-columns: 1.5fr 1fr;
+
+  @media (max-width: 576px) {
+    grid-template-columns: 1fr;
+  }
+}
 
 $c-physical: $text-color;
 $c-energy: $primary;

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -195,7 +195,9 @@ const humanizePart = (name: string) =>
             <table class="hull-table">
               <tbody>
                 <tr v-for="part in group.parts" :key="part.name">
-                  <td class="hull-table__name">{{ humanizePart(part.name) }}</td>
+                  <td class="hull-table__name">
+                    {{ humanizePart(part.name) }}
+                  </td>
                   <td class="num">
                     {{ toNumber(round(part.health), "integer") }}
                   </td>

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -5,18 +5,22 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import type { Hardpoint } from "@/services/fyApi";
+import Collapsed from "@/shared/components/Collapsed.vue";
+import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vue";
+import type { Hardpoint, ModelMetricsHullPartsItem } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useShieldStats } from "@/frontend/composables/useShieldStats";
 
 type Props = {
   hardpoints?: Hardpoint[];
   hullHealth?: number;
+  hullParts?: ModelMetricsHullPartsItem[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
   hardpoints: () => [],
   hullHealth: undefined,
+  hullParts: () => [],
 });
 
 const { t, toNumber } = useI18n();
@@ -25,8 +29,50 @@ const stats = useShieldStats(() => props.hardpoints);
 
 const round = (value: number) => Math.round(value);
 
+const expanded = ref(false);
+const hoveredCategory = ref<string | null>(null);
+
 const hasHull = computed(() => (props.hullHealth ?? 0) > 0);
 const hasData = computed(() => stats.value.hasData || hasHull.value);
+
+const CATEGORY_ORDER = ["vital", "secondary", "breakable", "subpart"] as const;
+
+const CATEGORY_COLORS: Record<string, string> = {
+  vital: "#d76a6a",
+  secondary: "#c67c7a",
+  breakable: "#b18e8d",
+  subpart: "#96898a",
+};
+
+const partGroups = computed(() =>
+  CATEGORY_ORDER.map((category) => {
+    const parts = props.hullParts
+      .filter((part) => part.category === category)
+      .sort((a, b) => b.health - a.health);
+
+    return {
+      category,
+      label: `labels.survivability.category.${category}`,
+      parts,
+      total: parts.reduce((sum, part) => sum + part.health, 0),
+    };
+  }).filter((group) => group.parts.length > 0),
+);
+
+const hullComposition = computed(() =>
+  partGroups.value.map((group) => ({
+    key: group.category,
+    label: group.label,
+    value: group.total,
+    color: CATEGORY_COLORS[group.category],
+  })),
+);
+
+const humanizePart = (name: string) =>
+  name
+    .replace(/^(dbr|lg)_/, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 </script>
 
 <template>
@@ -99,6 +145,67 @@ const hasData = computed(() => stats.value.hasData || hasHull.value);
         </div>
       </template>
 
+      <template v-if="hullComposition.length">
+        <div class="metrics-card__section-label">
+          {{ t("labels.survivability.hullComposition") }}
+        </div>
+        <CompositionBar
+          :segments="hullComposition"
+          :highlighted="hoveredCategory"
+          @highlight="hoveredCategory = $event"
+        />
+      </template>
+
+      <div v-if="hullParts.length" class="metrics-card__actions">
+        <button
+          type="button"
+          class="metrics-card__toggle"
+          @click="expanded = !expanded"
+        >
+          {{
+            expanded
+              ? t("labels.survivability.hideParts")
+              : t("labels.survivability.showParts")
+          }}
+        </button>
+      </div>
+
+      <Collapsed :visible="expanded" :duration="200">
+        <div class="metrics-card__breakdown">
+          <div
+            v-for="group in partGroups"
+            :key="group.category"
+            class="hull-group"
+            @mouseenter="hoveredCategory = group.category"
+            @mouseleave="hoveredCategory = null"
+          >
+            <div class="hull-group__header">
+              <span class="hull-group__label">
+                <span
+                  class="hull-group__swatch"
+                  :style="{ background: CATEGORY_COLORS[group.category] }"
+                />
+                {{ t(group.label) }}
+              </span>
+              <span class="hull-group__meta">
+                {{ group.parts.length }} ·
+                {{ toNumber(round(group.total), "integer") }} HP
+              </span>
+            </div>
+            <table class="hull-table">
+              <tbody>
+                <tr v-for="part in group.parts" :key="part.name">
+                  <td class="hull-table__name">{{ humanizePart(part.name) }}</td>
+                  <td class="num">
+                    {{ toNumber(round(part.health), "integer") }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Collapsed>
+
       <div class="metrics-card__footer">
         <span class="metrics-card__hint">
           {{ t("labels.survivability.hint") }}
@@ -127,6 +234,7 @@ $c-thermal: $warning;
 .resist {
   display: grid;
   gap: 10px;
+  margin-bottom: 20px;
 
   &__row {
     display: grid;
@@ -171,6 +279,77 @@ $c-thermal: $warning;
     color: $gray-light;
     text-align: right;
     font-variant-numeric: tabular-nums;
+  }
+}
+
+.hull-group {
+  margin-bottom: 14px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 4px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid rgba($gray-light, 0.28);
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: lighten($text-color, 10%);
+  }
+
+  &__swatch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 8px;
+    border-radius: 2px;
+    vertical-align: middle;
+  }
+
+  &__meta {
+    font-size: 11px;
+    color: $gray-light;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.hull-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  td {
+    padding: 9px 10px 9px 0;
+    border-bottom: 1px solid rgba($gray-light, 0.28);
+    color: $text-color;
+
+    &:first-child {
+      padding-left: 18px;
+    }
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+  }
+
+  .num {
+    text-align: right;
+    padding-right: 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__name {
+    color: lighten($text-color, 15%);
   }
 }
 </style>

--- a/app/frontend/frontend/components/Models/metricsCard.scss
+++ b/app/frontend/frontend/components/Models/metricsCard.scss
@@ -1,0 +1,189 @@
+// Shared visual frame for ship-page stat cards (combat, survivability, …).
+// Imported into each card's scoped <style>, so the generic class names
+// (`.metrics-card*`) are scoped per component.
+
+.metrics-card {
+  position: relative;
+  margin: 15px 0 40px;
+  background: $panel-bg;
+  border: 2px solid rgba($gray-light, 0.5);
+  border-radius: 16px;
+  box-shadow: 0 6px 18px -12px rgba(#000, 0.8);
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    left: 34px;
+    right: 34px;
+    height: 3px;
+    background: #4a4f54;
+    border-radius: 1px;
+  }
+
+  &::before {
+    top: -2px;
+  }
+
+  &::after {
+    bottom: -2px;
+  }
+
+  &__head {
+    padding: 16px 18px 12px;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 15px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: lighten($text-color, 15%);
+  }
+
+  &__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: $gold;
+    box-shadow: 0 0 10px 1px rgba($gold, 0.55);
+  }
+
+  &__body {
+    padding: 4px 18px 18px;
+  }
+
+  &__hero {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr;
+    gap: 1px;
+    background: rgba($gray-light, 0.28);
+    border: 1px solid rgba($gray-light, 0.28);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+
+    @media (max-width: 576px) {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  &__section-label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: $gray-light;
+    margin: 4px 0 10px;
+  }
+
+  &__divider {
+    height: 1px;
+    background: rgba($gray-light, 0.28);
+    margin: 20px 0;
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-top: 16px;
+    flex-wrap: wrap;
+  }
+
+  &__toggle {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 6px 13px;
+    background: transparent;
+    color: $text-color;
+    border: 1px solid rgba($gray-light, 0.5);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      color: lighten($text-color, 15%);
+      border-color: $primary;
+    }
+  }
+
+  &__hint {
+    font-size: 11.5px;
+    color: $gray;
+  }
+
+  &__tile {
+    position: relative;
+    background: $gray-black;
+    padding: 14px 16px;
+
+    &--primary {
+      grid-column: 1;
+
+      @media (max-width: 576px) {
+        grid-column: 1 / -1;
+      }
+
+      &::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 12px;
+        bottom: 12px;
+        width: 3px;
+        background: linear-gradient($gold, rgba($gold, 0.15));
+        border-radius: 2px;
+      }
+    }
+
+    &__label {
+      font-family: "Orbitron", tahoma, sans-serif;
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: $gray-light;
+      margin-bottom: 7px;
+    }
+
+    &__value {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      font-family: "Orbitron", tahoma, sans-serif;
+      font-weight: 700;
+      font-size: 24px;
+      line-height: 1;
+      color: lighten($text-color, 15%);
+      font-variant-numeric: tabular-nums;
+    }
+
+    &--primary &__value {
+      font-size: 40px;
+      color: #fff;
+
+      @media (max-width: 576px) {
+        font-size: 32px;
+      }
+    }
+
+    &__unit {
+      font-family: "Open Sans", sans-serif;
+      font-weight: 600;
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      color: $gray-light;
+    }
+
+    &__sub {
+      margin-top: 6px;
+      font-size: 11px;
+      color: $gray;
+    }
+  }
+}

--- a/app/frontend/frontend/components/Models/metricsCard.scss
+++ b/app/frontend/frontend/components/Models/metricsCard.scss
@@ -86,6 +86,16 @@
     margin: 20px 0;
   }
 
+  &__actions {
+    margin-top: 16px;
+  }
+
+  // Padding on an inner wrapper of the collapsible content, so the toggle has a
+  // gap from the revealed content without touching the animated Collapsed root.
+  &__breakdown {
+    padding-top: 16px;
+  }
+
   &__footer {
     display: flex;
     align-items: center;

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ComponentWeapon,
+} from "@/services/fyApi";
+import { computeLoadoutStats } from "./useLoadoutStats";
+
+function weaponHardpoint(
+  typeData: ComponentWeapon,
+  children: Hardpoint[] = [],
+  component: Partial<NonNullable<Hardpoint["component"]>> = {},
+): Hardpoint {
+  return {
+    id: Math.random().toString(),
+    name: "weapon",
+    category: HardpointCategoryEnum.WEAPONS,
+    component: { name: "Weapon", typeData, ...component } as Hardpoint["component"],
+    hardpoints: children,
+    createdAt: "",
+    updatedAt: "",
+  } as Hardpoint;
+}
+
+describe("computeLoadoutStats", () => {
+  it("returns empty stats when there are no weapons", () => {
+    const stats = computeLoadoutStats([]);
+
+    expect(stats.hasData).toBe(false);
+    expect(stats.weaponCount).toBe(0);
+    expect(stats.dps.total).toBe(0);
+    expect(stats.alpha.total).toBe(0);
+  });
+
+  it("computes projectile DPS as alpha × fireRate / 60", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint({
+        fireRate: 60,
+        pelletsPerShot: 1,
+        damagePerShot: { energy: 4670.46 },
+      }),
+    ]);
+
+    expect(stats.weaponCount).toBe(1);
+    expect(stats.alpha.energy).toBeCloseTo(4670.46);
+    expect(stats.dps.energy).toBeCloseTo(4670.46);
+  });
+
+  it("multiplies by pellet count and doubles the fire rate correctly", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint({
+        fireRate: 120,
+        pelletsPerShot: 4,
+        damagePerShot: { physical: 10 },
+      }),
+    ]);
+
+    // alpha = 10 × 4 = 40; dps = 40 × 120 / 60 = 80
+    expect(stats.alpha.physical).toBeCloseTo(40);
+    expect(stats.dps.physical).toBeCloseTo(80);
+  });
+
+  it("uses damagePerSecond directly for beam weapons and skips alpha", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint({
+        beam: true,
+        damagePerSecond: { energy: 500 },
+      }),
+    ]);
+
+    expect(stats.dps.energy).toBeCloseTo(500);
+    expect(stats.alpha.total).toBe(0);
+  });
+
+  it("excludes missiles from the totals", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint({
+        trackingSignal: "cross_section",
+        damagePerShot: { physical: 9999 },
+      } as ComponentWeapon),
+    ]);
+
+    expect(stats.weaponCount).toBe(0);
+    expect(stats.hasData).toBe(false);
+  });
+
+  it("recurses into nested turret hardpoints and sums damage types", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint(
+        {
+          fireRate: 60,
+          damagePerShot: { energy: 100 },
+        },
+        [
+          weaponHardpoint({
+            fireRate: 60,
+            damagePerShot: { physical: 50, distortion: 25 },
+          }),
+        ],
+      ),
+    ]);
+
+    expect(stats.weaponCount).toBe(2);
+    expect(stats.dps.energy).toBeCloseTo(100);
+    expect(stats.dps.physical).toBeCloseTo(50);
+    expect(stats.dps.distortion).toBeCloseTo(25);
+    expect(stats.dps.total).toBeCloseTo(175);
+  });
+
+  it("returns a per-weapon list sorted by DPS descending", () => {
+    const stats = computeLoadoutStats([
+      weaponHardpoint(
+        { fireRate: 60, damagePerShot: { energy: 100 } },
+        [],
+        { name: "Small Gun", size: "1" },
+      ),
+      weaponHardpoint(
+        { fireRate: 60, damagePerShot: { energy: 900 } },
+        [],
+        { name: "Big Gun", size: "4" },
+      ),
+    ]);
+
+    expect(stats.weapons.map((w) => w.name)).toEqual(["Big Gun", "Small Gun"]);
+    expect(stats.weapons[0].dps).toBeCloseTo(900);
+    expect(stats.weapons[0].size).toBe("4");
+  });
+});

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -124,5 +124,6 @@ describe("computeLoadoutStats", () => {
     expect(stats.weapons.map((w) => w.name)).toEqual(["Big Gun", "Small Gun"]);
     expect(stats.weapons[0].dps).toBeCloseTo(900);
     expect(stats.weapons[0].size).toBe("4");
+    expect(stats.weapons[0].type).toBe("energy");
   });
 });

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -15,7 +15,11 @@ function weaponHardpoint(
     id: Math.random().toString(),
     name: "weapon",
     category: HardpointCategoryEnum.WEAPONS,
-    component: { name: "Weapon", typeData, ...component } as Hardpoint["component"],
+    component: {
+      name: "Weapon",
+      typeData,
+      ...component,
+    } as Hardpoint["component"],
     hardpoints: children,
     createdAt: "",
     updatedAt: "",
@@ -109,16 +113,14 @@ describe("computeLoadoutStats", () => {
 
   it("returns a per-weapon list sorted by DPS descending", () => {
     const stats = computeLoadoutStats([
-      weaponHardpoint(
-        { fireRate: 60, damagePerShot: { energy: 100 } },
-        [],
-        { name: "Small Gun", size: "1" },
-      ),
-      weaponHardpoint(
-        { fireRate: 60, damagePerShot: { energy: 900 } },
-        [],
-        { name: "Big Gun", size: "4" },
-      ),
+      weaponHardpoint({ fireRate: 60, damagePerShot: { energy: 100 } }, [], {
+        name: "Small Gun",
+        size: "1",
+      }),
+      weaponHardpoint({ fireRate: 60, damagePerShot: { energy: 900 } }, [], {
+        name: "Big Gun",
+        size: "4",
+      }),
     ]);
 
     expect(stats.weapons.map((w) => w.name)).toEqual(["Big Gun", "Small Gun"]);

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -1,0 +1,121 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ComponentWeapon,
+} from "@/services/fyApi";
+
+export type DamageBreakdown = {
+  total: number;
+  physical: number;
+  energy: number;
+  distortion: number;
+  thermal: number;
+};
+
+export type WeaponStat = {
+  id: string;
+  name: string;
+  size?: string;
+  dps: number;
+};
+
+export type LoadoutStats = {
+  dps: DamageBreakdown;
+  alpha: DamageBreakdown;
+  weapons: WeaponStat[];
+  weaponCount: number;
+  hasData: boolean;
+};
+
+const DAMAGE_TYPES = ["physical", "energy", "distortion", "thermal"] as const;
+
+function emptyBreakdown(): DamageBreakdown {
+  return { total: 0, physical: 0, energy: 0, distortion: 0, thermal: 0 };
+}
+
+function addBreakdown(
+  target: DamageBreakdown,
+  damage: Partial<Record<string, number>> | undefined,
+  multiplier: number,
+) {
+  if (!damage) return;
+
+  for (const type of DAMAGE_TYPES) {
+    const value = damage[type];
+    if (typeof value === "number" && value > 0) {
+      const scaled = value * multiplier;
+      target[type] += scaled;
+      target.total += scaled;
+    }
+  }
+}
+
+function collectWeaponHardpoints(
+  hardpoints: Hardpoint[] | undefined,
+  collected: Hardpoint[] = [],
+): Hardpoint[] {
+  for (const hardpoint of hardpoints || []) {
+    if (
+      hardpoint.category === HardpointCategoryEnum.WEAPONS &&
+      hardpoint.component?.typeData
+    ) {
+      collected.push(hardpoint);
+    }
+
+    if (hardpoint.hardpoints?.length) {
+      collectWeaponHardpoints(hardpoint.hardpoints, collected);
+    }
+  }
+
+  return collected;
+}
+
+function isMissile(weapon: ComponentWeapon): boolean {
+  return "trackingSignal" in (weapon as Record<string, unknown>);
+}
+
+export function computeLoadoutStats(
+  hardpoints: Hardpoint[] | undefined,
+): LoadoutStats {
+  const weaponHardpoints = collectWeaponHardpoints(hardpoints);
+
+  const dps = emptyBreakdown();
+  const alpha = emptyBreakdown();
+  const weapons: WeaponStat[] = [];
+
+  for (const hardpoint of weaponHardpoints) {
+    const component = hardpoint.component!;
+    const weapon = component.typeData as ComponentWeapon;
+    const weaponDps = emptyBreakdown();
+
+    if (weapon.beam && weapon.damagePerSecond) {
+      addBreakdown(dps, weapon.damagePerSecond, 1);
+      addBreakdown(weaponDps, weapon.damagePerSecond, 1);
+    } else if (!isMissile(weapon) && weapon.fireRate && weapon.damagePerShot) {
+      const pellets = weapon.pelletsPerShot || 1;
+      addBreakdown(alpha, weapon.damagePerShot, pellets);
+      addBreakdown(dps, weapon.damagePerShot, (pellets * weapon.fireRate) / 60);
+      addBreakdown(weaponDps, weapon.damagePerShot, (pellets * weapon.fireRate) / 60);
+    } else {
+      continue;
+    }
+
+    weapons.push({
+      id: hardpoint.id,
+      name: component.name,
+      size: component.size,
+      dps: weaponDps.total,
+    });
+  }
+
+  weapons.sort((a, b) => b.dps - a.dps);
+
+  return { dps, alpha, weapons, weaponCount: weapons.length, hasData: weapons.length > 0 };
+}
+
+export function useLoadoutStats(
+  hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
+) {
+  return computed(() => computeLoadoutStats(toValue(hardpoints)));
+}

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -104,7 +104,11 @@ export function computeLoadoutStats(
       const pellets = weapon.pelletsPerShot || 1;
       addBreakdown(alpha, weapon.damagePerShot, pellets);
       addBreakdown(dps, weapon.damagePerShot, (pellets * weapon.fireRate) / 60);
-      addBreakdown(weaponDps, weapon.damagePerShot, (pellets * weapon.fireRate) / 60);
+      addBreakdown(
+        weaponDps,
+        weapon.damagePerShot,
+        (pellets * weapon.fireRate) / 60,
+      );
     } else {
       continue;
     }
@@ -124,7 +128,13 @@ export function computeLoadoutStats(
 
   weapons.sort((a, b) => b.dps - a.dps);
 
-  return { dps, alpha, weapons, weaponCount: weapons.length, hasData: weapons.length > 0 };
+  return {
+    dps,
+    alpha,
+    weapons,
+    weaponCount: weapons.length,
+    hasData: weapons.length > 0,
+  };
 }
 
 export function useLoadoutStats(

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -13,11 +13,14 @@ export type DamageBreakdown = {
   thermal: number;
 };
 
+export type DamageType = "physical" | "energy" | "distortion" | "thermal";
+
 export type WeaponStat = {
   id: string;
   name: string;
   size?: string;
   dps: number;
+  type: DamageType;
 };
 
 export type LoadoutStats = {
@@ -28,7 +31,12 @@ export type LoadoutStats = {
   hasData: boolean;
 };
 
-const DAMAGE_TYPES = ["physical", "energy", "distortion", "thermal"] as const;
+const DAMAGE_TYPES: DamageType[] = [
+  "physical",
+  "energy",
+  "distortion",
+  "thermal",
+];
 
 function emptyBreakdown(): DamageBreakdown {
   return { total: 0, physical: 0, energy: 0, distortion: 0, thermal: 0 };
@@ -101,11 +109,16 @@ export function computeLoadoutStats(
       continue;
     }
 
+    const type = DAMAGE_TYPES.reduce((best, current) =>
+      weaponDps[current] > weaponDps[best] ? current : best,
+    );
+
     weapons.push({
       id: hardpoint.id,
       name: component.name,
       size: component.size,
       dps: weaponDps.total,
+      type,
     });
   }
 

--- a/app/frontend/frontend/composables/useShieldStats.spec.ts
+++ b/app/frontend/frontend/composables/useShieldStats.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ComponentShield,
+} from "@/services/fyApi";
+import { computeShieldStats } from "./useShieldStats";
+
+function shieldHardpoint(typeData: ComponentShield): Hardpoint {
+  return {
+    id: Math.random().toString(),
+    name: "shield",
+    category: HardpointCategoryEnum.SHIELDGENERATOR,
+    component: { name: "Shield", typeData } as Hardpoint["component"],
+    hardpoints: [],
+    createdAt: "",
+    updatedAt: "",
+  } as Hardpoint;
+}
+
+describe("computeShieldStats", () => {
+  it("returns empty stats when there are no shields", () => {
+    const stats = computeShieldStats([]);
+
+    expect(stats.hasData).toBe(false);
+    expect(stats.shieldCount).toBe(0);
+    expect(stats.totalHp).toBe(0);
+  });
+
+  it("sums HP and regen across shields", () => {
+    const stats = computeShieldStats([
+      shieldHardpoint({ maxHealth: 10000, maxRegen: 1500 }),
+      shieldHardpoint({ maxHealth: 5000, maxRegen: 800 }),
+    ]);
+
+    expect(stats.shieldCount).toBe(2);
+    expect(stats.totalHp).toBe(15000);
+    expect(stats.totalRegen).toBe(2300);
+    expect(stats.hasData).toBe(true);
+  });
+
+  it("HP-weights resistances across shields", () => {
+    const stats = computeShieldStats([
+      shieldHardpoint({
+        maxHealth: 3000,
+        maxRegen: 0,
+        resistance: { physical: { max: 0.4 } },
+      }),
+      shieldHardpoint({
+        maxHealth: 1000,
+        maxRegen: 0,
+        resistance: { physical: { max: 0.2 } },
+      }),
+    ]);
+
+    // (0.4·3000 + 0.2·1000) / 4000 = 0.35
+    const physical = stats.resistances.find((r) => r.key === "physical");
+    expect(physical?.value).toBeCloseTo(0.35);
+  });
+
+  it("omits resistance types with no value", () => {
+    const stats = computeShieldStats([
+      shieldHardpoint({
+        maxHealth: 5000,
+        maxRegen: 0,
+        resistance: { energy: { max: 0.3 } },
+      }),
+    ]);
+
+    expect(stats.resistances.map((r) => r.key)).toEqual(["energy"]);
+  });
+});

--- a/app/frontend/frontend/composables/useShieldStats.ts
+++ b/app/frontend/frontend/composables/useShieldStats.ts
@@ -1,0 +1,101 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ComponentShield,
+} from "@/services/fyApi";
+
+export type Resistance = {
+  key: string;
+  label: string;
+  value: number;
+};
+
+export type ShieldStats = {
+  totalHp: number;
+  totalRegen: number;
+  shieldCount: number;
+  resistances: Resistance[];
+  hasData: boolean;
+};
+
+type ComponentShieldResistanceMap = NonNullable<ComponentShield["resistance"]>;
+
+const RESISTANCE_TYPES: {
+  key: keyof ComponentShieldResistanceMap;
+  label: string;
+}[] = [
+  { key: "physical", label: "labels.survivability.resistancePhysical" },
+  { key: "energy", label: "labels.survivability.resistanceEnergy" },
+  { key: "distortion", label: "labels.survivability.resistanceDistortion" },
+  { key: "thermal", label: "labels.survivability.resistanceThermal" },
+];
+
+function collectShieldHardpoints(
+  hardpoints: Hardpoint[] | undefined,
+  collected: Hardpoint[] = [],
+): Hardpoint[] {
+  for (const hardpoint of hardpoints || []) {
+    if (
+      hardpoint.category === HardpointCategoryEnum.SHIELDGENERATOR &&
+      hardpoint.component?.typeData
+    ) {
+      collected.push(hardpoint);
+    }
+
+    if (hardpoint.hardpoints?.length) {
+      collectShieldHardpoints(hardpoint.hardpoints, collected);
+    }
+  }
+
+  return collected;
+}
+
+export function computeShieldStats(
+  hardpoints: Hardpoint[] | undefined,
+): ShieldStats {
+  const shields = collectShieldHardpoints(hardpoints).map(
+    (hardpoint) => hardpoint.component!.typeData as ComponentShield,
+  );
+
+  let totalHp = 0;
+  let totalRegen = 0;
+
+  for (const shield of shields) {
+    totalHp += shield.maxHealth || 0;
+    totalRegen += shield.maxRegen || 0;
+  }
+
+  // Resistances are percentages, so they don't sum — average them, weighted
+  // by each shield's HP (a bigger shield contributes more to the effective
+  // resistance profile).
+  const resistances = RESISTANCE_TYPES.map(({ key, label }) => {
+    let weighted = 0;
+    let weight = 0;
+
+    for (const shield of shields) {
+      const hp = shield.maxHealth || 0;
+      const resistance = shield.resistance?.[key]?.max;
+      if (resistance != null && hp > 0) {
+        weighted += resistance * hp;
+        weight += hp;
+      }
+    }
+
+    return { key, label, value: weight > 0 ? weighted / weight : 0 };
+  }).filter((entry) => entry.value > 0);
+
+  return {
+    totalHp,
+    totalRegen,
+    shieldCount: shields.length,
+    resistances,
+    hasData: shields.length > 0 && totalHp > 0,
+  };
+}
+
+export function useShieldStats(
+  hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
+) {
+  return computed(() => computeShieldStats(toValue(hardpoints)));
+}

--- a/app/frontend/stylesheets/variables.scss
+++ b/app/frontend/stylesheets/variables.scss
@@ -17,6 +17,7 @@ $gray-darker: #272b30;
 $gray-black: #222;
 
 $gold: #d4af37;
+$cyan: #38bec9;
 
 $input-bg: $gray-dark;
 $input-border: $gray-darker;

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -594,6 +594,20 @@
         "damageThermal": "Thermal",
         "hint": "Sustained damage from the default loadout. Missiles excluded."
       },
+      "survivability": {
+        "title": "Survivability",
+        "shieldHp": "Shield HP",
+        "shieldHpSub": "total · all generators",
+        "regen": "Regen",
+        "regenSub": "at full charge",
+        "shields": "Generators",
+        "resistances": "Shield Resistances",
+        "resistancePhysical": "Physical",
+        "resistanceEnergy": "Energy",
+        "resistanceDistortion": "Distortion",
+        "resistanceThermal": "Thermal",
+        "hint": "Shield strength from the default loadout. Hull HP not yet available."
+      },
       "manufacturer": {
         "longName": "Long Name",
         "code": "Code",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -572,8 +572,27 @@
         "crew": "Crew",
         "speed": "Speed",
         "cargo": "Cargo",
+        "combat": "Combat",
         "hardpoints": "Hardpoints",
         "missileOptions": "Missle Options (if available)"
+      },
+      "combat": {
+        "title": "Combat",
+        "dps": "Total DPS",
+        "dpsSub": "sustained · all weapons",
+        "alpha": "Alpha",
+        "alphaSub": "per volley",
+        "weapons": "Weapons",
+        "composition": "Damage Composition",
+        "showBreakdown": "Show breakdown",
+        "hideBreakdown": "Hide breakdown",
+        "weaponName": "Weapon",
+        "size": "Size",
+        "damagePhysical": "Physical",
+        "damageEnergy": "Energy",
+        "damageDistortion": "Distortion",
+        "damageThermal": "Thermal",
+        "hint": "Sustained damage from the default loadout. Missiles excluded."
       },
       "manufacturer": {
         "longName": "Long Name",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -579,7 +579,7 @@
       "combat": {
         "title": "Combat",
         "dps": "Total DPS",
-        "dpsSub": "sustained · all weapons",
+        "dpsSub": "burst · all weapons",
         "alpha": "Alpha",
         "alphaSub": "per volley",
         "weapons": "Weapons",
@@ -592,21 +592,19 @@
         "damageEnergy": "Energy",
         "damageDistortion": "Distortion",
         "damageThermal": "Thermal",
-        "hint": "Sustained damage from the default loadout. Missiles excluded."
+        "hint": "Theoretical burst DPS from the default loadout, ignoring heat and power limits. Missiles excluded."
       },
       "survivability": {
         "title": "Survivability",
         "shieldHp": "Shield HP",
-        "shieldHpSub": "total · all generators",
-        "regen": "Regen",
-        "regenSub": "at full charge",
-        "shields": "Generators",
+        "hullHp": "Hull HP",
+        "hullHpSub": "total across all parts",
         "resistances": "Shield Resistances",
         "resistancePhysical": "Physical",
         "resistanceEnergy": "Energy",
         "resistanceDistortion": "Distortion",
         "resistanceThermal": "Thermal",
-        "hint": "Shield strength from the default loadout. Hull HP not yet available."
+        "hint": "Shield stats from the default loadout; hull HP is the sum of all part health."
       },
       "manufacturer": {
         "longName": "Long Name",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -599,6 +599,15 @@
         "shieldHp": "Shield HP",
         "hullHp": "Hull HP",
         "hullHpSub": "total across all parts",
+        "hullComposition": "Hull Composition",
+        "showParts": "Show hull parts",
+        "hideParts": "Hide hull parts",
+        "category": {
+          "vital": "Vital",
+          "secondary": "Secondary",
+          "breakable": "Breakable",
+          "subpart": "Subparts"
+        },
         "resistances": "Shield Resistances",
         "resistancePhysical": "Physical",
         "resistanceEnergy": "Energy",

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -71,6 +71,7 @@ module ScData
 
       private def update_metrics(model_data, update_params)
         update_params[:mass] = model_data.dig("mass")&.to_f
+        update_params[:hull_health] = model_data.dig("hull_health")&.to_f
         update_params[:sc_length] = model_data.dig("metrics", "y")&.to_f
         update_params[:sc_beam] = model_data.dig("metrics", "x")&.to_f
         update_params[:sc_height] = model_data.dig("metrics", "z")&.to_f

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -72,6 +72,7 @@ module ScData
       private def update_metrics(model_data, update_params)
         update_params[:mass] = model_data.dig("mass")&.to_f
         update_params[:hull_health] = model_data.dig("hull_health")&.to_f
+        update_params[:hull_parts] = model_data.dig("hull_parts")
         update_params[:sc_length] = model_data.dig("metrics", "y")&.to_f
         update_params[:sc_beam] = model_data.dig("metrics", "x")&.to_f
         update_params[:sc_height] = model_data.dig("metrics", "z")&.to_f

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -41,6 +41,7 @@ module ScData
               base_expediting_fee: values.dig("StaticEntityClassData", "SEntityInsuranceProperties", "shipInsuranceParams", "baseExpeditingFee")
             },
             mass: extract_mass(values.dig("Components", "VehicleComponentParams")),
+            hull_health: extract_hull_health(values.dig("Components", "VehicleComponentParams")),
             metrics: {
               x: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "x").to_f,
               y: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "y").to_f,
@@ -93,6 +94,7 @@ module ScData
               base_expediting_fee: insurance.dig("shipInsuranceParams", "baseExpeditingFee")
             },
             mass: extract_mass(values.dig("Components", "VehicleComponentParams")),
+            hull_health: extract_hull_health(values.dig("Components", "VehicleComponentParams")),
             metrics: {
               x: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "x").to_f,
               y: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "y").to_f,
@@ -234,6 +236,35 @@ module ScData
         definition_data = extract_modification_definition(definition_data, modification_key)
 
         definition_data.dig("Vehicle", "Parts", "Part", "mass")&.to_f
+      end
+
+      # Hull health is the sum of every part's `damageMax` in the vehicle
+      # implementation XML (matches the total hull HP shown by erkul.games).
+      private def extract_hull_health(component_params)
+        definition_file_path = component_params.dig("vehicleDefinition")
+
+        return if definition_file_path.blank?
+
+        modification_key = component_params.dig("modification")
+
+        definition_data = Hash.from_xml(File.read("#{definition_path}/#{definition_file_path}"))
+
+        definition_data = extract_modification_definition(definition_data, modification_key)
+
+        total = sum_part_damage(definition_data.dig("Vehicle", "Parts"))
+
+        total.positive? ? total : nil
+      end
+
+      private def sum_part_damage(node)
+        case node
+        when Hash
+          node.sum { |key, value| (key == "damageMax") ? value.to_f : sum_part_damage(value) }
+        when Array
+          node.sum { |value| sum_part_damage(value) }
+        else
+          0.0
+        end
       end
 
       private def extract_modification_definition(definition_data, modification_key)

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -41,7 +41,7 @@ module ScData
               base_expediting_fee: values.dig("StaticEntityClassData", "SEntityInsuranceProperties", "shipInsuranceParams", "baseExpeditingFee")
             },
             mass: extract_mass(values.dig("Components", "VehicleComponentParams")),
-            hull_health: extract_hull_health(values.dig("Components", "VehicleComponentParams")),
+            **extract_hull(values.dig("Components", "VehicleComponentParams")),
             metrics: {
               x: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "x").to_f,
               y: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "y").to_f,
@@ -94,7 +94,7 @@ module ScData
               base_expediting_fee: insurance.dig("shipInsuranceParams", "baseExpeditingFee")
             },
             mass: extract_mass(values.dig("Components", "VehicleComponentParams")),
-            hull_health: extract_hull_health(values.dig("Components", "VehicleComponentParams")),
+            **extract_hull(values.dig("Components", "VehicleComponentParams")),
             metrics: {
               x: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "x").to_f,
               y: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "y").to_f,
@@ -238,12 +238,14 @@ module ScData
         definition_data.dig("Vehicle", "Parts", "Part", "mass")&.to_f
       end
 
-      # Hull health is the sum of every part's `damageMax` in the vehicle
-      # implementation XML (matches the total hull HP shown by erkul.games).
-      private def extract_hull_health(component_params)
+      # Hull health comes from the vehicle implementation XML's part tree. Each
+      # structural part carries a `damageMax`; the ItemPort parts (weapon/thruster
+      # mounts) are excluded, matching the hull HP erkul.games reports. Returns the
+      # per-part breakdown and their sum.
+      private def extract_hull(component_params)
         definition_file_path = component_params.dig("vehicleDefinition")
 
-        return if definition_file_path.blank?
+        return {} if definition_file_path.blank?
 
         modification_key = component_params.dig("modification")
 
@@ -251,20 +253,41 @@ module ScData
 
         definition_data = extract_modification_definition(definition_data, modification_key)
 
-        total = sum_part_damage(definition_data.dig("Vehicle", "Parts"))
+        parts = collect_hull_parts(definition_data.dig("Vehicle", "Parts", "Part"))
 
-        total.positive? ? total : nil
+        return {} if parts.blank?
+
+        {
+          hull_health: parts.sum { |part| part[:health] },
+          hull_parts: parts
+        }
       end
 
-      private def sum_part_damage(node)
+      private def collect_hull_parts(node, parts = [])
         case node
-        when Hash
-          node.sum { |key, value| (key == "damageMax") ? value.to_f : sum_part_damage(value) }
         when Array
-          node.sum { |value| sum_part_damage(value) }
-        else
-          0.0
+          node.each { |value| collect_hull_parts(value, parts) }
+        when Hash
+          damage_max = node["damageMax"].to_f
+          if node["name"].present? && node["class"] != "ItemPort" && damage_max.positive?
+            parts << {name: node["name"], health: damage_max, category: part_category(node)}
+          end
+          collect_hull_parts(node.dig("Parts", "Part"), parts)
         end
+
+        parts
+      end
+
+      # Mirrors the part grouping erkul.games shows: a part that triggers ship
+      # destruction is vital, a standalone detachable part is secondary, a
+      # structural part with sub-parts is breakable, and a leaf detail is a subpart.
+      private def part_category(node)
+        behaviors = Array.wrap(node.dig("DamageBehaviors", "DamageBehavior")).map { |behavior| behavior["class"] }
+
+        return "vital" if behaviors.include?("Group")
+        return "secondary" if behaviors.include?("DetachPart")
+
+        node["Parts"].present? ? "breakable" : "subpart"
       end
 
       private def extract_modification_definition(definition_data, modification_key)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -32,6 +32,7 @@
 #  height                            :decimal(15, 2)   default(0.0), not null
 #  hidden                            :boolean          default(TRUE)
 #  holo_colored                      :boolean          default(FALSE)
+#  hull_health                       :decimal(15, 2)
 #  hydrogen_fuel_tank_size           :decimal(15, 2)
 #  hydrogen_fuel_tanks               :string
 #  images_count                      :integer          default(0)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -33,6 +33,7 @@
 #  hidden                            :boolean          default(TRUE)
 #  holo_colored                      :boolean          default(FALSE)
 #  hull_health                       :decimal(15, 2)
+#  hull_parts                        :jsonb
 #  hydrogen_fuel_tank_size           :decimal(15, 2)
 #  hydrogen_fuel_tanks               :string
 #  images_count                      :integer          default(0)

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -145,6 +145,7 @@ json.metrics do
   json.length_label model.length_label
   json.mass model.mass.to_f
   json.mass_label model.mass.to_f.to_s
+  json.hull_health model.hull_health.to_f if model.hull_health.present?
   json.quantum_fuel_tank_size model.quantum_fuel_tank_size&.to_f
   json.size model.size
   json.size_label model.size&.humanize

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -146,6 +146,9 @@ json.metrics do
   json.mass model.mass.to_f
   json.mass_label model.mass.to_f.to_s
   json.hull_health model.hull_health.to_f if model.hull_health.present?
+  if model.hull_parts.present?
+    json.hull_parts model.hull_parts.map { |part| {name: part["name"], health: part["health"].to_f, category: part["category"]} }
+  end
   json.quantum_fuel_tank_size model.quantum_fuel_tank_size&.to_f
   json.size model.size
   json.size_label model.size&.humanize

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_advocacy.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_bh.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ_lowfuel.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ_lowfuel.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_pir.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_crusader.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_microtech.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_microtech.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_ai_template.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_ff.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_ff.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_salvage.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "hull_health": 11900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Right",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 680.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Flap_Left",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingTip_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Right_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    },
+    {
+      "name": "HullTail_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Left_Tail_Fin_Flap",
+      "health": 10.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_ai_override.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_ai_override.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bis2950.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bis2950.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s03_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s03_test.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s05_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s05_test.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s10_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s10_test.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_civ.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_crim.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_uee.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_unmanned_salvage.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "hull_health": 27044.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_broken",
+      "health": 320.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wingtip_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_gladius.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_dunlevy.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_dunlevy.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir_elite.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pir.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_cfp.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim_ik.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim_ik.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_hh.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_hh.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec_hurstondynamics.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec_hurstondynamics.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_uee.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_xenothreat.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_fleetweek2024.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_fleetweek2024.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_restoration.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_restoration.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_salvage.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "hull_health": 6110.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "WingLeft",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingLeft_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Left_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Left_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingRight_Tip",
+      "health": 260.0,
+      "category": "secondary"
+    },
+    {
+      "name": "TipWing_Right_A",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "TipWing_Right_B",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Mid_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Belly_Wing_Left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Belly_Wing_Right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Right_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingRight",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingRight_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "RearWingLeft",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RearWingLeft_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rudder_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rudder_Left_Flap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FrontWing_Left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.5,
     "y": 21.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_template_shipboarded.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ea_ai_pir.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template_shipboarded.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ea_ai_pir.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt_qig.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_uee.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_xenothreat.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_ninetails.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_salvage.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_template.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 403400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 27000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 27000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt_qig.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_uee.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_xenothreat.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_showdown.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_showdown.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_ninetails.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_salvage.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "hull_health": 295600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "custom_decal",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 65000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 80000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_Right",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Left",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_MountB_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_mountA_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 72.0,
     "y": 120.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_aos.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_aos.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_ff_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_ff_boardedcombat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_gencrim_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_gencrim_boardedcombat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt_nointerior.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt_nointerior.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee_nointerior.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee_nointerior.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_boardedcombat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_noneboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_noneboarded.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_gamemaster.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_gamemaster.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_invictus.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_invictus.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_collector_military.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_collector_military.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_fw_25.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_fw_25.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 18015000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_uee.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_tsg.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_tsg.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "hull_health": 15515000.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3600000.0,
+      "category": "vital"
+    },
+    {
+      "name": "airlock_section",
+      "health": 375000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_Right",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_VFX_Hack",
+      "health": 1000000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "walkway_left",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_left",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearLeft",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_01_RearRight",
+      "health": 300000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 2150000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "escapepod_door_rear_left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "escapepod_door_rear_right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_antennamount",
+      "health": 190000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "walkway_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_mount_right",
+      "health": 100000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Idris_Thruster_Main_02_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 127.0,
     "y": 243.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "hull_health": 7852400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Rear_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Neck",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "hull_health": 7852400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Rear_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Neck",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "hull_health": 7852400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Rear_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Neck",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek_2021.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek_2021.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "hull_health": 7852400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Rear_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rear_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Left",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Mount_Right",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Neck",
+      "health": 1000000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Prong_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Left_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Left_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Front_Right_Top",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Front_Right_Bottom",
+      "health": 5000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded_nocargo.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded_nocargo.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_template_shipboarded.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_bis2024_temp.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ_def.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_crim.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_ninetails.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_a.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_a.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_b.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_b.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_c.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_c.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_showdown.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_showdown.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_teach.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_teach.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_unmanned_salvage.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "hull_health": 123002.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Main_Engine_BlockRight_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockRight",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Main_Engine_BlockLeft_VTOL",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_BlockLeft",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Joint_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Main_Engine_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft_Tip",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopRight_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_TopLeft_Block_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_Block",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_TopLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Top_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerRight_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerRight",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arms_LowerLeft_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_LowerLeft",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left_VTOL",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Arms_Lower_Pistons_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 50000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Bracket_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Right_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bracket_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_Bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Lower_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_A",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Aux_Arms_Top_Left_B",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Aux_Arms_Block_Left",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 120.0,
     "y": 160.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "hull_health": 66700.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 17000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 5700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Underbelly",
+      "health": 4500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_right_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_right_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_left_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_left_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Tail",
+      "health": 3300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rudder_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rudder_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "hull_health": 66700.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 17000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 5700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Underbelly",
+      "health": 4500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_right_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_right_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_left_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_left_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Tail",
+      "health": 3300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rudder_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rudder_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "hull_health": 66700.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 17000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 5700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Underbelly",
+      "health": 4500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_right_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_right_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_left_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_left_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Tail",
+      "health": 3300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rudder_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rudder_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_unmanned_salvage.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "hull_health": 66700.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 17000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 5700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Underbelly",
+      "health": 4500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_right_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_right_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_pitch_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_debris_left_top",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_debris_left_bottom",
+      "health": 5600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Tail",
+      "health": 3300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rudder_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rudder_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rudder_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "hull_health": 138981.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_lower_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_geom_l",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_2",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_lower_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_wing_slider_a_left_r",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_left_wing_damage",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_left_wing_flp_geom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_right_wing_damage",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_right_wing_flp_geom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 44.0,
     "y": 70.5,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_crim.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "hull_health": 138981.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_lower_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_geom_l",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_2",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_lower_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_wing_slider_a_left_r",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_left_wing_damage",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_left_wing_flp_geom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_right_wing_damage",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_right_wing_flp_geom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 44.0,
     "y": 70.5,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_mts.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "hull_health": 138981.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_lower_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_geom_l",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_2",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_lower_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_wing_slider_a_left_r",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_left_wing_damage",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_left_wing_flp_geom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_right_wing_damage",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_right_wing_flp_geom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 44.0,
     "y": 70.5,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_uee.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "hull_health": 138981.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_lower_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_geom_l",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_2",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_lower_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_wing_slider_a_left_r",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_left_wing_damage",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_left_wing_flp_geom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_right_wing_damage",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_right_wing_flp_geom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 44.0,
     "y": 70.5,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_unmanned_salvage.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "hull_health": 138981.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_lower_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_geom_l",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_2",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_lower_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_geom",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_damage",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rl_fin_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_mlr_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mlr_damage",
+      "health": 240.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_m_geom",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_m_damage",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rs_geom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "main_wing_slider_a_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_wing_slider_a_left_r",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "large_wing_piston_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_left_wing_damage",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_left_wing_flp_geom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_right_wing_damage",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_right_wing_flp_geom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 44.0,
     "y": 70.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_uee.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_ai_template.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_collector_milt.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_collector_milt.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_ff.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 15510.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_right_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "AEGS_Sabre_Firebird_winglet_left_debris",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_main_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "G_fuel_small_door",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 13550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_aileron_mesh_a",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_aileron_mesh_b",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_left_rear",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_aileron_mesh_b",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh_a",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_right_rear",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_collector_competition.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_collector_competition.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 13550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_aileron_mesh_a",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_aileron_mesh_b",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_left_rear",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_aileron_mesh_b",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh_a",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_right_rear",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_civ.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 13550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_aileron_mesh_a",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_aileron_mesh_b",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_left_rear",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_aileron_mesh_b",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh_a",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_right_rear",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_crim.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "hull_health": 13550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_l_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_bottom",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "peregrine_rear_wing_r_top",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_aileron_mesh_a",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_aileron_mesh_b",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_left_rear",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_aileron_mesh_b",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_aileron_mesh_a",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_right_rear",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_blacjac.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_hurston.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_uee.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_xenothreat.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "hull_health": 12516.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "bombay_door_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_left_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombay_door_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_right_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ground_fuel_port_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "hull_health": 12516.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "bombay_door_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_left_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombay_door_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_right_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ground_fuel_port_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "hull_health": 12516.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "bombay_door_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_left_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombay_door_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bombay_door_right_inside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ground_fuel_port_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landinggear_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_l2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_r2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_doors_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_sabre_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_unmanned_salvage.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "hull_health": 23013.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_nose_b_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_front_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_l_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_l_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bay_door_r_a",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bay_door_r_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Wing_Right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Front_Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "landinggear_door_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "shipitem_door_rear_l_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_l_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_01_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_02_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_rear_r_03_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shipitem_door_front_mesh",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/aegs_tiburon.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "hull_health": 187200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bridge_glass",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 68.0,
     "y": 121.0,

--- a/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "hull_health": 187200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bridge_glass",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 68.0,
     "y": 121.0,

--- a/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "hull_health": 187200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_bottom_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_right",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_engine_detach_main_top_left",
+      "health": 23000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bridge_glass",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 68.0,
     "y": 121.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_ea_ai_pir.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_unmanned_salvage.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_unmanned_salvage.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_blacjac.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_crusader.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_hurston.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_uee.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_xenothreat.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_unmanned_salvage.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_unmanned_salvage.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "hull_health": 42800.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Arm_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_R",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Right_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Right_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_L",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Fin_Left_Upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Fin_Left_Lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Geo",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Flaps_Geo",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Right",
+      "health": 1800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Back_Left",
+      "health": 1800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim_distortion.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim_distortion.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_ff.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_sec_blacjac.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_xenothreat.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_arrow_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_unmanned_salvage.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "hull_health": 7130.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2050.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.25,
     "y": 17.25,

--- a/data/sc_data/parsed/live/models/anvl_asgard.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "hull_health": 77000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_tail_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rl",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rr",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_roof_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_upper_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_upper_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_collector_military.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_collector_military.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "hull_health": 77000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_tail_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rl",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rr",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_roof_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_upper_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_upper_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "hull_health": 77000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_tail_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rl",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rr",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_roof_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_upper_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_upper_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "hull_health": 77000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_tail_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rl",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rr",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_roof_body",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_upper_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_upper_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_upper_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_right_flap",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_wing_left_flap",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "hull_health": 37800.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Ballista",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_front_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_front_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_back_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_tutorial.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_tutorial.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_fw22nfz.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_fw22nfz.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "hull_health": 6250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 4500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_underpanels_Right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Debris",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 16.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_ai_template_shipboarded.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_bis2950.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_bis2950.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_expedition.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_expedition.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ_def.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_crim.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_unmanned_salvage.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "hull_health": 88000.0,
+  "hull_parts": [
+    {
+      "name": "middle",
+      "health": 70000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wings_L",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wings_R",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front",
+      "health": 5000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 74.0,
     "y": 126.0,

--- a/data/sc_data/parsed/live/models/anvl_centurion.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5920"
   },
   "mass": 33276.0,
+  "hull_health": 33600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left04",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right04",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5920"
   },
   "mass": 33276.0,
+  "hull_health": 33600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left04",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right04",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s03_test.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s03_test.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s05_test.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s05_test.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_civ.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_crim.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_uee.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "hull_health": 34800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 5500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "shield_generator_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_outerdoor_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 7500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_glass",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 5500.0,
+      "category": "vital"
+    },
+    {
+      "name": "amunition_hatch_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "amunition_hatch_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_cover_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_left_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_left_rudder",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sidefin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailfin_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tailfin_right_rudder",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 2250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpitbay_gunnerdoor",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_avionicsaccess_panel",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_fuelaccess_panel_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bombbay_outerdoor_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "core_bottomshield",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "core_topshield",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_side_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_flap_main_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.0,
     "y": 22.75,

--- a/data/sc_data/parsed/live/models/anvl_hawk.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_ai_override.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_ai_override.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_bh.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_ff.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "hull_health": 16600.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 1900.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 1500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 23.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7_mk2_collector_mod.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7_mk2_collector_mod.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "5050"
   },
   "mass": 68317.0,
+  "hull_health": 15250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3150.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_copilot",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_pilot",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 16758.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_ff.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 16758.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_uee.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 16758.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod2_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_Tail_livery_decal_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_WingLeft_Debris_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_military.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_military.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_stealth.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_pu_ai_uee.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_civ.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_pu_ai_crim.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_advocacy.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_wildfire.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_wildfire.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt_leader.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt_leader.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_heartseeker.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_heartseeker.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 76786.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "5050"
   },
   "mass": 68317.0,
+  "hull_health": 15250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3150.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_copilot",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_pilot",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2_heartseeker.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2_heartseeker.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "5640"
   },
   "mass": 68317.0,
+  "hull_health": 15250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3150.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_copilot",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_pilot",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_mk2.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4070"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee_warlord.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee_warlord.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_mk2.json
@@ -14,6 +14,139 @@
     "base_expediting_fee": "4190"
   },
   "mass": 66117.0,
+  "hull_health": 13453.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_flap_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod1_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_nose_logo",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_wing_debris",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_debris_02",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cap_spine",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 22.0,
     "y": 22.5,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee_vixen.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee_vixen.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "hull_health": 15550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "IntakeLeft",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineHousing",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thrust_vector_flap_c",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_a",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "thrust_vector_flap_b",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "IntakeRight",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileBay_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 2650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRightRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingRight_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_R",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeftRear",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Debris",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "LG_Door_Rear_L",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Debris",
+      "health": 1500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.5,
     "y": 28.25,

--- a/data/sc_data/parsed/live/models/anvl_hurricane.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_ff.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_mts.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_uee.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "hull_health": 18226.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 7800.0,
+      "category": "vital"
+    },
+    {
+      "name": "canopy_exterior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_interior",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_left_flap",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bottom_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "stabilizer_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "stabilizer_right_flap",
+      "health": 25.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.5,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_crim.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_civ.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_crim.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_darkblue.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_darkblue.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_grey.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_grey.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_lightblue.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_lightblue.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_white.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_white.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_pu_ai_uee.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_bis2024_temp.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_military.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_military.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_stealth.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_military.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_military.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_stealth.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_plat.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_plat.json
@@ -14,6 +14,149 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "hull_health": 40200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 9200.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bot_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_top_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_center",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rear_wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mini_wing_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_mount_wing_b_S3_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "weapon_mount_wing_a_S4_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_top_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_bot_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_wing_flap_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 7650.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 350.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 25.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/anvl_paladin.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin.json
@@ -14,6 +14,229 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "hull_health": 149819.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_front_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_left",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_turret_base_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_cover",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_hull_cover_underside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_lower_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_sides",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_side_panel_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_panel_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_alcove_tech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_lock_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_barrier_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_track_spline_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_right",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_radar_unit",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_right",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_right",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_left",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_left",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_06_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_03_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_01_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 53.5,

--- a/data/sc_data/parsed/live/models/anvl_paladin_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_ai_super_civ.json
@@ -14,6 +14,229 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "hull_health": 149819.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_front_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_left",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_turret_base_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_cover",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_hull_cover_underside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_lower_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_sides",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_side_panel_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_panel_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_alcove_tech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_lock_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_barrier_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_track_spline_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_right",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_radar_unit",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_right",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_right",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_left",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_left",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_06_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_03_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_01_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 53.5,

--- a/data/sc_data/parsed/live/models/anvl_paladin_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_ai_super_crim.json
@@ -14,6 +14,229 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "hull_health": 149819.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_front_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_left",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_turret_base_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_cover",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_hull_cover_underside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_lower_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_sides",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_side_panel_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_panel_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_alcove_tech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_lock_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_barrier_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_track_spline_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_right",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_radar_unit",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_right",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_right",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_left",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_left",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_06_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_03_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_01_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 53.5,

--- a/data/sc_data/parsed/live/models/anvl_paladin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_pu_ai_crim.json
@@ -14,6 +14,229 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "hull_health": 149819.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_front_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_left",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_turret_base_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_cover",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_hull_cover_underside",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_lower_sides",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_sides",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_side_panel_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_panel_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_alcove_tech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_lock_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_turret_barrier_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_track_spline_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_upper_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_tip_right",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_flap_lower_bot_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_flap_lower_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_radar_unit",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_esc_pods_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_front_side_panel_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_right",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_right",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_left",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_fin_left",
+      "health": 1300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_tail_fin_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_04_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_underside_plate_02_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_06_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_04_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_03_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_02_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_outer_panels_addon_01_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 53.5,

--- a/data/sc_data/parsed/live/models/anvl_spartan.json
+++ b/data/sc_data/parsed/live/models/anvl_spartan.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "2475"
   },
   "mass": 36276.0,
+  "hull_health": 37801.0,
+  "hull_parts": [
+    {
+      "name": "ANVL_Spartan",
+      "health": 4200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "WheelFrontLeft01DmgGroup",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_left01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left04",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_left02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right01",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right02",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right03",
+      "health": 1700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_right04",
+      "health": 1700.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_bis2024_temp.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_ai_template.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_ai_template.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_collector_medic.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_collector_medic.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_civ.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_crim.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_civ.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_crim.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_unmanned_salvage.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "hull_health": 173201.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front_left_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Bottom",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "fuelport_inflight_housing",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_Main_thruster_base_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_right_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_rear_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_main_thruster_base_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_top",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_left_Main_Thruster_wing_bot",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_rear_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Flap_Top_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Flap_Top_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_top_plate",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_right_leg",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_main_thruster_base_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "terrapin_thruster_main_front_right",
+      "health": 10000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_advocacy.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_defendship.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_dropship.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_dropship.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy_spawn.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy_spawn.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_cfp.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_headhunters.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_headhunters.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_ninetails.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_xenothreat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_bis2950.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_bis2950.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_citizencon.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_citizencon.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_indestructible.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_indestructible.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_advocacy.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_bh_qig.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_bh_qig.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_ff.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt_qig.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_hurston.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_microtech.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_microtech.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_xenothreat.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_ninetails.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_salvage.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "hull_health": 90053.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Decal_Wing_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 25000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_RR",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_RL",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Engine_RR_Split",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_RL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_RL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Shell",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Lights_Nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Shell",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 38.0,
     "y": 48.0,

--- a/data/sc_data/parsed/live/models/argo_csv_cargo.json
+++ b/data/sc_data/parsed/live/models/argo_csv_cargo.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "190"
   },
   "mass": 1000.0,
+  "hull_health": 8100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "front",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_barbreakbottom_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_panelbreak_bumper_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_panelbreak_bumper_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_barbreakbottom_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel_rl_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel_rr_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_panelbreak_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panelbreak_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel_fl_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel_fr_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/argo_mole.json
+++ b/data/sc_data/parsed/live/models/argo_mole.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_mole_btala.json
+++ b/data/sc_data/parsed/live/models/argo_mole_btala.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_mole_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_mole_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_mole_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_mole_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_mole_teach.json
+++ b/data/sc_data/parsed/live/models/argo_mole_teach.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_mole_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/argo_mole_unmanned_salvage.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.0,
     "y": 45.0,

--- a/data/sc_data/parsed/live/models/argo_moth.json
+++ b/data/sc_data/parsed/live/models/argo_moth.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/argo_moth_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_moth_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/argo_moth_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_moth_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "hull_health": 130000.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Vtol_Rear_Left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Rear_Right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Top_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Bot_Right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_front_vtol_right",
+      "health": 4000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/argo_mpuv.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "205"
   },
   "mass": 9210.0,
+  "hull_health": 5920.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Cargo_Container_Exterior",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 240.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 10.5,

--- a/data/sc_data/parsed/live/models/argo_mpuv_1t.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_1t.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "205"
   },
   "mass": 6195.0,
+  "hull_health": 6380.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Power_Cap_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cooler_Cap_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "headlight_bot_r",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headlight_top_r",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headlight_top_l",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headlight_bot_l",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 10.5,

--- a/data/sc_data/parsed/live/models/argo_mpuv_pu_ai_civ_lorville.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_pu_ai_civ_lorville.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "205"
   },
   "mass": 9210.0,
+  "hull_health": 5920.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Cargo_Container_Exterior",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 240.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 10.5,

--- a/data/sc_data/parsed/live/models/argo_mpuv_transport.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_transport.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "270"
   },
   "mass": 9210.0,
+  "hull_health": 5920.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Cargo_Container_Exterior",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 240.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 10.5,

--- a/data/sc_data/parsed/live/models/argo_raft.json
+++ b/data/sc_data/parsed/live/models/argo_raft.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_raft_collector_indust.json
+++ b/data/sc_data/parsed/live/models/argo_raft_collector_indust.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ_def.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_raft_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/argo_raft_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "hull_health": 115700.0,
+  "hull_parts": [
+    {
+      "name": "Front",
+      "health": 40700.0,
+      "category": "vital"
+    },
+    {
+      "name": "ARGO_RAFT_FL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Right",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FR_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_FL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Rear_Left",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_LG_MainShaft_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ARGO_RAFT_RL_VTOL_Mesh",
+      "health": 7500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 39.5,

--- a/data/sc_data/parsed/live/models/argo_srv.json
+++ b/data/sc_data/parsed/live/models/argo_srv.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "hull_health": 34500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "VTOL_front_left_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_left_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_MainTractorBeamArm",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.5,
     "y": 31.5,

--- a/data/sc_data/parsed/live/models/argo_srv_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_srv_pu_ai_civ.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "hull_health": 34500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "VTOL_front_left_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_left_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_MainTractorBeamArm",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.5,
     "y": 31.5,

--- a/data/sc_data/parsed/live/models/argo_srv_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_srv_pu_ai_crim.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "hull_health": 34500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "vital"
+    },
+    {
+      "name": "VTOL_front_left_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_left_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_lower_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_front_right_upper_mesh",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_right_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_right_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_MainTractorBeamArm",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nacelle_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_mid_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_mid_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_cylinder_mesh",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "VTOL_rear_left_lower_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "VTOL_rear_left_upper_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 21.5,
     "y": 31.5,

--- a/data/sc_data/parsed/live/models/banu_defender.json
+++ b/data/sc_data/parsed/live/models/banu_defender.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "hull_health": 13800.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Pod",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Panels_02",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/banu_defender_bomb_test.json
+++ b/data/sc_data/parsed/live/models/banu_defender_bomb_test.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "hull_health": 13800.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Pod",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Panels_02",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "hull_health": 13800.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Pod",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Panels_02",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "hull_health": 13800.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Pod",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Panels_02",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_defendship.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "hull_health": 13800.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Pod",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Hull_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Panels_02",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.5,
     "y": 24.5,

--- a/data/sc_data/parsed/live/models/cnou_hoverquad.json
+++ b/data/sc_data/parsed/live/models/cnou_hoverquad.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "75"
   },
   "mass": 4850.0,
+  "hull_health": 3500.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "gravlev_nacelle_r_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "gravlev_nacelle_r_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "gravlev_nacelle_f_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "gravlev_nacelle_f_left",
+      "health": 450.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 1.32,
     "y": 1.45,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_citizencon2018.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_citizencon2018.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_ninetails.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_nt.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_mustang_omega.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_omega.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "hull_health": 10080.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "cockpit_glass_frame",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part02",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_part03",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/cnou_nomad.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ_def.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_teach.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_teach.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_unmanned.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_unmanned.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "hull_health": 9800.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "vertical_stabilizer_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "vertical_stabilizer_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "vertical_stabilizer_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "hull_health": 15350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3300.0,
+      "category": "vital"
+    },
+    {
+      "name": "plating_top_central_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_top_central_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_weapon",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_left",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "plating_engines_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_engines_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 20.18,
     "y": 23.07,

--- a/data/sc_data/parsed/live/models/crus_intrepid_collector_indust.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_collector_indust.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "hull_health": 15350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3300.0,
+      "category": "vital"
+    },
+    {
+      "name": "plating_top_central_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_top_central_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_weapon",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_left",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "plating_engines_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_engines_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 20.18,
     "y": 23.07,

--- a/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_civ.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "hull_health": 15350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3300.0,
+      "category": "vital"
+    },
+    {
+      "name": "plating_top_central_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_top_central_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_weapon",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_left",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "plating_engines_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_engines_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 20.18,
     "y": 23.07,

--- a/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_crim.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "hull_health": 15350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3300.0,
+      "category": "vital"
+    },
+    {
+      "name": "plating_top_central_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_top_central_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_weapon",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_left",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "plating_engines_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_engines_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 20.18,
     "y": 23.07,

--- a/data/sc_data/parsed/live/models/crus_intrepid_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_unmanned_salvage.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "hull_health": 15350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3300.0,
+      "category": "vital"
+    },
+    {
+      "name": "plating_top_central_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_top_central_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_weapon",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 100.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 3300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_left",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "plating_engines_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "plating_engines_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_fin_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_left",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_top_right",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 20.18,
     "y": 23.07,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_unmanned_salvage.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_bis2024_temp.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_civilian.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_civilian.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned_salvage.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "hull_health": 67600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 16500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 13500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear",
+      "health": 11700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_left",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_base_right",
+      "health": 10400.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_geo_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_flap_geo_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 47.5,
     "y": 44.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_ai_template_shipboarded.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_mission_pir_package.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_mission_pir_package.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ_def.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_crim.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_unmanned_salvage.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "hull_health": 41400.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 14000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_engine",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 55.0,
     "y": 51.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_collector_military.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_collector_military.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_civ.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_crim.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_ff.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_unmanned_salvage.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_collector_stealth.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_civ.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_crim.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_salvage.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_template.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "hull_health": 38600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tail",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "right_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "lower_wing_right",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lower_wing_left",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "left_wing",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy_translation",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_debris",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_debris",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_ai_template_shipboarded.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_bombless.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_bombless.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_collector_military.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_collector_military.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_ea_pir.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_ea_pir.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_s3bombs.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_s3bombs.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_ai_template_shipboarded.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_ai_template_shipboarded.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "hull_health": 78400.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Mesh",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_left",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_door_right",
+      "health": 4500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 94.0,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ea_ai_pir.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ea_outlaws.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ea_outlaws.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim_scattergun.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim_scattergun.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_nt.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_raceannouncer_scramble.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_raceannouncer_scramble.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "hull_health": 7980.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Bottom",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Landing_Gear_Door_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_left",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "intake_right",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tailFlap_left",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tailFlap_right",
+      "health": 40.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_left_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_right_attach",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Landing_Gear_Door_Right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Cockpit_Canopy_Door",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_front_attach",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.75,
     "y": 15.25,

--- a/data/sc_data/parsed/live/models/drak_caterpillar.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_halfcargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_halfcargomarkup.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_nocargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_nocargomarkup.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_halfcargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_halfcargomarkup.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_nocargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_nocargomarkup.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_template_shipboarded.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_boarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_boarded.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pirate.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pirate.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ_def.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_nt.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_hijacked.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_hijacked.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_shipshowdown.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_shipshowdown.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_ninetails.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_salvage.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "hull_health": 91500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Center_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Center_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 25500.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 39.5,
     "y": 13.4,

--- a/data/sc_data/parsed/live/models/drak_clipper.json
+++ b/data/sc_data/parsed/live/models/drak_clipper.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "hull_health": 26350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_cockpit_flap_l",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_face_grill",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_cockpit_flap_r",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_top_vent_detail",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_details_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_02",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_clamp",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mesh",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_03",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_lw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_main_mesh",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mesh",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_02_geo",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_base_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_rw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_geo",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_base_04",
+      "health": 170.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_rail_door_geo",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_bottom_part",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/drak_clipper_collector_military.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_collector_military.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "hull_health": 26350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_cockpit_flap_l",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_face_grill",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_cockpit_flap_r",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_top_vent_detail",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_details_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_02",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_clamp",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mesh",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_03",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_lw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_main_mesh",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mesh",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_02_geo",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_base_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_rw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_geo",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_base_04",
+      "health": 170.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_rail_door_geo",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_bottom_part",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/drak_clipper_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_pu_ai_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "hull_health": 26350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_cockpit_flap_l",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_face_grill",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_cockpit_flap_r",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_top_vent_detail",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_details_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_02",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_clamp",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mesh",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_03",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_lw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_main_mesh",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mesh",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_02_geo",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_base_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_rw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_geo",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_base_04",
+      "health": 170.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_rail_door_geo",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_bottom_part",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/drak_clipper_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_pu_ai_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "hull_health": 26350.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_cockpit_flap_l",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_face_grill",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_cockpit_flap_r",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_top_vent_detail",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_details_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_long_bar_02",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_clamp",
+      "health": 4500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_mesh",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_wing_tip_details_03",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_lw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_main_mesh",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_mesh",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_02_geo",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_base_01",
+      "health": 70.0,
+      "category": "subpart"
+    },
+    {
+      "name": "lg_headlight_rw",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_geo",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_antenna_base_04",
+      "health": 170.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_rail_door_geo",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_tail_bottom_part",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/drak_command_module.json
+++ b/data/sc_data/parsed/live/models/drak_command_module.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3000"
   },
   "mass": 120677.0,
+  "hull_health": 6700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_body_bottom_side_panel_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_bottom_side_panel_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_panel_cap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_armour_left_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_armour_left_02",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_armour_right_01",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_girders",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_side_panel_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_side_panel_left001",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_engine_brace_bottom",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_side_tube_left_greeble",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_side_tube_right_greeble",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_corsair.json
+++ b/data/sc_data/parsed/live/models/drak_corsair.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super_civ.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super_crim.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_template_shipboarded.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_exec_military.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_exec_military.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_exec_stealthindustrial.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_exec_stealthindustrial.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ_def.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_crim.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_ff.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_unmanned_salvage.json
@@ -14,6 +14,129 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "hull_health": 91000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "landing_gear_door_front_left_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_left_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_front_right_a",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "landing_gear_door_front_right_b",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "yaw_mesh_base",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pitch_mesh",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_hinge_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_bottom_hinge_b_mesh",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_mesh",
+      "health": 12500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "right_wing_mesh",
+      "health": 5000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rignt_wing_tip_antenna_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_top_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_rail_door_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_bottom_flap_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing_rotator_mesh",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_left_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_rotator_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_door_right_slider_mesh",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 30.0,
     "y": 53.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_a.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_a.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_template.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_a.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_a.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_template.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_template.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_bis2950.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ea_ai_pir.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_exec_military.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_exec_military.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_exec_stealth.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_mission_pir_package.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_mission_pir_package.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy_qig.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_cfp.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ_def.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim_qig.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_dropship.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_dropship.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ff.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_headhunters.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_headhunters.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ninetails.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_qig.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_reinforcements.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_reinforcements.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_elite.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_qig.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader_qig.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_xenothreat.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_boarding.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_boarding.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_pirate_crewless.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_pirate_crewless.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_shipshowdown.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_shipshowdown.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_ninetails.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "hull_health": 35770.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_ai_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_ai_template.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "hull_health": 35770.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_bis2950.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "hull_health": 35770.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "hull_health": 35770.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_ai_medicalrescue.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_ai_medicalrescue.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_ai_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_ai_template.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_bis2950.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ_def.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "hull_health": 34520.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6600.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1880.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 6200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "hull_health": 29760.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Base_Right",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 900.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/drak_cutter.json
+++ b/data/sc_data/parsed/live/models/drak_cutter.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_unmanned_salvage.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_unmanned_salvage.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_unmanned_salvage.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "hull_health": 17100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_armour_top",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_r_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisproxy_spoiler_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "vtol_l_geo",
+      "health": 3000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "hull_health": 1570.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 880.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_front_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_front_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_pink.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_pink.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "hull_health": 1570.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 880.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_front_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_front_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_ff.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "hull_health": 1570.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 880.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_front_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_front_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_template.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "hull_health": 1570.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 880.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_front_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_front_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_yellow.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_yellow.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "hull_health": 1570.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 880.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_front_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_front_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_left_main",
+      "health": 160.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_rear_right_main",
+      "health": 160.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem.json
+++ b/data/sc_data/parsed/live/models/drak_golem.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_btala.json
+++ b/data/sc_data/parsed/live/models/drak_golem_btala.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_collector_indust.json
+++ b/data/sc_data/parsed/live/models/drak_golem_collector_indust.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_low_fuel_temporary.json
+++ b/data/sc_data/parsed/live/models/drak_golem_low_fuel_temporary.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "hull_health": 20700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_fin_connector",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rr_fin",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_con",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_addon",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rl_fin",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_body_rear_latch",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_front_fuelcover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_civ.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "hull_health": 20700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_fin_connector",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rr_fin",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_con",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_addon",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rl_fin",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_body_rear_latch",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_front_fuelcover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_crim.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "hull_health": 20700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_fin_connector",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rr_fin",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_con",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_trac_beam_addon",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_rl_fin",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "det_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_m_body_rear_covers_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_body_rear_latch",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_front_fuelcover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_golem_pu_ai_civ.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_golem_pu_ai_crim.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_golem_teach.json
+++ b/data/sc_data/parsed/live/models/drak_golem_teach.json
@@ -14,6 +14,99 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "hull_health": 17300.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2350.0,
+      "category": "vital"
+    },
+    {
+      "name": "m_det_fr_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_fl_vtol",
+      "health": 1450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_body_rear",
+      "health": 2350.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_vtol_rear_cover_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_vtol_rear_cover_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "m_det_vtol_ext_main_housing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rr_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_cover",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_lside_cover",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_rl_fin",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_cover",
+      "health": 1600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fr_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "m_det_fl_lower_cover",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.5,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/drak_herald.json
+++ b/data/sc_data/parsed/live/models/drak_herald.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "hull_health": 6420.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "sat_array_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_lower",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "pipe_cover_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pipe_cover_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 24.75,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "hull_health": 6420.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "sat_array_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_lower",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "pipe_cover_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pipe_cover_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 24.75,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ_ftl.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ_ftl.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "hull_health": 6420.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "sat_array_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_lower",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "pipe_cover_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pipe_cover_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 24.75,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "hull_health": 6420.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "sat_array_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_lower",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_upper_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_flap_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "sat_array_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight_Detach",
+      "health": 660.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2100.0,
+      "category": "vital"
+    },
+    {
+      "name": "pipe_cover_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "pipe_cover_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 24.75,

--- a/data/sc_data/parsed/live/models/drak_ironclad.json
+++ b/data/sc_data/parsed/live/models/drak_ironclad.json
@@ -14,6 +14,219 @@
     "base_expediting_fee": "9000"
   },
   "mass": 720000.0,
+  "hull_health": 258000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 120000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_mid",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_deck_fence_piece087",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece090",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece098",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_r_002",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_l_000",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_l_001",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_r_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece092",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece096",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece099",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece086",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_677",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_679",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_683",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_687",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_735",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_755",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_757",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_underbelly_piece010",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_underbelly_piece006",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_machined007",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_machined005",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nose_armour",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_op_slats",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_op_slats002",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_op_slats004",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_l_001",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_r_001",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_l_002",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_r_002",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_004",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_003",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_01",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_693",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_fairing_018",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_fairing_043",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_box_detail_009",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_fender_end001",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_fender_end",
+      "health": 2000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 117.0,

--- a/data/sc_data/parsed/live/models/drak_ironclad_assault.json
+++ b/data/sc_data/parsed/live/models/drak_ironclad_assault.json
@@ -14,6 +14,219 @@
     "base_expediting_fee": "9000"
   },
   "mass": 720000.0,
+  "hull_health": 258000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 120000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_mid",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_deck_fence_piece087",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece090",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece098",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_r_002",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_l_000",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_l_001",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_mid_door_r_003",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece092",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece096",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece099",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_deck_fence_piece086",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_677",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_679",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_683",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_687",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_735",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_755",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_757",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_underbelly_piece010",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_underbelly_piece006",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_machined007",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_machined005",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nose_armour",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_op_slats",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_op_slats002",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_op_slats004",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_l_001",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_r_001",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_l_002",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_container_large_door_r_002",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_004",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_003",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_01",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_detatch_panel_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_hull_gate_693",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_fairing_018",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_fairing_043",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_box_detail_009",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_fender_end001",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_fender_end",
+      "health": 2000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 117.0,

--- a/data/sc_data/parsed/live/models/drak_mule.json
+++ b/data/sc_data/parsed/live/models/drak_mule.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "70"
   },
   "mass": 2000.0,
+  "hull_health": 10600.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_wheel_FL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_ML",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_FR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_MR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_RR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_RL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Cargo_Arms",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_FT",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Arm_Hinge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "sidetray_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sidetray_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Entry_Door_Lower",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Door_Arms",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Entry_Door_Upper_node",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Seat_Hatch",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/drak_pitbull.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "hull_health": 1950.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 550.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_back_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 6.0,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_civ.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "hull_health": 1950.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 550.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_back_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 6.0,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_crim.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "hull_health": 1950.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 550.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_back_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_guard_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 6.0,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/drak_vulture.json
+++ b/data/sc_data/parsed/live/models/drak_vulture.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ_def.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_crim.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_teach.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_teach.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_unmanned_salvage.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "hull_health": 43700.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_tail",
+      "health": 7000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "drone_wing_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "drone_wing_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_nacelle_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_nacelle_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debrisProxy_salvage_arm_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "main_engine_right",
+      "health": 2000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/eaobjectivedestructable_mininglaser.json
+++ b/data/sc_data/parsed/live/models/eaobjectivedestructable_mininglaser.json
@@ -14,6 +14,14 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "hull_health": 450000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 450000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/eaobjectivedestructable_satellite.json
+++ b/data/sc_data/parsed/live/models/eaobjectivedestructable_satellite.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "hull_health": 700001.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 450000.0,
+      "category": "vital"
+    },
+    {
+      "name": "OuterPetals_Panel04",
+      "health": 50000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "OuterPetals_Panel03",
+      "health": 50000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "OuterPetals_Panel02",
+      "health": 50000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "OuterPetals_Panel01",
+      "health": 50000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "OuterPetals_Panel00",
+      "health": 50000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glow",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/espr_prowler.json
+++ b/data/sc_data/parsed/live/models/espr_prowler.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme_spawn.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme_spawn.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_pu_ai_civ.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_pu_ai_crim.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_unmanned_salvage.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "hull_health": 76900.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 22000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "phalange_shield_right",
+      "health": 700.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "hull_health": 69300.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 18000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_right",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_collector_indust.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_collector_indust.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "hull_health": 69300.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 18000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_right",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "hull_health": 69300.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 18000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_right",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "hull_health": 69300.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 10500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 18000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_wing_stabilizer_right",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_wing_stabilizer_left",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_rear_wing_vertical_stabilizer_extra_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "humerus_base_e_right",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "humerus_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "ulna_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_phalange_a_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_b_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_c_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_phalange_d_right",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 34.0,

--- a/data/sc_data/parsed/live/models/espr_talon.json
+++ b/data/sc_data/parsed/live/models/espr_talon.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_talon_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_talon_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_unmanned_salvage.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/espr_talon_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_talon_unmanned_salvage.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "hull_health": 24930.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "eject_joint",
+      "health": 80.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Right",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_right",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "comp_jumpdrive_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_scanner_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_mid",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_rear",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_front",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "coolers_door_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shieldgen_door_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Leg_Left",
+      "health": 1900.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Leg_Lower_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "leg_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_small_segment_01_left",
+      "health": 1300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_small_feathers_01_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_02_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_03_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_04_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_05_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_06_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_small_feathers_07_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail_Left",
+      "health": 1650.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1850.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail_Right",
+      "health": 1650.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 15.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/gama_railen.json
+++ b/data/sc_data/parsed/live/models/gama_railen.json
@@ -14,6 +14,244 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "hull_health": 62168.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_003",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_004",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_005",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_002",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_upper_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_upper_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_lower_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_lower_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_004",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_002",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 53.0,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_railen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_railen_pu_ai_civ.json
@@ -14,6 +14,244 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "hull_health": 62168.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_003",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_004",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_005",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_002",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_upper_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_upper_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_lower_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_lower_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_004",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_002",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 53.0,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_railen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_railen_pu_ai_crim.json
@@ -14,6 +14,244 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "hull_health": 62168.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_003",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_004",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_right_piece_005",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_002",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_right_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_upper_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_upper_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_lower_thruster_big_cover",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_lower_thruster_small_cover",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_bottom_left_piece_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_tractorbeam_plate_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_a_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_b_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_tractorbeam_plate_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_004",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_002",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_top_left_piece_001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 53.0,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_syulen.json
+++ b/data/sc_data/parsed/live/models/gama_syulen.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_exec_military.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_exec_military.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_exec_stealth.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_pu_ai_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_unmanned_salvage.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "hull_health": 11740.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Bottom_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Small_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Left_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Top_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Left",
+      "health": 220.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Large_Right_Fin_Right",
+      "health": 220.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 28.0,
     "y": 25.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui.json
@@ -14,6 +14,254 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "hull_health": 70460.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 42000.0,
+      "category": "vital"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_upper",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_left_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_003",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a_lower",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b_lower",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_stone_cap_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 58.75,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_civ.json
@@ -14,6 +14,254 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "hull_health": 70460.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 42000.0,
+      "category": "vital"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_upper",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_left_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_003",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a_lower",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b_lower",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_stone_cap_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 58.75,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_crim.json
@@ -14,6 +14,254 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "hull_health": 70460.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 42000.0,
+      "category": "vital"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_upper",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_left_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_003",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a_lower",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b_lower",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_stone_cap_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 58.75,
     "y": 52.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_template.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_template.json
@@ -14,6 +14,254 @@
     "base_expediting_fee": "333"
   },
   "mass": 1348962.0,
+  "hull_health": 70460.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 42000.0,
+      "category": "vital"
+    },
+    {
+      "name": "anim_missiledoor_bottomleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_bottomright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upleft",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_missiledoor_upright",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_plate_right_upper",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_left",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_left_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_right",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_right_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_bottom_left",
+      "health": 3200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_arm_bottom_left_000",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_001",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_bottom_left_003",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_right_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_upper",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_sliding_mechanism_stone_hold_left_lower",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_top_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_aux_bottom_a",
+      "health": 2200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_cover_a_lower",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_thruster_cover_b_lower",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_right",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_arm_top_lower_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_000",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_001",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_002",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_arm_top_plate_right_003",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_antenna_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_a_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_b_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm_support_top_c_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_side_stone_cap_right_upper",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/glsn_basher.json
+++ b/data/sc_data/parsed/live/models/glsn_basher.json
@@ -14,6 +14,154 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "hull_health": 5194.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1300.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_wing_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_wing_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_inventory_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mohawk_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_nozzle",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_left",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_right",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_frame",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_screen",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.3,
     "y": 13.7,

--- a/data/sc_data/parsed/live/models/glsn_basher_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/glsn_basher_pu_ai_civ.json
@@ -14,6 +14,154 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "hull_health": 5194.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1300.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_wing_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_wing_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_inventory_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mohawk_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_nozzle",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_left",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_right",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_frame",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_screen",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.3,
     "y": 13.7,

--- a/data/sc_data/parsed/live/models/glsn_basher_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/glsn_basher_pu_ai_crim.json
@@ -14,6 +14,154 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "hull_health": 5194.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1300.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_wing_left",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_left_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_left_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_wing_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_shield_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right",
+      "health": 550.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engine_right_spike_01",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_02",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "engine_right_spike_03",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_inventory_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mohawk_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "harpoon_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_nozzle",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_arm",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "weapon_cover_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_left",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_cablemount_right",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_frame",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_canopy",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_screen",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.3,
     "y": 13.7,

--- a/data/sc_data/parsed/live/models/glsn_shiv.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_civ.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_civ.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_crim.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_crim.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_template.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_template.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosa.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosa.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosb.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosb.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosc.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosc.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "hull_health": 34300.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Right_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Right_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tail",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Missile_Housing_Right",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Right_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Missile_Housing_Left",
+      "health": 1400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Missile_Housing_Left_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_FL_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_FR_Split",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Thruster_Main_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fuel_greeble",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_panel",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Right_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_fin_Left_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Tail_bottom_greeble_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_Wing_Left_addons",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Wing_Left_addons_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_cage",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Left_addon",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_headlight_bar",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_03",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_01",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_bottom_02",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_Body_Right_addon",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 26.5,
     "y": 37.5,

--- a/data/sc_data/parsed/live/models/grin_mdc.json
+++ b/data/sc_data/parsed/live/models/grin_mdc.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "5060"
   },
   "mass": 13000.0,
+  "hull_health": 16991.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 14500.0,
+      "category": "vital"
+    },
+    {
+      "name": "bar_front_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_front_right_cover",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_roof",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fender_right_light",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_light_sheild_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bar_front",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fender_left_light",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bar_front_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_front_left_cover",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_light_sheild_right",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_rear",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "head_light_sheild_right",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "head_light_sheild_left",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_mtc.json
+++ b/data/sc_data/parsed/live/models/grin_mtc.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "540"
   },
   "mass": 13000.0,
+  "hull_health": 16991.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 14500.0,
+      "category": "vital"
+    },
+    {
+      "name": "bar_front_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_front_right_cover",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_roof",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fender_right_light",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_light_sheild_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bar_front",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fender_left_light",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bar_front_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_front_left_cover",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_light_sheild_right",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_rear",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "head_light_sheild_right",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "head_light_sheild_left",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_ptv.json
+++ b/data/sc_data/parsed/live/models/grin_ptv.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "115"
   },
   "mass": 1500.0,
+  "hull_health": 8510.0,
+  "hull_parts": [
+    {
+      "name": "GRIN_PTV",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheel1",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 1200.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_100_debris_wheel3",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel4",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris3",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_steering",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "glass_100_debris2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_100_debris1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightRightFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightLeftFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightRightFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightLeftFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "reverseLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "reverseLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
+++ b/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "115"
   },
   "mass": 1500.0,
+  "hull_health": 8510.0,
+  "hull_parts": [
+    {
+      "name": "GRIN_PTV",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheel1",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 1200.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_100_debris_wheel3",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel4",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_wheel2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris3",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_100_debris_steering",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "glass_100_debris2",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_100_debris1",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightRightFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "headLightLeftFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightRightFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "brakeLightLeftFlare",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "reverseLightRight",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "reverseLightLeft",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 2.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/grin_roc.json
+++ b/data/sc_data/parsed/live/models/grin_roc.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "1460"
   },
   "mass": 2000.0,
+  "hull_health": 9400.0,
+  "hull_parts": [
+    {
+      "name": "hardpoint_wheel_FL",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_FR",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_RL",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_RR",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "rollcage_main",
+      "health": 2250.0,
+      "category": "vital"
+    },
+    {
+      "name": "roof",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_frame",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "side_panel_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "windshield",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bottom_hatch",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "top_hatch_front",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 3.9,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_roc_ds.json
+++ b/data/sc_data/parsed/live/models/grin_roc_ds.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1825"
   },
   "mass": 2000.0,
+  "hull_health": 13902.0,
+  "hull_parts": [
+    {
+      "name": "GRIN_ROC_DS",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rollcage_main",
+      "health": 2250.0,
+      "category": "vital"
+    },
+    {
+      "name": "light_bar",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "roof",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_frame",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "windshield",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bottom_hatch",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "top_hatch_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_FL",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_FL_assembly",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_FR",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_FR_assembly",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_RL",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_RR",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_ML",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hardpoint_wheel_MR",
+      "health": 1500.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 5.0,
     "y": 6.6,

--- a/data/sc_data/parsed/live/models/grin_stv.json
+++ b/data/sc_data/parsed/live/models/grin_stv.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "540"
   },
   "mass": 2500.0,
+  "hull_health": 4250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 2500.0,
+      "category": "vital"
+    },
+    {
+      "name": "mesh_bonnet_plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Bonnet_Arm",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_fr",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_rl",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_rr",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fender_fl",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_utv.json
+++ b/data/sc_data/parsed/live/models/grin_utv.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "540"
   },
   "mass": 2500.0,
+  "hull_health": 4702.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 2450.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_door_comp_rear",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_grile_door",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_bonnet",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_footpad_rear",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_fender_rear_right",
+      "health": 250.0,
+      "category": "breakable"
+    },
+    {
+      "name": "RTT_Serial",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_fender_rear_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_fender_fr",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_fender_fl",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 2.6,
     "y": 4.0,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "hull_health": 8523.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1750.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_left_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_right_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bottom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_collector_military.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_collector_military.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "hull_health": 8523.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1750.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_left_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_right_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bottom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_collector_stealth.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "hull_health": 8523.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1750.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_left_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_right_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bottom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_civ.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "hull_health": 8523.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1750.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_left_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_right_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bottom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_crim.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "hull_health": 8523.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1750.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_left_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right_large",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_back_right_small",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "fin_bottom",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "hull_health": 7722.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_hood_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_right",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_collector_military.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_collector_military.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "hull_health": 7722.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_hood_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_right",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_civ.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "hull_health": 7722.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_hood_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_right",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_crim.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "hull_health": 7722.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "fairing_cannon_top_small_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_small_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "greeble_cooler_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new002",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_life_support_new001",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_battery",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_power_plant_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_shieldgen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_quantum_drive",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_radar",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_computer_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "personal_storage_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "flap_personal_storage",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "ladder_flap_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_hood_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fairing_cannon_top_large_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "fin_back_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_spoiler_right",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.5,
     "y": 21.5,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_pir.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_uee.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_uee.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_civ.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_crim.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_emerald.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_emerald.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_civ.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_crim.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "hull_health": 2430.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 950.0,
+      "category": "vital"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body2",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_animation_geo",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 7.75,
     "y": 12.0,

--- a/data/sc_data/parsed/live/models/misc_fortune.json
+++ b/data/sc_data/parsed/live/models/misc_fortune.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "hull_health": 59500.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 15200.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_fortune_thruster_front_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_front_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cargo_grid_panels_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cargo_grid_panels_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spine",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spoiler",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_fortune_collector_industrial.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_collector_industrial.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "hull_health": 59500.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 15200.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_fortune_thruster_front_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_front_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cargo_grid_panels_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cargo_grid_panels_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spine",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spoiler",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_fortune_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "hull_health": 59500.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 15200.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_fortune_thruster_front_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_front_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cargo_grid_panels_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cargo_grid_panels_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spine",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spoiler",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_fortune_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "hull_health": 59500.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 15200.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_fortune_thruster_front_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_front_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cargo_grid_panels_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cargo_grid_panels_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spine",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spoiler",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_fortune_teach.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_teach.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "hull_health": 59500.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 15200.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_fortune_thruster_front_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_front_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 15200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cargo_grid_panels_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cargo_grid_panels_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spine",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_fortune_thruster_rear_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spoiler",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_freelancer.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 34.0,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 34.0,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 34.0,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 34.0,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 34.0,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_ninetails.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "hull_health": 34900.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 9500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Roof_Scoop",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wingflap_Left",
+      "health": 640.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1960.0,
+      "category": "secondary"
+    },
+    {
+      "name": "WingFlap_Right",
+      "health": 640.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 23.5,
     "y": 38.0,

--- a/data/sc_data/parsed/live/models/misc_fury.json
+++ b/data/sc_data/parsed/live/models/misc_fury.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super_civ.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super_crim.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_lx.json
+++ b/data/sc_data/parsed/live/models/misc_fury_lx.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "1400"
   },
   "mass": 12832.0,
+  "hull_health": 2160.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 240.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_lx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_lx_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "1400"
   },
   "mass": 12832.0,
+  "hull_health": 2160.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 240.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 240.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_miru.json
+++ b/data/sc_data/parsed/live/models/misc_fury_miru.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "2299"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_miru_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_miru_pu_ai_civ.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "2299"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_fury_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_pu_ai_civ.json
@@ -14,6 +14,84 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "hull_health": 5830.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 750.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body_Top_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Front_Lower_Plate",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Top_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Top_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Top_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Left",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Left",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Wing_Bottom_Right",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_Slide_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_Flap_Bottom_Right",
+      "health": 340.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.4,
     "y": 7.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "hull_health": 91400.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "winglet_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "winglet_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle_connector_rear_geo",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "piston_01_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_tube",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_geo",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_02_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_spinner",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_bot",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_top",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_geo_front_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_geo_front_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "hull_health": 91400.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "winglet_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "winglet_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle_connector_rear_geo",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "piston_01_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_tube",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_geo",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_02_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_spinner",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_bot",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_top",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_geo_front_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_geo_front_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ_def.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "hull_health": 91400.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "winglet_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "winglet_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle_connector_rear_geo",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "piston_01_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_tube",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_geo",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_02_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_spinner",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_bot",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_top",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_geo_front_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_geo_front_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_crim.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "hull_health": 91400.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "winglet_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "winglet_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle_connector_rear_geo",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "piston_01_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_tube",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_geo",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_02_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_spinner",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_bot",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_top",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_geo_front_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_geo_front_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_unmanned_salvage.json
@@ -14,6 +14,259 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "hull_health": 91400.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "winglet_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "winglet_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle_connector_rear_geo",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_left",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_LB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_front_geo_right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "hydraulic_arm_connector_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hydraulic_cargoplates_mount_geo_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_cargoplate_top_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RT",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_cargoplate_bot_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "SHIELD_SDF_01_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_02_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_03_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "SHIELD_SDF_04_RB",
+      "health": 3200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "piston_01_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_tube",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "piston_02_geo",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_geo",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_02_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_rear_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_spinner",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_bot",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_geo_top",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hydraulic_arm_back_geo_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_lock_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_02_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_01_geo_centre_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 7000.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_geo_front_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_geo_front_left",
+      "health": 400.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.5,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b.json
@@ -14,6 +14,594 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "hull_health": 72789.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 40000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spindle_mainbar_00",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_mainbar_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_04",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_05",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_06",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_07",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_rear_lower_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.7,
     "y": 71.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_civ.json
@@ -14,6 +14,594 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "hull_health": 72789.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 40000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spindle_mainbar_00",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_mainbar_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_04",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_05",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_06",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_07",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_rear_lower_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.7,
     "y": 71.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_crim.json
@@ -14,6 +14,594 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "hull_health": 72789.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 40000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_top_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_middle_bottom_wing_large_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spindle",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spindle_mainbar_00",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_mainbar_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_front_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_front_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_bottom_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_bottom_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_04_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_04_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_04_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_03_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_geo_hinge_02_rear_top_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_top_02_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_02_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_plate_arms_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_spindle_plate_01_rear_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_plate_slider_base_rear_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_04",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_05",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_06",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_spindle_mainbar_07",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_rear_lower_wings_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_lower_wings_left",
+      "health": 100.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.7,
     "y": 71.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "hull_health": 323500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Door_L_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vtol_Door_R_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tunnel_Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Center_1_ph_geo",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FoldingSection001_geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 20500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris001",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Center",
+      "health": 9000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 36.05,
     "y": 91.17,

--- a/data/sc_data/parsed/live/models/misc_hull_c_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_ai_civ.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "hull_health": 323500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Door_L_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vtol_Door_R_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tunnel_Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Center_1_ph_geo",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FoldingSection001_geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 20500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris001",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Center",
+      "health": 9000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 36.05,
     "y": 91.17,

--- a/data/sc_data/parsed/live/models/misc_hull_c_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_ai_crim.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "hull_health": 323500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Door_L_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vtol_Door_R_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tunnel_Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Center_1_ph_geo",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FoldingSection001_geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 20500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris001",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Center",
+      "health": 9000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 36.05,
     "y": 91.17,

--- a/data/sc_data/parsed/live/models/misc_hull_c_unmanned.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_unmanned.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "hull_health": 323500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Door_L_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vtol_Door_R_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tunnel_Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Center_1_ph_geo",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FoldingSection001_geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 20500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris001",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Center",
+      "health": 9000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 36.05,
     "y": 91.17,

--- a/data/sc_data/parsed/live/models/misc_hull_c_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_unmanned_salvage.json
@@ -14,6 +14,164 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "hull_health": 323500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 60000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vtol_Door_L_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vtol_Door_R_Geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Tunnel_Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Center_1_ph_geo",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "FoldingSection001_geo",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer005",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer006",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer007",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer008",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer001",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer004",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer003",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Inner002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "DEBRIS_Strut_Outer002",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear",
+      "health": 20500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineTop_Right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineDebris001",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Center",
+      "health": 9000.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 36.05,
     "y": 91.17,

--- a/data/sc_data/parsed/live/models/misc_prospector.json
+++ b/data/sc_data/parsed/live/models/misc_prospector.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_btala.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_btala.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_collector_indust.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_collector_indust.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ_def.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_crim.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_ninetails.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt_nonlethal.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt_nonlethal.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_unmanned_ninetails.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_prospector_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_unmanned_salvage.json
@@ -14,6 +14,94 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "hull_health": 34000.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_FR",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_R",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Coupling_FL",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Basket_L",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_front",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear",
+      "health": 13800.0,
+      "category": "vital"
+    },
+    {
+      "name": "Coupling_RL",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Coupling_RR",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rear_Pipes",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_landinggear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_MainThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_MainThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_RetroThruster_right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 26.5,

--- a/data/sc_data/parsed/live/models/misc_razor.json
+++ b/data/sc_data/parsed/live/models/misc_razor.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_ex.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_lx.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_pu_ai_civ.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_razor_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_pu_ai_crim.json
@@ -14,6 +14,74 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "hull_health": 7200.0,
+  "hull_parts": [
+    {
+      "name": "hull_front",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_bridge_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hull_rear",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_rear_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_front",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_top",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_left",
+      "health": 550.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy_right",
+      "health": 550.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 9.0,
     "y": 12.5,

--- a/data/sc_data/parsed/live/models/misc_reliant.json
+++ b/data/sc_data/parsed/live/models/misc_reliant.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_ai_template.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_ai_template.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_ai_template.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_civ.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_crim.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_reliant_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_unmanned_salvage.json
@@ -14,6 +14,59 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "hull_health": 15460.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 3500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Left",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Top_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Vertical_Stabilizer_Wing_Bottom_Right",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 3500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Engine_Left",
+      "health": 1180.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Engine_Right",
+      "health": 1180.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 28.5,
     "y": 14.75,

--- a/data/sc_data/parsed/live/models/misc_starfarer.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded_nocargogridmarkup.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded_nocargogridmarkup.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_template_shipboarded.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_a.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_a.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_b.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_b.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c_lootable.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c_lootable.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_d.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_d.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_e.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_e.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_nose.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_nose.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 200000.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_left.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_left.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 400000.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_right.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_right.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 400000.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_uee.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_nointerior.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_nointerior.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_def.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel_fast.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel_fast.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_crim.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_nt.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_teach.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_teach.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_unmanned_ninetails.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_unmanned_salvage.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_a.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_a.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_b.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_b.json
@@ -14,6 +14,44 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "hull_health": 75800.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 31500.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_back_right",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "spoiler_mid",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "leg_right",
+      "health": 2200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_back_left",
+      "health": 3600.0,
+      "category": "secondary"
+    },
+    {
+      "name": "leg_left",
+      "health": 2200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 48.5,
     "y": 102.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "hull_health": 84200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_collector_indust.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_collector_indust.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "hull_health": 84200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_civ.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "hull_health": 84200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_crim.json
@@ -14,6 +14,109 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "hull_health": 84200.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 35000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 7000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac.json
@@ -14,6 +14,179 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "hull_health": 116600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_04",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_05",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_03",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_06",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_air_brake_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_air_brake_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_007",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_008",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_009",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_010",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_011",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_012",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_collector_military.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_collector_military.json
@@ -14,6 +14,179 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "hull_health": 116600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_04",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_05",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_03",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_06",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_air_brake_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_air_brake_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_007",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_008",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_009",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_010",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_011",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_012",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_civ.json
@@ -14,6 +14,179 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "hull_health": 116600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_04",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_05",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_03",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_06",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_air_brake_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_air_brake_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_007",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_008",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_009",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_010",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_011",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_012",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_crim.json
@@ -14,6 +14,179 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "hull_health": 116600.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 38000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_04",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_05",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_03",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_06",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_air_brake_left",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_left",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_connection_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_spoiler_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_left",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_spoiler_right",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 25000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_air_brake_right",
+      "health": 600.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_right_rear",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_fin_007",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_008",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_009",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_010",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_011",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nacelle_fin_012",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_plate_right",
+      "health": 6000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 3000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_rear",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_aileron_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 60.0,
     "y": 90.0,

--- a/data/sc_data/parsed/live/models/misc_starlite.json
+++ b/data/sc_data/parsed/live/models/misc_starlite.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "hull_health": 68250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 27000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_body_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_right",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_left",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 1750.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_clamp_detach",
+      "health": 100.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 19.9,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/misc_starlite_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlite_pu_ai_civ.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "hull_health": 68250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 27000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_body_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_right",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_left",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 1750.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_clamp_detach",
+      "health": 100.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 19.9,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/misc_starlite_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlite_pu_ai_crim.json
@@ -14,6 +14,54 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "hull_health": 68250.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 27000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_body_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_right",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_thruster_left",
+      "health": 11200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_spoiler",
+      "health": 1750.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_clamp_detach",
+      "health": 100.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 19.9,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_ai_template.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_ai_template.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_military.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_military.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "hull_health": 89300.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 8100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_body_shell_back",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_lg_panel_b_front_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_lg_panel_b_front_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_b_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_b_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top",
+      "health": 1900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 5600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nose_cap",
+      "health": 1200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_civ.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "hull_health": 89300.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 8100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_body_shell_back",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_lg_panel_b_front_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_lg_panel_b_front_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_b_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_b_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top",
+      "health": 1900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 5600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nose_cap",
+      "health": 1200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_crim.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "hull_health": 89300.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 8100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_body_shell_back",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_lg_panel_b_front_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_lg_panel_b_front_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_b_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_b_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top",
+      "health": 1900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 5600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nose_cap",
+      "health": 1200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_collector_military.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_collector_military.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "hull_health": 89300.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 8100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_body_shell_back",
+      "health": 1200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_left",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_lg_panel_b_front_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_left",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_top_a_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_top_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_flap_02_wing_top_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_arm_rear_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_guardian_mx_wing_bottom_right",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_hinge_attach_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_02_wing_bottom_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_flap_01_wing_bottom_right",
+      "health": 1200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_lg_panel_b_front_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_b_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_b_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_c_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top",
+      "health": 1900.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 5600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nose_cap",
+      "health": 1200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 26.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_civ.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_crim.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_ai_template.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_ai_template.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_collector_indust.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_collector_indust.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_civ.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_crim.json
@@ -14,6 +14,124 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "hull_health": 69200.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 7100.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_wing_left_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_left_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_left_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_right_top_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_right_top_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_arm_right_rear_top_a",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_left_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_left_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_bottom_right_middle",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_back",
+      "health": 2500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_right_front",
+      "health": 3000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_landing_gear_housing_right_front",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_thruster_arm_left_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_left_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_b",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_thruster_arm_right_c",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_body_top_front_a",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_top_front_b",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 16.3,
     "y": 24.3,

--- a/data/sc_data/parsed/live/models/mrai_pulse.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "hull_health": 1550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "arm_front_left_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_left_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "arm_front_right_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_right_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_left_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_right_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_right_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_housing_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_left_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/mrai_pulse_collector_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse_collector_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "hull_health": 1550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "arm_front_left_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_left_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "arm_front_right_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_right_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_left_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_right_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_right_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_housing_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_left_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/mrai_pulse_lx.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse_lx.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "hull_health": 1550.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 700.0,
+      "category": "vital"
+    },
+    {
+      "name": "arm_front_left_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_left_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "arm_front_right_debris_a",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "arm_front_right_debris_a_panel",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_left_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_panel_back_right_debris",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_right_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_housing_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_spoiler_upper_left_mesh",
+      "health": 50.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/orbital_sentry_prototype_a_pu_hos.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_prototype_a_pu_hos.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal_size2.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal_size2.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails_size2.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails_size2.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_uee.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_uee.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_securitynetwork.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_securitynetwork.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 11475.0,
+  "hull_parts": [
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/orig_100i.json
+++ b/data/sc_data/parsed/live/models/orig_100i.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_100i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_100i_pu_ai_civ.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_100i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_100i_pu_ai_crim.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_100i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_100i_unmanned_salvage.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_125a.json
+++ b/data/sc_data/parsed/live/models/orig_125a.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_125a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_125a_pu_ai_civ.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_125a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_125a_pu_ai_crim.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_135c.json
+++ b/data/sc_data/parsed/live/models/orig_135c.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_135c_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_135c_pu_ai_civ.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_135c_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_135c_pu_ai_crim.json
@@ -14,6 +14,29 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "hull_health": 4550.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 1700.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 850.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 1000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 1000.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/orig_300i.json
+++ b/data/sc_data/parsed/live/models/orig_300i.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_300i_ai_override.json
+++ b/data/sc_data/parsed/live/models/orig_300i_ai_override.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_300i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_300i_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_300i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_300i_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_300i_unmanned_restoration.json
+++ b/data/sc_data/parsed/live/models/orig_300i_unmanned_restoration.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_300i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_300i_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_315p.json
+++ b/data/sc_data/parsed/live/models/orig_315p.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_315p_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_315p_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_315p_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_315p_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_315p_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_315p_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_325a.json
+++ b/data/sc_data/parsed/live/models/orig_325a.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.5,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.5,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.5,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_mts.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.5,

--- a/data/sc_data/parsed/live/models/orig_325a_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_325a_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.5,

--- a/data/sc_data/parsed/live/models/orig_350r.json
+++ b/data/sc_data/parsed/live/models/orig_350r.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_350r_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_350r_pu_ai_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_350r_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_350r_pu_ai_crim.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_350r_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_350r_unmanned_salvage.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "hull_health": 8700.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "glass_canopy_front",
+      "health": 1500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_left",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_left_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_left",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_bottom",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_b_right",
+      "health": 500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right_top",
+      "health": 200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_flap_right",
+      "health": 200.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 27.0,

--- a/data/sc_data/parsed/live/models/orig_400i.json
+++ b/data/sc_data/parsed/live/models/orig_400i.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_400i_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_400i_ai_template_shipboarded.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ_def.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_crim.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_400i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_400i_unmanned_salvage.json
@@ -14,6 +14,34 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "hull_health": 81500.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 18000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose",
+      "health": 17500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingLeft",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 14000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Bridge",
+      "health": 18000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 56.0,

--- a/data/sc_data/parsed/live/models/orig_600i.json
+++ b/data/sc_data/parsed/live/models/orig_600i.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_600i_ai_template_shipboarded.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_bis2951.json
+++ b/data/sc_data/parsed/live/models/orig_600i_bis2951.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_executive_edition.json
+++ b/data/sc_data/parsed/live/models/orig_600i_executive_edition.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ_def.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_touring.json
+++ b/data/sc_data/parsed/live/models/orig_600i_touring.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_unmanned.json
+++ b/data/sc_data/parsed/live/models/orig_600i_unmanned.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_600i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_600i_unmanned_salvage.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "hull_health": 197250.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 8625.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 45000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Nose",
+      "health": 45000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 45000.0,
+      "category": "vital"
+    }
+  ],
   "metrics": {
     "x": 52.0,
     "y": 91.5,

--- a/data/sc_data/parsed/live/models/orig_85x.json
+++ b/data/sc_data/parsed/live/models/orig_85x.json
@@ -14,6 +14,24 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "hull_health": 2100.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 600.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 14.0,
     "y": 13.5,

--- a/data/sc_data/parsed/live/models/orig_85x_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_85x_pu_ai_civ.json
@@ -14,6 +14,24 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "hull_health": 2100.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 600.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 14.0,
     "y": 13.5,

--- a/data/sc_data/parsed/live/models/orig_85x_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_85x_pu_ai_crim.json
@@ -14,6 +14,24 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "hull_health": 2100.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 900.0,
+      "category": "vital"
+    },
+    {
+      "name": "wing_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right",
+      "health": 600.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 14.0,
     "y": 13.5,

--- a/data/sc_data/parsed/live/models/orig_890jump.json
+++ b/data/sc_data/parsed/live/models/orig_890jump.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_ai_civ_shipboarded.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_ai_template_shipboarded.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_drug_01.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_drug_01.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_hijacked.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_hijacked.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_hijacked_pisces.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_hijacked_pisces.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ_def.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_unmanned.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_unmanned.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_unmanned_salvage.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "hull_health": 153200.0,
+  "hull_parts": [
+    {
+      "name": "Body_Front",
+      "health": 100000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Front",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Nose",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorA_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TL",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "MissileLauncher_hatchDoorB_TR",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Left_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Rear",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Atrium",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_Front_Top",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Glass_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Dining",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Left_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bar",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Glass_Right_Bridge",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 80.0,
     "y": 210.0,

--- a/data/sc_data/parsed/live/models/orig_m50.json
+++ b/data/sc_data/parsed/live/models/orig_m50.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_advocacy.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_civ.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_crim.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_ninetails.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_nt.json
@@ -14,6 +14,69 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "hull_health": 2281.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "PowerplantHousingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingLeft",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "WingRight",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "PowerplantHousingLeft",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 400.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "LadderHatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontRight",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "WingFrontLeft",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineCover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m80.json
+++ b/data/sc_data/parsed/live/models/orig_m80.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "hull_health": 17000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wings_top_right",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_top_left",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "spoiler_top_middle",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_bottom_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_bottom_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_middle",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m80_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_m80_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "hull_health": 17000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wings_top_right",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_top_left",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "spoiler_top_middle",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_bottom_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_bottom_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_middle",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_m80_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_m80_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "hull_health": 17000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wings_top_right",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_top_left",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_end_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "spoiler_side_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "spoiler_top_middle",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wings_bottom_right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_bottom_left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_middle",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_fin_small_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "shoulder_wing_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "canopy",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 11.0,
     "y": 11.5,

--- a/data/sc_data/parsed/live/models/orig_x1.json
+++ b/data/sc_data/parsed/live/models/orig_x1.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "hull_health": 2820.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 530.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_body_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "door_body_inner_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_glass",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_cap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_break",
+      "health": 50.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_right_break",
+      "health": 50.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 5.19,
     "y": 1.55,

--- a/data/sc_data/parsed/live/models/orig_x1_force.json
+++ b/data/sc_data/parsed/live/models/orig_x1_force.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "hull_health": 2820.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 530.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_body_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "door_body_inner_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_glass",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_cap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_break",
+      "health": 50.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_right_break",
+      "health": 50.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 5.19,
     "y": 1.55,

--- a/data/sc_data/parsed/live/models/orig_x1_velocity.json
+++ b/data/sc_data/parsed/live/models/orig_x1_velocity.json
@@ -14,6 +14,144 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "hull_health": 2820.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 530.0,
+      "category": "vital"
+    },
+    {
+      "name": "door_body_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_bottom",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_bottom_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_body_leg_top_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose",
+      "health": 450.0,
+      "category": "breakable"
+    },
+    {
+      "name": "door_body_inner_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_right_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "foot_glass_left_top",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "door_nose_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 340.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_glass",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_left_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_cap",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_left_break",
+      "health": 50.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_component_door_right_break",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_wing_right_break",
+      "health": 50.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 5.19,
     "y": 1.55,

--- a/data/sc_data/parsed/live/models/probe_comms_1_a.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_a.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "hull_health": 15727.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "left_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_a_psec.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_a_psec.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "hull_health": 15727.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "left_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_b_civ.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_b_civ.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 15727.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "left_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_ninetails.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_ninetails.json
@@ -14,6 +14,64 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "hull_health": 15727.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "left_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dish_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "cockpit",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 6000.0,
+      "category": "vital"
+    },
+    {
+      "name": "receiver_02",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_01",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "receiver_03",
+      "health": 75.0,
+      "category": "subpart"
+    },
+    {
+      "name": "right_wing",
+      "health": 125.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail",
+      "health": 1250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 40.0,
     "y": 18.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_civ.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_crim.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_1.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_1.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_2.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_2.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_3.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_3.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_civ.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_crim.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_collector_stealth.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_1.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_1.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_2.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_2.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_3.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_3.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 54.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_civ.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_crim.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_civ.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_crim.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_civ.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_crim.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_civ.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_crim.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_civ.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_crim.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_se.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_se.json
@@ -14,6 +14,294 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 6350.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 3100.0,
+      "category": "vital"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose_Landing_Gear_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_radar_relay",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_right_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "anim_door_dorsal_comp_left_mech",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Right_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_right_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "anim_door_shield_gen_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Landing_Gear_Left_Door_Left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_rear_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_04_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_03_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_02_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mesh_door_fan_left_front_01_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_left_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_top",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_door_comp_bay_right_bottom",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Debris_Hack_Hardpoint_Retro_Thruster_Right",
+      "health": 200.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_ea_ai_pir.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_nt.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "hull_health": 19417.0,
+  "hull_parts": [
+    {
+      "name": "geo_nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_side_fins",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body",
+      "health": 300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "geo_wing_base_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_base_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_power_plant_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_power_plant_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "_geo_fuel_port_cover_back",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_bottom",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail_end",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.7,
     "y": 27.4,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_missilemodule_temp.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_missilemodule_temp.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "hull_health": 19417.0,
+  "hull_parts": [
+    {
+      "name": "geo_nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_side_fins",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body",
+      "health": 300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "geo_wing_base_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_base_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_power_plant_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_power_plant_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "_geo_fuel_port_cover_back",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_bottom",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail_end",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.7,
     "y": 27.4,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_civ.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "hull_health": 19417.0,
+  "hull_parts": [
+    {
+      "name": "geo_nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_side_fins",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body",
+      "health": 300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "geo_wing_base_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_base_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_power_plant_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_power_plant_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "_geo_fuel_port_cover_back",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_bottom",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail_end",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.7,
     "y": 27.4,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_crim.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "hull_health": 19417.0,
+  "hull_parts": [
+    {
+      "name": "geo_nose",
+      "health": 3000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_shield_gen_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_side_fins",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body",
+      "health": 300.0,
+      "category": "secondary"
+    },
+    {
+      "name": "geo_wing_base_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_right_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_base_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cooler_left_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_wing_top_front_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_top_rear_left",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_power_plant_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_power_plant_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_q_drive_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_computer_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_gravity_gen_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_b",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_battery_housing_door_a",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "_geo_fuel_port_cover_back",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_bottom",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_front_right",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_rear_right",
+      "health": 800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_wing_bottom_left",
+      "health": 1700.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail",
+      "health": 1000.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_tail_end",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_tail_spoiler",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_wing_right",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.7,
     "y": 27.4,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_civ.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_crim.json
@@ -14,6 +14,39 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "hull_health": 5740.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 1940.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 1880.0,
+      "category": "vital"
+    },
+    {
+      "name": "Wing_Bottom_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Left",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Bottom_Right",
+      "health": 480.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Top_Right",
+      "health": 480.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 19.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "hull_health": 370200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineMount_Right",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top_antennas",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineMount_Left",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top_antennas",
+      "health": 20000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Bridge",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_mesh",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_top_mesh",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 40000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_fleetweek_2021.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_fleetweek_2021.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "hull_health": 370200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineMount_Right",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top_antennas",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineMount_Left",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top_antennas",
+      "health": 20000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Bridge",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_mesh",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_top_mesh",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 40000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_nointerior.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_nointerior.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "hull_health": 370200.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Tail",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "EngineMount_Right",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_right_top_antennas",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "EngineMount_Left",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_main",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "thruster_left_top_antennas",
+      "health": 20000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Bridge",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_mesh",
+      "health": 20000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rsi_bengal_bridge_top_mesh",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Nose",
+      "health": 40000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 0.0,
     "y": 0.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir_elite.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt_qig.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac_qig.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader_qig.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_ninetails.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_salvage.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation_Aquila",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation_Aquila",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation_Aquila",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_unmanned_salvage.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation_Aquila",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_emerald.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_emerald.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_piano.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_piano.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ_def.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 63.5,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_military.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_military.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ_def.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_crim.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_salvage.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_template.json
@@ -14,6 +14,284 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "hull_health": 180844.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Constellation",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "neck",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_TurretHousings",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingl_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 15000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_wingr_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_bottom_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nose_turret_door_top_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_lightgroup",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_body_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_body_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 20000.0,
+      "category": "vital"
+    },
+    {
+      "name": "misslerack_arm_tail_left_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_tower_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "misslerack_arm_tail_right_arm",
+      "health": 1750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nacelle_bottom_right",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_naceller_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "nacelle_bottom_left",
+      "health": 15000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_bot_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_out",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_front_in",
+      "health": 20.0,
+      "category": "subpart"
+    },
+    {
+      "name": "turbine_cover_nacellel_top_rear_in",
+      "health": 20.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 27.75,
     "y": 70.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 58.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes_ai_civ.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 58.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes_ai_crim.json
@@ -14,6 +14,329 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "hull_health": 116700.0,
+  "hull_parts": [
+    {
+      "name": "geo_body",
+      "health": 33000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dmg_belly_wing_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_belly_wing_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_center",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_inner_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_Fuelport_Front_Door001",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_nose_antenna_outer_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_wing_nose_bottom_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_right_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_nose_left_top_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_right",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_right_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_right_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_rear",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_tail_side_wings_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_tail_side_wings_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_rear_panel_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_top_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_bottom_center",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_body_left",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dmg_left_hull_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_left_hull_bottom_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_right_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_mount_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "geo_nacelle_antenna_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_top",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_bottom",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_nacelle_left_side",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_tail_antenna_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_k",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_left_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_panel_top_right_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_a",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_b",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_c",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_d",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_e",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_f",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_g",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_h",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_j",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dmg_body_plates_i",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 73.0,
     "y": 58.0,

--- a/data/sc_data/parsed/live/models/rsi_lynx.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "1080"
   },
   "mass": 10372.0,
+  "hull_health": 22700.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Lynx",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 11000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.7,
     "y": 7.75,

--- a/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "1080"
   },
   "mass": 10372.0,
+  "hull_health": 22700.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Lynx",
+      "health": 1800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 11000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 5.7,
     "y": 7.75,

--- a/data/sc_data/parsed/live/models/rsi_mantis.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_bomb_test.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_bomb_test.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_advocacy.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bh.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bjs.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bjs.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_civ.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_crim.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_mts.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_ninetails.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_crusader.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_hurston.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_uee.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_xenothreat.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_unmanned.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_unmanned.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "6750"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_unmanned_salvage.json
@@ -14,6 +14,104 @@
     "base_expediting_fee": "6750"
   },
   "mass": 224923.0,
+  "hull_health": 32500.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2650.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bottom_hull",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "rear_frame_interdiction",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "top_cover_mid",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_top_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "interdiction_bottom_cover_right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_left",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_left",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_right",
+      "health": 1800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "tail_wing_right",
+      "health": 4000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "engine_right",
+      "health": 2800.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_collector_military.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_collector_military.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_collector_stealth.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_civ.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_crim.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_temp_laserrepeater.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_temp_laserrepeater.json
@@ -14,6 +14,184 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "hull_health": 30150.0,
+  "hull_parts": [
+    {
+      "name": "body_main",
+      "health": 2750.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose_wingmount_right",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_spine_mid_housing",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_right",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_right",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_right",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_right",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_tail_wing_left",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_engine_connector_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "engines_base_left",
+      "health": 2800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_engine_left",
+      "health": 2800.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_wing_topcover_inner_left",
+      "health": 150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_topside_inner_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "glass_ext",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_spine",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_exhaust_housing",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_outer_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_cap_rear_inner_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_spine_topside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_main_rear_connector",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_main_underside_torp_bay",
+      "health": 200.0,
+      "category": "breakable"
+    },
+    {
+      "name": "nose_wingmount_left",
+      "health": 1050.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_diffuser",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_small_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_left",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_body_underside_fin_right",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 17.0,
     "y": 30.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus.json
@@ -14,6 +14,454 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "hull_health": 389204.0,
+  "hull_parts": [
+    {
+      "name": "geo_main_wings",
+      "health": 95000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_bottom_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_bottom_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_top_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_left_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_right_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_top_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_rear_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_front",
+      "health": 95000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 100.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super.json
@@ -14,6 +14,454 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "hull_health": 389204.0,
+  "hull_parts": [
+    {
+      "name": "geo_main_wings",
+      "health": 95000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_bottom_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_bottom_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_top_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_left_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_right_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_top_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_rear_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_front",
+      "health": 95000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 100.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super_civ.json
@@ -14,6 +14,454 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "hull_health": 389204.0,
+  "hull_parts": [
+    {
+      "name": "geo_main_wings",
+      "health": 95000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_bottom_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_bottom_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_top_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_left_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_right_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_top_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_rear_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_front",
+      "health": 95000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 100.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super_crim.json
@@ -14,6 +14,454 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "hull_health": 389204.0,
+  "hull_parts": [
+    {
+      "name": "geo_main_wings",
+      "health": 95000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_bottom_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_bottom_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_top_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_left_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_right_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_top_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_rear_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_front",
+      "health": 95000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 100.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_pu_ai_crim.json
@@ -14,6 +14,454 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "hull_health": 389204.0,
+  "hull_parts": [
+    {
+      "name": "geo_main_wings",
+      "health": 95000.0,
+      "category": "vital"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_wing_left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_main_wings_panels_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_bottom_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_bottom_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_bottom_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_bottom_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_left",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_air_brake_top_left",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_left_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_nacelle_top_right",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_nacelle_antenna_top_right_02",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_air_brake_top_right",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_side_08_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_rear_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_left",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_top_spoiler_right",
+      "health": 4000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_front",
+      "health": 95000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "dbr_front_panel_side_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_01_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_airlock_sides_02_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_side_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_panel_bottom_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_top_antenna_right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_01_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_02_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_03_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_04_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_05_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_07_left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_superstructure_panel_top_06_left",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 50.0,
     "y": 100.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super_civ.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super_crim.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_template.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_collector_military.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_collector_military.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_civ.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_crim.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff_boyd.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff_boyd.json
@@ -14,6 +14,364 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "hull_health": 3947100.0,
+  "hull_parts": [
+    {
+      "name": "M_Body",
+      "health": 918000.0,
+      "category": "vital"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Top_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Mesh_DET_Rear_Aileron_Fin_Bot_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Underside_Plate",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Right",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_AirbrakePanel_Bot_Left",
+      "health": 10000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Mesh_DET_Airbrake_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_L_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Body_LG_Front_Hatch_rear_R_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Bottom_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Top_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Bottom_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Left",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Turret_Hatch_Slide_Top_Right",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Body_Side_Panel_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Rear",
+      "health": 720000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Right",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Rear_Vent_Left",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Neck_Front",
+      "health": 440000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Nose_Top_Cover_Panel",
+      "health": 2500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Right",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Nose_Side_Detail_Left",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Topside_Cover_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Side_Plate_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Hatch_Static",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_04_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_03_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_02_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_EscPod_01_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Tip_Left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Neck_Front_Aileron_Rotator_Left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Nose",
+      "health": 220000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_Rear",
+      "health": 1200000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Top_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Top_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rear_DET_Mesh_Thruster_Cap_Top_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Top_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Right",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Right",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Right",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Base_Bot_Left",
+      "health": 45000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Cap_Bot_Left",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Rear_Mesh_Thruster_Fin_Tip_Bot_Left",
+      "health": 1000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Left",
+      "health": 60000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "M_DET_Mesh_Thruster_Housing_Middle_Right",
+      "health": 60000.0,
+      "category": "breakable"
+    }
+  ],
   "metrics": {
     "x": 87.0,
     "y": 181.0,

--- a/data/sc_data/parsed/live/models/rsi_salvation.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "hull_health": 5503.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_cockpit_door_down",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_door_up_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_salvage_tanker",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.5,
     "y": 14.5,

--- a/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "hull_health": 5503.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_cockpit_door_down",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_door_up_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_salvage_tanker",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.5,
     "y": 14.5,

--- a/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_crim.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "hull_health": 5503.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_cockpit_door_down",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_door_up_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_salvage_tanker",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.5,
     "y": 14.5,

--- a/data/sc_data/parsed/live/models/rsi_salvation_template.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_template.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "333"
   },
   "mass": 62245.0,
+  "hull_health": 5503.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2400.0,
+      "category": "vital"
+    },
+    {
+      "name": "geo_cockpit_door_down",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "geo_cockpit_door_up_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_salvage_tanker",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_right",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_upper_wing",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_right_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_left_lower_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_guard_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_rear_plate_left",
+      "health": 400.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_left_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_front_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "dbr_back_right_wing",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 18.0,
     "y": 8.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_civ.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_crim.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_unmanned_salvage.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_civ.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim_distortion.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim_distortion.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_uee.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_stealth.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_unmanned_salvage.json
@@ -14,6 +14,114 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "hull_health": 43660.0,
+  "hull_parts": [
+    {
+      "name": "Body",
+      "health": 6500.0,
+      "category": "vital"
+    },
+    {
+      "name": "Tail",
+      "health": 6500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Retractor_Top_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Right",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Right",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Right",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Right",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Bottom_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Bottom_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Bottom_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Mechanism_Top_Left",
+      "health": 3500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Retractor_Top_Left",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Rotator_Top_Left",
+      "health": 2200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Rotator_Top_Tip_Left",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_turret",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Canopy_Front",
+      "health": 80.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Canopy_Rear",
+      "health": 80.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 12667.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 12667.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
@@ -14,6 +14,89 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "hull_health": 25200.0,
+  "hull_parts": [
+    {
+      "name": "RSI_Ursa_Rover",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Body",
+      "health": 13000.0,
+      "category": "vital"
+    },
+    {
+      "name": "wheel1",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel1_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel1_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel2_center",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel2_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel3",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel3_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel4",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel4_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel5",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel5_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wheel6",
+      "health": 1500.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheel6_mudguard",
+      "health": 150.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_ai_template.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_collector_indust.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_collector_indust.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ_def.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_ai_template.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_collector_indust.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_collector_indust.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_civ.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_crim.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned_salvage.json
@@ -14,6 +14,49 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "hull_health": 32000.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 15000.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 9000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "bar_left_debris",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_top_left_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_top_right_debris",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_left_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wing_bottom_right_debris",
+      "health": 1200.0,
+      "category": "secondary"
+    },
+    {
+      "name": "bar_right_debris",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 35.0,
     "y": 46.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "1345"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "1605"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "1135"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "hull_health": 6910.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Cyclone",
+      "health": 1500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wheelFL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelFR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBR",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "wheelBL",
+      "health": 800.0,
+      "category": "secondary"
+    },
+    {
+      "name": "body",
+      "health": 2000.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_armor_plating_left",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_bl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fl",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mud_flap_fr",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_armor_plating_right",
+      "health": 50.0,
+      "category": "breakable"
+    },
+    {
+      "name": "mud_flap_br",
+      "health": 25.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hood",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "livery_decal",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_livery_decal",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_decals",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$lod1_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod2_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod3_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod4_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$lod5_body_decals",
+      "health": 1.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_nova.json
+++ b/data/sc_data/parsed/live/models/tmbl_nova.json
@@ -14,6 +14,134 @@
     "base_expediting_fee": "7398"
   },
   "mass": 73190.0,
+  "hull_health": 127600.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Nova",
+      "health": 40000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_mesh",
+      "health": 40000.0,
+      "category": "vital"
+    },
+    {
+      "name": "hardpoint_drive_sprocket_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_small_right",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_drive_sprocket_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_small_left",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "primary_turret_debris",
+      "health": 30000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "hardpoint_wheel_right_07",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_06",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_05",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_04",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_03",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_02",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_01",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_07",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_06",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_05",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_04",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_03",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_02",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_01",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_hidden_rear_09",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_left_hidden_front_08",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_hidden_front_08",
+      "health": 800.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_right_hidden_rear_09",
+      "health": 800.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 12.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/tmbl_storm.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm.json
@@ -14,6 +14,339 @@
     "base_expediting_fee": "1730"
   },
   "mass": 54230.0,
+  "hull_health": 115600.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Storm",
+      "health": 35000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 27000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tread_cover_FL",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Component_Door_FL_Back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FL_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_front_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_front_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_RL",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "component_door_RL_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_RL_back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_a_rear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_b_rear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_RR",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "component_door_RR_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_RR_back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_shield_a_back_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_shield_b_rear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_FR",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "blast_plate_front_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FR_Back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FR_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_front_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_rear_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_rear_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_00",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_014",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_014",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_013",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_013",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_12",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_11",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_01",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_08",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_04",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_02",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_12",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_00",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_11",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_08",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_01",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_04",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_02",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_gap1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_gap1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_gap2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_gap2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_center2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_center1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_center2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_center1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_bumper_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_bumper_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_hidden2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_hidden2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_body_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_body_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_body_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_body_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.25,
     "y": 7.65,

--- a/data/sc_data/parsed/live/models/tmbl_storm_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm_aa.json
@@ -14,6 +14,339 @@
     "base_expediting_fee": "1740"
   },
   "mass": 54230.0,
+  "hull_health": 115600.0,
+  "hull_parts": [
+    {
+      "name": "TMBL_Storm",
+      "health": 35000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body",
+      "health": 27000.0,
+      "category": "vital"
+    },
+    {
+      "name": "tread_cover_FL",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Component_Door_FL_Back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FL_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_front_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_front_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_RL",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "component_door_RL_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_RL_back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_a_rear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_b_rear_left",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_RR",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "component_door_RR_front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_RR_back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_shield_a_back_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_shield_b_rear_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tread_cover_FR",
+      "health": 5000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "blast_plate_front_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FR_Back",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Component_Door_FR_Front",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_front_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_rear_left",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "component_door_rear_right",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_00",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_014",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_014",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_013",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_013",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_12",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_11",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_01",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_08",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_hidden",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_04",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_02",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_12",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_00",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_11",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_08",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_06",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_01",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_04",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_02",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_gap1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_gap1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_gap2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_gap2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_center2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_center1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_right_center2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_left_center1",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_bumper_left",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_front_bumper_right",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_left_hidden2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_wheel_rear_right_hidden2",
+      "health": 700.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_body_right",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_body_left",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "radar_detail_body_right",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "blast_plate_body_left",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 10.25,
     "y": 7.65,

--- a/data/sc_data/parsed/live/models/vncl_blade.json
+++ b/data/sc_data/parsed/live/models/vncl_blade.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "hull_health": 7950.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Belly",
+      "health": 750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rib1_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib1_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.5,

--- a/data/sc_data/parsed/live/models/vncl_blade_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_ai_defendship.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "hull_health": 7950.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Belly",
+      "health": 750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rib1_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib1_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.5,

--- a/data/sc_data/parsed/live/models/vncl_blade_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_pu_ai_van.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "hull_health": 7950.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Belly",
+      "health": 750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rib1_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib1_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.5,

--- a/data/sc_data/parsed/live/models/vncl_blade_swarm.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_swarm.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "hull_health": 7950.0,
+  "hull_parts": [
+    {
+      "name": "Nose",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "Spoiler",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Left_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Belly",
+      "health": 750.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Rib1_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Right",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib7_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib6_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib5_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib4_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib3_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib2_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Rib1_Left",
+      "health": 50.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right",
+      "health": 700.0,
+      "category": "secondary"
+    },
+    {
+      "name": "Wing_Right_Tip",
+      "health": 275.0,
+      "category": "secondary"
+    }
+  ],
   "metrics": {
     "x": 16.5,
     "y": 20.5,

--- a/data/sc_data/parsed/live/models/vncl_glaive.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_ai_defendship.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_ea_ai_van_prime.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_ea_ai_van_prime.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_pu_ai_van.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler.json
@@ -14,6 +14,469 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "hull_health": 5370010.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "bottom_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_front",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bottom_antenas_e",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_left_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_upper_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_lower_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_upper_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_lower_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_03",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_rear",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_3",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_left_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_right",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_01",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_right_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_left_01",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_arm_left_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_right_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_03",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_04",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_03",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_04",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 125.0,
     "y": 425.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler_ai.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler_ai.json
@@ -14,6 +14,469 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "hull_health": 5370010.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "bottom_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_front",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bottom_antenas_e",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_left_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_upper_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_lower_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_upper_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_lower_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_03",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_rear",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_3",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_left_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_right",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_01",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_right_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_left_01",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_arm_left_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_right_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_03",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_04",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_03",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_04",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 125.0,
     "y": 425.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler_pu_ai_van.json
@@ -14,6 +14,469 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "hull_health": 5370010.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 5000000.0,
+      "category": "vital"
+    },
+    {
+      "name": "bottom_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_front",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "bottom_antenas_e",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_bottom_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_antenas_c",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_antenas_b",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_a",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_antenas_d",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_left_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_left_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_left_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right_spike",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_front_right_tip",
+      "health": 3000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_rear_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_upper_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_left_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_rear_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rear_lower_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_right_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_upper_right",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_01",
+      "health": 8000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_upper_right_spike",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rear_lower_left",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_01",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_wing_rear_lower_left_02",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_left_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_rear_right_tip",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_01",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_02",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_top_chunk_03",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_left",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_rear",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_underside_plate_right",
+      "health": 2000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_3",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_left_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_left_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_left_addon",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_top_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_right",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_01",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_right_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_right_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_right_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_arm_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_arm_left_01",
+      "health": 50000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_arm_spike_02",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_01",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_03",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_left_arm_spike_04",
+      "health": 5000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_front_arm_left_02",
+      "health": 10000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "debris_front_left_antenas",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_05",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_06",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "body_side_right_mid_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_side_right_mid_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_03",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_left_04",
+      "health": 8000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_02",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_01",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_03",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "debris_body_side_right_04",
+      "health": 6000.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_1",
+      "health": 500.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_right_addon_2",
+      "health": 500.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 125.0,
     "y": 425.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_alpha.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_alpha.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_hunter.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_hunter.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_defendship.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_van.json
@@ -14,6 +14,159 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "hull_health": 11701.0,
+  "hull_parts": [
+    {
+      "name": "nose",
+      "health": 4000.0,
+      "category": "vital"
+    },
+    {
+      "name": "body",
+      "health": 4000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 480.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_arm",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_gun",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailA",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailB",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailC",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_blade",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_rightA_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_rightA_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_lock",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherA_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherB_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherB_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherC_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherC_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tailD_featherD_hinge",
+      "health": 1.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tailD_featherD_end",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "landing_gear_rear_cover",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 24.0,
     "y": 33.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_civ.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_crim.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_vandull.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_vandull.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_defendship.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_van.json
@@ -14,6 +14,174 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "hull_health": 47314.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 12500.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 2000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_left_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_left_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "hardpoint_vehicle_destroyed",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_comp_lower_hatch",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_01_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_02_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_rear_03_left",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right",
+      "health": 8500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_spike",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip",
+      "health": 6000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_right_tip_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_blade_mid",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "mesh_lg_door_front_right",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_01",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_02",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_tip_spike_03",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_outer",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_inner",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "wing_right_blade_rear",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 32.0,
     "y": 36.0,

--- a/data/sc_data/parsed/live/models/xian_nox.json
+++ b/data/sc_data/parsed/live/models/xian_nox.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "hull_health": 2231.0,
+  "hull_parts": [
+    {
+      "name": "body_back",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_nacelle_l",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_l",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_nacelle_r",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_r",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 120.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "front_cowling",
+      "health": 225.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.32,
     "y": 1.45,

--- a/data/sc_data/parsed/live/models/xian_nox_collector_mod.json
+++ b/data/sc_data/parsed/live/models/xian_nox_collector_mod.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "hull_health": 2231.0,
+  "hull_parts": [
+    {
+      "name": "body_back",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_nacelle_l",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_l",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_nacelle_r",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_r",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 120.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "front_cowling",
+      "health": 225.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.32,
     "y": 1.45,

--- a/data/sc_data/parsed/live/models/xian_nox_kue.json
+++ b/data/sc_data/parsed/live/models/xian_nox_kue.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "hull_health": 2231.0,
+  "hull_parts": [
+    {
+      "name": "body_back",
+      "health": 400.0,
+      "category": "vital"
+    },
+    {
+      "name": "rear_nacelle_l",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_l",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "rear_nacelle_r",
+      "health": 320.0,
+      "category": "breakable"
+    },
+    {
+      "name": "$physics_proxy_rear_nacelle_r",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "body_front",
+      "health": 120.0,
+      "category": "vital"
+    },
+    {
+      "name": "nose",
+      "health": 440.0,
+      "category": "vital"
+    },
+    {
+      "name": "front_cowling",
+      "health": 225.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_nose",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_front",
+      "health": 1.0,
+      "category": "subpart"
+    },
+    {
+      "name": "$physics_proxy_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    },
+    {
+      "name": "DMG_body_back",
+      "health": 200.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 1.32,
     "y": 1.45,

--- a/data/sc_data/parsed/live/models/xian_scout.json
+++ b/data/sc_data/parsed/live/models/xian_scout.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xian_scout_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/xian_scout_pu_ai_civ.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xian_scout_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/xian_scout_pu_ai_crim.json
@@ -14,6 +14,119 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "hull_health": 14100.0,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 2150.0,
+      "category": "vital"
+    },
+    {
+      "name": "body_nose",
+      "health": 2150.0,
+      "category": "breakable"
+    },
+    {
+      "name": "cockpit_rim",
+      "health": 1600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "sub_frame",
+      "health": 2000.0,
+      "category": "secondary"
+    },
+    {
+      "name": "small_wing_left",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "small_wing_right",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Right_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Upper",
+      "health": 300.0,
+      "category": "subpart"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Shoulder",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Elbow",
+      "health": 300.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower_Thruster_Housing",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "Wing_Left_Lower",
+      "health": 300.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 13.5,
     "y": 32.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "hull_health": 10975.880000000001,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3675.88,
+      "category": "vital"
+    },
+    {
+      "name": "ejection_mesh_top",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_item_tray_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_item_tray_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_ai_defendship.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "hull_health": 10975.880000000001,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3675.88,
+      "category": "vital"
+    },
+    {
+      "name": "ejection_mesh_top",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_item_tray_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_item_tray_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_civ.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "hull_health": 10975.880000000001,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3675.88,
+      "category": "vital"
+    },
+    {
+      "name": "ejection_mesh_top",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_item_tray_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_item_tray_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_crim.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "hull_health": 10975.880000000001,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3675.88,
+      "category": "vital"
+    },
+    {
+      "name": "ejection_mesh_top",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_item_tray_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_item_tray_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 24.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_unmanned_salvage.json
@@ -14,6 +14,79 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "hull_health": 10975.880000000001,
+  "hull_parts": [
+    {
+      "name": "body",
+      "health": 3675.88,
+      "category": "vital"
+    },
+    {
+      "name": "ejection_mesh_top",
+      "health": 100.0,
+      "category": "subpart"
+    },
+    {
+      "name": "tail_left",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_left",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_left",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_bottom_right",
+      "health": 1000.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_bottom_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wings_rotator_top_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "wing_front_right",
+      "health": 500.0,
+      "category": "breakable"
+    },
+    {
+      "name": "tail_right",
+      "health": 600.0,
+      "category": "breakable"
+    },
+    {
+      "name": "front_item_tray_door_left",
+      "health": 250.0,
+      "category": "subpart"
+    },
+    {
+      "name": "front_item_tray_door_right",
+      "health": 250.0,
+      "category": "subpart"
+    }
+  ],
   "metrics": {
     "x": 23.0,
     "y": 24.0,

--- a/db/migrate/20260724085043_add_hull_health_to_models.rb
+++ b/db/migrate/20260724085043_add_hull_health_to_models.rb
@@ -1,0 +1,5 @@
+class AddHullHealthToModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :models, :hull_health, :decimal, precision: 15, scale: 2
+  end
+end

--- a/db/migrate/20260728180221_add_hull_parts_to_models.rb
+++ b/db/migrate/20260728180221_add_hull_parts_to_models.rb
@@ -1,0 +1,5 @@
+class AddHullPartsToModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :models, :hull_parts, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_24_085043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -714,6 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_120000) do
     t.decimal "height", precision: 15, scale: 2, default: "0.0", null: false
     t.boolean "hidden", default: true
     t.boolean "holo_colored", default: false
+    t.decimal "hull_health", precision: 15, scale: 2
     t.decimal "hydrogen_fuel_tank_size", precision: 15, scale: 2
     t.string "hydrogen_fuel_tanks"
     t.integer "images_count", default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_085043) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_28_180221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -715,6 +715,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_085043) do
     t.boolean "hidden", default: true
     t.boolean "holo_colored", default: false
     t.decimal "hull_health", precision: 15, scale: 2
+    t.jsonb "hull_parts"
     t.decimal "hydrogen_fuel_tank_size", precision: 15, scale: 2
     t.string "hydrogen_fuel_tanks"
     t.integer "images_count", default: 0

--- a/docs/exec-plans/loadout-dps-calculator.md
+++ b/docs/exec-plans/loadout-dps-calculator.md
@@ -1,0 +1,55 @@
+# Loadout DPS Calculator
+
+Goal: build toward an in-app DPS / loadout calculator comparable to erkul.games and
+spviewer.eu, which today are only linked to externally from the hardpoints view.
+
+## Context / current state
+
+The raw combat data is already imported from extracted game files and exposed on the
+API:
+
+- `useModelHardpoints(slug, { source })` returns a flat `Hardpoint[]`, each with
+  `category`, `group`, `component.typeData`, and nested `hardpoints[]` (turret guns).
+- `ComponentWeapon.typeData`: `damagePerShot` / `damagePerSecond` (per damage type:
+  physical/energy/distortion/thermal/biochemical/stun), `fireRate` (rounds **per
+  minute** — S9 cannon = 60), `pelletsPerShot`, `speed`, `range`, `beam`.
+- Per-component stats already render in `Models/Hardpoints/Details/index.vue`.
+- `number.json` already defines a `dps` format (`"%{count} DPS"`).
+
+What's missing (see the full gap analysis): a calculation/aggregation layer, aggregate
+UI, a real per-hardpoint picker + persistence, and ship hull HP for EHP/TTK.
+
+## This slice: read-only aggregate DPS panel (frontend-only)
+
+No backend, no migration, no new API. Aggregate the **default-equipped** components
+already returned by `useModelHardpoints` and display headline combat numbers on the
+ship page, reflecting the existing game-files / ship-matrix source toggle.
+
+### Steps
+
+1. **`composables/useLoadoutStats.ts`** — pure rollup over `Hardpoint[]`.
+   - Recursively collect weapon hardpoints (`category === WEAPONS`) with a component.
+   - Classify each `ComponentWeapon`:
+     - beam (`beam && damagePerSecond`) → contributes to sustained DPS only.
+     - projectile (`fireRate && damagePerShot`, not beam) → alpha = `Σ perShot ×
+       pellets`; DPS = `alpha × fireRate / 60`.
+     - missile (has `trackingSignal`, no `fireRate`) → excluded in v1 (one-shot; note
+       as follow-up).
+   - Output `dps` and `alpha` as `{ total, physical, energy, distortion, thermal }`,
+     plus `weaponCount` and `hasData`.
+2. **`useLoadoutStats.spec.ts`** — vitest unit test with synthetic hardpoints
+   (projectile + beam + nested turret gun) asserting the arithmetic.
+3. **`components/Models/CombatMetrics/index.vue`** — mirrors `BaseMetrics` styling;
+   renders total DPS, alpha, and per-damage-type split. Renders only when
+   `weaponCount > 0`.
+4. **Mount** in `Models/Hardpoints/new.vue` (owns hardpoints + source toggle) so it
+   tracks the selected source.
+5. **i18n** — add `labels.metrics.combat` and a `labels.combat.*` block (en).
+
+### Explicitly deferred
+
+- Missiles, gimbal/convergence, spread/recoil.
+- Sustained-vs-burst power/heat budget simulation.
+- EHP / TTK (needs ship hull HP import — absent on `Model`).
+- Interactive per-hardpoint picker + persistence to `VehicleLoadoutHardpoint`.
+- Loadout-vs-loadout comparison.

--- a/docs/exec-plans/loadout-dps-calculator.md
+++ b/docs/exec-plans/loadout-dps-calculator.md
@@ -3,53 +3,80 @@
 Goal: build toward an in-app DPS / loadout calculator comparable to erkul.games and
 spviewer.eu, which today are only linked to externally from the hardpoints view.
 
-## Context / current state
+Branch: `feat/loadout-dps-readonly`.
 
-The raw combat data is already imported from extracted game files and exposed on the
-API:
+## Data foundation (already imported from extracted game files)
 
 - `useModelHardpoints(slug, { source })` returns a flat `Hardpoint[]`, each with
   `category`, `group`, `component.typeData`, and nested `hardpoints[]` (turret guns).
 - `ComponentWeapon.typeData`: `damagePerShot` / `damagePerSecond` (per damage type:
   physical/energy/distortion/thermal/biochemical/stun), `fireRate` (rounds **per
-  minute** — S9 cannon = 60), `pelletsPerShot`, `speed`, `range`, `beam`.
-- Per-component stats already render in `Models/Hardpoints/Details/index.vue`.
-- `number.json` already defines a `dps` format (`"%{count} DPS"`).
+  minute**), `pelletsPerShot`, `speed`, `range`, `beam`.
+- `ComponentShield.typeData`: `maxHealth`, `maxRegen`, per-type `resistance.{type}.max`.
+- Hull HP: **not** in the Foundry Records entity (`SHealthComponentParams.Health` is a
+  placeholder). It lives in the CryEngine vehicle implementation XML at
+  `Data/Scripts/Entities/Vehicles/Implementations/Xml/<ship>.xml`, referenced by the
+  entity's `VehicleComponentParams.vehicleDefinition`, as `<Part damageMax>` per part.
+  `vehicleHullDamageNormalizationValue` is a damage-normalization constant, **not** hull
+  HP (600i: 55k vs real 197k) — do not use it.
 
-What's missing (see the full gap analysis): a calculation/aggregation layer, aggregate
-UI, a real per-hardpoint picker + persistence, and ship hull HP for EHP/TTK.
+## Done
 
-## This slice: read-only aggregate DPS panel (frontend-only)
+### Read-only aggregate DPS panel (frontend-only)
+- `composables/useLoadoutStats.ts` (+ spec) — rolls up default-loadout weapons into
+  `dps` and `alpha` per damage type, plus a per-weapon list. Recurses into turrets;
+  excludes missiles.
+- `components/Models/CombatMetrics/index.vue` — hero tiles (total DPS, alpha, weapon
+  count), damage-composition bar with hover-isolate, animated collapsible per-weapon
+  table (`Collapsed`).
+- Note: our DPS = alpha × fireRate/60 = erkul **burst** DPS (theoretical max fire
+  rate), labelled "burst". We do **not** model heat/power throttling, so we don't
+  produce erkul's lower "sustained" number.
 
-No backend, no migration, no new API. Aggregate the **default-equipped** components
-already returned by `useModelHardpoints` and display headline combat numbers on the
-ship page, reflecting the existing game-files / ship-matrix source toggle.
+### Survivability card (frontend + backend)
+- `composables/useShieldStats.ts` (+ spec) — total shield HP, regen, HP-weighted
+  per-type resistances from default-loadout shields.
+- `components/Models/SurvivabilityMetrics/index.vue` — shield HP + hull HP tiles,
+  resistance bars.
+- Shared frame extracted to `components/Models/metricsCard.scss`.
 
-### Steps
+### Hull HP end-to-end pipeline
+- Parser `ScData::Parser::ModelsParser#extract_hull_health` sums `<Part damageMax>`
+  from the implementation XML → `hull_health` on parsed model JSON (regenerated).
+- Migration `add hull_health` + `ModelsLoader` maps it.
+- API: `hullHealth` on the model metrics schema + jbuilder (omitted when absent).
+- Validated vs erkul within patch tolerance (600i 198,500 vs 197,250; 211/245 models
+  populated — the rest have no implementation XML).
 
-1. **`composables/useLoadoutStats.ts`** — pure rollup over `Hardpoint[]`.
-   - Recursively collect weapon hardpoints (`category === WEAPONS`) with a component.
-   - Classify each `ComponentWeapon`:
-     - beam (`beam && damagePerSecond`) → contributes to sustained DPS only.
-     - projectile (`fireRate && damagePerShot`, not beam) → alpha = `Σ perShot ×
-       pellets`; DPS = `alpha × fireRate / 60`.
-     - missile (has `trackingSignal`, no `fireRate`) → excluded in v1 (one-shot; note
-       as follow-up).
-   - Output `dps` and `alpha` as `{ total, physical, energy, distortion, thermal }`,
-     plus `weaponCount` and `hasData`.
-2. **`useLoadoutStats.spec.ts`** — vitest unit test with synthetic hardpoints
-   (projectile + beam + nested turret gun) asserting the arithmetic.
-3. **`components/Models/CombatMetrics/index.vue`** — mirrors `BaseMetrics` styling;
-   renders total DPS, alpha, and per-damage-type split. Renders only when
-   `weaponCount > 0`.
-4. **Mount** in `Models/Hardpoints/new.vue` (owns hardpoints + source toggle) so it
-   tracks the selected source.
-5. **i18n** — add `labels.metrics.combat` and a `labels.combat.*` block (en).
+### Layout
+- Combat + survivability cards sit in a two-column row at the top of the hardpoints
+  section (`Models/Hardpoints/new.vue`).
 
-### Explicitly deferred
+## Still missing / next slices
 
-- Missiles, gimbal/convergence, spread/recoil.
-- Sustained-vs-burst power/heat budget simulation.
-- EHP / TTK (needs ship hull HP import — absent on `Model`).
-- Interactive per-hardpoint picker + persistence to `VehicleLoadoutHardpoint`.
-- Loadout-vs-loadout comparison.
+1. **Per-part hull exposure** — we only expose the total. erkul shows each part
+   (name, HP) and a vital / secondary / breakable / subpart classification. Parts and
+   `damageMax` are available in the implementation XML; the class split needs more
+   digging into the part damage-behavior data. Would need a `hull_parts` store
+   (jsonb column or table), API array, and a breakdown UI.
+2. **EHP / time-to-kill** — combine shield HP (× resistances) + hull HP into an
+   effective-HP / TTK-vs-a-loadout figure. Now unblocked by hull HP.
+3. **Sustained DPS** — model power draw vs power-plant output and heat vs cooler
+   capacity to derive erkul's throttled sustained DPS (currently burst only).
+4. **Interactive per-hardpoint picker + persistence** — swap components per slot and
+   recompute; persist to the existing `VehicleLoadoutHardpoint` table (schema ready).
+5. **Loadout-vs-loadout / ship-vs-ship combat comparison** — extend `compare.vue`.
+6. **Weapon detail gaps** — spread/recoil and projectile falloff aren't imported, so
+   effective-DPS-at-range can't be computed yet. Missiles and gimbal/convergence
+   deferred.
+7. **i18n** — only `en` has the new `labels.combat.*` / `labels.survivability.*` keys
+   and the `dps` number format; other locales fall back to English.
+
+## Verification / ops notes
+
+- Tests: `pnpm vitest run app/frontend/frontend/composables/*.spec.ts` (loadout +
+  shield stats).
+- Regenerating hull HP after a game-data version bump: rerun `ModelsParser#all` (writes
+  `data/sc_data/parsed/.../models`), then `ScData::Loader::ModelsLoader#all`.
+- After schema changes: `./bin/generate-schema` (regenerates swagger + orval client),
+  then format + lint.

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -9541,6 +9541,8 @@ components:
               type: number
             massLabel:
               type: string
+            hullHealth:
+              type: number
             quantumFuelTankSize:
               type: number
             size:
@@ -9963,6 +9965,8 @@ components:
               type: number
             massLabel:
               type: string
+            hullHealth:
+              type: number
             quantumFuelTankSize:
               type: number
             size:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -9543,6 +9543,27 @@ components:
               type: string
             hullHealth:
               type: number
+            hullParts:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  health:
+                    type: number
+                  category:
+                    type: string
+                    enum:
+                    - vital
+                    - secondary
+                    - breakable
+                    - subpart
+                required:
+                - name
+                - health
+                - category
+                additionalProperties: false
             quantumFuelTankSize:
               type: number
             size:
@@ -9967,6 +9988,27 @@ components:
               type: string
             hullHealth:
               type: number
+            hullParts:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  health:
+                    type: number
+                  category:
+                    type: string
+                    enum:
+                    - vital
+                    - secondary
+                    - breakable
+                    - subpart
+                required:
+                - name
+                - health
+                - category
+                additionalProperties: false
             quantumFuelTankSize:
               type: number
             size:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10300,6 +10300,27 @@ components:
               type: string
             hullHealth:
               type: number
+            hullParts:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  health:
+                    type: number
+                  category:
+                    type: string
+                    enum:
+                    - vital
+                    - secondary
+                    - breakable
+                    - subpart
+                required:
+                - name
+                - health
+                - category
+                additionalProperties: false
             quantumFuelTankSize:
               type: number
             size:
@@ -10606,6 +10627,27 @@ components:
               type: string
             hullHealth:
               type: number
+            hullParts:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  health:
+                    type: number
+                  category:
+                    type: string
+                    enum:
+                    - vital
+                    - secondary
+                    - breakable
+                    - subpart
+                required:
+                - name
+                - health
+                - category
+                additionalProperties: false
             quantumFuelTankSize:
               type: number
             size:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10298,6 +10298,8 @@ components:
               type: number
             massLabel:
               type: string
+            hullHealth:
+              type: number
             quantumFuelTankSize:
               type: number
             size:
@@ -10602,6 +10604,8 @@ components:
               type: number
             massLabel:
               type: string
+            hullHealth:
+              type: number
             quantumFuelTankSize:
               type: number
             size:

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -30,6 +30,7 @@
 #  height                            :decimal(15, 2)   default(0.0), not null
 #  hidden                            :boolean          default(TRUE)
 #  holo_colored                      :boolean          default(FALSE)
+#  hull_health                       :decimal(15, 2)
 #  hydrogen_fuel_tank_size           :decimal(15, 2)
 #  hydrogen_fuel_tanks               :string
 #  images_count                      :integer          default(0)

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -31,6 +31,7 @@
 #  hidden                            :boolean          default(TRUE)
 #  holo_colored                      :boolean          default(FALSE)
 #  hull_health                       :decimal(15, 2)
+#  hull_parts                        :jsonb
 #  hydrogen_fuel_tank_size           :decimal(15, 2)
 #  hydrogen_fuel_tanks               :string
 #  images_count                      :integer          default(0)


### PR DESCRIPTION
## What

Adds read-only **combat** and **survivability** panels to the ship page's hardpoints section — a first step toward an in-app erkul.games / spviewer.eu equivalent, which we currently only link out to. Everything is computed from the ship's **default loadout** (the components the hardpoints API already returns).

### Combat card
- Total DPS, alpha strike, weapon count
- Damage-composition bar (physical / energy / distortion / thermal) with hover-isolate
- Animated collapsible per-weapon breakdown
- Powered by `useLoadoutStats` (recurses turrets, excludes missiles)
- ⚠️ Our DPS = `alpha × fireRate/60` = erkul's **burst** DPS (theoretical max fire rate). We don't model heat/power throttling, so it's labelled "burst", not "sustained".

### Survivability card
- Shield HP + regen + HP-weighted resistances (`useShieldStats`)
- **Hull HP** tile

### Hull HP pipeline (new game-file extraction)
Hull HP is **not** in the Foundry Records entity (`SHealthComponentParams.Health` is a placeholder, and `vehicleHullDamageNormalizationValue` is a normalization constant, not HP). It's the sum of `<Part damageMax>` in the CryEngine vehicle **implementation XML** (`Data/Scripts/Entities/Vehicles/Implementations/Xml/<ship>.xml`), referenced by the entity's `vehicleDefinition`.

- Parser: `ModelsParser#extract_hull_health`
- Migration `hull_health` column + `ModelsLoader` mapping
- API: `hullHealth` on model metrics (omitted when a ship has no implementation XML)
- Validated vs erkul within patch tolerance — **600i: 198,500 vs erkul 197,250**; 211/245 in-game models populated

## Notes
- Regenerated parsed model JSON (958 files, each `+hull_health`) and the swagger schema.
- Shared card frame extracted to `Models/metricsCard.scss`.
- Tests: `useLoadoutStats.spec.ts` + `useShieldStats.spec.ts` (11 cases). eslint / vue-tsc / standardrb clean.

## Still open (see `docs/exec-plans/loadout-dps-calculator.md`)
Per-part hull exposure (vital/secondary/breakable), EHP/TTK, sustained-DPS (power/heat sim), interactive per-hardpoint picker + persistence, loadout comparison, non-`en` i18n.

🤖