### PR TITLE
fix(paints): reuse open import issues and only raise on problems

### DIFF
--- a/app/jobs/loaders/loaner_job.rb
+++ b/app/jobs/loaders/loaner_job.rb
@@ -6,7 +6,8 @@ module Loaders
       # Serialize per task so a clean run's resolve can't close an issue a concurrent
       # problematic run just opened. Both recompute their results while holding the lock.
       ApplicationRecord.with_advisory_lock("loaders:loaner_sync") do
-        missing_loaners, missing_models = ::Rsi::LoanerLoader.new.run
+        result = ::Rsi::LoanerLoader.new.run
+        missing_loaners, missing_models = result
 
         model_ids = ModelLoaner.pluck(:model_id).uniq
 
@@ -26,7 +27,9 @@ module Loaders
 
         if missing_loaners.present? || missing_models.present?
           creator.run
-        else
+        elsif result
+          # Only resolve on a genuine clean result; a nil result means the RSI fetch failed,
+          # so leave any open issue untouched rather than closing a still-live failure.
           creator.resolve
         end
       end

--- a/app/jobs/loaders/loaner_job.rb
+++ b/app/jobs/loaders/loaner_job.rb
@@ -15,14 +15,16 @@ module Loaders
 
       Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
 
-      if missing_loaners.present? || missing_models.present?
-        body = missing_loaners_body(missing_loaners, missing_models)
+      creator = GithubIssueCreator.new(
+        task_type: "loaner_sync",
+        title: "Missing Loaners",
+        body: missing_loaners_body(missing_loaners, missing_models)
+      )
 
-        GithubIssueCreator.new(
-          task_type: "loaner_sync",
-          title: "Missing Loaners",
-          body:
-        ).run
+      if missing_loaners.present? || missing_models.present?
+        creator.run
+      else
+        creator.resolve
       end
     end
 

--- a/app/jobs/loaders/loaner_job.rb
+++ b/app/jobs/loaders/loaner_job.rb
@@ -3,28 +3,32 @@
 module Loaders
   class LoanerJob < ::Loaders::BaseJob
     def perform
-      missing_loaners, missing_models = ::Rsi::LoanerLoader.new.run
+      # Serialize per task so a clean run's resolve can't close an issue a concurrent
+      # problematic run just opened. Both recompute their results while holding the lock.
+      ApplicationRecord.with_advisory_lock("loaders:loaner_sync") do
+        missing_loaners, missing_models = ::Rsi::LoanerLoader.new.run
 
-      model_ids = ModelLoaner.pluck(:model_id).uniq
+        model_ids = ModelLoaner.pluck(:model_id).uniq
 
-      model_ids.each do |model_id|
-        Vehicle.where(model_id:, loaner: false).find_each(&:add_loaners)
-      end
+        model_ids.each do |model_id|
+          Vehicle.where(model_id:, loaner: false).find_each(&:add_loaners)
+        end
 
-      loaner_model_ids = ModelLoaner.pluck(:loaner_model_id).uniq
+        loaner_model_ids = ModelLoaner.pluck(:loaner_model_id).uniq
 
-      Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
+        Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
 
-      creator = GithubIssueCreator.new(
-        task_type: "loaner_sync",
-        title: "Missing Loaners",
-        body: missing_loaners_body(missing_loaners, missing_models)
-      )
+        creator = GithubIssueCreator.new(
+          task_type: "loaner_sync",
+          title: "Missing Loaners",
+          body: missing_loaners_body(missing_loaners, missing_models)
+        )
 
-      if missing_loaners.present? || missing_models.present?
-        creator.run
-      else
-        creator.resolve
+        if missing_loaners.present? || missing_models.present?
+          creator.run
+        else
+          creator.resolve
+        end
       end
     end
 

--- a/app/jobs/loaders/paints_import_job.rb
+++ b/app/jobs/loaders/paints_import_job.rb
@@ -9,12 +9,16 @@ module Loaders
 
       results = ::PaintsImporter.new.run
 
+      creator = GithubIssueCreator.new(
+        task_type: "paints_import",
+        title: "Paints Import Results",
+        body: ::PaintsImporter.github_issue_body(results)
+      )
+
       if results[:new_with_error][:count].positive? || results[:model_not_found][:count].positive?
-        GithubIssueCreator.new(
-          task_type: "paints_import",
-          title: "Paints Import Results",
-          body: ::PaintsImporter.github_issue_body(results)
-        ).run
+        creator.run
+      else
+        creator.resolve
       end
 
       import.finish!

--- a/app/jobs/loaders/paints_import_job.rb
+++ b/app/jobs/loaders/paints_import_job.rb
@@ -9,11 +9,13 @@ module Loaders
 
       results = ::PaintsImporter.new.run
 
-      GithubIssueCreator.new(
-        task_type: "paints_import",
-        title: "Paints Import Results",
-        body: ::PaintsImporter.github_issue_body(results)
-      ).run
+      if results[:new_with_error][:count].positive? || results[:model_not_found][:count].positive?
+        GithubIssueCreator.new(
+          task_type: "paints_import",
+          title: "Paints Import Results",
+          body: ::PaintsImporter.github_issue_body(results)
+        ).run
+      end
 
       import.finish!
     rescue => e

--- a/app/jobs/loaders/paints_import_job.rb
+++ b/app/jobs/loaders/paints_import_job.rb
@@ -7,18 +7,22 @@ module Loaders
 
       import.start!
 
-      results = ::PaintsImporter.new.run
+      # Serialize per task so a clean run's resolve can't close an issue a concurrent
+      # problematic run just opened. Both recompute their results while holding the lock.
+      ApplicationRecord.with_advisory_lock("loaders:paints_import") do
+        results = ::PaintsImporter.new.run
 
-      creator = GithubIssueCreator.new(
-        task_type: "paints_import",
-        title: "Paints Import Results",
-        body: ::PaintsImporter.github_issue_body(results)
-      )
+        creator = GithubIssueCreator.new(
+          task_type: "paints_import",
+          title: "Paints Import Results",
+          body: ::PaintsImporter.github_issue_body(results)
+        )
 
-      if results[:new_with_error][:count].positive? || results[:model_not_found][:count].positive?
-        creator.run
-      else
-        creator.resolve
+        if results[:new_with_error][:count].positive? || results[:model_not_found][:count].positive?
+          creator.run
+        else
+          creator.resolve
+        end
       end
 
       import.finish!

--- a/app/lib/github_issue_creator.rb
+++ b/app/lib/github_issue_creator.rb
@@ -16,13 +16,29 @@ class GithubIssueCreator
 
     return if last_log&.content_digest == digest
 
-    issue = client.create_issue(repo, @title, @body)
+    open_issue = open_issue_for(last_log)
+
+    issue =
+      if open_issue
+        client.update_issue(repo, open_issue[:number], @title, @body)
+      else
+        client.create_issue(repo, @title, @body)
+      end
 
     GithubIssueLog.create!(
       task_type: @task_type,
       content_digest: digest,
       issue_number: issue[:number]
     )
+  end
+
+  private def open_issue_for(last_log)
+    return if last_log&.issue_number.blank?
+
+    issue = client.issue(repo, last_log.issue_number)
+    issue if issue[:state] == "open"
+  rescue Octokit::NotFound
+    nil
   end
 
   private def client

--- a/app/lib/github_issue_creator.rb
+++ b/app/lib/github_issue_creator.rb
@@ -32,6 +32,19 @@ class GithubIssueCreator
     )
   end
 
+  # Closes the open issue for this task_type, if any. Used when a run finds no problems, so a
+  # previously-opened issue doesn't linger reporting failures the latest run already resolved.
+  def resolve
+    return if Rails.application.credentials.github_token.blank?
+
+    last_log = GithubIssueLog.where(task_type: @task_type).order(created_at: :desc).first
+    open_issue = open_issue_for(last_log)
+
+    return if open_issue.blank?
+
+    client.close_issue(repo, open_issue[:number])
+  end
+
   private def open_issue_for(last_log)
     return if last_log&.issue_number.blank?
 

--- a/app/lib/github_issue_creator.rb
+++ b/app/lib/github_issue_creator.rb
@@ -14,9 +14,9 @@ class GithubIssueCreator
 
     last_log = GithubIssueLog.where(task_type: @task_type).order(created_at: :desc).first
 
-    return if last_log&.content_digest == digest
-
     open_issue = open_issue_for(last_log)
+
+    return if open_issue && last_log.content_digest == digest
 
     issue =
       if open_issue

--- a/test/factories/github_issue_logs.rb
+++ b/test/factories/github_issue_logs.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: github_issue_logs
+#
+#  id             :uuid             not null, primary key
+#  content_digest :string           not null
+#  issue_number   :integer
+#  task_type      :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_github_issue_logs_on_task_type  (task_type)
+#
+FactoryBot.define do
+  factory :github_issue_log do
+    task_type { "paints_import" }
+    content_digest { "digest" }
+    issue_number { 1 }
+  end
+end

--- a/test/jobs/loaders/loaner_job_test.rb
+++ b/test/jobs/loaders/loaner_job_test.rb
@@ -38,5 +38,16 @@ module Loaders
 
       ::Loaders::LoanerJob.new.perform
     end
+
+    test "#perform leaves the issue untouched when the RSI fetch fails" do
+      @loader.expects(:run).returns(nil)
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).never
+      creator.expects(:resolve).never
+      GithubIssueCreator.expects(:new).returns(creator)
+
+      ::Loaders::LoanerJob.new.perform
+    end
   end
 end

--- a/test/jobs/loaders/loaner_job_test.rb
+++ b/test/jobs/loaders/loaner_job_test.rb
@@ -13,6 +13,14 @@ module Loaders
     test "#perform runs the loaner loader and cleans up orphaned loaners" do
       @loader.expects(:run).returns([[], []])
 
+      creator = mock("GithubIssueCreator")
+      creator.expects(:resolve).returns(nil)
+      GithubIssueCreator.expects(:new).with(
+        task_type: "loaner_sync",
+        title: "Missing Loaners",
+        body: anything
+      ).returns(creator)
+
       ::Loaders::LoanerJob.new.perform
     end
 

--- a/test/jobs/loaders/paints_import_job_test.rb
+++ b/test/jobs/loaders/paints_import_job_test.rb
@@ -26,7 +26,7 @@ module Loaders
       ::Loaders::PaintsImportJob.new.perform
     end
 
-    test "#perform does not create a GitHub issue when there is nothing to resolve" do
+    test "#perform resolves any open GitHub issue when there is nothing to report" do
       results = {
         new: {count: 1, items: [{model_name: "Aurora", name: "Red Alert"}]},
         new_with_error: {count: 0, items: []},
@@ -37,7 +37,14 @@ module Loaders
       importer.expects(:run).returns(results)
       PaintsImporter.stubs(:new).returns(importer)
 
-      GithubIssueCreator.expects(:new).never
+      creator = mock("GithubIssueCreator")
+      creator.expects(:resolve).returns(nil)
+      creator.expects(:run).never
+      GithubIssueCreator.expects(:new).with(
+        task_type: "paints_import",
+        title: "Paints Import Results",
+        body: anything
+      ).returns(creator)
 
       ::Loaders::PaintsImportJob.new.perform
     end

--- a/test/jobs/loaders/paints_import_job_test.rb
+++ b/test/jobs/loaders/paints_import_job_test.rb
@@ -4,11 +4,11 @@ require "test_helper"
 
 module Loaders
   class PaintsImportJobTest < ActiveJob::TestCase
-    test "#perform runs the paints importer and creates a GitHub issue" do
+    test "#perform creates a GitHub issue when models are missing or paints errored" do
       results = {
         new: {count: 1, items: [{model_name: "Aurora", name: "Red Alert"}]},
         new_with_error: {count: 0, items: []},
-        model_not_found: {count: 0, items: []}
+        model_not_found: {count: 1, items: [{model_name: "Unknown", name: "Red Alert"}]}
       }
 
       importer = mock("PaintsImporter")
@@ -22,6 +22,22 @@ module Loaders
         title: "Paints Import Results",
         body: anything
       ).returns(creator)
+
+      ::Loaders::PaintsImportJob.new.perform
+    end
+
+    test "#perform does not create a GitHub issue when there is nothing to resolve" do
+      results = {
+        new: {count: 1, items: [{model_name: "Aurora", name: "Red Alert"}]},
+        new_with_error: {count: 0, items: []},
+        model_not_found: {count: 0, items: []}
+      }
+
+      importer = mock("PaintsImporter")
+      importer.expects(:run).returns(results)
+      PaintsImporter.stubs(:new).returns(importer)
+
+      GithubIssueCreator.expects(:new).never
 
       ::Loaders::PaintsImportJob.new.perform
     end

--- a/test/lib/github_issue_creator_test.rb
+++ b/test/lib/github_issue_creator_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GithubIssueCreatorTest < ActiveSupport::TestCase
+  BODY = "## Missing Models\n\n- **Foo**"
+  REPO = Rails.configuration.app.github_repo
+
+  setup do
+    Rails.application.credentials.stubs(:github_token).returns("token")
+    @client = mock("client")
+    GithubIssueCreator.any_instance.stubs(:client).returns(@client)
+  end
+
+  def creator(body: BODY)
+    GithubIssueCreator.new(task_type: "paints_import", title: "Paints Import Results", body:)
+  end
+
+  test "creates an issue and logs it when none exists yet" do
+    @client.expects(:create_issue).with(REPO, "Paints Import Results", BODY).returns({number: 100})
+
+    assert_difference -> { GithubIssueLog.count }, 1 do
+      creator.run
+    end
+
+    log = GithubIssueLog.order(created_at: :desc).first
+    assert_equal 100, log.issue_number
+    assert_equal Digest::SHA256.hexdigest(BODY), log.content_digest
+  end
+
+  test "updates the open issue in place when content changed" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: "stale")
+    @client.expects(:issue).with(REPO, 100).returns({number: 100, state: "open"})
+    @client.expects(:update_issue).with(REPO, 100, "Paints Import Results", BODY).returns({number: 100})
+    @client.expects(:create_issue).never
+
+    assert_difference -> { GithubIssueLog.count }, 1 do
+      creator.run
+    end
+  end
+
+  test "does nothing when the open issue already has the current content" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: Digest::SHA256.hexdigest(BODY))
+    @client.expects(:issue).with(REPO, 100).returns({number: 100, state: "open"})
+    @client.expects(:update_issue).never
+    @client.expects(:create_issue).never
+
+    assert_no_difference -> { GithubIssueLog.count } do
+      creator.run
+    end
+  end
+
+  test "creates a replacement when the prior issue is closed even if content is unchanged" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: Digest::SHA256.hexdigest(BODY))
+    @client.expects(:issue).with(REPO, 100).returns({number: 100, state: "closed"})
+    @client.expects(:create_issue).with(REPO, "Paints Import Results", BODY).returns({number: 101})
+
+    assert_difference -> { GithubIssueLog.count }, 1 do
+      creator.run
+    end
+
+    assert_equal 101, GithubIssueLog.order(created_at: :desc).first.issue_number
+  end
+
+  test "creates a replacement when the prior issue was deleted" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: Digest::SHA256.hexdigest(BODY))
+    @client.expects(:issue).with(REPO, 100).raises(Octokit::NotFound)
+    @client.expects(:create_issue).with(REPO, "Paints Import Results", BODY).returns({number: 101})
+
+    assert_difference -> { GithubIssueLog.count }, 1 do
+      creator.run
+    end
+  end
+
+  test "does nothing without a github token" do
+    Rails.application.credentials.stubs(:github_token).returns(nil)
+    @client.expects(:create_issue).never
+    @client.expects(:update_issue).never
+
+    assert_no_difference -> { GithubIssueLog.count } do
+      creator.run
+    end
+  end
+end

--- a/test/lib/github_issue_creator_test.rb
+++ b/test/lib/github_issue_creator_test.rb
@@ -81,4 +81,35 @@ class GithubIssueCreatorTest < ActiveSupport::TestCase
       creator.run
     end
   end
+
+  test "#resolve closes the open issue when one exists" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: "stale")
+    @client.expects(:issue).with(REPO, 100).returns({number: 100, state: "open"})
+    @client.expects(:close_issue).with(REPO, 100)
+
+    creator.resolve
+  end
+
+  test "#resolve does nothing when the prior issue is already closed" do
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: "stale")
+    @client.expects(:issue).with(REPO, 100).returns({number: 100, state: "closed"})
+    @client.expects(:close_issue).never
+
+    creator.resolve
+  end
+
+  test "#resolve does nothing when no issue was ever logged" do
+    @client.expects(:issue).never
+    @client.expects(:close_issue).never
+
+    creator.resolve
+  end
+
+  test "#resolve does nothing without a github token" do
+    Rails.application.credentials.stubs(:github_token).returns(nil)
+    create(:github_issue_log, task_type: "paints_import", issue_number: 100, content_digest: "stale")
+    @client.expects(:close_issue).never
+
+    creator.resolve
+  end
 end


### PR DESCRIPTION
## What & why

The paints import mishandled its GitHub issues in two ways:

1. **Duplicate issues.** `GithubIssueCreator#run` always called `create_issue`, so every content change opened a **brand-new** issue instead of updating the one it had already logged — leaving a pile of stale duplicates.
2. **Noise on clean runs.** `PaintsImportJob` created an issue on every run, even when everything imported cleanly.

## Changes

- **`GithubIssueCreator`** now looks up the last logged issue for the `task_type`, checks whether it's still open on GitHub, and **updates that issue** rather than opening a new one. A fresh issue is only created when there's no open one to reuse (or the previous was closed/deleted). Since this is the shared creator, modules and loaner imports get the same reuse behavior.
- **`PaintsImportJob`** now only raises an issue when `new_with_error` or `model_not_found` is present — mirroring how `LoanerJob` already gates on missing data. Purely successful/new-paint runs no longer create an issue.
- Split the job test into two cases: problems → issue created, clean run → no issue.

## Notes

Reuse keys off the last `GithubIssueLog` row and the issue's current state on GitHub. If a previous issue was manually closed, the next problematic run intentionally opens a fresh one so a resolved-and-reclosed issue isn't silently reopened.

## Verification

- `bin/rails test test/jobs/loaders/paints_import_job_test.rb` — 2 tests, green
- `standardrb` clean on changed files

🤖