### PR TITLE
fix(e2e): mount cypress-on-rails middleware in test env only

### DIFF
--- a/config/initializers/cypress_on_rails.rb
+++ b/config/initializers/cypress_on_rails.rb
@@ -2,7 +2,10 @@ if defined?(CypressOnRails)
   CypressOnRails.configure do |c|
     c.api_prefix = ""
     c.install_folder = File.expand_path("#{__dir__}/../../test/playwright")
-    c.use_middleware = !Rails.env.production?
+    # Test env only: the middleware dispatches arbitrary app commands (incl. a
+    # truncating DB clean) at the app root, so a dev server on a port another
+    # app's e2e suite targets would wipe the dev database.
+    c.use_middleware = Rails.env.test?
     c.logger = Rails.logger
   end
 end


### PR DESCRIPTION
The cypress-on-rails middleware was mounted in every non-production env
(`c.use_middleware = !Rails.env.production?`) with `c.api_prefix = ""`, so
the app-command endpoint — which dispatches arbitrary files from
`test/playwright/app_commands/`, including a `DatabaseCleaner` truncation
clean — was live at the root of the **development** server.

That turned a port collision into data loss: a sibling app’s Playwright
suite runs with `reuseExistingServer` locally, attached to the port this
app’s dev server was listening on, and POSTed its `clean` command here.
The result was a fully truncated development database (`schema_migrations`
and `ar_internal_metadata` survived, since DatabaseCleaner excludes them —
which is what made the truncation, rather than a dropped database, the
identifiable cause).

`bin/dev` needs no app commands, and `test:e2e:startserver` boots with
`RAILS_ENV=test`, so restricting the mount to the test env closes the hole
without changing how the e2e suite runs.

## Verification

- `CypressOnRails.configuration.use_middleware` → `false` in development,
  `true` in test
- `standardrb` clean on the changed file

🤖