### PR TITLE
fix(hardpoints): redesign follow-ups — power pips + missile metric

### DIFF
--- a/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
@@ -33,6 +33,10 @@ import utilityItemsIconUrl from "@/images/hardpoints/utility_items.svg";
 import qedIconUrl from "@/images/hardpoints/qed.svg";
 import empIconUrl from "@/images/hardpoints/emp.svg";
 import type { ComponentPowerPlant } from "@/services/fyApi";
+import {
+  powerPlantContextKey,
+  type PowerPlantContext,
+} from "@/frontend/components/Models/Hardpoints/powerPlant";
 
 type Props = {
   hardpoints: Hardpoint[];
@@ -43,24 +47,42 @@ const props = defineProps<Props>();
 
 const { t, toNumber } = useI18n();
 
-const powerPips = computed(() => {
+const powerPlantContext = computed<PowerPlantContext | null>(() => {
   if (props.category !== HardpointCategoryEnum.POWERPLANT) return null;
 
   const plants = props.hardpoints
     .map((hp) => hp.component)
     .filter((c) => c?.typeData && "powerBase" in c.typeData && c.size);
 
-  const n = plants.length;
-  if (n === 0) return null;
+  if (plants.length === 0) return null;
+
+  return {
+    count: plants.length,
+    sizeSum: plants.reduce((sum, c) => sum + Number(c!.size), 0),
+  };
+});
+
+// Each plant item resolves its own pip share from this ship-level context.
+provide(powerPlantContextKey, powerPlantContext);
+
+const powerPips = computed(() => {
+  const context = powerPlantContext.value;
+  if (!context) return null;
+
+  const plants = props.hardpoints
+    .map((hp) => hp.component)
+    .filter((c) => c?.typeData && "powerBase" in c.typeData && c.size);
 
   const baseSegments = plants.reduce(
     (sum, c) =>
-      sum + Math.round((c!.typeData as ComponentPowerPlant).powerBase! / n),
+      sum +
+      Math.round(
+        (c!.typeData as ComponentPowerPlant).powerBase! / context.count,
+      ),
     0,
   );
-  const sizeSum = plants.reduce((sum, c) => sum + Number(c!.size), 0);
 
-  return baseSegments + (n - 1) * sizeSum;
+  return baseSegments + (context.count - 1) * context.sizeSum;
 });
 
 const modelSlug = inject<ComputedRef<string> | undefined>(

--- a/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
@@ -32,7 +32,6 @@ import missilesIconUrl from "@/images/hardpoints/missiles.svg";
 import utilityItemsIconUrl from "@/images/hardpoints/utility_items.svg";
 import qedIconUrl from "@/images/hardpoints/qed.svg";
 import empIconUrl from "@/images/hardpoints/emp.svg";
-import type { ComponentPowerPlant } from "@/services/fyApi";
 import {
   powerPlantContextKey,
   type PowerPlantContext,
@@ -45,7 +44,7 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const { t, toNumber } = useI18n();
+const { t } = useI18n();
 
 const powerPlantContext = computed<PowerPlantContext | null>(() => {
   if (props.category !== HardpointCategoryEnum.POWERPLANT) return null;
@@ -64,26 +63,6 @@ const powerPlantContext = computed<PowerPlantContext | null>(() => {
 
 // Each plant item resolves its own pip share from this ship-level context.
 provide(powerPlantContextKey, powerPlantContext);
-
-const powerPips = computed(() => {
-  const context = powerPlantContext.value;
-  if (!context) return null;
-
-  const plants = props.hardpoints
-    .map((hp) => hp.component)
-    .filter((c) => c?.typeData && "powerBase" in c.typeData && c.size);
-
-  const baseSegments = plants.reduce(
-    (sum, c) =>
-      sum +
-      Math.round(
-        (c!.typeData as ComponentPowerPlant).powerBase! / context.count,
-      ),
-    0,
-  );
-
-  return baseSegments + (context.count - 1) * context.sizeSum;
-});
 
 const modelSlug = inject<ComputedRef<string> | undefined>(
   "modelSlug",
@@ -184,9 +163,6 @@ const icons = {
       />
       <span class="hardpoint-category__name">
         {{ t(`labels.hardpoint.categories.${category}`) }}
-      </span>
-      <span v-if="powerPips" class="hardpoint-category__stat">
-        {{ toNumber(powerPips, "powerPips") }}
       </span>
       <Btn
         v-if="category === HardpointCategoryEnum.CARGOGRID && modelSlug"

--- a/app/frontend/frontend/components/Models/Hardpoints/powerPlant.spec.ts
+++ b/app/frontend/frontend/components/Models/Hardpoints/powerPlant.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { powerPlantPips, type PowerPlantContext } from "./powerPlant";
+
+describe("powerPlantPips", () => {
+  it("splits a two-identical-plant ship evenly and sums to the total (Guardian QI)", () => {
+    // 2x size-1 plants, powerBase 16 → category total 18 pips.
+    const context: PowerPlantContext = { count: 2, sizeSum: 2 };
+    const perPlant = powerPlantPips(16, 1, context);
+
+    expect(perPlant).toBe(9);
+    expect(perPlant * context.count).toBe(18);
+  });
+
+  it("returns the full total for a single-plant ship", () => {
+    const context: PowerPlantContext = { count: 1, sizeSum: 3 };
+
+    // n = 1 → round(powerBase/1) + 0
+    expect(powerPlantPips(14, 3, context)).toBe(14);
+  });
+
+  it("yields integer shares that sum to the category total for four plants", () => {
+    // 4x size-2 plants, powerBase 30.
+    const n = 4;
+    const size = 2;
+    const powerBase = 30;
+    const context: PowerPlantContext = { count: n, sizeSum: n * size };
+
+    const perPlant = powerPlantPips(powerBase, size, context);
+    const total = n * Math.round(powerBase / n) + (n - 1) * context.sizeSum;
+
+    expect(Number.isInteger(perPlant)).toBe(true);
+    expect(perPlant * n).toBe(total);
+  });
+
+  it("weights mixed plants by size while summing to the total", () => {
+    // A size-1 (powerBase 10) and a size-2 (powerBase 20) plant.
+    const context: PowerPlantContext = { count: 2, sizeSum: 3 };
+    const small = powerPlantPips(10, 1, context);
+    const large = powerPlantPips(20, 2, context);
+
+    // per-plant: round(base/2) + (2-1)*size
+    expect(small).toBe(Math.round(10 / 2) + 1); // 6
+    expect(large).toBe(Math.round(20 / 2) + 2); // 12
+
+    const total =
+      Math.round(10 / 2) + Math.round(20 / 2) + (2 - 1) * context.sizeSum;
+    expect(small + large).toBe(total);
+  });
+});

--- a/app/frontend/frontend/components/Models/Hardpoints/powerPlant.ts
+++ b/app/frontend/frontend/components/Models/Hardpoints/powerPlant.ts
@@ -1,0 +1,23 @@
+import type { ComputedRef, InjectionKey } from "vue";
+
+export type PowerPlantContext = {
+  count: number;
+  sizeSum: number;
+};
+
+// Provided by the power-plant Category so each plant item can resolve its own
+// pip share (pips are a ship-level value derived from every plant together).
+export const powerPlantContextKey: InjectionKey<
+  ComputedRef<PowerPlantContext | null>
+> = Symbol("powerPlantContext");
+
+// A single plant's share of the ship's power pips. Sums across all plants to the
+// category total shown in the header (Math.round(powerBase / n) summed, plus the
+// (n - 1) * Σsize coupling term split evenly by size).
+export function powerPlantPips(
+  powerBase: number,
+  size: number,
+  context: PowerPlantContext,
+): number {
+  return Math.round(powerBase / context.count) + (context.count - 1) * size;
+}

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -12,6 +12,10 @@ import {
 } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { sustainedRatio } from "@/frontend/composables/useLoadoutStats";
+import {
+  powerPlantContextKey,
+  powerPlantPips,
+} from "@/frontend/components/Models/Hardpoints/powerPlant";
 
 export type HardpointStat = {
   label: string;
@@ -43,6 +47,10 @@ export const useHardpointStats = (
     "weaponPowerRatio",
     undefined,
   );
+
+  // Ship-level power-plant context (plant count + size sum), provided by the
+  // power-plant Category, so each plant can show its own pip share.
+  const powerPlantContext = inject(powerPlantContextKey, undefined);
 
   const stat = (
     labelKey: string,
@@ -315,6 +323,17 @@ export const useHardpointStats = (
       if (pp.powerBase) {
         result.push(
           stat("powerPlants.output", pp.powerBase, "powerOutput", true),
+        );
+      }
+      const context = toValue(powerPlantContext);
+      const size = Number(hp.component?.size);
+      if (pp.powerBase && context && size) {
+        result.push(
+          stat(
+            "powerPlants.pips",
+            powerPlantPips(pp.powerBase, size, context),
+            "powerPips",
+          ),
         );
       }
     } else if (category === HardpointCategoryEnum.QUANTUMDRIVE) {

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -320,6 +320,10 @@ export const useHardpointStats = (
       }
     } else if (category === HardpointCategoryEnum.POWERPLANT) {
       const pp = typeData as ComponentPowerPlant;
+      // Output is a per-plant rating, so it stays as-is even on a stacked row.
+      // Pips are a ship-pool contribution, so they sum across the stack (the
+      // total the category header used to show).
+      const stackCount = Math.max(1, Math.round(Number(toValue(count) ?? 1)));
       if (pp.powerBase) {
         result.push(
           stat("powerPlants.output", pp.powerBase, "powerOutput", true),
@@ -331,7 +335,7 @@ export const useHardpointStats = (
         result.push(
           stat(
             "powerPlants.pips",
-            powerPlantPips(pp.powerBase, size, context),
+            powerPlantPips(pp.powerBase, size, context) * stackCount,
             "powerPips",
           ),
         );

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -174,7 +174,21 @@ export const useHardpointStats = (
         }
       } else if ("trackingSignal" in typeData) {
         if (weapon.damagePerShot) {
-          addDamageBreakdown(result, weapon.damagePerShot);
+          // Lead with total payload damage as the key metric; only spell out the
+          // per-type split when the warhead actually mixes damage types.
+          const entries = Object.entries(weapon.damagePerShot).filter(
+            ([, value]) => typeof value === "number" && value > 0,
+          );
+          const total = entries.reduce(
+            (sum, [, value]) => sum + (value as number),
+            0,
+          );
+          if (total) {
+            result.push(stat("missiles.damage", total, "damage", true));
+          }
+          if (entries.length > 1) {
+            addDamageBreakdown(result, weapon.damagePerShot);
+          }
         }
         if (weapon.speed) {
           result.push(stat("missiles.speed", weapon.speed, "missileSpeed"));

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -823,7 +823,8 @@
           "coolingRate": "Cooling Rate"
         },
         "powerPlants": {
-          "output": "Output"
+          "output": "Output",
+          "pips": "Pips"
         },
         "quantumDrives": {
           "speed": "Speed",

--- a/docs/exec-plans/erkul-data-gaps.md
+++ b/docs/exec-plans/erkul-data-gaps.md
@@ -208,16 +208,15 @@ damage type (composition) and per-weapon, but not by who controls the weapon.
 - **Source:** the hardpoint's control type is in the mount data (pilot vs
   turret); needs a group axis on the loadout-stats aggregation.
 
-## 12. Hull part classification (P2, not parsed)
+## 12. Hull part classification — DONE
 
 erkul: **Vital 2 (40 000 hp) / Secondary 9 (26 600 hp) / Breakable 6 (5 400 hp)
 / Subpart 2 (5 000 hp)**, 27 parts total.
 
-- **Source:** part damage-behavior flags in the vehicle implementation XML (the
-  same file the total `damageMax` sum already comes from — see
-  `project_hull_hp_source`).
-- **Have:** total hull HP + a summed `hullParts` breakdown; the vital / secondary
-  / breakable / subpart class split is not parsed.
+- **Shipped:** the parser classifies each part (`part_category`) and the model
+  exposes `hullParts[{name, health, category}]` with the vital / secondary /
+  breakable / subpart enum. The Survivability card renders the breakdown by
+  class (behind the "Show parts" toggle). Not a gap.
 
 ---
 


### PR DESCRIPTION
Follow-up fixes to the hardpoints redesign.

**Power-plant pips** (regression — the redesign dropped the per-item pips):
- Reinstates `powerPlant.ts` (`powerPlantPips` + `PowerPlantContext` + injection key) and its unit test, the Category `provide`, the `powerPlants.pips` label, and the per-plant stat in `useHardpointStats`.
- In compact mode a stacked spot totals its **pip share** across the stack (a ship-pool contribution). Output stays the per-plant rating.
- Drops the now-redundant category-header pips total.

**Missiles** — missile rows had no key metric (no gold headline). Lead with total payload **damage**; keep the per-type split only for mixed-damage warheads.

**Docs** — marked erkul-data-gaps §12 (hull part classification) as already shipped (it's in the Survivability card behind *Show parts*).

Verified: prettier + eslint clean, `powerPlant.spec.ts` 4/4.

🤖