### PR TITLE
feat(sim): power-allocation foundation (parsing + engine core)

### DIFF
--- a/app/frontend/frontend/composables/powerSim.spec.ts
+++ b/app/frontend/frontend/composables/powerSim.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { allocatePower, weaponPoolRatio, type PowerPort } from "./powerSim";
+
+// erkul's `ue`: the weapon pool is `poolSize` size-1 blocks, of which the first
+// `consumption` are enabled (the rest disabled).
+function weaponBlocks(poolSize: number, consumption: number): PowerPort[] {
+  return Array.from({ length: poolSize }, (_, i) => ({
+    portPath: `w${i}`,
+    family: "weapon" as const,
+    size: 1,
+    disabled: i >= consumption,
+  }));
+}
+
+function block(
+  portPath: string,
+  family: PowerPort["family"],
+  extra: Partial<PowerPort> = {},
+): PowerPort {
+  return { portPath, family, size: 1, ...extra };
+}
+
+describe("allocatePower", () => {
+  it("fills weapons to min(consumption, poolSize) when power is ample (Asgard)", () => {
+    // Asgard: weapon pool 4, consumption 8 → weapon gets 4 → ratio 0.5.
+    const ports = weaponBlocks(4, 8);
+    const state = allocatePower(ports, 20, {
+      weaponConsumption: 8,
+      weaponPoolSize: 4,
+    });
+
+    expect(state.perFamily.weapon).toBe(4);
+    expect(weaponPoolRatio(state, 8)).toBeCloseTo(0.5);
+  });
+
+  it("caps weapon segments at consumption when the pool is larger", () => {
+    // pool 10 but only 3 consumption → weapon fills to 3, ratio 1.
+    const ports = weaponBlocks(10, 3);
+    const state = allocatePower(ports, 20, {
+      weaponConsumption: 3,
+      weaponPoolSize: 10,
+    });
+
+    expect(state.perFamily.weapon).toBe(3);
+    expect(weaponPoolRatio(state, 3)).toBe(1);
+  });
+
+  it("starves weapons when segments run out — the case the sim adds over max-power", () => {
+    // Life support (critical, 2) + shield (3) consume first; only 3 segments
+    // total, so weapons can't reach their pool of 4 → ratio drops below 0.5.
+    const ports: PowerPort[] = [
+      block("ls0", "lifeSupport", { critical: true }),
+      block("ls1", "lifeSupport", { critical: true }),
+      ...weaponBlocks(4, 8),
+    ];
+    const state = allocatePower(ports, 3, {
+      weaponConsumption: 8,
+      weaponPoolSize: 4,
+    });
+
+    // 2 segments to life support (critical, base), 1 left for the weapon fill.
+    expect(state.perFamily.lifeSupport).toBe(2);
+    expect(state.perFamily.weapon).toBe(1);
+    expect(weaponPoolRatio(state, 8)).toBeCloseTo(1 / 8);
+  });
+
+  it("gives the weapon base segment before shields fill (SCM priority)", () => {
+    const ports: PowerPort[] = [
+      ...weaponBlocks(4, 8),
+      block("s0", "shield"),
+      block("s1", "shield"),
+    ];
+    // Only 1 segment: the weapon base (nt weapon 1) takes it before shield fill.
+    const state = allocatePower(ports, 1, {
+      weaponConsumption: 8,
+      weaponPoolSize: 4,
+    });
+
+    expect(state.perFamily.weapon).toBe(1);
+    expect(state.perFamily.shield).toBe(0);
+  });
+});

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -1,0 +1,197 @@
+// Ship power-segment allocation — ported from erkul's `co()` engine
+// (chunk-FWWRRMGF.js). A power plant produces a number of power *segments*; the
+// IFCS distributes them across component families (weapons, shields, engines,
+// …). This module reproduces that default auto-distribution and is the engine
+// the future interactive pip UI will drive (users override per-family targets).
+//
+// Ported so far: the allocation state + atomic primitives (D/W/$/nt/et/ot) and
+// the SCM/NAV base+fill passes (Zn/Jn). Deferred (documented in
+// docs/exec-plans/flight-power-heat-sim.md): the cooler heat-balancing pass
+// (`ft`, needs the heat model), the refinement passes (`Ct`/`rt`), and building
+// the ports from live loadout data.
+
+export type PowerFamily =
+  | "weapon"
+  | "engine"
+  | "shield"
+  | "qdrive"
+  | "radar"
+  | "lifeSupport"
+  | "coolers"
+  | "qed"
+  | "emp"
+  | "miningLaser"
+  | "salvage"
+  | "tractorBeam"
+  | "towingbeam";
+
+export const POWER_FAMILIES: PowerFamily[] = [
+  "weapon",
+  "engine",
+  "shield",
+  "qdrive",
+  "radar",
+  "lifeSupport",
+  "coolers",
+  "qed",
+  "emp",
+  "miningLaser",
+  "salvage",
+  "tractorBeam",
+  "towingbeam",
+];
+
+// A single allocatable segment block. erkul models each family as a set of
+// size-1 blocks (e.g. the weapon pool is `poolSize` blocks, of which
+// `consumption` are enabled); `critical` blocks (life support) must be powered.
+export type PowerPort = {
+  portPath: string;
+  family: PowerFamily;
+  size: number;
+  critical?: boolean;
+  disabled?: boolean;
+  selected?: boolean;
+};
+
+export type FlightMode = "SCM" | "NAV";
+
+export type AllocationState = {
+  remaining: number;
+  perFamily: Record<PowerFamily, number>;
+  perPort: Record<string, number>;
+};
+
+function emptyState(total: number): AllocationState {
+  const perFamily = Object.fromEntries(
+    POWER_FAMILIES.map((f) => [f, 0]),
+  ) as Record<PowerFamily, number>;
+  return { remaining: total, perFamily, perPort: {} };
+}
+
+// D: the atomic allocate — mark a block selected and debit the pools.
+function alloc(state: AllocationState, port: PowerPort): void {
+  port.selected = true;
+  state.perPort[port.portPath] =
+    (state.perPort[port.portPath] ?? 0) + port.size;
+  state.perFamily[port.family] += port.size;
+  state.remaining -= port.size;
+}
+
+// W: base pass — allocate only the *critical* blocks that still fit.
+function allocCritical(ports: PowerPort[], state: AllocationState): void {
+  for (const p of ports) {
+    if (!p.disabled && p.critical && !p.selected && p.size <= state.remaining) {
+      alloc(state, p);
+    }
+  }
+}
+
+// $: greedily fill a family until a block doesn't fit.
+function fillGreedy(ports: PowerPort[], state: AllocationState): void {
+  for (const p of ports) {
+    if (p.disabled || p.selected) continue;
+    if (p.size > state.remaining) break;
+    alloc(state, p);
+  }
+}
+
+// nt: allocate weapon blocks up to `cap` segments (the weapon base).
+function weaponBase(
+  ports: PowerPort[],
+  cap: number,
+  state: AllocationState,
+): void {
+  const target = Math.min(cap, state.remaining);
+  let taken = 0;
+  for (const p of ports) {
+    if (taken >= target) break;
+    if (p.disabled || p.selected) continue;
+    if (p.size > state.remaining) break;
+    alloc(state, p);
+    taken += p.size;
+  }
+}
+
+// et/ot: fill a family up to `target` total segments for that family.
+function fillTo(
+  ports: PowerPort[],
+  family: PowerFamily,
+  target: number,
+  state: AllocationState,
+): void {
+  const need = target - state.perFamily[family];
+  if (need <= 0) return;
+  let taken = 0;
+  for (const p of ports) {
+    if (p.disabled || p.selected) continue;
+    if (taken + p.size > need || p.size > state.remaining) break;
+    alloc(state, p);
+    taken += p.size;
+    if (taken >= need) break;
+  }
+}
+
+export type AllocateOptions = {
+  mode?: FlightMode;
+  // Weapon fill target = min(weaponConsumptionPoints, weaponPoolSize).
+  weaponConsumption: number;
+  weaponPoolSize: number;
+};
+
+// co(): the default auto-distribution (base pass Zn, then fill pass Jn).
+// The cooler heat-balancing pass and refinements are not yet ported.
+export function allocatePower(
+  ports: PowerPort[],
+  totalSegments: number,
+  opts: AllocateOptions,
+): AllocationState {
+  const mode = opts.mode ?? "SCM";
+  const state = emptyState(totalSegments);
+  const of = (f: PowerFamily) => ports.filter((p) => p.family === f);
+
+  // Zn — base: critical blocks per family in priority order, weapon base 1.
+  allocCritical(of("lifeSupport"), state);
+  allocCritical(of("miningLaser"), state);
+  allocCritical(of("salvage"), state);
+  if (mode === "SCM") {
+    allocCritical(of("emp"), state);
+    weaponBase(of("weapon"), 1, state);
+    allocCritical(of("shield"), state);
+  } else {
+    allocCritical(of("qdrive"), state);
+  }
+  allocCritical(of("radar"), state);
+  allocCritical(of("engine"), state);
+
+  // Jn — fill.
+  fillGreedy(of("miningLaser"), state);
+  fillGreedy(of("salvage"), state);
+  if (mode === "SCM") {
+    fillTo(
+      of("weapon"),
+      "weapon",
+      Math.min(opts.weaponConsumption, opts.weaponPoolSize),
+      state,
+    );
+    fillGreedy(of("shield"), state);
+    fillGreedy(of("radar"), state);
+    fillGreedy(of("engine"), state);
+  } else {
+    fillGreedy(of("qdrive"), state);
+    fillGreedy(of("radar"), state);
+    fillGreedy(of("engine"), state);
+  }
+
+  return state;
+}
+
+// The weapon family's sustained-DPS power ratio = allocated weapon segments /
+// weapon consumption (erkul's `poolRatio`). Equals `min(1, poolSize/consumption)`
+// on ships with ample power, and less when the ship is segment-starved.
+export function weaponPoolRatio(
+  state: AllocationState,
+  weaponConsumption: number,
+): number {
+  if (weaponConsumption <= 0) return 1;
+  return Math.min(1, state.perFamily.weapon / weaponConsumption);
+}

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -556,6 +556,19 @@ module ScData
           }.compact
         end
 
+        # Power draw + its power-range modifier for power-drawing components —
+        # inputs for the ship-wide power-allocation sim (erkul's `z` /
+        # `powerRanges`). Only components that actually draw Power need this, so
+        # power_ranges is tied to a present power_consumption.
+        if item[:type_data].is_a?(Hash)
+          power_draw = extract_resource_consumption(values, "Power")
+          if power_draw.present?
+            item[:type_data][:power_consumption] ||= power_draw
+            power_ranges = extract_power_ranges(values)
+            item[:type_data][:power_ranges] ||= power_ranges if power_ranges.present?
+          end
+        end
+
         item
       end
 

--- a/data/sc_data/parsed/live/items/aegs_emp_device_s4.json
+++ b/data/sc_data/parsed/live/items/aegs_emp_device_s4.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 1.5,
-    "cooldown_time": 22.0
+    "cooldown_time": 22.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/aegs_emp_sentinel_s4.json
+++ b/data/sc_data/parsed/live/items/aegs_emp_sentinel_s4.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 1.5,
-    "cooldown_time": 40.0
+    "cooldown_time": 40.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_aagun_cc_s3.json
+++ b/data/sc_data/parsed/live/items/amrs_aagun_cc_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 100.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1500.0,
       "requested_ammo_load": 9000.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s2.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2250.0,
       "requested_ammo_load": 13500.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s3.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3375.0,
       "requested_ammo_load": 20200.0
     },
-    "power_consumption": 1.5
+    "power_consumption": 1.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s4.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 5060.0,
       "requested_ammo_load": 30300.0
     },
-    "power_consumption": 1.3
+    "power_consumption": 1.3,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s5.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 7595.0,
       "requested_ammo_load": 45500.0
     },
-    "power_consumption": 2.1
+    "power_consumption": 2.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_lasercannon_s6.json
+++ b/data/sc_data/parsed/live/items/amrs_lasercannon_s6.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 11395.0,
       "requested_ammo_load": 68300.0
     },
-    "power_consumption": 2.4
+    "power_consumption": 2.4,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/amrs_scattergun_s3.json
+++ b/data/sc_data/parsed/live/items/amrs_scattergun_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2566.67,
       "requested_ammo_load": 15400.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/anvl_ballisticgatling_bespoke.json
+++ b/data/sc_data/parsed/live/items/anvl_ballisticgatling_bespoke.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.629,
       "overheat_fix_time": 3.19
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/anvl_hawk_emp_device_s2.json
+++ b/data/sc_data/parsed/live/items/anvl_hawk_emp_device_s2.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 0.75,
-    "cooldown_time": 12.0
+    "cooldown_time": 12.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticgatling_s4.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticgatling_s4.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.756,
       "overheat_fix_time": 4.21
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticgatling_s4_lowpoly.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticgatling_s4_lowpoly.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.756,
       "overheat_fix_time": 4.21
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticgatling_s6.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticgatling_s6.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.833,
       "overheat_fix_time": 4.91
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s1.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s1.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.165,
       "overheat_fix_time": 0.746
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s1_shark.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s1_shark.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.165,
       "overheat_fix_time": 0.746
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s2.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s2.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.173,
       "overheat_fix_time": 0.805
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s2_shark.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s2_shark.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.173,
       "overheat_fix_time": 0.805
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s3.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s3.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.182,
       "overheat_fix_time": 0.87
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s3_shark.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s3_shark.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.182,
       "overheat_fix_time": 0.87
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_ballisticscattergun_s6.json
+++ b/data/sc_data/parsed/live/items/apar_ballisticscattergun_s6.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.2,
       "overheat_fix_time": 0.986
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/apar_massdriver_s2.json
+++ b/data/sc_data/parsed/live/items/apar_massdriver_s2.json
@@ -88,6 +88,20 @@
       "time_till_cooling_starts": 1.24,
       "overheat_fix_time": 6.71
     },
-    "power_consumption": 1.6
+    "power_consumption": 1.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/asad_distortionrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/asad_distortionrepeater_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 750.0,
       "requested_ammo_load": 4500.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/asad_distortionrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/asad_distortionrepeater_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1123.0,
       "requested_ammo_load": 6737.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/asad_distortionrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/asad_distortionrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1689.0,
       "requested_ammo_load": 10132.0
     },
-    "power_consumption": 0.75
+    "power_consumption": 0.75,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/banu_tachyoncannon_s1.json
+++ b/data/sc_data/parsed/live/items/banu_tachyoncannon_s1.json
@@ -116,6 +116,20 @@
       "requested_regen_per_second": 1500.0,
       "requested_ammo_load": 1000.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/banu_tachyoncannon_s2.json
+++ b/data/sc_data/parsed/live/items/banu_tachyoncannon_s2.json
@@ -116,6 +116,20 @@
       "requested_regen_per_second": 2250.0,
       "requested_ammo_load": 1300.0
     },
-    "power_consumption": 1.6
+    "power_consumption": 1.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/banu_tachyoncannon_s3.json
+++ b/data/sc_data/parsed/live/items/banu_tachyoncannon_s3.json
@@ -116,6 +116,20 @@
       "requested_regen_per_second": 3300.0,
       "requested_ammo_load": 1600.0
     },
-    "power_consumption": 2.0
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticcannon_s4.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticcannon_s4.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.84,
       "overheat_fix_time": 4.32
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticcannon_s7_idris.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticcannon_s7_idris.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.6,
       "overheat_fix_time": 10.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticcannon_s7_tiburon.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticcannon_s7_tiburon.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.6,
       "overheat_fix_time": 10.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticcannon_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticcannon_vng_s2.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.4,
       "overheat_fix_time": 5.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_hornet_bespoke.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_hornet_bespoke.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.5,
       "overheat_fix_time": 6.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_pdc_s1.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_pdc_s1.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.3,
       "overheat_fix_time": 4.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_s4.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_s4.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.485,
       "overheat_fix_time": 2.23
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_s5.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_s5.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.509,
       "overheat_fix_time": 2.41
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_s6.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_s6.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.534,
       "overheat_fix_time": 2.61
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_s7.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_s7.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.729,
       "overheat_fix_time": 4.08
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticgatling_s7_collector.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticgatling_s7_collector.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.729,
       "overheat_fix_time": 4.08
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticrepeater_s1.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.33,
       "overheat_fix_time": 1.49
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticrepeater_s2.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.346,
       "overheat_fix_time": 1.61
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticrepeater_s3.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.364,
       "overheat_fix_time": 1.74
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_ballisticrepeater_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_ballisticrepeater_vng_s2.json
@@ -52,6 +52,20 @@
       "time_till_cooling_starts": 0.346,
       "overheat_fix_time": 1.61
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_distortioncannon_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_distortioncannon_vng_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1125.0,
       "requested_ammo_load": 6750.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_distortionrepeater_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_distortionrepeater_vng_s2.json
@@ -54,6 +54,20 @@
       "requested_regen_per_second": 1125.0,
       "requested_ammo_load": 6750.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7.json
+++ b/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7.json
@@ -120,6 +120,20 @@
       "time_till_cooling_starts": 0.884,
       "overheat_fix_time": 4.73
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7_dummy.json
+++ b/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7_dummy.json
@@ -104,6 +104,20 @@
       "time_till_cooling_starts": 0.884,
       "overheat_fix_time": 4.73
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7_lowpoly.json
+++ b/data/sc_data/parsed/live/items/behr_javelinballisticcannon_s7_lowpoly.json
@@ -106,6 +106,20 @@
       "time_till_cooling_starts": 0.884,
       "overheat_fix_time": 4.73
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1867.0,
       "requested_ammo_load": 11200.0
     },
-    "power_consumption": 0.704
+    "power_consumption": 0.704,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s1_cleanair.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s1_cleanair.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1867.0,
       "requested_ammo_load": 11200.0
     },
-    "power_consumption": 0.704
+    "power_consumption": 0.704,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s2.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2815.0,
       "requested_ammo_load": 16887.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s2_cleanair.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s2_cleanair.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2815.0,
       "requested_ammo_load": 16887.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s3.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4220.0,
       "requested_ammo_load": 25320.0
     },
-    "power_consumption": 1.3
+    "power_consumption": 1.3,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s3_cleanair.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s3_cleanair.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4220.0,
       "requested_ammo_load": 25320.0
     },
-    "power_consumption": 1.3
+    "power_consumption": 1.3,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s4.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 6330.0,
       "requested_ammo_load": 37980.0
     },
-    "power_consumption": 1.6
+    "power_consumption": 1.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s5.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 9483.0,
       "requested_ammo_load": 56900.0
     },
-    "power_consumption": 1.9
+    "power_consumption": 1.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s6.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s6.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 14292.0,
       "requested_ammo_load": 85750.0
     },
-    "power_consumption": 2.2
+    "power_consumption": 2.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s6_securitynetwork.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s6_securitynetwork.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 14292.0,
       "requested_ammo_load": 85750.0
     },
-    "power_consumption": 2.2
+    "power_consumption": 2.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s6_turret.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s6_turret.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 14292.0,
       "requested_ammo_load": 85750.0
     },
-    "power_consumption": 2.2
+    "power_consumption": 2.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s7.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s7.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.5
+    "power_consumption": 2.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s7_idris_m.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s7_idris_m.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.5
+    "power_consumption": 2.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s7_idris_m_dummy.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s7_idris_m_dummy.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.5
+    "power_consumption": 2.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s7_lowpoly.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s7_lowpoly.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.5
+    "power_consumption": 2.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s7_turret.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s7_turret.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.5
+    "power_consumption": 2.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s8.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s8.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 32033.0,
       "requested_ammo_load": 192200.0
     },
-    "power_consumption": 2.8
+    "power_consumption": 2.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s9.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s9.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 48050.0,
       "requested_ammo_load": 288300.0
     },
-    "power_consumption": 3.1
+    "power_consumption": 3.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_s9_lowpoly.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_s9_lowpoly.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 48050.0,
       "requested_ammo_load": 288300.0
     },
-    "power_consumption": 3.1
+    "power_consumption": 3.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_sf7e_s7.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_sf7e_s7.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.93
+    "power_consumption": 2.93,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_sf7e_s7_collector.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_sf7e_s7_collector.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 21355.0,
       "requested_ammo_load": 128130.0
     },
-    "power_consumption": 2.93
+    "power_consumption": 2.93,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_lasercannon_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_lasercannon_vng_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2808.0,
       "requested_ammo_load": 16850.0
     },
-    "power_consumption": 1.43
+    "power_consumption": 1.43,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_laserrepeater_pdc_s1.json
+++ b/data/sc_data/parsed/live/items/behr_laserrepeater_pdc_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 0.352
+    "power_consumption": 0.352,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_laserrepeater_s10.json
+++ b/data/sc_data/parsed/live/items/behr_laserrepeater_s10.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 55271.0,
       "requested_ammo_load": 331625.0
     },
-    "power_consumption": 1.8
+    "power_consumption": 1.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_laserrepeater_s10_securitynetwork.json
+++ b/data/sc_data/parsed/live/items/behr_laserrepeater_s10_securitynetwork.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 55271.0,
       "requested_ammo_load": 331625.0
     },
-    "power_consumption": 1.8
+    "power_consumption": 1.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_laserrepeater_s10_securitynetwork_weak.json
+++ b/data/sc_data/parsed/live/items/behr_laserrepeater_s10_securitynetwork_weak.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 55271.0,
       "requested_ammo_load": 331625.0
     },
-    "power_consumption": 1.8
+    "power_consumption": 1.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_laserrepeater_vng_s2.json
+++ b/data/sc_data/parsed/live/items/behr_laserrepeater_vng_s2.json
@@ -54,6 +54,20 @@
       "requested_regen_per_second": 3232.0,
       "requested_ammo_load": 19390.0
     },
-    "power_consumption": 0.713
+    "power_consumption": 0.713,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_massdriver_s12.json
+++ b/data/sc_data/parsed/live/items/behr_massdriver_s12.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 1.41,
       "overheat_fix_time": 8.69
     },
-    "power_consumption": 5.6
+    "power_consumption": 5.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/behr_nova_ballisticgatling_s5.json
+++ b/data/sc_data/parsed/live/items/behr_nova_ballisticgatling_s5.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.5,
       "overheat_fix_time": 5.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/bengal_ballisticcannon_s7.json
+++ b/data/sc_data/parsed/live/items/bengal_ballisticcannon_s7.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.884,
       "overheat_fix_time": 4.73
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/bengal_ballisticcannon_s8.json
+++ b/data/sc_data/parsed/live/items/bengal_ballisticcannon_s8.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.928,
       "overheat_fix_time": 5.11
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/bengal_ballisticgatling_s6.json
+++ b/data/sc_data/parsed/live/items/bengal_ballisticgatling_s6.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.631,
       "overheat_fix_time": 3.29
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/bengal_turret_ballisticcannon_s8.json
+++ b/data/sc_data/parsed/live/items/bengal_turret_ballisticcannon_s8.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.802,
       "overheat_fix_time": 4.06
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/brra_lasercannon_ap_automatedturret.json
+++ b/data/sc_data/parsed/live/items/brra_lasercannon_ap_automatedturret.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s1.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s1.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.605,
       "overheat_fix_time": 2.64
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s2.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s2.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.635,
       "overheat_fix_time": 2.85
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s3.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s3.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.667,
       "overheat_fix_time": 3.08
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s4.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s4.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.7,
       "overheat_fix_time": 3.32
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s5.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s5.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.735,
       "overheat_fix_time": 3.59
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_ballisticcannon_s6.json
+++ b/data/sc_data/parsed/live/items/espr_ballisticcannon_s6.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.772,
       "overheat_fix_time": 3.88
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1267.0,
       "requested_ammo_load": 7600.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s2.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1904.0,
       "requested_ammo_load": 11425.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s3.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2850.0,
       "requested_ammo_load": 17100.0
     },
-    "power_consumption": 1.5
+    "power_consumption": 1.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s4.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s4.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 4275.0,
       "requested_ammo_load": 25650.0
     },
-    "power_consumption": 1.8
+    "power_consumption": 1.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s5.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s5.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 38375.0
     },
-    "power_consumption": 2.1
+    "power_consumption": 2.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/espr_lasercannon_s6.json
+++ b/data/sc_data/parsed/live/items/espr_lasercannon_s6.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 9623.0,
       "requested_ammo_load": 57737.5
     },
-    "power_consumption": 2.4
+    "power_consumption": 2.4,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticcannon_s1.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticcannon_s1.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.66,
       "overheat_fix_time": 2.98
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticcannon_s2.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticcannon_s2.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.693,
       "overheat_fix_time": 3.22
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticcannon_s3.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticcannon_s3.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.727,
       "overheat_fix_time": 3.48
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticgatling_s1.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticgatling_s1.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.495,
       "overheat_fix_time": 2.24
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticgatling_s2.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticgatling_s2.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.519,
       "overheat_fix_time": 2.42
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/gats_ballisticgatling_s3.json
+++ b/data/sc_data/parsed/live/items/gats_ballisticgatling_s3.json
@@ -112,6 +112,20 @@
       "time_till_cooling_starts": 0.545,
       "overheat_fix_time": 2.61
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/glsn_ballisticgatling_s2.json
+++ b/data/sc_data/parsed/live/items/glsn_ballisticgatling_s2.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.3,
       "overheat_fix_time": 6.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/glsn_ballisticgatling_s4.json
+++ b/data/sc_data/parsed/live/items/glsn_ballisticgatling_s4.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.5,
       "overheat_fix_time": 6.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/glsn_laserrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/glsn_laserrepeater_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 0.8
+    "power_consumption": 0.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/glsn_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/glsn_laserrepeater_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3031.0,
       "requested_ammo_load": 18187.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserbeam_bespoke.json
+++ b/data/sc_data/parsed/live/items/hrst_laserbeam_bespoke.json
@@ -72,6 +72,21 @@
     },
     "heat_per_second": 50000.0,
     "full_damage_range": 4000.0,
-    "zero_damage_range": 5000.0
+    "zero_damage_range": 5000.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserbeam_tiburon.json
+++ b/data/sc_data/parsed/live/items/hrst_laserbeam_tiburon.json
@@ -72,6 +72,21 @@
     },
     "heat_per_second": 7.0,
     "full_damage_range": 1000.0,
-    "zero_damage_range": 2500.0
+    "zero_damage_range": 2500.0,
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2155.0,
       "requested_ammo_load": 12932.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 3232.0,
       "requested_ammo_load": 19390.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 4853.0,
       "requested_ammo_load": 29120.0
     },
-    "power_consumption": 0.75
+    "power_consumption": 0.75,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s4.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s4.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 7280.0,
       "requested_ammo_load": 43680.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s4_turret.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s4_turret.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 3000.0,
       "requested_ammo_load": 30000.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s5.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s5.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 10914.0,
       "requested_ammo_load": 65485.0
     },
-    "power_consumption": 1.05
+    "power_consumption": 1.05,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserrepeater_s6.json
+++ b/data/sc_data/parsed/live/items/hrst_laserrepeater_s6.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 16377.0,
       "requested_ammo_load": 98262.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserscattergun_s1.json
+++ b/data/sc_data/parsed/live/items/hrst_laserscattergun_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1867.0,
       "requested_ammo_load": 11200.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserscattergun_s2.json
+++ b/data/sc_data/parsed/live/items/hrst_laserscattergun_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2933.0,
       "requested_ammo_load": 17600.0
     },
-    "power_consumption": 0.8
+    "power_consumption": 0.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_laserscattergun_s3.json
+++ b/data/sc_data/parsed/live/items/hrst_laserscattergun_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 4133.0,
       "requested_ammo_load": 24800.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_nova_ballisticcannon_s5.json
+++ b/data/sc_data/parsed/live/items/hrst_nova_ballisticcannon_s5.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 1.21,
       "overheat_fix_time": 6.71
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/hrst_storm_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/hrst_storm_laserrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 4853.0,
       "requested_ammo_load": 29120.0
     },
-    "power_consumption": 0.863
+    "power_consumption": 0.863,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/jokr_distortioncannon_s1.json
+++ b/data/sc_data/parsed/live/items/jokr_distortioncannon_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 750.0,
       "requested_ammo_load": 4500.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/jokr_distortioncannon_s2.json
+++ b/data/sc_data/parsed/live/items/jokr_distortioncannon_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1125.0,
       "requested_ammo_load": 6750.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/jokr_distortioncannon_s3.json
+++ b/data/sc_data/parsed/live/items/jokr_distortioncannon_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1690.0,
       "requested_ammo_load": 10140.0
     },
-    "power_consumption": 1.5
+    "power_consumption": 1.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kbar_ballisticcannon_s1.json
+++ b/data/sc_data/parsed/live/items/kbar_ballisticcannon_s1.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.798,
       "overheat_fix_time": 3.94
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kbar_ballisticcannon_s2.json
+++ b/data/sc_data/parsed/live/items/kbar_ballisticcannon_s2.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.838,
       "overheat_fix_time": 4.26
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kbar_ballisticcannon_s3.json
+++ b/data/sc_data/parsed/live/items/kbar_ballisticcannon_s3.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.88,
       "overheat_fix_time": 4.6
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_pdc_s2.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_pdc_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 0.502
+    "power_consumption": 0.502,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1355.0,
       "requested_ammo_load": 8100.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s1_atls.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s1_atls.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1355.0,
       "requested_ammo_load": 8100.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s1_mr01.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s1_mr01.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1355.0,
       "requested_ammo_load": 8100.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s2_mr01.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s2_mr01.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2025.0,
       "requested_ammo_load": 12150.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3031.0,
       "requested_ammo_load": 18187.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s3_mr01.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s3_mr01.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3031.0,
       "requested_ammo_load": 18187.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s4.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4544.0,
       "requested_ammo_load": 27262.5
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s4_lowpoly.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s4_lowpoly.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4544.0,
       "requested_ammo_load": 27262.5
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s5.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 6819.0,
       "requested_ammo_load": 40912.0
     },
-    "power_consumption": 1.05
+    "power_consumption": 1.05,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_idris_m.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_idris_m.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 6819.0,
       "requested_ammo_load": 40912.0
     },
-    "power_consumption": 1.05
+    "power_consumption": 1.05,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_lowpoly.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_lowpoly.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 6819.0,
       "requested_ammo_load": 40912.0
     },
-    "power_consumption": 1.05
+    "power_consumption": 1.05,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_turret.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s5_turret.json
@@ -85,6 +85,20 @@
       "requested_regen_per_second": 6819.0,
       "requested_ammo_load": 40912.0
     },
-    "power_consumption": 1.05
+    "power_consumption": 1.05,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s6.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s6.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 10231.0,
       "requested_ammo_load": 61387.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_laserrepeater_s6_lowpoly.json
+++ b/data/sc_data/parsed/live/items/klwe_laserrepeater_s6_lowpoly.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 10231.0,
       "requested_ammo_load": 61387.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_massdriver_s1.json
+++ b/data/sc_data/parsed/live/items/klwe_massdriver_s1.json
@@ -114,6 +114,20 @@
       "time_till_cooling_starts": 0.907,
       "overheat_fix_time": 4.29
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_massdriver_s10.json
+++ b/data/sc_data/parsed/live/items/klwe_massdriver_s10.json
@@ -88,6 +88,20 @@
       "time_till_cooling_starts": 1.0,
       "overheat_fix_time": 5.0
     },
-    "power_consumption": 4.8
+    "power_consumption": 4.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_massdriver_s10_lowpoly.json
+++ b/data/sc_data/parsed/live/items/klwe_massdriver_s10_lowpoly.json
@@ -88,6 +88,20 @@
       "time_till_cooling_starts": 1.0,
       "overheat_fix_time": 5.0
     },
-    "power_consumption": 4.8
+    "power_consumption": 4.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_massdriver_s2.json
+++ b/data/sc_data/parsed/live/items/klwe_massdriver_s2.json
@@ -114,6 +114,20 @@
       "time_till_cooling_starts": 0.952,
       "overheat_fix_time": 4.63
     },
-    "power_consumption": 1.6
+    "power_consumption": 1.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/klwe_massdriver_s3.json
+++ b/data/sc_data/parsed/live/items/klwe_massdriver_s3.json
@@ -114,6 +114,20 @@
       "time_till_cooling_starts": 1.0,
       "overheat_fix_time": 5.0
     },
-    "power_consumption": 2.0
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/krig_ballisticgatling_bespoke_s4.json
+++ b/data/sc_data/parsed/live/items/krig_ballisticgatling_bespoke_s4.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.5,
       "overheat_fix_time": 6.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/krig_ballisticgatling_s2.json
+++ b/data/sc_data/parsed/live/items/krig_ballisticgatling_s2.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 0.571,
       "overheat_fix_time": 2.78
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/krig_lasercannon_s3.json
+++ b/data/sc_data/parsed/live/items/krig_lasercannon_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3375.0,
       "requested_ammo_load": 20250.0
     },
-    "power_consumption": 1.73
+    "power_consumption": 1.73,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/krig_laserrepeater_bespoke_s4.json
+++ b/data/sc_data/parsed/live/items/krig_laserrepeater_bespoke_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4544.0,
       "requested_ammo_load": 27262.5
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kron_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/kron_lasercannon_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1267.0,
       "requested_ammo_load": 7600.0
     },
-    "power_consumption": 0.9
+    "power_consumption": 0.9,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kron_lasercannon_s2.json
+++ b/data/sc_data/parsed/live/items/kron_lasercannon_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1904.0,
       "requested_ammo_load": 11425.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/kron_lasercannon_s3.json
+++ b/data/sc_data/parsed/live/items/kron_lasercannon_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2850.0,
       "requested_ammo_load": 17100.0
     },
-    "power_consumption": 1.5
+    "power_consumption": 1.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_emp_device_s2.json
+++ b/data/sc_data/parsed/live/items/mxox_emp_device_s2.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 0.75,
-    "cooldown_time": 12.0
+    "cooldown_time": 12.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutroncannon_s1.json
+++ b/data/sc_data/parsed/live/items/mxox_neutroncannon_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1500.0,
       "requested_ammo_load": 9000.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutroncannon_s2.json
+++ b/data/sc_data/parsed/live/items/mxox_neutroncannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2250.0,
       "requested_ammo_load": 13500.0
     },
-    "power_consumption": 0.8
+    "power_consumption": 0.8,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutroncannon_s3.json
+++ b/data/sc_data/parsed/live/items/mxox_neutroncannon_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 3375.0,
       "requested_ammo_load": 20250.0
     },
-    "power_consumption": 1.0
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutronrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/mxox_neutronrepeater_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1758.0,
       "requested_ammo_load": 10550.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutronrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/mxox_neutronrepeater_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2638.0,
       "requested_ammo_load": 15825.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/mxox_neutronrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/mxox_neutronrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 3958.0,
       "requested_ammo_load": 23750.0
     },
-    "power_consumption": 0.75
+    "power_consumption": 0.75,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/none_laserrepeater_s1.json
+++ b/data/sc_data/parsed/live/items/none_laserrepeater_s1.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1875.0,
       "requested_ammo_load": 11250.0
     },
-    "power_consumption": 0.45
+    "power_consumption": 0.45,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/none_laserrepeater_s2.json
+++ b/data/sc_data/parsed/live/items/none_laserrepeater_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2813.0,
       "requested_ammo_load": 16875.0
     },
-    "power_consumption": 0.6
+    "power_consumption": 0.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/none_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/none_laserrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 4200.0,
       "requested_ammo_load": 25200.0
     },
-    "power_consumption": 0.75
+    "power_consumption": 0.75,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/prar_distortionscattergun_s4.json
+++ b/data/sc_data/parsed/live/items/prar_distortionscattergun_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4800.0,
       "requested_ammo_load": 28800.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/prar_distortionscattergun_s5.json
+++ b/data/sc_data/parsed/live/items/prar_distortionscattergun_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 7200.0,
       "requested_ammo_load": 63600.0
     },
-    "power_consumption": 1.4
+    "power_consumption": 1.4,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/prar_distortionscattergun_s6.json
+++ b/data/sc_data/parsed/live/items/prar_distortionscattergun_s6.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 10600.0,
       "requested_ammo_load": 63600.0
     },
-    "power_consumption": 1.6
+    "power_consumption": 1.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_acas_s01_foxfire_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_acas_s01_foxfire_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_acas_s01_lightfire_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_acas_s01_lightfire_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_acas_s02_sparkfire_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_acas_s02_sparkfire_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_acas_s02_sunfire_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_acas_s02_sunfire_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_aegs_s04_javelin_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_aegs_s04_javelin_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 6.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s01_burst_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s01_burst_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s01_flood_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s01_flood_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s01_rush_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s01_rush_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s02_cascade_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s02_cascade_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s02_flash_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s02_flash_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s02_torrent_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s02_torrent_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s03_echo_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s03_echo_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s03_fissure_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s03_fissure_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_arcc_s03_impulse_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_arcc_s03_impulse_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s01_colossus_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s01_colossus_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s01_goliath_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s01_goliath_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s01_vulcan_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s01_vulcan_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s02_bolon_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s02_bolon_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s02_huracan_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s02_huracan_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s02_yaluk_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s02_yaluk_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s03_agni_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s03_agni_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s03_kama_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s03_kama_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_just_s03_vesta_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_just_s03_vesta_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_orig_s04_890j_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_orig_s04_890j_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s01_drift_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s01_drift_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s01_spectre_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s01_spectre_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s01_zephyr_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s01_zephyr_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s02_bolt_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s02_bolt_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s02_nova_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s02_nova_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_raco_s02_spicule_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_raco_s02_spicule_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s01_atlas_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s01_atlas_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s01_eos_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s01_eos_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s01_hyperion_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s01_hyperion_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s02_aither_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s02_aither_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s02_hemera_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s02_hemera_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s02_khaos_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s02_khaos_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s03_erebos_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s03_erebos_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s03_metis_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s03_metis_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_rsi_s03_tyche_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_rsi_s03_tyche_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_s01_template.json
+++ b/data/sc_data/parsed/live/items/qdrv_s01_template.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 0.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_s02_template.json
+++ b/data/sc_data/parsed/live/items/qdrv_s02_template.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 0.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_s03_template.json
+++ b/data/sc_data/parsed/live/items/qdrv_s03_template.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 0.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_s04_template.json
+++ b/data/sc_data/parsed/live/items/qdrv_s04_template.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 0.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_s04_vncl_mauler.json
+++ b/data/sc_data/parsed/live/items/qdrv_s04_vncl_mauler.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 11.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s01_expedition_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s01_expedition_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s01_voyage_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s01_voyage_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s01_wayfare_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s01_wayfare_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 2.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s02_odyssey_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s02_odyssey_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s02_quest_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s02_quest_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s02_sojourn_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s02_sojourn_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s03_drifter_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s03_drifter_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s03_ranger_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s03_ranger_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_tars_s03_wanderer_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_tars_s03_wanderer_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s01_beacon_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s01_beacon_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s01_siren_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s01_siren_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s01_vk00_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s01_vk00_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 3.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s02_crossfield_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s02_crossfield_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s02_xl1_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s02_xl1_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s02_yeager_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s02_yeager_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 4.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s03_balandin_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s03_balandin_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s03_pontes_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s03_pontes_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s03_ts2_scitem.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s03_ts2_scitem.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 5.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/qdrv_wetk_s04_idris_temp.json
+++ b/data/sc_data/parsed/live/items/qdrv_wetk_s04_idris_temp.json
@@ -71,6 +71,21 @@
       "min_jump_distance": 0.0,
       "ifcs_handover_down_time": 0.0,
       "ifcs_handover_respool_time": 0.0
+    },
+    "power_consumption": 6.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 0.7
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 0.85
+      },
+      "high": {
+        "start": 1.0,
+        "modifier": 1.0
+      }
     }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_ballisticcannon_s5_meteor_bespoke.json
+++ b/data/sc_data/parsed/live/items/rsi_ballisticcannon_s5_meteor_bespoke.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 1.2,
       "overheat_fix_time": 6.5
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_bespoke_ballisticcannon_a.json
+++ b/data/sc_data/parsed/live/items/rsi_bespoke_ballisticcannon_a.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 1.0,
       "overheat_fix_time": 4.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_mantis_emp_device.json
+++ b/data/sc_data/parsed/live/items/rsi_mantis_emp_device.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 0.75,
-    "cooldown_time": 12.0
+    "cooldown_time": 12.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_meteor_laserrepeater_s5.json
+++ b/data/sc_data/parsed/live/items/rsi_meteor_laserrepeater_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4544.0,
       "requested_ammo_load": 27262.5
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_perseus_ballisticcannon_b_s8.json
+++ b/data/sc_data/parsed/live/items/rsi_perseus_ballisticcannon_b_s8.json
@@ -86,6 +86,20 @@
       "time_till_cooling_starts": 1.2,
       "overheat_fix_time": 7.0
     },
-    "power_consumption": 0.1
+    "power_consumption": 0.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/rsi_scorpius_emp_device.json
+++ b/data/sc_data/parsed/live/items/rsi_scorpius_emp_device.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 250.0,
     "pressure": 0.0,
     "unleash_time": 1.5,
-    "cooldown_time": 16.0
+    "cooldown_time": 16.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/tmbl_emp_device_s1.json
+++ b/data/sc_data/parsed/live/items/tmbl_emp_device_s1.json
@@ -30,6 +30,21 @@
     "min_phys_radius": 150.0,
     "pressure": 0.0,
     "unleash_time": 0.75,
-    "cooldown_time": 6.0
+    "cooldown_time": 6.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/toag_lasergatling_s2.json
+++ b/data/sc_data/parsed/live/items/toag_lasergatling_s2.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 1742.0,
       "requested_ammo_load": 10450.0
     },
-    "power_consumption": 0.335
+    "power_consumption": 0.335,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/toag_laserrepeater_s3.json
+++ b/data/sc_data/parsed/live/items/toag_laserrepeater_s3.json
@@ -114,6 +114,20 @@
       "requested_regen_per_second": 2531.0,
       "requested_ammo_load": 15187.0
     },
-    "power_consumption": 0.652
+    "power_consumption": 0.652,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vanduul_laserbeam_s12_tsg.json
+++ b/data/sc_data/parsed/live/items/vanduul_laserbeam_s12_tsg.json
@@ -72,6 +72,21 @@
     },
     "heat_per_second": 50000.0,
     "full_damage_range": 9500.0,
-    "zero_damage_range": 10000.0
+    "zero_damage_range": 10000.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_laserbeam_s9.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_laserbeam_s9.json
@@ -72,6 +72,21 @@
     },
     "heat_per_second": 50000.0,
     "full_damage_range": 4000.0,
-    "zero_damage_range": 5000.0
+    "zero_damage_range": 5000.0,
+    "power_consumption": 1.0,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_lasercannon_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 100.0
     },
-    "power_consumption": 0.25
+    "power_consumption": 0.25,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_laserrepeater_s6.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_laserrepeater_s6.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 100.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s2.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1690.0,
       "requested_ammo_load": 3750.0
     },
-    "power_consumption": 0.25
+    "power_consumption": 0.25,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s4.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s4.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 600.0,
       "requested_ammo_load": 5625.0
     },
-    "power_consumption": 0.25
+    "power_consumption": 0.25,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s5.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 600.0,
       "requested_ammo_load": 5625.0
     },
-    "power_consumption": 2.1
+    "power_consumption": 2.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s8.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_plasmacannon_s8.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 100.0
     },
-    "power_consumption": 0.25
+    "power_consumption": 0.25,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_tachyonbeam_s10.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_tachyonbeam_s10.json
@@ -72,6 +72,21 @@
     },
     "heat_per_second": 50000.0,
     "full_damage_range": 4000.0,
-    "zero_damage_range": 5000.0
+    "zero_damage_range": 5000.0,
+    "power_consumption": 0.25,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_gen2_tachyoncannon_s7.json
+++ b/data/sc_data/parsed/live/items/vncl_gen2_tachyoncannon_s7.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 25.0,
       "requested_ammo_load": 100.0
     },
-    "power_consumption": 3.6
+    "power_consumption": 3.6,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_lasercannon_s1.json
+++ b/data/sc_data/parsed/live/items/vncl_lasercannon_s1.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 650.0,
       "requested_ammo_load": 5625.0
     },
-    "power_consumption": 1.13
+    "power_consumption": 1.13,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_lasercannon_s2.json
+++ b/data/sc_data/parsed/live/items/vncl_lasercannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 1690.0,
       "requested_ammo_load": 3750.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_neutroncannon_s5.json
+++ b/data/sc_data/parsed/live/items/vncl_neutroncannon_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 600.0,
       "requested_ammo_load": 5625.0
     },
-    "power_consumption": 1.4
+    "power_consumption": 1.4,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_plasmacannon_s2.json
+++ b/data/sc_data/parsed/live/items/vncl_plasmacannon_s2.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 2810.0,
       "requested_ammo_load": 16860.0
     },
-    "power_consumption": 1.2
+    "power_consumption": 1.2,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_plasmacannon_s3.json
+++ b/data/sc_data/parsed/live/items/vncl_plasmacannon_s3.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 4220.0,
       "requested_ammo_load": 3750.0
     },
-    "power_consumption": 1.5
+    "power_consumption": 1.5,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/data/sc_data/parsed/live/items/vncl_plasmacannon_s5.json
+++ b/data/sc_data/parsed/live/items/vncl_plasmacannon_s5.json
@@ -88,6 +88,20 @@
       "requested_regen_per_second": 600.0,
       "requested_ammo_load": 5625.0
     },
-    "power_consumption": 2.1
+    "power_consumption": 2.1,
+    "power_ranges": {
+      "low": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "medium": {
+        "start": 0.0,
+        "modifier": 1.0
+      },
+      "high": {
+        "start": 0.0,
+        "modifier": 1.0
+      }
+    }
   }
 }

--- a/docs/exec-plans/flight-power-heat-sim.md
+++ b/docs/exec-plans/flight-power-heat-sim.md
@@ -35,6 +35,18 @@ full sim for **segment-starved** ships (rare) and the **interactive** case (user
 moves pips off weapons). So the sim's real payoffs are the **pip UI** (its reason
 to exist), **§6** emitted signatures, and **§3 / §8**.
 
+## Integration finding (2026-08-09)
+
+Family map from our `item_type` → erkul family: `WeaponGun`→weapon, `Shield`→
+shield, `Cooler`→coolers, `Radar`→radar, `QuantumDrive`→qdrive, `EMP`→emp,
+`PowerPlant`→segment source (`power_base`). **Coverage gap:** we don't currently
+parse a Power draw for `engine`/`lifeSupport` families that erkul's `co()`
+allocates to — so a faithful full allocation needs those added (or confirmed
+absent) plus the exact non-weapon block sizing. Until then the allocation core
+(`powerSim.ts`) stays a standalone tested unit, **not wired** into the shipped
+sustained calc (which is already exact for non-starved ships, so wiring an
+incomplete allocation would risk a regression for no visible gain).
+
 ## Source of truth
 
 erkul's client-side calc engine, reverse-engineered from its JS bundle:

--- a/docs/exec-plans/flight-power-heat-sim.md
+++ b/docs/exec-plans/flight-power-heat-sim.md
@@ -17,6 +17,24 @@ those subsystems. Each was individually spiked and confirmed sim-blocked
 | **§3** Per-weapon overheat state ("NO OVERHEAT") | Heat sim |
 | **§8** Flight boost (boosted SCM, boost regen, boost delay) | IFCS/flight sim |
 
+## Strategic driver — the interactive power-distribution calculator
+
+Confirmed 2026-08-09: the end goal is an erkul-style **interactive pip UI** where
+the user allocates power to weapons / shields / engines / etc. and sees DPS,
+sustained, and signatures respond live. That is what this sim is *for* — it's the
+dependency for the calculator's headline interactive feature. The `co()` port
+isn't just to reproduce erkul's *default* numbers; it becomes the **allocation
+engine the UI drives**: `co()` computes the auto-distribution, and the calculator
+lets the user override per-family pips, re-running the sim.
+
+**Finding (2026-08-09) — §1 is already exact at the default distribution.** From
+the decoded `Jn`, weapons are filled to `min(weaponConsumptionPoints, poolSize)`
+segments, so the default `poolRatio = min(1, poolSize/consumption)` = the
+`weaponPowerRatio` we already ship (Asgard → 1 681, exact). §1 only needs the
+full sim for **segment-starved** ships (rare) and the **interactive** case (user
+moves pips off weapons). So the sim's real payoffs are the **pip UI** (its reason
+to exist), **§6** emitted signatures, and **§3 / §8**.
+
 ## Source of truth
 
 erkul's client-side calc engine, reverse-engineered from its JS bundle:

--- a/docs/exec-plans/flight-power-heat-sim.md
+++ b/docs/exec-plans/flight-power-heat-sim.md
@@ -165,6 +165,33 @@ Findings from `chunk-FWWRRMGF.js` (2026-08-08):
 - Helpers to port: `Xn, Zn, Jn, ft, it, Ct, rt, tt, W, $, nt, et, D, Rt, me, yt,
   X, fo` + the `$n` family model.
 
+### Allocation primitives (decoded 2026-08-09)
+
+State `= {remaining, perPort:{}, perFamily:{…0}}`; each port `= {portPath,
+family, size, disabled, critical, selected, poweredOn, floor, units}` where
+`size` = the segments the component occupies.
+
+- **`D(state, port, family)`** — the atomic allocate: `port.selected=true;
+  perPort[port]+=size; perFamily[family]+=size; remaining-=size`. (`Re` = undo.)
+- **`W(ports, family, state)`** — base pass, **critical only**: allocate each
+  `!disabled && critical && !selected && size<=remaining`.
+- **`$(ports, family, state)`** — greedy fill a family: allocate each
+  `!disabled && !selected` until one doesn't fit (`size>remaining` → break).
+- **`nt(ports, cap, state)`** — weapons base: allocate weapon ports up to `cap`
+  segments (`Zn` calls `nt(weapon, 1)`).
+- **`et(ports, family, target, state)`** → **`ot`**: fill a family up to
+  `target - perFamily[family]` more segments (`Jn` calls
+  `et(weapon, min(weaponConsumptionPoints, poolSize))`).
+- **`Ae(ports, portPath, n, family, state)`** — fill one specific port up to n.
+- **`it(cooler, …, state)`** — **heat-coupled**: scan cooler segments from
+  `floor..units`, return the first where `cooling(seg) ≥ coolingConsumptionPerSec`
+  (this is the power↔heat link `ft` iterates).
+
+**Port model TODO (next decode):** how erkul builds each port's `size` /
+`family` / `critical` / `floor` / `units` from the item + loadout data (the
+`lo`/`An`/`Kn`/`te` helpers) — the input mapping the TS sim needs before it can
+run the passes above.
+
 ### ⚠️ Power ↔ heat are coupled
 
 `ft` balances cooler segments against **heat generation vs cooling**, so the


### PR DESCRIPTION
Foundation for the interactive power-distribution calculator (exec-plan: `docs/exec-plans/flight-power-heat-sim.md`).

- **Parsing** — per-component **power draw** + **power ranges** for all 254 power-drawing components (generalized from weapon-only), reusing the existing resource helpers. The inputs the allocation sim needs.
- **Allocation core** — `powerSim.ts`: a faithful port of erkul's `co()` allocation core (state + atomic primitives + SCM/NAV base/fill passes) with `weaponPoolRatio`, **unit-tested** incl. the segment-starvation case. Standalone building block — **not yet wired** into the shipped sustained calc (which is already exact for non-starved ships; wiring an incomplete allocation would risk a regression).
- **Docs** — full decode of erkul's allocation engine (primitives, port model, family map) + the coverage gap (engine/lifeSupport draw) the next phase closes.

No behavior change to shipped stats — this is groundwork the pip UI consumes.

🤖