### PR TITLE
chore(setup): generate frontend type declarations during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -205,11 +205,16 @@ FileUtils.chdir APP_ROOT do
   docker = run_step "Starting Docker services", "docker compose up -d --wait --wait-timeout 30", async: true
   run_step_wait(ruby_deps, node_deps, docker)
 
-  # Group B: Prepare databases and build Vite test assets (need deps + Docker)
+  # Group B: Prepare databases and build Vite assets (need deps + Docker)
   dev_db = run_step "Preparing database (dev)", "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix} bin/rails db:prepare", async: true
   test_db = run_step "Preparing database (test)", "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix} RAILS_ENV=test bin/rails db:prepare", async: true
   vite_build = run_step "Building email assets (test)", "bin/build-email-assets", async: true
-  run_step_wait(dev_db, test_db, vite_build)
+  # auto-imports.d.ts and components.d.ts are gitignored and only written by the
+  # Vite plugins, so vue-tsc reports every auto-imported symbol as undefined
+  # until a build has run at least once. Builds to vite-dev, so it does not race
+  # the email assets build over the vite-test manifest.
+  frontend_types = run_step "Generating frontend type declarations", "bin/vite build", async: true
+  run_step_wait(dev_db, test_db, vite_build, frontend_types)
 
   # Group C: Clean logs/tmp (need databases)
   clean = run_step "Cleaning logs and temp files", "bin/rails log:clear tmp:clear", async: true


### PR DESCRIPTION
`app/frontend/auto-imports.d.ts` and `app/frontend/components.d.ts` are gitignored and only written by the Vite plugins (`unplugin-auto-import` / `unplugin-vue-components`). Nothing in `bin/setup` ran a build with the main Vite config, so on a fresh clone or a new worktree `pnpm vue-tsc` reported *every* auto-imported symbol as undefined — thousands of bogus `Cannot find name 'ref'` errors — until you happened to run `bin/dev` or a build.

CI already works around this: the `tsc` job runs `bin/vite build --clear --mode=test` before `vue-tsc`. This brings local setup in line.

## Change

One step added to `bin/setup`, in the existing parallel group:

```ruby
frontend_types = run_step "Generating frontend type declarations", "bin/vite build", async: true
```

Runs in the default (development) mode, so it outputs to `public/vite-dev` and does **not** race `bin/build-email-assets` over the shared `public/vite-test` manifest.

## Verified

Deleted `auto-imports.d.ts`, `components.d.ts`, the generated `services/fy*Api` clients, and `log/` + `tmp/`, then ran `bin/setup`:

- all of them regenerate, no manual steps
- `pnpm vue-tsc` → **0 errors** immediately afterwards
- `bin/rails test` runs (needs the recreated `log/`)
- setup wall-clock went ~30s → 38s, since the build runs alongside the email assets build

## Note

The generated API clients (`services/fyApi`, `fyAdminApi`, `fyOAuthApi`) were already covered — `pnpm install` re-runs the `postinstall` → `generate-api-client` hook on every invocation, even when dependencies are already satisfied. Worth knowing that they go stale after any rebase that touches `swagger/`, which surfaces as confusing `MISSING_EXPORT` build errors; re-running `bin/setup` (or `pnpm install`) fixes it.

🤖
