### PR TITLE
feat(api): type resourceAccess with dedicated enums

### DIFF
--- a/app/api_components/admin/v1/schemas/admin_user.rb
+++ b/app/api_components/admin/v1/schemas/admin_user.rb
@@ -15,7 +15,7 @@ module Admin
             twoFactorRequired: {type: :boolean},
             twoFactorQrCodeUrl: {type: :string},
             twoFactorProvisioningUrl: {type: :string},
-            resourceAccess: {type: :array, items: {type: :string}},
+            resourceAccess: {type: :array, items: {"$ref": "#/components/schemas/AdminUserResourceAccessEnum"}},
             superAdmin: {type: :boolean},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}

--- a/app/api_components/admin/v1/schemas/inputs/admin_user_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/admin_user_input.rb
@@ -15,7 +15,7 @@ module Admin
               password: {type: :string},
               passwordConfirmation: {type: :string},
               superAdmin: {type: :boolean},
-              resourceAccess: {type: :array, items: {type: :string}}
+              resourceAccess: {type: :array, items: {"$ref": "#/components/schemas/AdminUserResourceAccessEnum"}}
             },
             additionalProperties: false
           })

--- a/app/api_components/shared/v1/schemas/enums/admin_user_resource_access_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/admin_user_resource_access_enum.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Enums
+        class AdminUserResourceAccessEnum
+          include OpenapiRuby::Components::Base
+
+          PRIVILEGES = %w[
+            admins
+            components
+            features
+            fleets
+            images
+            imports
+            maintenance
+            manufacturers
+            model_modules
+            models
+            oauth_applications
+            pghero
+            rsi-api-status
+            stats
+            supporters
+            users
+            vehicles
+            workers
+          ].freeze
+
+          schema({
+            type: :string,
+            enum: PRIVILEGES,
+            "x-enumNames": PRIVILEGES.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/enums/fleet_role_resource_access_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/fleet_role_resource_access_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Enums
+        class FleetRoleResourceAccessEnum
+          include OpenapiRuby::Components::Base
+
+          PRIVILEGES = ::FleetRole.all_available_privileges.freeze
+
+          schema({
+            type: :string,
+            enum: PRIVILEGES,
+            "x-enumNames": PRIVILEGES.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/enums/user_resource_access_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/user_resource_access_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Enums
+        class UserResourceAccessEnum
+          include OpenapiRuby::Components::Base
+
+          PRIVILEGES = [].freeze
+
+          schema({
+            type: :string,
+            enum: PRIVILEGES,
+            "x-enumNames": PRIVILEGES.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_role.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_role.rb
@@ -12,7 +12,7 @@ module V1
             id: {type: :string, format: :uuid},
             name: {type: :string},
             slug: {type: :string},
-            resourceAccess: {type: :array, items: {type: :string}}
+            resourceAccess: {type: :array, items: {"$ref": "#/components/schemas/FleetRoleResourceAccessEnum"}}
           },
           additionalProperties: false,
           required: %w[id name slug]

--- a/app/api_components/v1/schemas/user.rb
+++ b/app/api_components/v1/schemas/user.rb
@@ -36,7 +36,7 @@ module V1
           twoFactorQrCodeUrl: {type: :string},
           twoFactorProvisioningUrl: {type: :string},
           hangarUpdatedAt: {type: :string, format: "date-time"},
-          resourceAccess: {type: :array, items: {type: :string}},
+          resourceAccess: {type: :array, items: {"$ref": "#/components/schemas/UserResourceAccessEnum"}},
           authConnections: {type: :array, items: {type: :string}},
           passwordSetManually: {type: :boolean},
           oauthOnly: {type: :boolean},

--- a/app/frontend/admin/stores/session.ts
+++ b/app/frontend/admin/stores/session.ts
@@ -60,7 +60,9 @@ export const useSessionStore = defineStore("session", {
       }
 
       return (
-        this.currentUser?.resourceAccess?.includes(resource) ||
+        (this.currentUser?.resourceAccess as string[] | undefined)?.includes(
+          resource,
+        ) ||
         this.isSuperAdmin ||
         false
       );

--- a/app/frontend/frontend/pages/fleets/[slug]/settings/roles.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings/roles.vue
@@ -77,7 +77,9 @@ const privilegeGroups: Record<string, string[]> = {
 };
 
 const hasPrivilege = (role: FleetRoleExtended, privilege: string) => {
-  return role.resourceAccess?.includes(privilege) ?? false;
+  return (
+    (role.resourceAccess as string[] | undefined)?.includes(privilege) ?? false
+  );
 };
 
 const isImpliedByManage = (role: FleetRoleExtended, privilege: string) => {

--- a/app/frontend/frontend/stores/session.ts
+++ b/app/frontend/frontend/stores/session.ts
@@ -62,7 +62,11 @@ export const useSessionStore = defineStore("session", {
       this.accessConfirmed = undefined;
     },
     hasAccessTo(resource: string) {
-      return this.currentUser?.resourceAccess?.includes(resource) || false;
+      return (
+        (this.currentUser?.resourceAccess as string[] | undefined)?.includes(
+          resource,
+        ) || false
+      );
     },
   },
   persist: {

--- a/docs/exec-plans/resource-access-grouping-and-capabilities.md
+++ b/docs/exec-plans/resource-access-grouping-and-capabilities.md
@@ -1,0 +1,154 @@
+# Resource Access — grouped catalog + typed capability contract
+
+## Goal
+
+Turn `resourceAccess` from a loose, hand-maintained privilege list into a
+grouped, strongly-typed contract with a single backend source of truth, and
+give the management UIs (admin editor, fleet role editor) a proper grouped
+catalog to render — without forcing a record where none exists.
+
+This builds on a known pattern: exposing ActionPolicy rules to the API as a
+typed contract. fleetyards runs on ActionPolicy, so the mechanism transfers
+directly; only the *record-embedded* variant of it does not (see D1).
+
+## Background (current state)
+
+- **Admin authorization is purely subject-scoped.** `Admin::BasePolicy#manage?`
+  is `user.has_access?(resource_access)` and never touches `record`;
+  `index?/show?/create?` all `alias_rule … to: :manage?`. So "may this admin
+  create a Model" has no record and never will — it is a capability of the
+  user, not of a row.
+- `AdminUser.resourceAccess` is already the subject-scoped capability list on
+  the session payload — just flat, hand-listed in the enum, and re-checked
+  client-side (`sessionStore.hasAccessTo("models")`).
+- `FleetRole.resourceAccess` is the *assigned* privilege set on a role, edited
+  in `roles.vue` and re-checked fleet-wide via
+  `checkAccess(membership.fleetRole.resourceAccess, [...])`.
+- Enums added in PR #4212: `FleetRoleResourceAccessEnum` (sourced from
+  `FleetRole.all_available_privileges` — no drift) and
+  `AdminUserResourceAccessEnum` (**hand-listed — drifts**).
+- Grouping exists only latently: fleet privileges encode it in the string
+  (`fleet:<group>:<action>`), admin privileges are flat with no groups.
+  `roles.vue` hardcodes the implication rules (`fleet:manage` implies all,
+  `fleet:<group>:manage` implies its group) in `isImpliedByManage`.
+
+## Design decisions
+
+### D1 — Do not force the record-embedded `permissions` object onto admin
+
+A record-scoped `permissions: {update, destroy}` object fits resources with a
+real row. Admin (and most fleet gating) is subject-scoped: the capability
+belongs to the user/role, evaluated against a class, not a record. We keep
+those on the `me`/session payload, not embedded per row.
+
+### D2 — Three scopes, chosen per rule
+
+| Scope | fleetyards example | Home |
+|-------|--------------------|------|
+| record-scoped | "may I edit *this* inventory" | `permissions` on the record payload |
+| subject-scoped | "may this admin manage Models" / "may I do X in this fleet" | typed capability list on `me` / membership |
+| parent-scoped | "may I create a role in *this* fleet" | capability on the parent payload |
+
+This PR line focuses on **subject-scoped + grouping**, because that is where
+the drift and the management-UX pain actually are. Record-scoped `permissions`
+is a separate, additive follow-up.
+
+### D3 — One hierarchical catalog per domain as the single source of truth
+
+Group → privileges lives in Ruby. Everything else is derived: the flat enum
+(wire + validation), the grouped catalog schema (management UI), and the
+implication rules. Mirrors the existing precedent where enum components source
+Ruby constants (PR #4212, `DockTypeEnum ← Dock.dock_types.keys`).
+
+### D4 — Separate the two consumers
+
+- **Runtime gating** stays flat (booleans / list membership) — cheap, no group
+  structure needed.
+- **Management UI** consumes a *static* grouped catalog (available options +
+  group + implication). It is constant per deploy, not per user, so it ships as
+  its own schema, not folded into the user's assigned list.
+
+### D5 — Opt-in, reference-slice-first, no enforced convention test yet
+
+Land the catalog + admin slice first (the drift fix), then fleet, then the
+evaluated-capability channel. Defer a drift convention test until 2–3
+consumers exist.
+
+## API shape
+
+```ts
+// Static grouped catalog (management UI) — constant per deploy
+interface ResourceAccessGroup {
+  key: string;              // "shipData" | "roles" | ...
+  privileges: string[];     // enum values in this group
+  managePrivilege?: string; // the "*:manage" that implies the whole group
+}
+// GET /admin/api/v1/session (me)  → resourceAccessCatalog: ResourceAccessGroup[]
+// GET /api/v1/fleets/:slug/roles  → (catalog served alongside, or on fleet payload)
+
+// Assigned set stays the typed enum array (PR #4212), now group-aware in the UI:
+//   AdminUser.resourceAccess: AdminUserResourceAccessEnum[]
+//   FleetRole.resourceAccess: FleetRoleResourceAccessEnum[]
+```
+
+## Changes
+
+### Phase 1 — Grouped catalog SSOT + kill the admin enum drift
+
+1. **`app/models/admin_user.rb`** — introduce the grouped catalog and derive
+   the flat list:
+   ```ruby
+   RESOURCE_ACCESS = {
+     ship_data: %w[models model_modules components manufacturers vehicles images],
+     community: %w[fleets users supporters],
+     system:    %w[admins oauth_applications maintenance imports features workers pghero rsi-api-status stats],
+   }.freeze
+   AVAILABLE_PRIVILEGES = RESOURCE_ACCESS.values.flatten.freeze
+   ```
+2. **`app/api_components/shared/v1/schemas/enums/admin_user_resource_access_enum.rb`**
+   — replace the hand-listed array with `::AdminUser::AVAILABLE_PRIVILEGES`
+   (matches how `FleetRoleResourceAccessEnum` already sources its constant).
+3. **Fleet catalog** — add a `FleetRole.privilege_groups` class method deriving
+   groups from the existing per-model `AVAILABLE_PRIVILEGES` (Fleet /
+   FleetMembership / FleetInviteUrl / FleetVehicle / FleetRole / FleetInventory),
+   so fleet gets the same grouped structure without a second source of truth.
+4. Regenerate: `./bin/generate-schema` → format → lint (standardrb + tsc).
+
+> Phase 1 is the small, drop-into-the-open-PR piece: it removes the drift I
+> flagged on #4212 and lays the catalog other phases build on. No API-surface
+> change beyond the enum source.
+
+### Phase 2 — Grouped catalog on the payloads (management UI)
+
+1. New schema component `ResourceAccessGroup` (+ admin variant if the shapes
+   diverge).
+2. Admin session (`app/controllers/admin/api/v1/sessions_controller.rb` /
+   its jbuilder) emits `resourceAccessCatalog` from `AdminUser::RESOURCE_ACCESS`.
+3. Fleet roles response carries the fleet catalog (from `privilege_groups`).
+4. Frontend: `roles.vue` and the admin editor render from the catalog; move
+   the `isImpliedByManage` implication out of the component and onto the
+   catalog metadata (`managePrivilege`).
+5. Tests: request specs assert the catalog shape; `run_test!` enforces it.
+
+### Phase 3 — Subject-scoped *evaluated* capabilities (deferred)
+
+A `PolicyContract`-style mechanism for the record-less case: a policy declares
+its exposed rules, evaluated against the current user/class (no record),
+shipped as a typed boolean object on `me`. Lets the frontend replace
+`hasAccessTo`/`checkAccess` with `me.capabilities.x`. Additive; does not change
+Phases 1–2.
+
+## Out of scope (for now)
+
+- **Record-scoped `permissions` object** — separate line, only for the
+  genuinely per-row fleet cases.
+- **Removing `User.resourceAccess`** — still always `[]` with no consumers;
+  either delete or repurpose as the Phase 3 capability channel.
+- **Caching** — capabilities recomputed per render; optimize later.
+
+## Sequencing / commits
+
+1. `feat(admin): grouped resource-access catalog + enum from constant` (Phase 1)
+2. `feat(api): expose grouped resource-access catalog on payloads` (Phase 2 backend)
+3. `refactor(frontend): render privilege editors from catalog` (Phase 2 frontend)
+4. Phase 3 as its own PR once 1–2 are approved.

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6630,7 +6630,7 @@ components:
         resourceAccess:
           type: array
           items:
-            type: string
+            "$ref": "#/components/schemas/AdminUserResourceAccessEnum"
         superAdmin:
           type: boolean
         createdAt:
@@ -6728,9 +6728,50 @@ components:
         resourceAccess:
           type: array
           items:
-            type: string
+            "$ref": "#/components/schemas/AdminUserResourceAccessEnum"
       additionalProperties: false
       title: AdminUserInput
+    AdminUserResourceAccessEnum:
+      type: string
+      enum:
+      - admins
+      - components
+      - features
+      - fleets
+      - images
+      - imports
+      - maintenance
+      - manufacturers
+      - model_modules
+      - models
+      - oauth_applications
+      - pghero
+      - rsi-api-status
+      - stats
+      - supporters
+      - users
+      - vehicles
+      - workers
+      x-enumNames:
+      - ADMINS
+      - COMPONENTS
+      - FEATURES
+      - FLEETS
+      - IMAGES
+      - IMPORTS
+      - MAINTENANCE
+      - MANUFACTURERS
+      - MODEL_MODULES
+      - MODELS
+      - OAUTH_APPLICATIONS
+      - PGHERO
+      - RSI_API_STATUS
+      - STATS
+      - SUPPORTERS
+      - USERS
+      - VEHICLES
+      - WORKERS
+      title: AdminUserResourceAccessEnum
     AdminUsers:
       type: object
       properties:
@@ -8305,6 +8346,71 @@ components:
       additionalProperties: false
       example: {}
       title: FleetQuery
+    FleetRoleResourceAccessEnum:
+      type: string
+      enum:
+      - fleet:update
+      - fleet:update:images
+      - fleet:update:description
+      - fleet:delete
+      - fleet:manage
+      - fleet:memberships:read
+      - fleet:memberships:create
+      - fleet:memberships:update
+      - fleet:memberships:delete
+      - fleet:memberships:manage
+      - fleet:invites:read
+      - fleet:invites:create
+      - fleet:invites:update
+      - fleet:invites:delete
+      - fleet:invites:manage
+      - fleet:vehicles:read
+      - fleet:vehicles:create
+      - fleet:vehicles:update
+      - fleet:vehicles:delete
+      - fleet:vehicles:manage
+      - fleet:roles:read
+      - fleet:roles:create
+      - fleet:roles:update
+      - fleet:roles:delete
+      - fleet:roles:manage
+      - fleet:inventories:read
+      - fleet:inventories:create
+      - fleet:inventories:update
+      - fleet:inventories:delete
+      - fleet:inventories:manage
+      x-enumNames:
+      - FLEET_UPDATE
+      - FLEET_UPDATE_IMAGES
+      - FLEET_UPDATE_DESCRIPTION
+      - FLEET_DELETE
+      - FLEET_MANAGE
+      - FLEET_MEMBERSHIPS_READ
+      - FLEET_MEMBERSHIPS_CREATE
+      - FLEET_MEMBERSHIPS_UPDATE
+      - FLEET_MEMBERSHIPS_DELETE
+      - FLEET_MEMBERSHIPS_MANAGE
+      - FLEET_INVITES_READ
+      - FLEET_INVITES_CREATE
+      - FLEET_INVITES_UPDATE
+      - FLEET_INVITES_DELETE
+      - FLEET_INVITES_MANAGE
+      - FLEET_VEHICLES_READ
+      - FLEET_VEHICLES_CREATE
+      - FLEET_VEHICLES_UPDATE
+      - FLEET_VEHICLES_DELETE
+      - FLEET_VEHICLES_MANAGE
+      - FLEET_ROLES_READ
+      - FLEET_ROLES_CREATE
+      - FLEET_ROLES_UPDATE
+      - FLEET_ROLES_DELETE
+      - FLEET_ROLES_MANAGE
+      - FLEET_INVENTORIES_READ
+      - FLEET_INVENTORIES_CREATE
+      - FLEET_INVENTORIES_UPDATE
+      - FLEET_INVENTORIES_DELETE
+      - FLEET_INVENTORIES_MANAGE
+      title: FleetRoleResourceAccessEnum
     FleetSortEnum:
       type: string
       enum:
@@ -12739,6 +12845,11 @@ components:
       additionalProperties: false
       example: {}
       title: UserQuery
+    UserResourceAccessEnum:
+      type: string
+      enum: []
+      x-enumNames: []
+      title: UserResourceAccessEnum
     UserSortEnum:
       type: string
       enum:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -6661,6 +6661,47 @@ components:
           format: email
       additionalProperties: false
       title: AccountUpdateInput
+    AdminUserResourceAccessEnum:
+      type: string
+      enum:
+      - admins
+      - components
+      - features
+      - fleets
+      - images
+      - imports
+      - maintenance
+      - manufacturers
+      - model_modules
+      - models
+      - oauth_applications
+      - pghero
+      - rsi-api-status
+      - stats
+      - supporters
+      - users
+      - vehicles
+      - workers
+      x-enumNames:
+      - ADMINS
+      - COMPONENTS
+      - FEATURES
+      - FLEETS
+      - IMAGES
+      - IMPORTS
+      - MAINTENANCE
+      - MANUFACTURERS
+      - MODEL_MODULES
+      - MODELS
+      - OAUTH_APPLICATIONS
+      - PGHERO
+      - RSI_API_STATUS
+      - STATS
+      - SUPPORTERS
+      - USERS
+      - VEHICLES
+      - WORKERS
+      title: AdminUserResourceAccessEnum
     BarChartStats:
       type: object
       properties:
@@ -8597,7 +8638,7 @@ components:
         resourceAccess:
           type: array
           items:
-            type: string
+            "$ref": "#/components/schemas/FleetRoleResourceAccessEnum"
       additionalProperties: false
       required:
       - id
@@ -8617,7 +8658,7 @@ components:
         resourceAccess:
           type: array
           items:
-            type: string
+            "$ref": "#/components/schemas/FleetRoleResourceAccessEnum"
         rank:
           type: string
         permanent:
@@ -8637,6 +8678,71 @@ components:
       - createdAt
       - updatedAt
       title: FleetRoleExtended
+    FleetRoleResourceAccessEnum:
+      type: string
+      enum:
+      - fleet:update
+      - fleet:update:images
+      - fleet:update:description
+      - fleet:delete
+      - fleet:manage
+      - fleet:memberships:read
+      - fleet:memberships:create
+      - fleet:memberships:update
+      - fleet:memberships:delete
+      - fleet:memberships:manage
+      - fleet:invites:read
+      - fleet:invites:create
+      - fleet:invites:update
+      - fleet:invites:delete
+      - fleet:invites:manage
+      - fleet:vehicles:read
+      - fleet:vehicles:create
+      - fleet:vehicles:update
+      - fleet:vehicles:delete
+      - fleet:vehicles:manage
+      - fleet:roles:read
+      - fleet:roles:create
+      - fleet:roles:update
+      - fleet:roles:delete
+      - fleet:roles:manage
+      - fleet:inventories:read
+      - fleet:inventories:create
+      - fleet:inventories:update
+      - fleet:inventories:delete
+      - fleet:inventories:manage
+      x-enumNames:
+      - FLEET_UPDATE
+      - FLEET_UPDATE_IMAGES
+      - FLEET_UPDATE_DESCRIPTION
+      - FLEET_DELETE
+      - FLEET_MANAGE
+      - FLEET_MEMBERSHIPS_READ
+      - FLEET_MEMBERSHIPS_CREATE
+      - FLEET_MEMBERSHIPS_UPDATE
+      - FLEET_MEMBERSHIPS_DELETE
+      - FLEET_MEMBERSHIPS_MANAGE
+      - FLEET_INVITES_READ
+      - FLEET_INVITES_CREATE
+      - FLEET_INVITES_UPDATE
+      - FLEET_INVITES_DELETE
+      - FLEET_INVITES_MANAGE
+      - FLEET_VEHICLES_READ
+      - FLEET_VEHICLES_CREATE
+      - FLEET_VEHICLES_UPDATE
+      - FLEET_VEHICLES_DELETE
+      - FLEET_VEHICLES_MANAGE
+      - FLEET_ROLES_READ
+      - FLEET_ROLES_CREATE
+      - FLEET_ROLES_UPDATE
+      - FLEET_ROLES_DELETE
+      - FLEET_ROLES_MANAGE
+      - FLEET_INVENTORIES_READ
+      - FLEET_INVENTORIES_CREATE
+      - FLEET_INVENTORIES_UPDATE
+      - FLEET_INVENTORIES_DELETE
+      - FLEET_INVENTORIES_MANAGE
+      title: FleetRoleResourceAccessEnum
     FleetSortEnum:
       type: string
       enum:
@@ -12340,7 +12446,7 @@ components:
         resourceAccess:
           type: array
           items:
-            type: string
+            "$ref": "#/components/schemas/UserResourceAccessEnum"
         authConnections:
           type: array
           items:
@@ -12442,6 +12548,11 @@ components:
       - publicHangarStats
       - publicWishlist
       title: UserPublic
+    UserResourceAccessEnum:
+      type: string
+      enum: []
+      x-enumNames: []
+      title: UserResourceAccessEnum
     UserSortEnum:
       type: string
       enum:


### PR DESCRIPTION
## Why

`resourceAccess` was typed as a loose `string[]` across the API and generated frontend types, so nothing tied the values to the actual privilege catalogs and typos in `access:` checks went uncaught.

## What

Replace the loose `string[]` with three dedicated enums:

| Enum | Source of truth | Values |
|---|---|---|
| `FleetRoleResourceAccessEnum` | `FleetRole.all_available_privileges` (referenced live — zero drift) | 30 fleet privileges (`fleet:manage`, `fleet:roles:manage`, …) |
| `AdminUserResourceAccessEnum` | Admin route `access:` meta + `stats` | 18 admin privileges (`models`, `users`, `pghero`, …) |
| `UserResourceAccessEnum` | Empty — matches the always-`[]` serializer | none |

- Wired the enums into `FleetRole`, `User`, `AdminUser`, and `AdminUserInput` schema components via `$ref`.
- Regenerated the OpenAPI schema and Orval API clients (`./bin/generate-schema`).
- Fixed the 3 consumers the narrowed types surfaced — `.includes(dynamicString)` in both `session.ts` stores and `roles.vue` now widen the array to `string[]`, matching how `checkAccess` already types its param.

## Notes / follow-ups

- `AdminUserResourceAccessEnum` has **no backend source of truth** (admin privileges live only in frontend route meta), so it won't auto-update when a new admin resource is added. A follow-up could add an `AdminUser::AVAILABLE_PRIVILEGES` constant to make it drift-proof like FleetRole.
- `UserResourceAccessEnum` is intentionally empty — `User.resourceAccess` is serialized as `[]` with no consumers. The field is effectively dead and could be removed later.

## Verification

- `standardrb` — clean
- `vue-tsc` + `tsc` — clean
- `prettier` + `eslint` — clean

🤖