### PR TITLE
feat(api): type the armor component (ComponentArmor schema)

### DIFF
--- a/app/api_components/shared/v1/schemas/component.rb
+++ b/app/api_components/shared/v1/schemas/component.rb
@@ -60,6 +60,7 @@ module Shared
               anyOf: [
                 {"$ref": "#/components/schemas/ComponentQuantumDrive"},
                 {"$ref": "#/components/schemas/ComponentJumpDrive"},
+                {"$ref": "#/components/schemas/ComponentArmor"},
                 {"$ref": "#/components/schemas/CargoHold"},
                 {"$ref": "#/components/schemas/FuelTank"},
                 {"$ref": "#/components/schemas/ComponentThruster"},

--- a/app/api_components/shared/v1/schemas/component_armor.rb
+++ b/app/api_components/shared/v1/schemas/component_armor.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentArmor
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            health: {type: :number},
+            damagePhysical: {type: :number},
+            damageEnergy: {type: :number},
+            damageDistortion: {type: :number},
+            damageThermal: {type: :number},
+            damageBiochemical: {type: :number},
+            damageStun: {type: :number},
+            deflectionPhysical: {type: :number},
+            deflectionEnergy: {type: :number},
+            deflectionDistortion: {type: :number},
+            deflectionThermal: {type: :number},
+            selfResistancePhysical: {type: :number},
+            selfResistanceEnergy: {type: :number},
+            selfResistanceDistortion: {type: :number},
+            selfResistanceThermal: {type: :number},
+            signalInfrared: {type: :number},
+            signalElectromagnetic: {type: :number},
+            signalCrossSection: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -9,6 +9,7 @@ import {
   type ComponentQuantumDrive,
   type ComponentJumpDrive,
   type ComponentThruster,
+  type ComponentArmor,
 } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { sustainedRatio } from "@/frontend/composables/useLoadoutStats";
@@ -517,12 +518,12 @@ export const useHardpointStats = (
         result.push(stat("weapons.range", cm.range as number, "weaponRange"));
       }
     } else if (category === HardpointCategoryEnum.ARMOR) {
-      const armor = typeData as Record<string, unknown>;
-      if (typeof armor.health === "number" && armor.health > 0) {
+      const armor = typeData as ComponentArmor;
+      if (armor.health && armor.health > 0) {
         result.push(stat("armor.hp", armor.health, "integer", true));
       }
       // erkul-style damage reduction = 1 − the incoming-damage multiplier.
-      const reductionTypes: [string, string][] = [
+      const reductionTypes: [keyof ComponentArmor, string][] = [
         ["damagePhysical", "armor.physical"],
         ["damageEnergy", "armor.energy"],
         ["damageDistortion", "armor.distortion"],
@@ -534,7 +535,7 @@ export const useHardpointStats = (
           result.push(resistanceStat(labelKey, 1 - mult));
         }
       }
-      const deflectTypes: [string, string][] = [
+      const deflectTypes: [keyof ComponentArmor, string][] = [
         ["deflectionPhysical", "armor.deflectPhysical"],
         ["deflectionEnergy", "armor.deflectEnergy"],
       ];
@@ -546,7 +547,7 @@ export const useHardpointStats = (
       }
       // Self-resistance: how the armor resists damage to itself (1 − multiplier;
       // can be negative when a damage type is amplified, matching erkul).
-      const selfResistTypes: [string, string][] = [
+      const selfResistTypes: [keyof ComponentArmor, string][] = [
         ["selfResistancePhysical", "armor.selfPhysical"],
         ["selfResistanceEnergy", "armor.selfEnergy"],
       ];

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7011,6 +7011,7 @@ components:
           anyOf:
           - "$ref": "#/components/schemas/ComponentQuantumDrive"
           - "$ref": "#/components/schemas/ComponentJumpDrive"
+          - "$ref": "#/components/schemas/ComponentArmor"
           - "$ref": "#/components/schemas/CargoHold"
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
@@ -7039,6 +7040,47 @@ components:
       - createdAt
       - updatedAt
       title: Component
+    ComponentArmor:
+      type: object
+      properties:
+        health:
+          type: number
+        damagePhysical:
+          type: number
+        damageEnergy:
+          type: number
+        damageDistortion:
+          type: number
+        damageThermal:
+          type: number
+        damageBiochemical:
+          type: number
+        damageStun:
+          type: number
+        deflectionPhysical:
+          type: number
+        deflectionEnergy:
+          type: number
+        deflectionDistortion:
+          type: number
+        deflectionThermal:
+          type: number
+        selfResistancePhysical:
+          type: number
+        selfResistanceEnergy:
+          type: number
+        selfResistanceDistortion:
+          type: number
+        selfResistanceThermal:
+          type: number
+        signalInfrared:
+          type: number
+        signalElectromagnetic:
+          type: number
+        signalCrossSection:
+          type: number
+      additionalProperties: false
+      title: ComponentArmor
     ComponentClassEnum:
       type: string
       enum:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -6962,6 +6962,7 @@ components:
           anyOf:
           - "$ref": "#/components/schemas/ComponentQuantumDrive"
           - "$ref": "#/components/schemas/ComponentJumpDrive"
+          - "$ref": "#/components/schemas/ComponentArmor"
           - "$ref": "#/components/schemas/CargoHold"
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
@@ -6990,6 +6991,47 @@ components:
       - createdAt
       - updatedAt
       title: Component
+    ComponentArmor:
+      type: object
+      properties:
+        health:
+          type: number
+        damagePhysical:
+          type: number
+        damageEnergy:
+          type: number
+        damageDistortion:
+          type: number
+        damageThermal:
+          type: number
+        damageBiochemical:
+          type: number
+        damageStun:
+          type: number
+        deflectionPhysical:
+          type: number
+        deflectionEnergy:
+          type: number
+        deflectionDistortion:
+          type: number
+        deflectionThermal:
+          type: number
+        selfResistancePhysical:
+          type: number
+        selfResistanceEnergy:
+          type: number
+        selfResistanceDistortion:
+          type: number
+        selfResistanceThermal:
+          type: number
+        signalInfrared:
+          type: number
+        signalElectromagnetic:
+          type: number
+        signalCrossSection:
+          type: number
+      additionalProperties: false
+      title: ComponentArmor
     ComponentClassEnum:
       type: string
       enum:


### PR DESCRIPTION
Follow-up to the armor Defense stats (#4262).

**Typing (the gap):** armor `typeData` was flowing through untyped (`Record<string, unknown>`), unlike the other components. Adds a **ComponentArmor** schema to the `Component.typeData` OpenAPI union (health, damage multipliers, deflection, self-resistance, signal multipliers) and consumes the generated type in `useHardpointStats`.

**On "new values not displayed":** verified it's **not a code bug** — the full path is correct (DB → `deep_format_keys` camelization → `response_validation: disabled` → typed frontend). It was a **stale DB**: the armor components need the SC data reloaded to carry the new `type_data` (confirmed on `armr_anvl_arrow`: health 3300, deflection 12, self-res 0.81). The deploy loader handles this.

Verified: prettier + eslint + standardrb + tsc clean; `ComponentArmor` generated and wired.

🤖