### PR TITLE
chore(ci): unblock the dependency PR queue (libvips, seeds redis, vue-tsc 3.3.9)

### DIFF
--- a/.github/workflows/api-schema-check.job.yml
+++ b/.github/workflows/api-schema-check.job.yml
@@ -44,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -48,6 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -27,8 +27,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis:6.2.10-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v7
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/app/frontend/shared/components/base/Table/SortableLink/index.vue
+++ b/app/frontend/shared/components/base/Table/SortableLink/index.vue
@@ -4,7 +4,7 @@ export default {
 };
 </script>
 
-<script lang="ts" setup generic="T">
+<script lang="ts" setup>
 import { useTableSorting } from "@/shared/composables/useTableSorting";
 
 type Props = {

--- a/app/frontend/shared/components/base/Table2/Cell/index.vue
+++ b/app/frontend/shared/components/base/Table2/Cell/index.vue
@@ -4,7 +4,7 @@ export default {
 };
 </script>
 
-<script lang="ts" setup generic="T">
+<script lang="ts" setup>
 import {
   BaseTableColAlignmentEnum,
   BaseTableHeaderColVariantEnum,


### PR DESCRIPTION
Prep work so the open dependabot queue can go green.

## Why

#4220 was merged from a stale base, so its squash reverted roughly twenty dependency bumps that were already on `main`, plus the CI changes that shipped with them. That is why dependabot re-opened PRs for rails 8.1.3.1 (#4279), docker/login-action 4.6.0 (#4288) and the playwright group (#4273) — those exact bumps had landed once already (#4225, #4226, #4228) and were rolled back.

## Changes

**`chore(ci)`** — restore the `Install libvips` step in `ruby-tests`, `seeds` and `api-schema-check`, and the `redis` service in `seeds` (both added in #4225, lost in #4220).

Rails 8.1.3.1 is a security release that calls `Vips.block_untrusted(true)` while booting Active Storage, so `ruby-vips` has to load at boot. Without the system libvips library the `LoadError` message matches neither `/libvips/` nor `/image_processing/`, so Active Storage's rescue misses it and Rails aborts:

```
LoadError: ImageProcessing::Vips requires the ruby-vips gem.
  image_processing-2.0.2/lib/image_processing/vips.rb:5
  activestorage-8.1.3.1/lib/active_storage/transformers/vips.rb:10
  activestorage-8.1.3.1/lib/active_storage/engine.rb:101
```

That is the current failure on #4279 across all three jobs. Production already has libvips (`Dockerfile:17`) and Postgres 16, so only CI was affected.

**`fix(base-table)`** — drop the unused `generic="T"` from `Table2/Cell` and `Table/SortableLink`. vue-tsc 3.3.9 (#4276) reports both as `TS6133`. Neither component references `T`: `Cell` has no data props, and `SortableLink.field` must stay `string | number | symbol` because `Table2/Header` passes `column.attributeKey || column.name`, and `name` is a plain `string` rather than `keyof T`. `Table2/Header` genuinely uses its generic and is untouched.

Verified locally against both vue-tsc 3.3.5 (current) and 3.3.9 — clean under each.

## Follow-up

`docker/login-action` and the playwright container image are still on their reverted versions; #4288 and #4273 restore those, so they are left alone here.

🤖