### PR TITLE
feat(hangar): add hangar.link-compatible export

### DIFF
--- a/app/controllers/api/v1/hangars_controller.rb
+++ b/app/controllers/api/v1/hangars_controller.rb
@@ -8,10 +8,10 @@ module Api
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "hangar", "hangar:read" },
         unless: :user_signed_in?,
-        only: %i[show export items]
+        only: %i[show export export_hangar_link items]
       before_action -> { doorkeeper_authorize! "hangar", "hangar:write" },
         unless: :user_signed_in?,
-        except: %i[show export items]
+        except: %i[show export export_hangar_link items]
 
       after_action -> { pagination_header(:vehicles) }, only: %i[show]
 
@@ -93,21 +93,13 @@ module Api
       def export
         authorize! to: :show?, with: ::HangarPolicy
 
-        scope = authorized_scope(Vehicle.all).visible.purchased
+        @vehicles = export_vehicles
+      end
 
-        scope = loaner_included?(scope)
-        scope = bundled_included?(scope)
+      def export_hangar_link
+        authorize! to: :show?, with: ::HangarPolicy
 
-        vehicle_query_params["sorts"] = "model_name asc"
-
-        @q = scope.ransack(vehicle_query_params)
-
-        @vehicles = Vehicle.where(
-          Vehicle.arel_table[:id].in(@q.result(distinct: true).reorder(nil).select(:id).arel)
-        )
-          .order(@q.result.order_values)
-          .includes(model: [:manufacturer])
-          .joins(model: [:manufacturer])
+        @vehicles = export_vehicles
       end
 
       def sync_rsi_hangar
@@ -184,6 +176,24 @@ module Api
         return if errors.blank?
 
         render json: ValidationError.new("vehicle.move_all_ingame_to_wish_list", errors:), status: :bad_request
+      end
+
+      private def export_vehicles
+        scope = authorized_scope(Vehicle.all).visible.purchased
+
+        scope = loaner_included?(scope)
+        scope = bundled_included?(scope)
+
+        vehicle_query_params["sorts"] = "model_name asc"
+
+        @q = scope.ransack(vehicle_query_params)
+
+        Vehicle.where(
+          Vehicle.arel_table[:id].in(@q.result(distinct: true).reorder(nil).select(:id).arel)
+        )
+          .order(@q.result.order_values)
+          .includes(model: [:manufacturer])
+          .joins(model: [:manufacturer])
       end
 
       private def import_params

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -485,7 +485,7 @@ const openDisplayOptionsModal = () => {
           :aria-label="t('actions.exportHangarLink')"
           @click="exportHangarLink"
         >
-          <i class="fa-light fa-download" />
+          <i class="fa-light fa-link" />
           <span>{{ t("actions.exportHangarLink") }}</span>
         </Btn>
 

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -46,6 +46,7 @@ import {
   useHangar as useHangarQuery,
   useHangarGroups as useHangarGroupsQuery,
   hangarExport as fetchHangarExport,
+  hangarLinkExport as fetchHangarLinkExport,
   useDestroyHangar as useDestroyHangarMutation,
   type HangarParams,
   getHangarQueryKey,
@@ -201,14 +202,8 @@ useSubscription({
   received: () => debounce(fetch, 500),
 });
 
-const exportJson = async () => {
-  if (!currentUser?.value) {
-    return;
-  }
-
-  const exportedData = await fetchHangarExport(hangarQueryParams);
-
-  if (!exportedData || !window.URL) {
+const downloadExport = (exportedData: unknown, suffix: string) => {
+  if (!currentUser?.value || !exportedData || !window.URL) {
     displayAlert({ text: t("messages.hangarExport.failure") });
     return;
   }
@@ -223,7 +218,7 @@ const exportJson = async () => {
 
   link.setAttribute(
     "download",
-    `fleetyards-${currentUser.value.username}-hangar-${format(
+    `fleetyards-${currentUser.value.username}-${suffix}-${format(
       new Date(),
       "yyyy-MM-dd",
     )}.json`,
@@ -234,6 +229,22 @@ const exportJson = async () => {
   link.click();
 
   document.body.removeChild(link);
+};
+
+const exportJson = async () => {
+  if (!currentUser?.value) {
+    return;
+  }
+
+  downloadExport(await fetchHangarExport(hangarQueryParams), "hangar");
+};
+
+const exportHangarLink = async () => {
+  if (!currentUser?.value) {
+    return;
+  }
+
+  downloadExport(await fetchHangarLinkExport(hangarQueryParams), "hangar-link");
 };
 
 const showResetIngameModal = () => {
@@ -467,6 +478,15 @@ const openDisplayOptionsModal = () => {
         >
           <i class="fa-light fa-download" />
           <span>{{ t("actions.export") }}</span>
+        </Btn>
+
+        <Btn
+          :size="BtnSizesEnum.SMALL"
+          :aria-label="t('actions.exportHangarLink')"
+          @click="exportHangarLink"
+        >
+          <i class="fa-light fa-download" />
+          <span>{{ t("actions.exportHangarLink") }}</span>
         </Btn>
 
         <HangarImportBtn :size="BtnSizesEnum.SMALL" @finished="fetch" />

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -33,6 +33,7 @@
       "more": "Mehr...",
       "showMore": "Mehr anzeigen",
       "export": "Export",
+      "exportHangarLink": "Export für hangar.link",
       "import": "Importieren",
       "here": "hier",
       "backToList": "Zurück zur Liste",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -33,6 +33,7 @@
       "more": "More...",
       "showMore": "Show more",
       "export": "Export",
+      "exportHangarLink": "Export for hangar.link",
       "import": "Import",
       "here": "here",
       "backToList": "Back to List",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -27,6 +27,7 @@
       "more": "Más...",
       "showMore": "Mostrar más",
       "export": "Exportar",
+      "exportHangarLink": "Exportar a hangar.link",
       "import": "Importar",
       "here": "aquí",
       "backToList": "Volver a la lista",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -27,6 +27,7 @@
       "more": "Détails...",
       "showMore": "Afficher plus",
       "export": "Exporter",
+      "exportHangarLink": "Exporter vers hangar.link",
       "import": "Importer",
       "here": "ici",
       "backToList": "Retour à la liste",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -27,6 +27,7 @@
       "more": "Di più...",
       "showMore": "Mostra altro",
       "export": "Esporta",
+      "exportHangarLink": "Esporta per hangar.link",
       "import": "Importa",
       "here": "qui",
       "backToList": "Torna alla lista",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -27,6 +27,7 @@
       "more": "更多...",
       "showMore": "显示更多",
       "export": "导出",
+      "exportHangarLink": "导出到 hangar.link",
       "import": "导入",
       "here": "这里",
       "backToList": "返回列表",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -27,6 +27,7 @@
       "more": "更多...",
       "showMore": "顯示更多",
       "export": "匯出",
+      "exportHangarLink": "匯出至 hangar.link",
       "import": "匯入",
       "here": "這裡",
       "backToList": "返回列表",

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -673,6 +673,13 @@ class Model < ApplicationRecord
     frontend_model_url(slug:)
   end
 
+  def hangar_link_slug
+    return legacy_slug if legacy_slug.present?
+
+    prefix = "#{manufacturer&.code&.downcase}-"
+    slug&.start_with?(prefix) ? slug.delete_prefix(prefix) : slug
+  end
+
   private def broadcast_update
     ActionCable.server.broadcast("models", to_json)
   end

--- a/app/views/api/v1/hangars/export_hangar_link.jbuilder
+++ b/app/views/api/v1/hangars/export_hangar_link.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @vehicles, partial: "api/v1/vehicles/export", as: :vehicle, locals: {hangar_link: true}

--- a/app/views/api/v1/vehicles/_export.jbuilder
+++ b/app/views/api/v1/vehicles/_export.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.name vehicle.export_name
-json.slug vehicle.model.slug
+json.slug local_assigns[:hangar_link] ? vehicle.model.hangar_link_slug : vehicle.model.slug
 json.ship_code vehicle.model.sc_data_identifier
 json.manufacturer_name vehicle.model.manufacturer.name
 json.manufacturer_code vehicle.model.manufacturer.code

--- a/config/routes/api/hangar_routes.rb
+++ b/config/routes/api/hangar_routes.rb
@@ -2,6 +2,7 @@ resource :hangar, only: %i[show destroy] do
   get :items
   put :import
   get :export
+  get "export/hangar-link", to: "hangars#export_hangar_link"
   put "sync-rsi-hangar", to: "hangars#sync_rsi_hangar"
   get "sync-rsi-hangar/status", to: "hangars#sync_rsi_hangar_status"
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2546,6 +2546,46 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/hangar/export/hangar-link":
+    get:
+      summary: Export your personal Hangar for hangar.link
+      tags:
+      - Hangar
+      operationId: hangarLinkExport
+      parameters:
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/HangarQuery"
+        style: deepObject
+        explode: true
+        required: false
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - hangar
+        - hangar:read
+      - OpenId:
+        - hangar
+        - hangar:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/VehicleExport"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/hangar/groups":
     post:
       summary: HangarGroup create

--- a/test/integration/api/v1/hangar_link_export_test.rb
+++ b/test/integration/api/v1/hangar_link_export_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::HangarLinkExportTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/hangar/export/hangar-link" do
+    get("Export your personal Hangar for hangar.link") do
+      operationId "hangarLinkExport"
+      tags "Hangar"
+      produces "application/json"
+
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/HangarQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["hangar", "hangar:read"]},
+        {OpenId: ["hangar", "hangar:read"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :array, items: {"$ref": "#/components/schemas/VehicleExport"}
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  test "GET /hangar/export/hangar-link returns vehicle exports" do
+    user = create(:user, wanted_vehicle_count: 2, vehicle_count: 3)
+    sign_in user
+
+    assert_api_response :get, 200 do
+      assert_operator parsed_body.count, :>, 0
+    end
+  end
+
+  test "GET /hangar/export/hangar-link emits the manufacturer-free slug" do
+    user = create(:user)
+    manufacturer = create(:manufacturer, code: "DRAK")
+    model = create(:model, name: "Corsair", manufacturer:)
+    model.update_columns(legacy_slug: "corsair", slug: "drak-corsair")
+    create(:vehicle, user:, model:, wanted: false)
+
+    sign_in user
+
+    assert_api_response :get, 200 do
+      assert_equal ["corsair"], parsed_body.map { |vehicle| vehicle["slug"] }
+    end
+  end
+
+  test "GET /hangar/export/hangar-link returns 401 when not signed in" do
+    assert_api_response :get, 401
+  end
+
+  test "GET /hangar/export/hangar-link with OAuth bearer token" do
+    user = create(:user, wanted_vehicle_count: 2, vehicle_count: 3)
+
+    assert_api_response :get, 200, headers: oauth_headers_for(user, scopes: ["hangar", "hangar:read"])
+  end
+end

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ModelTest < ActiveSupport::TestCase
+  test "#hangar_link_slug returns the legacy_slug when present" do
+    manufacturer = create(:manufacturer, code: "DRAK")
+    model = create(:model, name: "Corsair", manufacturer:)
+    model.update_columns(legacy_slug: "corsair", slug: "drak-corsair")
+
+    assert_equal "corsair", model.hangar_link_slug
+  end
+
+  test "#hangar_link_slug strips the manufacturer code prefix when no legacy_slug" do
+    manufacturer = create(:manufacturer, code: "DRAK")
+    model = create(:model, name: "Corsair", manufacturer:)
+    model.update_columns(legacy_slug: nil, slug: "drak-corsair")
+
+    assert_equal "corsair", model.hangar_link_slug
+  end
+
+  test "#hangar_link_slug returns the slug unchanged when it lacks the manufacturer prefix" do
+    manufacturer = create(:manufacturer, code: "DRAK")
+    model = create(:model, name: "Corsair", manufacturer:)
+    model.update_columns(legacy_slug: nil, slug: "corsair")
+
+    assert_equal "corsair", model.hangar_link_slug
+  end
+end

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -2,6 +2,127 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: models
+#
+#  id                                :uuid             not null, primary key
+#  active                            :boolean          default(TRUE)
+#  adi_map                           :boolean          default(FALSE)
+#  beam                              :decimal(15, 2)   default(0.0), not null
+#  cargo                             :decimal(15, 2)
+#  cargo_holds                       :string
+#  classification                    :string(255)
+#  description                       :text
+#  dock_size                         :integer
+#  erkul_identifier                  :string
+#  extended_beam                     :decimal(15, 2)
+#  extended_fleetchart_offset_beam   :decimal(15, 2)
+#  extended_fleetchart_offset_length :decimal(15, 2)
+#  extended_height                   :decimal(15, 2)
+#  extended_length                   :decimal(15, 2)
+#  external_fuel_tanks               :string
+#  fleetchart_offset_beam            :decimal(15, 2)
+#  fleetchart_offset_length          :decimal(15, 2)
+#  focus                             :string(255)
+#  fuel_consumption                  :decimal(15, 2)
+#  ground                            :boolean          default(FALSE)
+#  ground_acceleration               :decimal(15, 2)
+#  ground_decceleration              :decimal(15, 2)
+#  ground_max_speed                  :decimal(15, 2)
+#  ground_reverse_speed              :decimal(15, 2)
+#  height                            :decimal(15, 2)   default(0.0), not null
+#  hidden                            :boolean          default(TRUE)
+#  holo_colored                      :boolean          default(FALSE)
+#  hydrogen_fuel_tank_size           :decimal(15, 2)
+#  hydrogen_fuel_tanks               :string
+#  images_count                      :integer          default(0)
+#  in_game                           :boolean          default(FALSE), not null
+#  last_updated_at                   :datetime
+#  legacy_slug                       :string
+#  length                            :decimal(15, 2)   default(0.0), not null
+#  loaners_count                     :integer          default(0), not null
+#  mass                              :decimal(15, 2)   default(0.0), not null
+#  max_crew                          :integer
+#  max_speed                         :decimal(15, 2)
+#  max_speed_acceleration            :decimal(15, 2)
+#  max_speed_decceleration           :decimal(15, 2)
+#  min_crew                          :integer
+#  model_paints_count                :integer          default(0)
+#  module_hardpoints_count           :integer          default(0)
+#  name                              :string(255)
+#  notified                          :boolean          default(FALSE)
+#  on_sale                           :boolean          default(FALSE)
+#  pitch                             :decimal(15, 2)
+#  pitch_boosted                     :decimal(15, 2)
+#  player_ownable                    :boolean          default(TRUE), not null
+#  pledge_price                      :decimal(15, 2)
+#  positions_need_curation           :boolean          default(FALSE)
+#  price                             :decimal(15, 2)
+#  production_note                   :string(255)
+#  production_status                 :string(255)
+#  quantum_fuel_tank_size            :decimal(15, 2)
+#  quantum_fuel_tanks                :string
+#  refuel_boom                       :string
+#  reverse_speed_boosted             :decimal(15, 2)
+#  roll                              :decimal(15, 2)
+#  roll_boosted                      :decimal(15, 2)
+#  rsi_beam                          :decimal(15, 2)   default(0.0), not null
+#  rsi_cargo                         :decimal(15, 2)
+#  rsi_classification                :string
+#  rsi_ctm_url                       :string
+#  rsi_description                   :text
+#  rsi_focus                         :string
+#  rsi_height                        :decimal(15, 2)   default(0.0), not null
+#  rsi_length                        :decimal(15, 2)   default(0.0), not null
+#  rsi_mass                          :decimal(15, 2)   default(0.0), not null
+#  rsi_max_crew                      :integer
+#  rsi_max_speed                     :decimal(15, 2)
+#  rsi_min_crew                      :integer
+#  rsi_name                          :string
+#  rsi_pitch                         :decimal(15, 2)
+#  rsi_pledge_slug                   :string
+#  rsi_pledge_value                  :integer
+#  rsi_roll                          :decimal(15, 2)
+#  rsi_scm_speed                     :decimal(15, 2)
+#  rsi_size                          :string
+#  rsi_slug                          :string
+#  rsi_store_url                     :string
+#  rsi_yaw                           :decimal(15, 2)
+#  sales_page_url                    :string
+#  sc_beam                           :decimal(15, 2)
+#  sc_height                         :decimal(15, 2)
+#  sc_key                            :string
+#  sc_length                         :decimal(15, 2)
+#  scm_speed                         :decimal(15, 2)
+#  scm_speed_acceleration            :decimal(15, 2)
+#  scm_speed_boosted                 :decimal(15, 2)
+#  scm_speed_decceleration           :decimal(15, 2)
+#  size                              :string
+#  slug                              :string(255)
+#  store_images_updated_at           :datetime
+#  store_url                         :string(255)
+#  upgrade_kits_count                :integer          default(0)
+#  videos_count                      :integer          default(0)
+#  yaw                               :decimal(15, 2)
+#  yaw_boosted                       :decimal(15, 2)
+#  created_at                        :datetime
+#  updated_at                        :datetime
+#  base_model_id                     :uuid
+#  manufacturer_id                   :uuid
+#  rsi_chassis_id                    :integer
+#  rsi_id                            :integer
+#
+# Indexes
+#
+#  index_models_on_base_model_id             (base_model_id)
+#  index_models_on_classification            (classification)
+#  index_models_on_legacy_slug               (legacy_slug)
+#  index_models_on_manufacturer_id           (manufacturer_id)
+#  index_models_on_manufacturer_id_and_name  (manufacturer_id,name) UNIQUE
+#  index_models_on_production_status         (production_status)
+#  index_models_on_size                      (size)
+#
 class ModelTest < ActiveSupport::TestCase
   test "#hangar_link_slug returns the legacy_slug when present" do
     manufacturer = create(:manufacturer, code: "DRAK")


### PR DESCRIPTION
## Why

hangar.link's fleet canvas (`hangar.link/fleet/canvas` → "load from file") imports our hangar-export JSON and matches each ship by the **`slug`** field, resolving it through an alias table against a ship DB keyed by **bare** slugs (`corsair`, `reclaimer`, `mercury-star-runner`).

Since #3695 ("add manufacturer codes to model URLs") prefixed every model `slug` with the manufacturer code (`drak-corsair`, `crus-mercury-star-runner`), the export's slugs stopped matching. hangar.link silently dropped all but the handful its alias table happens to cover (e.g. `argo-srv`→`srv`, `argo-raft`→`raft`) — hence the "only RAFT and SRV import" symptom.

## What

A dedicated export endpoint that emits the same payload as the standard hangar export but with **manufacturer-free** slugs, so hangar.link resolves them again — without changing the general export (which keeps the prefixed slugs for our own ecosystem/round-trip).

- `GET /hangar/export/hangar-link` (`export_hangar_link` action, reuses the vehicle export partial via `locals: { hangar_link: true }`).
- `Model#hangar_link_slug` → `legacy_slug` (the exact pre-#3695 slug #3695 backfilled), else strips the `<code>-` prefix.
- Frontend: **"Export for hangar.link"** button on the hangar page (chain-link icon nodding to hangar.link's mark), localized across all 7 locales.
- OpenAPI op `hangarLinkExport` declared via integration test; `schema.yaml` + Orval client regenerated.

## Verification

Real-data check — ships that previously dropped now emit hangar.link-resolvable slugs:

| Ship | old (fails) | new | resolves via |
|---|---|---|---|
| Corsair | `drak-corsair` | `corsair` | direct |
| Mercury | `crus-mercury-star-runner` | `mercury` | alias → `mercury-star-runner` |
| Ursa | `rsi-ursa` | `ursa` | alias → `ursa-rover` |
| F7A Hornet Mk II | `anvl-f7a-hornet-mk-ii` | `f7a-hornet-mk-ii` | alias → `f7a-mkii` |

- New model + integration tests (incl. an assertion the emitted slug is bare); existing hangar export + round-trip import tests still green.
- `vue-tsc`, `standardrb`, eslint all clean.

## Not included (follow-up)

The **fleet** export (`fleet_vehicles/_export.jbuilder`) and **wishlist** export have the identical prefixed-slug issue and could get the same treatment.

🤖
