### PR TITLE
feat(hardpoints): complete armor Defense stats + row polish

### DIFF
--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -544,6 +544,18 @@ export const useHardpointStats = (
           result.push(stat(labelKey, val, "integer"));
         }
       }
+      // Self-resistance: how the armor resists damage to itself (1 − multiplier;
+      // can be negative when a damage type is amplified, matching erkul).
+      const selfResistTypes: [string, string][] = [
+        ["selfResistancePhysical", "armor.selfPhysical"],
+        ["selfResistanceEnergy", "armor.selfEnergy"],
+      ];
+      for (const [key, labelKey] of selfResistTypes) {
+        const mult = armor[key];
+        if (typeof mult === "number" && mult !== 1) {
+          result.push(resistanceStat(labelKey, 1 - mult));
+        }
+      }
     } else if (category === HardpointCategoryEnum.FUEL_INTAKES) {
       const fi = typeData as Record<string, unknown>;
       // Fuel rates are small fractions (e.g. 0.2, 2.5); format with toNumber

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -506,7 +506,9 @@ export const useHardpointStats = (
         );
       }
       if (cm.maxAmmo) {
-        result.push(stat("weapons.ammo", cm.maxAmmo as number, "integer"));
+        result.push(
+          stat("weapons.ammo", cm.maxAmmo as number, "integer", true),
+        );
       }
       if (cm.speed) {
         result.push(stat("weapons.speed", cm.speed as number, "weaponSpeed"));
@@ -544,15 +546,18 @@ export const useHardpointStats = (
       }
     } else if (category === HardpointCategoryEnum.FUEL_INTAKES) {
       const fi = typeData as Record<string, unknown>;
-      if (fi.fuelPushRate) {
-        result.push(
-          stat("fuelIntakes.pushRate", fi.fuelPushRate as number, "fuelRate"),
-        );
+      // Fuel rates are small fractions (e.g. 0.2, 2.5); format with toNumber
+      // directly — the shared `stat` helper integer-rounds, collapsing them to 0.
+      const fuelRate = (labelKey: string, value: number, primary = false) => ({
+        label: t(`labels.hardpoint.${labelKey}`),
+        value: String(toNumber(value, "fuelRate")),
+        primary,
+      });
+      if (typeof fi.fuelPushRate === "number" && fi.fuelPushRate > 0) {
+        result.push(fuelRate("fuelIntakes.pushRate", fi.fuelPushRate, true));
       }
-      if (fi.minimumRate) {
-        result.push(
-          stat("fuelIntakes.minRate", fi.minimumRate as number, "fuelRate"),
-        );
+      if (typeof fi.minimumRate === "number" && fi.minimumRate > 0) {
+        result.push(fuelRate("fuelIntakes.minRate", fi.minimumRate));
       }
     }
 

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -516,16 +516,30 @@ export const useHardpointStats = (
       }
     } else if (category === HardpointCategoryEnum.ARMOR) {
       const armor = typeData as Record<string, unknown>;
-      const armorTypes: [string, string][] = [
+      if (typeof armor.health === "number" && armor.health > 0) {
+        result.push(stat("armor.hp", armor.health, "integer", true));
+      }
+      // erkul-style damage reduction = 1 − the incoming-damage multiplier.
+      const reductionTypes: [string, string][] = [
         ["damagePhysical", "armor.physical"],
         ["damageEnergy", "armor.energy"],
         ["damageDistortion", "armor.distortion"],
         ["damageThermal", "armor.thermal"],
       ];
-      for (const [key, labelKey] of armorTypes) {
+      for (const [key, labelKey] of reductionTypes) {
+        const mult = armor[key];
+        if (typeof mult === "number" && mult < 1) {
+          result.push(resistanceStat(labelKey, 1 - mult));
+        }
+      }
+      const deflectTypes: [string, string][] = [
+        ["deflectionPhysical", "armor.deflectPhysical"],
+        ["deflectionEnergy", "armor.deflectEnergy"],
+      ];
+      for (const [key, labelKey] of deflectTypes) {
         const val = armor[key];
         if (typeof val === "number" && val > 0) {
-          result.push(resistanceStat(labelKey, val));
+          result.push(stat(labelKey, val, "integer"));
         }
       }
     } else if (category === HardpointCategoryEnum.FUEL_INTAKES) {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -856,7 +856,9 @@
           "distortion": "Distortion",
           "thermal": "Thermal",
           "deflectPhysical": "Phys Deflect",
-          "deflectEnergy": "Energy Deflect"
+          "deflectEnergy": "Energy Deflect",
+          "selfPhysical": "Self-Res Phys",
+          "selfEnergy": "Self-Res Energy"
         },
         "fuelIntakes": {
           "pushRate": "Push Rate",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -850,10 +850,13 @@
           "rs": "RS"
         },
         "armor": {
+          "hp": "HP",
           "physical": "Physical",
           "energy": "Energy",
           "distortion": "Distortion",
-          "thermal": "Thermal"
+          "thermal": "Thermal",
+          "deflectPhysical": "Phys Deflect",
+          "deflectEnergy": "Energy Deflect"
         },
         "fuelIntakes": {
           "pushRate": "Push Rate",

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -522,13 +522,19 @@ module ScData
           armor_data = values.dig("Components", "SCItemVehicleArmorParams")
           damage_info = armor_data.dig("damageMultiplier", "DamageInfo") if armor_data.dig("damageMultiplier").is_a?(Hash)
           signal_data = armor_data.dig("signalCrossSection", "SItemSignalEmission") if armor_data.dig("signalCrossSection").is_a?(Hash)
+          deflection = armor_data.dig("armorDeflection", "deflectionValue")
           item[:type_data] = {
+            health: values.dig("Components", "SHealthComponentParams", "Health")&.to_f,
             damage_physical: damage_info&.dig("DamagePhysical")&.to_f,
             damage_energy: damage_info&.dig("DamageEnergy")&.to_f,
             damage_distortion: damage_info&.dig("DamageDistortion")&.to_f,
             damage_thermal: damage_info&.dig("DamageThermal")&.to_f,
             damage_biochemical: damage_info&.dig("DamageBiochemical")&.to_f,
             damage_stun: damage_info&.dig("DamageStun")&.to_f,
+            deflection_physical: deflection&.dig("DamagePhysical")&.to_f,
+            deflection_energy: deflection&.dig("DamageEnergy")&.to_f,
+            deflection_distortion: deflection&.dig("DamageDistortion")&.to_f,
+            deflection_thermal: deflection&.dig("DamageThermal")&.to_f,
             signal_infrared: signal_data&.dig("Infrared")&.to_f,
             signal_electromagnetic: signal_data&.dig("Electromagnetic")&.to_f,
             signal_cross_section: signal_data&.dig("CrossSection")&.to_f

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -523,8 +523,13 @@ module ScData
           damage_info = armor_data.dig("damageMultiplier", "DamageInfo") if armor_data.dig("damageMultiplier").is_a?(Hash)
           signal_data = armor_data.dig("signalCrossSection", "SItemSignalEmission") if armor_data.dig("signalCrossSection").is_a?(Hash)
           deflection = armor_data.dig("armorDeflection", "deflectionValue")
+          resistances = values.dig("Components", "SHealthComponentParams", "DamageResistances", "DamageResistance")
           item[:type_data] = {
             health: values.dig("Components", "SHealthComponentParams", "Health")&.to_f,
+            self_resistance_physical: resistances&.dig("PhysicalResistance", "Multiplier")&.to_f,
+            self_resistance_energy: resistances&.dig("EnergyResistance", "Multiplier")&.to_f,
+            self_resistance_distortion: resistances&.dig("DistortionResistance", "Multiplier")&.to_f,
+            self_resistance_thermal: resistances&.dig("ThermalResistance", "Multiplier")&.to_f,
             damage_physical: damage_info&.dig("DamagePhysical")&.to_f,
             damage_energy: damage_info&.dig("DamageEnergy")&.to_f,
             damage_distortion: damage_info&.dig("DamageDistortion")&.to_f,

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_stalker.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_stalker.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1232.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_stalker.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_stalker.json
@@ -22,11 +22,16 @@
     "health": 1232.0
   },
   "type_data": {
+    "health": 1232.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_titan.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_titan.json
@@ -22,11 +22,16 @@
     "health": 2640.0
   },
   "type_data": {
+    "health": 2640.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_titan.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_titan.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2640.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_warlock.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_warlock.json
@@ -22,11 +22,16 @@
     "health": 2640.0
   },
   "type_data": {
+    "health": 2640.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_avenger_warlock.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_avenger_warlock.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2640.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_eclipse.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_eclipse.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2464.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_eclipse.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_eclipse.json
@@ -22,11 +22,16 @@
     "health": 2464.0
   },
   "type_data": {
+    "health": 2464.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_gladius.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_gladius.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_gladius.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_gladius.json
@@ -22,11 +22,16 @@
     "health": 3300.0
   },
   "type_data": {
+    "health": 3300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_hammerhead.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_hammerhead.json
@@ -22,11 +22,16 @@
     "health": 25740.0
   },
   "type_data": {
+    "health": 25740.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 531.0,
+    "deflection_energy": 380.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_hammerhead.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_hammerhead.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 25740.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_idris.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris.json
@@ -22,11 +22,16 @@
     "health": 72930.0
   },
   "type_data": {
+    "health": 72930.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 528.0,
+    "deflection_energy": 462.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_idris.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 72930.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_invincible.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_invincible.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 72930.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 0.0,
+    "self_resistance_thermal": 0.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_invincible.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_invincible.json
@@ -22,11 +22,16 @@
     "health": 72930.0
   },
   "type_data": {
+    "health": 72930.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 528.0,
+    "deflection_energy": 462.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_m.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_m.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 87516.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_m.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_m.json
@@ -22,11 +22,16 @@
     "health": 87516.0
   },
   "type_data": {
+    "health": 87516.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 554.0,
+    "deflection_energy": 485.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_p.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_p.json
@@ -22,11 +22,16 @@
     "health": 72930.0
   },
   "type_data": {
+    "health": 72930.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 528.0,
+    "deflection_energy": 462.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_idris_p.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_idris_p.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 72930.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_javelin.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_javelin.json
@@ -22,11 +22,16 @@
     "health": 117810.0
   },
   "type_data": {
+    "health": 117810.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 539.0,
+    "deflection_energy": 473.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_javelin.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_javelin.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 117810.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_javelin_invulnerable.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_javelin_invulnerable.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 117810.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.0,
     "damage_distortion": 0.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_javelin_invulnerable.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_javelin_invulnerable.json
@@ -22,11 +22,16 @@
     "health": 117810.0
   },
   "type_data": {
+    "health": 117810.0,
     "damage_physical": 0.75,
     "damage_energy": 0.0,
     "damage_distortion": 0.0,
     "damage_thermal": 0.0,
     "damage_biochemical": 0.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 539.0,
+    "deflection_energy": 473.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_reclaimer.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_reclaimer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 32912.0,
+    "self_resistance_physical": 0.76,
+    "self_resistance_energy": 1.14,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_reclaimer.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_reclaimer.json
@@ -22,11 +22,16 @@
     "health": 32912.0
   },
   "type_data": {
+    "health": 32912.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 495.0,
+    "deflection_energy": 418.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_redeemer.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_redeemer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 21120.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_redeemer.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_redeemer.json
@@ -22,11 +22,16 @@
     "health": 21120.0
   },
   "type_data": {
+    "health": 21120.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_retaliator.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_retaliator.json
@@ -22,11 +22,16 @@
     "health": 18480.0
   },
   "type_data": {
+    "health": 18480.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_retaliator.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_retaliator.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18480.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2772.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre.json
@@ -22,11 +22,16 @@
     "health": 2772.0
   },
   "type_data": {
+    "health": 2772.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre_firebird.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre_firebird.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4752.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre_firebird.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre_firebird.json
@@ -22,11 +22,16 @@
     "health": 4752.0
   },
   "type_data": {
+    "health": 4752.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre_peregrine.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre_peregrine.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1584.0,
+    "self_resistance_physical": 0.95,
+    "self_resistance_energy": 1.43,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_sabre_peregrine.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabre_peregrine.json
@@ -22,11 +22,16 @@
     "health": 1584.0
   },
   "type_data": {
+    "health": 1584.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_sabreraven.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabreraven.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2218.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_sabreraven.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_sabreraven.json
@@ -22,11 +22,16 @@
     "health": 2218.0
   },
   "type_data": {
+    "health": 2218.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_template.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1815.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_template.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_template.json
@@ -22,11 +22,16 @@
     "health": 1815.0
   },
   "type_data": {
+    "health": 1815.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_tiburon.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_tiburon.json
@@ -22,11 +22,16 @@
     "health": 25740.0
   },
   "type_data": {
+    "health": 25740.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 531.0,
+    "deflection_energy": 380.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_tiburon.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_tiburon.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 25740.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_harbinger.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_harbinger.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_harbinger.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_harbinger.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_hoplite.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_hoplite.json
@@ -22,11 +22,16 @@
     "health": 14850.0
   },
   "type_data": {
+    "health": 14850.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_hoplite.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_hoplite.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 14850.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_sentinel.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_sentinel.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_aegs_vanguard_sentinel.json
+++ b/data/sc_data/parsed/live/items/armr_aegs_vanguard_sentinel.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_arrow.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_arrow.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_arrow.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_arrow.json
@@ -22,11 +22,16 @@
     "health": 3300.0
   },
   "type_data": {
+    "health": 3300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 12.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_asgard.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_asgard.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 23760.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_asgard.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_asgard.json
@@ -22,11 +22,16 @@
     "health": 23760.0
   },
   "type_data": {
+    "health": 23760.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 139.0,
+    "deflection_energy": 88.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_ballista.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_ballista.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2145.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_ballista.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_ballista.json
@@ -22,11 +22,16 @@
     "health": 2145.0
   },
   "type_data": {
+    "health": 2145.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 3.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_c8_pisces.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8_pisces.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2420.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_c8_pisces.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8_pisces.json
@@ -22,11 +22,16 @@
     "health": 2420.0
   },
   "type_data": {
+    "health": 2420.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 12.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_c8r_pisces.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8r_pisces.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2420.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_c8r_pisces.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8r_pisces.json
@@ -22,11 +22,16 @@
     "health": 2420.0
   },
   "type_data": {
+    "health": 2420.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 12.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_c8x_pisces_expedition.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8x_pisces_expedition.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2420.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_c8x_pisces_expedition.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_c8x_pisces_expedition.json
@@ -22,11 +22,16 @@
     "health": 2420.0
   },
   "type_data": {
+    "health": 2420.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 12.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_carrack.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_carrack.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18700.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_carrack.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_carrack.json
@@ -22,11 +22,16 @@
     "health": 18700.0
   },
   "type_data": {
+    "health": 18700.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 420.0,
+    "deflection_energy": 240.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_centurion.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_centurion.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2145.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_centurion.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_centurion.json
@@ -22,11 +22,16 @@
     "health": 2145.0
   },
   "type_data": {
+    "health": 2145.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 3.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_fc7r.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_fc7r.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_fc7r.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_fc7r.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_gladiator.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_gladiator.json
@@ -22,11 +22,16 @@
     "health": 10560.0
   },
   "type_data": {
+    "health": 10560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_gladiator.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_gladiator.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10560.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hawk.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hawk.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hawk.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hawk.json
@@ -22,11 +22,16 @@
     "health": 3300.0
   },
   "type_data": {
+    "health": 3300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 12.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7a.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7a.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7a.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7a.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7c.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7c.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7c.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7c.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm_mk2.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cm_mk2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3080.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr.json
@@ -22,11 +22,16 @@
     "health": 3080.0
   },
   "type_data": {
+    "health": 3080.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr_mk2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3080.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cr_mk2.json
@@ -22,11 +22,16 @@
     "health": 3080.0
   },
   "type_data": {
+    "health": 3080.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs_mk2.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 24.0,
+    "deflection_energy": 13.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hornet_f7cs_mk2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hurricane.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hurricane.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_hurricane.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_hurricane.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 54.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_lightning_f8.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_lightning_f8.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10890.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_lightning_f8.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_lightning_f8.json
@@ -22,11 +22,16 @@
     "health": 10890.0
   },
   "type_data": {
+    "health": 10890.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 54.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_paladin.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_paladin.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18480.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_paladin.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_paladin.json
@@ -22,11 +22,16 @@
     "health": 18480.0
   },
   "type_data": {
+    "health": 18480.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 139.0,
+    "deflection_energy": 88.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_spartan.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_spartan.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2145.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_spartan.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_spartan.json
@@ -22,11 +22,16 @@
     "health": 2145.0
   },
   "type_data": {
+    "health": 2145.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 3.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_template.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_template.json
@@ -22,11 +22,16 @@
     "health": 1210.0
   },
   "type_data": {
+    "health": 1210.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 3.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_template.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1210.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_terrapin.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_terrapin.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 62.0,
+    "deflection_energy": 33.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_terrapin.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_terrapin.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_terrapin_medic.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_terrapin_medic.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 62.0,
+    "deflection_energy": 33.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_anvl_terrapin_medic.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_terrapin_medic.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_valkyrie.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_valkyrie.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 23760.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_anvl_valkyrie.json
+++ b/data/sc_data/parsed/live/items/armr_anvl_valkyrie.json
@@ -22,11 +22,16 @@
     "health": 23760.0
   },
   "type_data": {
+    "health": 23760.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 139.0,
+    "deflection_energy": 88.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_csv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_csv.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_csv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_csv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_mole.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mole.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 11220.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.14,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_mole.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mole.json
@@ -22,11 +22,16 @@
     "health": 11220.0
   },
   "type_data": {
+    "health": 11220.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 45.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_moth.json
+++ b/data/sc_data/parsed/live/items/armr_argo_moth.json
@@ -22,11 +22,16 @@
     "health": 11220.0
   },
   "type_data": {
+    "health": 11220.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 45.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_moth.json
+++ b/data/sc_data/parsed/live/items/armr_argo_moth.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 11220.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.14,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_mpuv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mpuv.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_mpuv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mpuv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_mpuv_1t.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mpuv_1t.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_mpuv_1t.json
+++ b/data/sc_data/parsed/live/items/armr_argo_mpuv_1t.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_raft.json
+++ b/data/sc_data/parsed/live/items/armr_argo_raft.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_raft.json
+++ b/data/sc_data/parsed/live/items/armr_argo_raft.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 45.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_srv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_srv.json
@@ -22,11 +22,16 @@
     "health": 3740.0
   },
   "type_data": {
+    "health": 3740.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_argo_srv.json
+++ b/data/sc_data/parsed/live/items/armr_argo_srv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3740.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.14,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_template.json
+++ b/data/sc_data/parsed/live/items/armr_argo_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_argo_template.json
+++ b/data/sc_data/parsed/live/items/armr_argo_template.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_banu_defender.json
+++ b/data/sc_data/parsed/live/items/armr_banu_defender.json
@@ -22,11 +22,16 @@
     "health": 5400.0
   },
   "type_data": {
+    "health": 5400.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_banu_defender.json
+++ b/data/sc_data/parsed/live/items/armr_banu_defender.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 5400.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_banu_template.json
+++ b/data/sc_data/parsed/live/items/armr_banu_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1485.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_banu_template.json
+++ b/data/sc_data/parsed/live/items/armr_banu_template.json
@@ -22,11 +22,16 @@
     "health": 1485.0
   },
   "type_data": {
+    "health": 1485.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_hoverquad.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_hoverquad.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_hoverquad.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_hoverquad.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_alpha.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_alpha.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_alpha.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_alpha.json
@@ -22,11 +22,16 @@
     "health": 2000.0
   },
   "type_data": {
+    "health": 2000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_beta.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_beta.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_beta.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_beta.json
@@ -22,11 +22,16 @@
     "health": 2000.0
   },
   "type_data": {
+    "health": 2000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_delta.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_delta.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_delta.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_delta.json
@@ -22,11 +22,16 @@
     "health": 2000.0
   },
   "type_data": {
+    "health": 2000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_gamma.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_gamma.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_gamma.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_gamma.json
@@ -22,11 +22,16 @@
     "health": 2000.0
   },
   "type_data": {
+    "health": 2000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_omega.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_omega.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_mustang_omega.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_mustang_omega.json
@@ -22,11 +22,16 @@
     "health": 2000.0
   },
   "type_data": {
+    "health": 2000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_nomad.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_nomad.json
@@ -22,11 +22,16 @@
     "health": 2200.0
   },
   "type_data": {
+    "health": 2200.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_cnou_nomad.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_nomad.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2200.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_template.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_cnou_template.json
+++ b/data/sc_data/parsed/live/items/armr_cnou_template.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_intrepid.json
+++ b/data/sc_data/parsed/live/items/armr_crus_intrepid.json
@@ -22,11 +22,16 @@
     "health": 3200.0
   },
   "type_data": {
+    "health": 3200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_intrepid.json
+++ b/data/sc_data/parsed/live/items/armr_crus_intrepid.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3200.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_spirit.json
+++ b/data/sc_data/parsed/live/items/armr_crus_spirit.json
@@ -22,11 +22,16 @@
     "health": 9600.0
   },
   "type_data": {
+    "health": 9600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 36.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_spirit.json
+++ b/data/sc_data/parsed/live/items/armr_crus_spirit.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_star_runner.json
+++ b/data/sc_data/parsed/live/items/armr_crus_star_runner.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 14560.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_star_runner.json
+++ b/data/sc_data/parsed/live/items/armr_crus_star_runner.json
@@ -22,11 +22,16 @@
     "health": 14560.0
   },
   "type_data": {
+    "health": 14560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 127.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starfighter_inferno.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starfighter_inferno.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 14400.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_starfighter_inferno.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starfighter_inferno.json
@@ -22,11 +22,16 @@
     "health": 14400.0
   },
   "type_data": {
+    "health": 14400.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 36.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starfighter_ion.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starfighter_ion.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 14400.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_starfighter_ion.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starfighter_ion.json
@@ -22,11 +22,16 @@
     "health": 14400.0
   },
   "type_data": {
+    "health": 14400.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 36.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter.json
@@ -22,11 +22,16 @@
     "health": 13000.0
   },
   "type_data": {
+    "health": 13000.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 385.0,
+    "deflection_energy": 300.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 13000.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter_a2.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter_a2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 25350.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter_a2.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter_a2.json
@@ -22,11 +22,16 @@
     "health": 25350.0
   },
   "type_data": {
+    "health": 25350.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 385.0,
+    "deflection_energy": 300.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter_m2.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter_m2.json
@@ -22,11 +22,16 @@
     "health": 23400.0
   },
   "type_data": {
+    "health": 23400.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 385.0,
+    "deflection_energy": 300.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_starlifter_m2.json
+++ b/data/sc_data/parsed/live/items/armr_crus_starlifter_m2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 23400.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_crus_template.json
+++ b/data/sc_data/parsed/live/items/armr_crus_template.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_crus_template.json
+++ b/data/sc_data/parsed/live/items/armr_crus_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_buccaneer.json
+++ b/data/sc_data/parsed/live/items/armr_drak_buccaneer.json
@@ -22,11 +22,16 @@
     "health": 2160.0
   },
   "type_data": {
+    "health": 2160.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_buccaneer.json
+++ b/data/sc_data/parsed/live/items/armr_drak_buccaneer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2160.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_caterpillar.json
+++ b/data/sc_data/parsed/live/items/armr_drak_caterpillar.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 16830.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_caterpillar.json
+++ b/data/sc_data/parsed/live/items/armr_drak_caterpillar.json
@@ -22,11 +22,16 @@
     "health": 16830.0
   },
   "type_data": {
+    "health": 16830.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 300.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_clipper.json
+++ b/data/sc_data/parsed/live/items/armr_drak_clipper.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2880.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_clipper.json
+++ b/data/sc_data/parsed/live/items/armr_drak_clipper.json
@@ -22,11 +22,16 @@
     "health": 2880.0
   },
   "type_data": {
+    "health": 2880.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_command_module.json
+++ b/data/sc_data/parsed/live/items/armr_drak_command_module.json
@@ -22,11 +22,16 @@
     "health": 3366.0
   },
   "type_data": {
+    "health": 3366.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_command_module.json
+++ b/data/sc_data/parsed/live/items/armr_drak_command_module.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3366.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_corsair.json
+++ b/data/sc_data/parsed/live/items/armr_drak_corsair.json
@@ -22,11 +22,16 @@
     "health": 15120.0
   },
   "type_data": {
+    "health": 15120.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 95.0,
+    "deflection_energy": 100.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_corsair.json
+++ b/data/sc_data/parsed/live/items/armr_drak_corsair.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 15120.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_black.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_black.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 7290.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_black.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_black.json
@@ -22,11 +22,16 @@
     "health": 7290.0
   },
   "type_data": {
+    "health": 7290.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_blue.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_blue.json
@@ -22,11 +22,16 @@
     "health": 4860.0
   },
   "type_data": {
+    "health": 4860.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_blue.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_blue.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4860.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_red.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_red.json
@@ -22,11 +22,16 @@
     "health": 4860.0
   },
   "type_data": {
+    "health": 4860.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_red.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_red.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4860.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_steel.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_steel.json
@@ -22,11 +22,16 @@
     "health": 10935.0
   },
   "type_data": {
+    "health": 10935.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 29.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_cutlass_steel.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutlass_steel.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10935.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_cutter.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutter.json
@@ -22,11 +22,16 @@
     "health": 1980.0
   },
   "type_data": {
+    "health": 1980.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_cutter.json
+++ b/data/sc_data/parsed/live/items/armr_drak_cutter.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1980.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_dragonfly.json
+++ b/data/sc_data/parsed/live/items/armr_drak_dragonfly.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1170.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_dragonfly.json
+++ b/data/sc_data/parsed/live/items/armr_drak_dragonfly.json
@@ -22,11 +22,16 @@
     "health": 1170.0
   },
   "type_data": {
+    "health": 1170.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_golem.json
+++ b/data/sc_data/parsed/live/items/armr_drak_golem.json
@@ -22,11 +22,16 @@
     "health": 6732.0
   },
   "type_data": {
+    "health": 6732.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 18.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_golem.json
+++ b/data/sc_data/parsed/live/items/armr_drak_golem.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6732.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_herald.json
+++ b/data/sc_data/parsed/live/items/armr_drak_herald.json
@@ -22,11 +22,16 @@
     "health": 4896.0
   },
   "type_data": {
+    "health": 4896.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 18.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_herald.json
+++ b/data/sc_data/parsed/live/items/armr_drak_herald.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4896.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_ironclad.json
+++ b/data/sc_data/parsed/live/items/armr_drak_ironclad.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 26010.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.72,
     "damage_energy": 0.96,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_ironclad.json
+++ b/data/sc_data/parsed/live/items/armr_drak_ironclad.json
@@ -22,11 +22,16 @@
     "health": 26010.0
   },
   "type_data": {
+    "health": 26010.0,
     "damage_physical": 0.72,
     "damage_energy": 0.96,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 300.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_ironclad_assault.json
+++ b/data/sc_data/parsed/live/items/armr_drak_ironclad_assault.json
@@ -22,11 +22,16 @@
     "health": 20790.0
   },
   "type_data": {
+    "health": 20790.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 331.0,
+    "deflection_energy": 315.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_ironclad_assault.json
+++ b/data/sc_data/parsed/live/items/armr_drak_ironclad_assault.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 20790.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_mule.json
+++ b/data/sc_data/parsed/live/items/armr_drak_mule.json
@@ -22,11 +22,16 @@
     "health": 2340.0
   },
   "type_data": {
+    "health": 2340.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_mule.json
+++ b/data/sc_data/parsed/live/items/armr_drak_mule.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2340.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_pitbull.json
+++ b/data/sc_data/parsed/live/items/armr_drak_pitbull.json
@@ -22,11 +22,16 @@
     "health": 1350.0
   },
   "type_data": {
+    "health": 1350.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_pitbull.json
+++ b/data/sc_data/parsed/live/items/armr_drak_pitbull.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1350.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.02,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_template.json
+++ b/data/sc_data/parsed/live/items/armr_drak_template.json
@@ -22,11 +22,16 @@
     "health": 990.0
   },
   "type_data": {
+    "health": 990.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_template.json
+++ b/data/sc_data/parsed/live/items/armr_drak_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 990.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_drak_vulture.json
+++ b/data/sc_data/parsed/live/items/armr_drak_vulture.json
@@ -22,11 +22,16 @@
     "health": 6732.0
   },
   "type_data": {
+    "health": 6732.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 18.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_drak_vulture.json
+++ b/data/sc_data/parsed/live/items/armr_drak_vulture.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6732.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 0.96,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_espr_prowler.json
+++ b/data/sc_data/parsed/live/items/armr_espr_prowler.json
@@ -22,11 +22,16 @@
     "health": 12150.0
   },
   "type_data": {
+    "health": 12150.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 39.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_espr_prowler.json
+++ b/data/sc_data/parsed/live/items/armr_espr_prowler.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 12150.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_espr_prowler_utility.json
+++ b/data/sc_data/parsed/live/items/armr_espr_prowler_utility.json
@@ -22,11 +22,16 @@
     "health": 12150.0
   },
   "type_data": {
+    "health": 12150.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 32.0,
+    "deflection_energy": 39.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_espr_prowler_utility.json
+++ b/data/sc_data/parsed/live/items/armr_espr_prowler_utility.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 12150.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_espr_talon.json
+++ b/data/sc_data/parsed/live/items/armr_espr_talon.json
@@ -22,11 +22,16 @@
     "health": 3000.0
   },
   "type_data": {
+    "health": 3000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 8.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_espr_talon.json
+++ b/data/sc_data/parsed/live/items/armr_espr_talon.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3000.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_espr_template.json
+++ b/data/sc_data/parsed/live/items/armr_espr_template.json
@@ -22,11 +22,16 @@
     "health": 1650.0
   },
   "type_data": {
+    "health": 1650.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 4.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_espr_template.json
+++ b/data/sc_data/parsed/live/items/armr_espr_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1650.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_gama_railen.json
+++ b/data/sc_data/parsed/live/items/armr_gama_railen.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 11968.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_gama_railen.json
+++ b/data/sc_data/parsed/live/items/armr_gama_railen.json
@@ -22,11 +22,16 @@
     "health": 11968.0
   },
   "type_data": {
+    "health": 11968.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_gama_syulen.json
+++ b/data/sc_data/parsed/live/items/armr_gama_syulen.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4352.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_gama_syulen.json
+++ b/data/sc_data/parsed/live/items/armr_gama_syulen.json
@@ -22,11 +22,16 @@
     "health": 4352.0
   },
   "type_data": {
+    "health": 4352.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_gama_template.json
+++ b/data/sc_data/parsed/live/items/armr_gama_template.json
@@ -22,11 +22,16 @@
     "health": 1496.0
   },
   "type_data": {
+    "health": 1496.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_gama_template.json
+++ b/data/sc_data/parsed/live/items/armr_gama_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1496.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_gama_tyilui.json
+++ b/data/sc_data/parsed/live/items/armr_gama_tyilui.json
@@ -22,11 +22,16 @@
     "health": 10560.0
   },
   "type_data": {
+    "health": 10560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_gama_tyilui.json
+++ b/data/sc_data/parsed/live/items/armr_gama_tyilui.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10560.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_glsn_basher.json
+++ b/data/sc_data/parsed/live/items/armr_glsn_basher.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1600.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_glsn_basher.json
+++ b/data/sc_data/parsed/live/items/armr_glsn_basher.json
@@ -22,11 +22,16 @@
     "health": 1600.0
   },
   "type_data": {
+    "health": 1600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 8.0,
+    "deflection_energy": 6.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_glsn_shiv.json
+++ b/data/sc_data/parsed/live/items/armr_glsn_shiv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 8100.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_glsn_shiv.json
+++ b/data/sc_data/parsed/live/items/armr_glsn_shiv.json
@@ -22,11 +22,16 @@
     "health": 8100.0
   },
   "type_data": {
+    "health": 8100.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 29.0,
+    "deflection_energy": 23.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_mdc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_mdc.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1170.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_mdc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_mdc.json
@@ -22,11 +22,16 @@
     "health": 1170.0
   },
   "type_data": {
+    "health": 1170.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_mtc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_mtc.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1170.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_mtc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_mtc.json
@@ -22,11 +22,16 @@
     "health": 1170.0
   },
   "type_data": {
+    "health": 1170.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_roc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_roc.json
@@ -22,11 +22,16 @@
     "health": 1989.0
   },
   "type_data": {
+    "health": 1989.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_roc.json
+++ b/data/sc_data/parsed/live/items/armr_grin_roc.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1989.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_roc_ds.json
+++ b/data/sc_data/parsed/live/items/armr_grin_roc_ds.json
@@ -22,11 +22,16 @@
     "health": 1989.0
   },
   "type_data": {
+    "health": 1989.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_roc_ds.json
+++ b/data/sc_data/parsed/live/items/armr_grin_roc_ds.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1989.0,
+    "self_resistance_physical": 0.68,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_stv.json
+++ b/data/sc_data/parsed/live/items/armr_grin_stv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1170.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_stv.json
+++ b/data/sc_data/parsed/live/items/armr_grin_stv.json
@@ -22,11 +22,16 @@
     "health": 1170.0
   },
   "type_data": {
+    "health": 1170.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_template.json
+++ b/data/sc_data/parsed/live/items/armr_grin_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 990.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_template.json
+++ b/data/sc_data/parsed/live/items/armr_grin_template.json
@@ -22,11 +22,16 @@
     "health": 990.0
   },
   "type_data": {
+    "health": 990.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_grin_utv.json
+++ b/data/sc_data/parsed/live/items/armr_grin_utv.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1170.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_grin_utv.json
+++ b/data/sc_data/parsed/live/items/armr_grin_utv.json
@@ -22,11 +22,16 @@
     "health": 1170.0
   },
   "type_data": {
+    "health": 1170.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_archimedes.json
+++ b/data/sc_data/parsed/live/items/armr_krig_archimedes.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 360.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_archimedes.json
+++ b/data/sc_data/parsed/live/items/armr_krig_archimedes.json
@@ -22,11 +22,16 @@
     "health": 360.0
   },
   "type_data": {
+    "health": 360.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_l21_wolf.json
+++ b/data/sc_data/parsed/live/items/armr_krig_l21_wolf.json
@@ -22,11 +22,16 @@
     "health": 2700.0
   },
   "type_data": {
+    "health": 2700.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_l21_wolf.json
+++ b/data/sc_data/parsed/live/items/armr_krig_l21_wolf.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2700.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_l22_alphawolf.json
+++ b/data/sc_data/parsed/live/items/armr_krig_l22_alphawolf.json
@@ -22,11 +22,16 @@
     "health": 2700.0
   },
   "type_data": {
+    "health": 2700.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_l22_alphawolf.json
+++ b/data/sc_data/parsed/live/items/armr_krig_l22_alphawolf.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2700.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_merlin.json
+++ b/data/sc_data/parsed/live/items/armr_krig_merlin.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 360.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_merlin.json
+++ b/data/sc_data/parsed/live/items/armr_krig_merlin.json
@@ -22,11 +22,16 @@
     "health": 360.0
   },
   "type_data": {
+    "health": 360.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_s65_stingray.json
+++ b/data/sc_data/parsed/live/items/armr_krig_s65_stingray.json
@@ -22,11 +22,16 @@
     "health": 900.0
   },
   "type_data": {
+    "health": 900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_krig_s65_stingray.json
+++ b/data/sc_data/parsed/live/items/armr_krig_s65_stingray.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 900.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_template.json
+++ b/data/sc_data/parsed/live/items/armr_krig_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 495.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_krig_template.json
+++ b/data/sc_data/parsed/live/items/armr_krig_template.json
@@ -22,11 +22,16 @@
     "health": 495.0
   },
   "type_data": {
+    "health": 495.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_fortune.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fortune.json
@@ -22,11 +22,16 @@
     "health": 4114.0
   },
   "type_data": {
+    "health": 4114.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_fortune.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fortune.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4114.0,
+    "self_resistance_physical": 0.8,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10560.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer.json
@@ -22,11 +22,16 @@
     "health": 10560.0
   },
   "type_data": {
+    "health": 10560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 41.0,
+    "deflection_energy": 43.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer_dur.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer_dur.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10560.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer_dur.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer_dur.json
@@ -22,11 +22,16 @@
     "health": 10560.0
   },
   "type_data": {
+    "health": 10560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 41.0,
+    "deflection_energy": 43.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer_mis.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer_mis.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 15840.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_freelancer_mis.json
+++ b/data/sc_data/parsed/live/items/armr_misc_freelancer_mis.json
@@ -22,11 +22,16 @@
     "health": 15840.0
   },
   "type_data": {
+    "health": 15840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 41.0,
+    "deflection_energy": 43.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_fury.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fury.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1650.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_fury.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fury.json
@@ -22,11 +22,16 @@
     "health": 1650.0
   },
   "type_data": {
+    "health": 1650.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_fury_lx.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fury_lx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 550.0,
+    "self_resistance_physical": 1.0,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_fury_lx.json
+++ b/data/sc_data/parsed/live/items/armr_misc_fury_lx.json
@@ -22,11 +22,16 @@
     "health": 550.0
   },
   "type_data": {
+    "health": 550.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_hull_a.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_a.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4840.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_hull_a.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_a.json
@@ -22,11 +22,16 @@
     "health": 4840.0
   },
   "type_data": {
+    "health": 4840.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 18.0,
+    "deflection_energy": 19.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_hull_b.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_b.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 7260.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_hull_b.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_b.json
@@ -22,11 +22,16 @@
     "health": 7260.0
   },
   "type_data": {
+    "health": 7260.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 41.0,
+    "deflection_energy": 43.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_hull_c.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_c.json
@@ -22,11 +22,16 @@
     "health": 12100.0
   },
   "type_data": {
+    "health": 12100.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 360.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_hull_c.json
+++ b/data/sc_data/parsed/live/items/armr_misc_hull_c.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 12100.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_prospector.json
+++ b/data/sc_data/parsed/live/items/armr_misc_prospector.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 8228.0,
+    "self_resistance_physical": 0.8,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_prospector.json
+++ b/data/sc_data/parsed/live/items/armr_misc_prospector.json
@@ -22,11 +22,16 @@
     "health": 8228.0
   },
   "type_data": {
+    "health": 8228.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 18.0,
+    "deflection_energy": 19.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_razor.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1320.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_razor.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor.json
@@ -22,11 +22,16 @@
     "health": 1320.0
   },
   "type_data": {
+    "health": 1320.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_razor_ex.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor_ex.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1320.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_razor_ex.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor_ex.json
@@ -22,11 +22,16 @@
     "health": 1320.0
   },
   "type_data": {
+    "health": 1320.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_razor_lx.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor_lx.json
@@ -22,11 +22,16 @@
     "health": 440.0
   },
   "type_data": {
+    "health": 440.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_razor_lx.json
+++ b/data/sc_data/parsed/live/items/armr_misc_razor_lx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 440.0,
+    "self_resistance_physical": 1.0,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_reliant.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant.json
@@ -22,11 +22,16 @@
     "health": 2200.0
   },
   "type_data": {
+    "health": 2200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_reliant.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2200.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_mako.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_mako.json
@@ -22,11 +22,16 @@
     "health": 2200.0
   },
   "type_data": {
+    "health": 2200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_mako.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_mako.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2200.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_sen.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_sen.json
@@ -22,11 +22,16 @@
     "health": 2200.0
   },
   "type_data": {
+    "health": 2200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_sen.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_sen.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2200.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_tana.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_tana.json
@@ -22,11 +22,16 @@
     "health": 3300.0
   },
   "type_data": {
+    "health": 3300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_reliant_tana.json
+++ b/data/sc_data/parsed/live/items/armr_misc_reliant_tana.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3300.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer.json
@@ -22,11 +22,16 @@
     "health": 12100.0
   },
   "type_data": {
+    "health": 12100.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 360.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 12100.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini.json
@@ -22,11 +22,16 @@
     "health": 18150.0
   },
   "type_data": {
+    "health": 18150.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 331.0,
+    "deflection_energy": 378.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18150.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini_derelict.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini_derelict.json
@@ -22,11 +22,16 @@
     "health": 18150.0
   },
   "type_data": {
+    "health": 18150.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 331.0,
+    "deflection_energy": 378.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini_derelict.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starfarer_gemini_derelict.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18150.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starlancer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlancer.json
@@ -22,11 +22,16 @@
     "health": 12100.0
   },
   "type_data": {
+    "health": 12100.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 360.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starlancer.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlancer.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 12100.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starlancer_tac.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlancer_tac.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 18150.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_starlancer_tac.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlancer_tac.json
@@ -22,11 +22,16 @@
     "health": 18150.0
   },
   "type_data": {
+    "health": 18150.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 347.0,
+    "deflection_energy": 396.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starlite.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlite.json
@@ -22,11 +22,16 @@
     "health": 4114.0
   },
   "type_data": {
+    "health": 4114.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 10.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_misc_starlite.json
+++ b/data/sc_data/parsed/live/items/armr_misc_starlite.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4114.0,
+    "self_resistance_physical": 0.8,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_template.json
+++ b/data/sc_data/parsed/live/items/armr_misc_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1210.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_misc_template.json
+++ b/data/sc_data/parsed/live/items/armr_misc_template.json
@@ -22,11 +22,16 @@
     "health": 1210.0
   },
   "type_data": {
+    "health": 1210.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 5.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_mrai_guardian.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_guardian.json
@@ -22,11 +22,16 @@
     "health": 9000.0
   },
   "type_data": {
+    "health": 9000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 54.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_mrai_guardian.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_guardian.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9000.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_mrai_guardian_mx.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_guardian_mx.json
@@ -22,11 +22,16 @@
     "health": 10800.0
   },
   "type_data": {
+    "health": 10800.0,
     "damage_physical": 0.75,
     "damage_energy": 1.1,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 54.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_mrai_guardian_mx.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_guardian_mx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 10800.0,
+    "self_resistance_physical": 0.85,
+    "self_resistance_energy": 1.21,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 1.1,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_mrai_pulse.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_pulse.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_mrai_pulse.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_pulse.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_mrai_pulse_lx.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_pulse_lx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 650.0,
+    "self_resistance_physical": 1.0,
+    "self_resistance_energy": 1.43,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_mrai_pulse_lx.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_pulse_lx.json
@@ -22,11 +22,16 @@
     "health": 650.0
   },
   "type_data": {
+    "health": 650.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_mrai_template.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_mrai_template.json
+++ b/data/sc_data/parsed/live/items/armr_mrai_template.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_100i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_100i.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_100i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_100i.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_125a.json
+++ b/data/sc_data/parsed/live/items/armr_orig_125a.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_125a.json
+++ b/data/sc_data/parsed/live/items/armr_orig_125a.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_135c.json
+++ b/data/sc_data/parsed/live/items/armr_orig_135c.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_135c.json
+++ b/data/sc_data/parsed/live/items/armr_orig_135c.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_300i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_300i.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_300i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_300i.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_315p.json
+++ b/data/sc_data/parsed/live/items/armr_orig_315p.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_315p.json
+++ b/data/sc_data/parsed/live/items/armr_orig_315p.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_325a.json
+++ b/data/sc_data/parsed/live/items/armr_orig_325a.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_325a.json
+++ b/data/sc_data/parsed/live/items/armr_orig_325a.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_350r.json
+++ b/data/sc_data/parsed/live/items/armr_orig_350r.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1920.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_350r.json
+++ b/data/sc_data/parsed/live/items/armr_orig_350r.json
@@ -22,11 +22,16 @@
     "health": 1920.0
   },
   "type_data": {
+    "health": 1920.0,
     "damage_physical": 0.8,
     "damage_energy": 0.65,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_400i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_400i.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 13440.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_400i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_400i.json
@@ -22,11 +22,16 @@
     "health": 13440.0
   },
   "type_data": {
+    "health": 13440.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 95.0,
+    "deflection_energy": 90.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_600i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_600i.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 15600.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_600i.json
+++ b/data/sc_data/parsed/live/items/armr_orig_600i.json
@@ -22,11 +22,16 @@
     "health": 15600.0
   },
   "type_data": {
+    "health": 15600.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 315.0,
+    "deflection_energy": 270.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_85x.json
+++ b/data/sc_data/parsed/live/items/armr_orig_85x.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2400.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_85x.json
+++ b/data/sc_data/parsed/live/items/armr_orig_85x.json
@@ -22,11 +22,16 @@
     "health": 2400.0
   },
   "type_data": {
+    "health": 2400.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_890j.json
+++ b/data/sc_data/parsed/live/items/armr_orig_890j.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 32640.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_890j.json
+++ b/data/sc_data/parsed/live/items/armr_orig_890j.json
@@ -22,11 +22,16 @@
     "health": 32640.0
   },
   "type_data": {
+    "health": 32640.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 405.0,
+    "deflection_energy": 342.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_m50.json
+++ b/data/sc_data/parsed/live/items/armr_orig_m50.json
@@ -22,11 +22,16 @@
     "health": 960.0
   },
   "type_data": {
+    "health": 960.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 9.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_m50.json
+++ b/data/sc_data/parsed/live/items/armr_orig_m50.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 960.0,
+    "self_resistance_physical": 0.9,
+    "self_resistance_energy": 1.2,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.85,
     "damage_energy": 0.7,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_m80.json
+++ b/data/sc_data/parsed/live/items/armr_orig_m80.json
@@ -22,11 +22,16 @@
     "health": 7200.0
   },
   "type_data": {
+    "health": 7200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 41.0,
+    "deflection_energy": 32.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_m80.json
+++ b/data/sc_data/parsed/live/items/armr_orig_m80.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 7200.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_template.json
+++ b/data/sc_data/parsed/live/items/armr_orig_template.json
@@ -22,11 +22,16 @@
     "health": 1320.0
   },
   "type_data": {
+    "health": 1320.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_orig_template.json
+++ b/data/sc_data/parsed/live/items/armr_orig_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1320.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_x1.json
+++ b/data/sc_data/parsed/live/items/armr_orig_x1.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1560.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_orig_x1.json
+++ b/data/sc_data/parsed/live/items/armr_orig_x1.json
@@ -22,11 +22,16 @@
     "health": 1560.0
   },
   "type_data": {
+    "health": 1560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_apollo.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_apollo.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 15840.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_apollo.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_apollo.json
@@ -22,11 +22,16 @@
     "health": 15840.0
   },
   "type_data": {
+    "health": 15840.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_apollo_medivac.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_apollo_medivac.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 17424.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_apollo_medivac.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_apollo_medivac.json
@@ -22,11 +22,16 @@
     "health": 17424.0
   },
   "type_data": {
+    "health": 17424.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 121.0,
+    "deflection_energy": 116.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_cl.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_cl.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_cl.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_cl.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_es.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_es.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_es.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_es.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_ln.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_ln.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_ln.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_ln.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_lx.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_lx.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_lx.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_lx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_mk2.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_mk2.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_mk2.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_mr.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_mr.json
@@ -22,11 +22,16 @@
     "health": 3840.0
   },
   "type_data": {
+    "health": 3840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_aurora_mr.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_aurora_mr.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3840.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_bengal.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_bengal.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 220320.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_bengal.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_bengal.json
@@ -22,11 +22,16 @@
     "health": 220320.0
   },
   "type_data": {
+    "health": 220320.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 550.0,
+    "deflection_energy": 479.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_andromeda.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_andromeda.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 20160.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_andromeda.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_andromeda.json
@@ -22,11 +22,16 @@
     "health": 20160.0
   },
   "type_data": {
+    "health": 20160.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_phoenix.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_phoenix.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 13440.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_phoenix.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_phoenix.json
@@ -22,11 +22,16 @@
     "health": 13440.0
   },
   "type_data": {
+    "health": 13440.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_taurus.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_taurus.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 13440.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_constellation_taurus.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_constellation_taurus.json
@@ -22,11 +22,16 @@
     "health": 13440.0
   },
   "type_data": {
+    "health": 13440.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_hermes.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_hermes.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 15840.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_hermes.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_hermes.json
@@ -22,11 +22,16 @@
     "health": 15840.0
   },
   "type_data": {
+    "health": 15840.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 116.0,
+    "deflection_energy": 110.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_lynx.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_lynx.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1560.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_lynx.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_lynx.json
@@ -22,11 +22,16 @@
     "health": 1560.0
   },
   "type_data": {
+    "health": 1560.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_mantis.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_mantis.json
@@ -22,11 +22,16 @@
     "health": 5760.0
   },
   "type_data": {
+    "health": 5760.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 22.0,
+    "deflection_energy": 18.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_mantis.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_mantis.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 5760.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_meteor.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_meteor.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 7200.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.95,
     "damage_distortion": 0.95,

--- a/data/sc_data/parsed/live/items/armr_rsi_meteor.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_meteor.json
@@ -22,11 +22,16 @@
     "health": 7200.0
   },
   "type_data": {
+    "health": 7200.0,
     "damage_physical": 0.75,
     "damage_energy": 0.95,
     "damage_distortion": 0.95,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 22.0,
+    "deflection_energy": 18.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_perseus.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_perseus.json
@@ -22,11 +22,16 @@
     "health": 48672.0
   },
   "type_data": {
+    "health": 48672.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 495.0,
+    "deflection_energy": 418.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_perseus.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_perseus.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 48672.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_polaris.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_polaris.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 48960.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_polaris.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_polaris.json
@@ -22,11 +22,16 @@
     "health": 48960.0
   },
   "type_data": {
+    "health": 48960.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 495.0,
+    "deflection_energy": 418.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_salvation.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_salvation.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 4488.0,
+    "self_resistance_physical": 0.76,
+    "self_resistance_energy": 1.2,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_salvation.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_salvation.json
@@ -22,11 +22,16 @@
     "health": 4488.0
   },
   "type_data": {
+    "health": 4488.0,
     "damage_physical": 0.7,
     "damage_energy": 0.5,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_scorpius.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_scorpius.json
@@ -22,11 +22,16 @@
     "health": 8640.0
   },
   "type_data": {
+    "health": 8640.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_scorpius.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_scorpius.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 8640.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.28,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_template.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_template.json
@@ -22,11 +22,16 @@
     "health": 1320.0
   },
   "type_data": {
+    "health": 1320.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_template.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1320.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_ursa.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_ursa.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1560.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_ursa.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_ursa.json
@@ -22,11 +22,16 @@
     "health": 1560.0
   },
   "type_data": {
+    "health": 1560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_zeus_cl.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_zeus_cl.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 11520.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_zeus_cl.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_zeus_cl.json
@@ -22,11 +22,16 @@
     "health": 11520.0
   },
   "type_data": {
+    "health": 11520.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_rsi_zeus_es.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_zeus_es.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 11520.0,
+    "self_resistance_physical": 0.86,
+    "self_resistance_energy": 1.35,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_rsi_zeus_es.json
+++ b/data/sc_data/parsed/live/items/armr_rsi_zeus_es.json
@@ -22,11 +22,16 @@
     "health": 11520.0
   },
   "type_data": {
+    "health": 11520.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 40.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_template.json
+++ b/data/sc_data/parsed/live/items/armr_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 0.0,
+    "self_resistance_physical": 1.0,
+    "self_resistance_energy": 1.0,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_template.json
+++ b/data/sc_data/parsed/live/items/armr_template.json
@@ -22,11 +22,16 @@
     "health": 0.0
   },
   "type_data": {
+    "health": 0.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 0.0,
+    "deflection_energy": 0.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_aa.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_aa.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_aa.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_aa.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_mt.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_mt.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_mt.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_mt.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_tr.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_tr.json
@@ -22,11 +22,16 @@
     "health": 1300.0
   },
   "type_data": {
+    "health": 1300.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_cyclone_tr.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_cyclone_tr.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1300.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_nova.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_nova.json
@@ -22,11 +22,16 @@
     "health": 3900.0
   },
   "type_data": {
+    "health": 3900.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_nova.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_nova.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3900.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_storm.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_storm.json
@@ -22,11 +22,16 @@
     "health": 3900.0
   },
   "type_data": {
+    "health": 3900.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_storm.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_storm.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3900.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_storm_aa.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_storm_aa.json
@@ -22,11 +22,16 @@
     "health": 3900.0
   },
   "type_data": {
+    "health": 3900.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 8.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_storm_aa.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_storm_aa.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3900.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_tmbl_template.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_template.json
@@ -22,11 +22,16 @@
     "health": 1100.0
   },
   "type_data": {
+    "health": 1100.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_tmbl_template.json
+++ b/data/sc_data/parsed/live/items/armr_tmbl_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1100.0,
+    "self_resistance_physical": 0.81,
+    "self_resistance_energy": 1.22,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.6,
     "damage_energy": 0.4,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_blade.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_blade.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 3300.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_blade.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_blade.json
@@ -22,11 +22,16 @@
     "health": 3300.0
   },
   "type_data": {
+    "health": 3300.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 11.0,
+    "deflection_energy": 7.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_vncl_glaive.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_glaive.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_glaive.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_glaive.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 22.0,
+    "deflection_energy": 14.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_vncl_mauler.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_mauler.json
@@ -22,11 +22,16 @@
     "health": 72930.0
   },
   "type_data": {
+    "health": 72930.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 528.0,
+    "deflection_energy": 378.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_vncl_mauler.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_mauler.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 72930.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_scythe.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_scythe.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6600.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_scythe.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_scythe.json
@@ -22,11 +22,16 @@
     "health": 6600.0
   },
   "type_data": {
+    "health": 6600.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 22.0,
+    "deflection_energy": 14.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_vncl_stinger.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_stinger.json
@@ -22,11 +22,16 @@
     "health": 9900.0
   },
   "type_data": {
+    "health": 9900.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 50.0,
+    "deflection_energy": 32.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_vncl_stinger.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_stinger.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 9900.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_template.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1815.0,
+    "self_resistance_physical": 0.72,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_vncl_template.json
+++ b/data/sc_data/parsed/live/items/armr_vncl_template.json
@@ -22,11 +22,16 @@
     "health": 1815.0
   },
   "type_data": {
+    "health": 1815.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 6.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_xian_nox.json
+++ b/data/sc_data/parsed/live/items/armr_xian_nox.json
@@ -22,11 +22,16 @@
     "health": 1560.0
   },
   "type_data": {
+    "health": 1560.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_xian_nox.json
+++ b/data/sc_data/parsed/live/items/armr_xian_nox.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1560.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_xian_scout.json
+++ b/data/sc_data/parsed/live/items/armr_xian_scout.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 2400.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_xian_scout.json
+++ b/data/sc_data/parsed/live/items/armr_xian_scout.json
@@ -22,11 +22,16 @@
     "health": 2400.0
   },
   "type_data": {
+    "health": 2400.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 10.0,
+    "deflection_energy": 9.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_xian_template.json
+++ b/data/sc_data/parsed/live/items/armr_xian_template.json
@@ -22,11 +22,16 @@
     "health": 1320.0
   },
   "type_data": {
+    "health": 1320.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_xian_template.json
+++ b/data/sc_data/parsed/live/items/armr_xian_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1320.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.08,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_xnaa_santokyai.json
+++ b/data/sc_data/parsed/live/items/armr_xnaa_santokyai.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 6000.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_xnaa_santokyai.json
+++ b/data/sc_data/parsed/live/items/armr_xnaa_santokyai.json
@@ -22,11 +22,16 @@
     "health": 6000.0
   },
   "type_data": {
+    "health": 6000.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 20.0,
+    "deflection_energy": 16.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/data/sc_data/parsed/live/items/armr_xnaa_template.json
+++ b/data/sc_data/parsed/live/items/armr_xnaa_template.json
@@ -23,6 +23,10 @@
   },
   "type_data": {
     "health": 1650.0,
+    "self_resistance_physical": 0.77,
+    "self_resistance_energy": 1.15,
+    "self_resistance_distortion": 1.0,
+    "self_resistance_thermal": 1.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,

--- a/data/sc_data/parsed/live/items/armr_xnaa_template.json
+++ b/data/sc_data/parsed/live/items/armr_xnaa_template.json
@@ -22,11 +22,16 @@
     "health": 1650.0
   },
   "type_data": {
+    "health": 1650.0,
     "damage_physical": 0.75,
     "damage_energy": 0.6,
     "damage_distortion": 1.0,
     "damage_thermal": 1.0,
     "damage_biochemical": 1.0,
-    "damage_stun": 1.0
+    "damage_stun": 1.0,
+    "deflection_physical": 5.0,
+    "deflection_energy": 4.0,
+    "deflection_distortion": 0.0,
+    "deflection_thermal": 0.0
   }
 }

--- a/docs/exec-plans/erkul-data-gaps.md
+++ b/docs/exec-plans/erkul-data-gaps.md
@@ -135,17 +135,16 @@ gimbal 80 °/s).
 - **Source:** mount / joint params in the item or vehicle XML.
 - **Have:** not parsed.
 
-## 5. Armor stats (P2, not parsed)
+## 5. Armor stats — DONE
 
-erkul Defense card: **Armor HP 23 760**, **deflection** (Phys 139 / Energy 88),
-**damage reduction** (Phys 30% / Energy 50%), **self-resistance** (Phys 19% /
-Energy -15%).
+erkul Defense card: **Armor HP**, **deflection** (Phys/Energy), **damage
+reduction** (Phys/Energy), **self-resistance** (Phys/Energy, can be negative).
 
-- **Source:** ship armor component (`SCItemVehicleArmorParams` or similar) in the
-  entity / implementation XML.
-- **Have:** we parse armor damage resistances for the ARMOR hardpoint category
-  (physical/energy/distortion/thermal %) but not the ship-level armor HP,
-  deflection, damage reduction, or self-resistance summary.
+- **Shipped:** the armor component parses **Health**, per-type **deflection**
+  (`SCItemVehicleArmorParams → armorDeflection`), the **damage-reduction**
+  multipliers (`damageMultiplier`, shown as `1 − mult`), and **self-resistance**
+  (`SHealthComponentParams → DamageResistances`, also `1 − mult` so amplified
+  types read negative). Armor rows headline HP and show all four.
 
 ## 6. Emitted signatures + modifiers (P2, mostly blocked on the power/heat sim)
 

--- a/docs/exec-plans/erkul-data-gaps.md
+++ b/docs/exec-plans/erkul-data-gaps.md
@@ -147,16 +147,33 @@ Energy -15%).
   (physical/energy/distortion/thermal %) but not the ship-level armor HP,
   deflection, damage reduction, or self-resistance summary.
 
-## 6. Emitted signatures + modifiers (P2, not parsed)
+## 6. Emitted signatures + modifiers (P2, mostly blocked on the power/heat sim)
 
 erkul: emitted **IR 8.4k / EM 31.2k / CS 30.4k** plus armor signature modifiers
 (EM/IR/CS +9%).
 
-- **Source:** component/entity signature params (power plant EM, IR emission,
-  cross-section) + armor signature multipliers.
-- **Have:** radar *detection* signatures only (the `signatureDetection`
-  sensitivities we already surface on RADAR). The ship's own *emitted* IR/EM/CS
-  is not parsed.
+**Spike (2026-08-07) — decoded from erkul's JS** (`chunk-FWWRRMGF.js`: `Ao`,
+`Ro`, `dr`, `pr`). erkul's `signature = {em, ir, crossSection:{x,y,z},
+armorModifier, sources[]}`:
+
+- **CS** = `vehicle.crossSection.{x,y,z} × armor.signalCrossSection`, and the UI
+  shows the **max axis**. Source data is static:
+  `crossSectionParams → SSCSignatureSystemManualCrossSectionParams → crossSection`
+  (Asgard 20139/7624/27912; max 27912 × ~1.09 armor ≈ erkul's 30.4k). **Clean +
+  implementable.**
+- **EM** (`dr`) = Σ each component's `emNominal` (its resource `Online`-state
+  `signature.em.nominal`) **scaled by the live power allocation** — only
+  `poweredOn` components, weighted by `activeSegments`, power-range modifiers,
+  then × armor EM multiplier.
+- **IR** (`pr`) = Σ `irNominal × (activeSegments/units) × power-range modifier ×
+  ship coolingRatio × armor IR multiplier`.
+
+**Verdict:** EM/IR are live functions of the **power-allocation + heat
+simulation** we don't have (same blocker as §1 sustained DPS). Faithful EM/IR
+needs that subsystem — not a gap-fill. **Only CS is cleanly deliverable.**
+
+- **Have:** radar *detection* signatures (RADAR); armor signal multipliers
+  (parsed on the armor component).
 
 ## 7. Countermeasures counts (P3, may partly have)
 


### PR DESCRIPTION
Defense-card + hardpoint-row improvements.

**Armor (§5)**
- Parse armor **Health** + per-type **deflection**; rows headline HP and show deflection.
- Damage stats now show **reduction** (`1 − multiplier`) to match erkul (physical was reading 70% where it should be 30%).
- Regenerated the 209 armor item JSONs.

**Fuel intakes** (erkul doesn't show these; we do)
- Headline **fuelPushRate** as the key metric.
- Fixed the min-rate display: the shared `stat` helper integer-rounds, which collapsed fractional rates (0.2 → 0/blank); fuel rates now format with one decimal.

**Countermeasures** — rows now headline **ammo** count (previously no key metric).

**Docs** — recorded the §6 emitted-signature spike: EM/IR are functions of the power/heat sim (blocked, like sustained DPS); only cross-section is cleanly derivable.

Verified: prettier + eslint + standardrb clean; armor parser output confirmed on the Drake Golem (HP 6732, deflection 18/16).

🤖