### PR TITLE
feat: EHP & time-to-kill on the survivability card

### DIFF
--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -42,12 +42,26 @@ const hasData = computed(() => stats.value.hasData || hasHull.value);
 // `1 / (1 - resistance)` more of that type before the hull is exposed. Distortion
 // is excluded — it downs shields rather than destroying the hull.
 const EHP_TYPES = [
-  { key: "physical", label: "labels.survivability.resistancePhysical", color: "#c8c8c8" },
-  { key: "energy", label: "labels.survivability.resistanceEnergy", color: "#428bca" },
-  { key: "thermal", label: "labels.survivability.resistanceThermal", color: "#fa6800" },
+  {
+    key: "physical",
+    label: "labels.survivability.resistancePhysical",
+    color: "#c8c8c8",
+  },
+  {
+    key: "energy",
+    label: "labels.survivability.resistanceEnergy",
+    color: "#428bca",
+  },
+  {
+    key: "thermal",
+    label: "labels.survivability.resistanceThermal",
+    color: "#fa6800",
+  },
 ];
 
-const combinedHp = computed(() => (props.hullHealth ?? 0) + stats.value.totalHp);
+const combinedHp = computed(
+  () => (props.hullHealth ?? 0) + stats.value.totalHp,
+);
 
 const effectiveHp = computed(() => {
   if (combinedHp.value <= 0) return [];

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -35,6 +35,33 @@ const hoveredCategory = ref<string | null>(null);
 const hasHull = computed(() => (props.hullHealth ?? 0) > 0);
 const hasData = computed(() => stats.value.hasData || hasHull.value);
 
+// Combined survivability pool (shield HP + hull HP), and the resistance-adjusted
+// effective HP against each hull-lethal damage type: shields absorb
+// `1 / (1 - resistance)` more of that type before the hull is exposed. Distortion
+// is excluded — it downs shields rather than destroying the hull.
+const EHP_TYPES = [
+  { key: "physical", label: "labels.survivability.resistancePhysical", color: "#c8c8c8" },
+  { key: "energy", label: "labels.survivability.resistanceEnergy", color: "#428bca" },
+  { key: "thermal", label: "labels.survivability.resistanceThermal", color: "#fa6800" },
+];
+
+const combinedHp = computed(() => (props.hullHealth ?? 0) + stats.value.totalHp);
+
+const effectiveHp = computed(() => {
+  if (combinedHp.value <= 0) return [];
+
+  const hull = props.hullHealth ?? 0;
+  const shield = stats.value.totalHp;
+  const resistance = Object.fromEntries(
+    stats.value.resistances.map((entry) => [entry.key, entry.value]),
+  );
+
+  return EHP_TYPES.map(({ key, label, color }) => {
+    const value = Math.min(resistance[key] ?? 0, 0.95);
+    return { key, label, color, value: hull + shield / (1 - value) };
+  });
+});
+
 const CATEGORY_ORDER = ["vital", "secondary", "breakable", "subpart"] as const;
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -86,10 +113,19 @@ const humanizePart = (name: string) =>
 
     <div class="metrics-card__body">
       <div class="metrics-card__hero">
-        <div
-          v-if="stats.hasData"
-          class="metrics-card__tile metrics-card__tile--primary"
-        >
+        <div class="metrics-card__tile metrics-card__tile--primary">
+          <div class="metrics-card__tile__label">
+            {{ t("labels.survivability.totalHp") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(round(combinedHp), "integer") }}
+            <span class="metrics-card__tile__unit">HP</span>
+          </div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.survivability.totalHpSub") }}
+          </div>
+        </div>
+        <div v-if="stats.hasData" class="metrics-card__tile">
           <div class="metrics-card__tile__label">
             {{ t("labels.survivability.shieldHp") }}
           </div>
@@ -102,11 +138,7 @@ const humanizePart = (name: string) =>
             {{ toNumber(stats.shieldCount, "integer") }}×
           </div>
         </div>
-        <div
-          v-if="hasHull"
-          class="metrics-card__tile"
-          :class="{ 'metrics-card__tile--primary': !stats.hasData }"
-        >
+        <div v-if="hasHull" class="metrics-card__tile">
           <div class="metrics-card__tile__label">
             {{ t("labels.survivability.hullHp") }}
           </div>
@@ -119,6 +151,21 @@ const humanizePart = (name: string) =>
           </div>
         </div>
       </div>
+
+      <template v-if="effectiveHp.length">
+        <div class="metrics-card__section-label">
+          {{ t("labels.survivability.effectiveHp") }}
+        </div>
+        <div class="ehp">
+          <div v-for="entry in effectiveHp" :key="entry.key" class="ehp__item">
+            <span class="ehp__swatch" :style="{ background: entry.color }" />
+            <span class="ehp__label">{{ t(entry.label) }}</span>
+            <span class="ehp__value">
+              {{ toNumber(round(entry.value), "integer") }}
+            </span>
+          </div>
+        </div>
+      </template>
 
       <template v-if="stats.resistances.length">
         <div class="metrics-card__section-label">
@@ -220,18 +267,51 @@ const humanizePart = (name: string) =>
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
 
-.metrics-card__hero {
-  grid-template-columns: 1.5fr 1fr;
-
-  @media (max-width: 576px) {
-    grid-template-columns: 1fr;
-  }
-}
-
 $c-physical: $text-color;
 $c-energy: $primary;
 $c-distortion: $cyan;
 $c-thermal: $warning;
+
+.ehp {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 20px;
+
+  @media (max-width: 576px) {
+    grid-template-columns: 1fr;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    background: $gray-black;
+    border: 1px solid rgba($gray-light, 0.28);
+    border-radius: 6px;
+  }
+
+  &__swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    flex: none;
+  }
+
+  &__label {
+    font-size: 12px;
+    color: $gray-light;
+    flex: 1;
+  }
+
+  &__value {
+    font-weight: 700;
+    font-size: 13px;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+  }
+}
 
 .resist {
   display: grid;

--- a/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/SurvivabilityMetrics/index.vue
@@ -10,6 +10,7 @@ import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vu
 import type { Hardpoint, ModelMetricsHullPartsItem } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useShieldStats } from "@/frontend/composables/useShieldStats";
+import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
 
 type Props = {
   hardpoints?: Hardpoint[];
@@ -26,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { t, toNumber } = useI18n();
 
 const stats = useShieldStats(() => props.hardpoints);
+const loadout = useLoadoutStats(() => props.hardpoints);
 
 const round = (value: number) => Math.round(value);
 
@@ -60,6 +62,16 @@ const effectiveHp = computed(() => {
     const value = Math.min(resistance[key] ?? 0, 0.95);
     return { key, label, color, value: hull + shield / (1 - value) };
   });
+});
+
+// Mirror-match estimate: seconds for an identical ship's own burst DPS to chew
+// through the combined HP pool. Ignores shield regen and resistances — a rough
+// "how tanky" figure, not a duel simulation.
+const ttk = computed(() => {
+  const dps = loadout.value.dps.total;
+  if (dps <= 0 || combinedHp.value <= 0) return null;
+
+  return combinedHp.value / dps;
 });
 
 const CATEGORY_ORDER = ["vital", "secondary", "breakable", "subpart"] as const;
@@ -150,6 +162,12 @@ const humanizePart = (name: string) =>
             {{ t("labels.survivability.hullHpSub") }}
           </div>
         </div>
+      </div>
+
+      <div v-if="ttk" class="ttk">
+        <span class="ttk__label">{{ t("labels.survivability.ttk") }}</span>
+        <span class="ttk__value">~{{ toNumber(round(ttk), "integer") }}s</span>
+        <span class="ttk__note">{{ t("labels.survivability.ttkSub") }}</span>
       </div>
 
       <template v-if="effectiveHp.length">
@@ -271,6 +289,47 @@ $c-physical: $text-color;
 $c-energy: $primary;
 $c-distortion: $cyan;
 $c-thermal: $warning;
+
+.ttk {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 10px 12px;
+  background: $gray-black;
+  border: 1px solid rgba($gray-light, 0.28);
+  border-radius: 6px;
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: $gray-light;
+  }
+
+  &__value {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-weight: 700;
+    font-size: 16px;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__note {
+    margin-left: auto;
+    font-size: 11px;
+    color: $gray;
+  }
+
+  @media (max-width: 576px) {
+    flex-wrap: wrap;
+
+    &__note {
+      margin-left: 0;
+    }
+  }
+}
 
 .ehp {
   display: grid;

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -596,6 +596,9 @@
       },
       "survivability": {
         "title": "Survivability",
+        "totalHp": "Total HP",
+        "totalHpSub": "shield + hull",
+        "effectiveHp": "Effective HP",
         "shieldHp": "Shield HP",
         "hullHp": "Hull HP",
         "hullHpSub": "total across all parts",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -599,6 +599,8 @@
         "totalHp": "Total HP",
         "totalHpSub": "shield + hull",
         "effectiveHp": "Effective HP",
+        "ttk": "Time to Kill",
+        "ttkSub": "vs its own guns · burst · no regen",
         "shieldHp": "Shield HP",
         "hullHp": "Hull HP",
         "hullHpSub": "total across all parts",


### PR DESCRIPTION
Stacked on #4207 (`feat/loadout-dps-readonly`) — review/merge that first.

## What

Adds effective-HP and a time-to-kill estimate to the survivability card. Frontend-only — computed from the `hullHealth` and shield data already exposed by the base branch.

### Total HP
Headline tile = shield HP + hull HP (the raw combined pool), with Shield HP and Hull HP as secondary tiles.

### Effective HP (resistance-adjusted)
Per hull-lethal damage type: `EHP = hull + shield / (1 − resist)`. Shields cut incoming damage of a type by their resistance %, so they effectively absorb more before the hull is exposed. Shown for **physical / energy / thermal**. **Distortion is excluded** — it downs shields rather than destroying the hull, so it isn't "HP to kill".

### Time to Kill (mirror match)
`combined HP ÷ the ship's own burst DPS` — a rough "how tanky" figure for an even matchup. Ignores shield regen and resistances; hidden for weaponless ships.

## Notes
- No backend/data changes — reuses the base branch's hull-HP pipeline and shield stats.
- lint / vue-tsc / composable tests green.

🤖