### PR TITLE
feat(sc-data): load ship cross-section signature

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -75,6 +75,7 @@ module ScData
         update_params[:hull_parts] = model_data.dig("hull_parts")
         update_params[:hull_doors] = extract_hull_doors(model_data)
         update_params[:weapon_pool_size] = model_data.dig("weapon_pool_size")
+        update_params[:signature_cross_section] = model_data.dig("signature_cross_section")
         update_params[:sc_length] = model_data.dig("metrics", "y")&.to_f
         update_params[:sc_beam] = model_data.dig("metrics", "x")&.to_f
         update_params[:sc_height] = model_data.dig("metrics", "z")&.to_f

--- a/app/models/fleet_inventory.rb
+++ b/app/models/fleet_inventory.rb
@@ -10,7 +10,7 @@
 #  managed_by  :uuid
 #  name        :string           not null
 #  slug        :string           not null
-#  visibility  :integer          default("members_only"), not null
+#  visibility  :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  fleet_id    :uuid             not null

--- a/app/models/fleet_inventory_item.rb
+++ b/app/models/fleet_inventory_item.rb
@@ -6,14 +6,14 @@
 #
 #  id                 :uuid             not null, primary key
 #  added_by           :uuid
-#  category           :integer          default("commodity"), not null
-#  entry_type         :integer          default("deposit"), not null
+#  category           :integer          default(0), not null
+#  entry_type         :integer          default(0), not null
 #  item_type          :string
 #  name               :string           not null
 #  notes              :text
 #  quality            :integer          default(0)
 #  quantity           :decimal(15, 2)   default(0.0), not null
-#  unit               :integer          default("scu"), not null
+#  unit               :integer          default(0), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  fleet_inventory_id :uuid             not null

--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -14,7 +14,7 @@
 #  invited_by        :uuid
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
-#  ships_filter      :integer          default("all")
+#  ships_filter      :integer          default(0)
 #  used_invite_token :string
 #  verified          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -99,6 +99,7 @@
 #  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
 #  scm_speed_decceleration           :decimal(15, 2)
+#  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
 #  store_images_updated_at           :datetime

--- a/app/models/model_position.rb
+++ b/app/models/model_position.rb
@@ -8,7 +8,7 @@
 #  name          :string           not null
 #  position      :integer          default(0), not null
 #  position_type :integer          not null
-#  source        :integer          default("sc_data"), not null
+#  source        :integer          default(0), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  hardpoint_id  :uuid

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -6,7 +6,7 @@
 #
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
-#  bought_via           :integer          default("pledge_store")
+#  bought_via           :integer          default(0)
 #  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)

--- a/db/migrate/20260811120000_add_signature_cross_section_to_models.rb
+++ b/db/migrate/20260811120000_add_signature_cross_section_to_models.rb
@@ -1,0 +1,5 @@
+class AddSignatureCrossSectionToModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :models, :signature_cross_section, :float
+  end
+end

--- a/db/migrate/20260811130000_change_signature_cross_section_to_jsonb.rb
+++ b/db/migrate/20260811130000_change_signature_cross_section_to_jsonb.rb
@@ -1,0 +1,11 @@
+class ChangeSignatureCrossSectionToJsonb < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :models, :signature_cross_section
+    add_column :models, :signature_cross_section, :jsonb
+  end
+
+  def down
+    remove_column :models, :signature_cross_section
+    add_column :models, :signature_cross_section, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -784,6 +784,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_120000) do
     t.decimal "scm_speed_acceleration", precision: 15, scale: 2
     t.decimal "scm_speed_boosted", precision: 15, scale: 2
     t.decimal "scm_speed_decceleration", precision: 15, scale: 2
+    t.jsonb "signature_cross_section"
     t.string "size"
     t.string "slug", limit: 255
     t.datetime "store_images_updated_at", precision: nil

--- a/test/factories/fleet_inventories.rb
+++ b/test/factories/fleet_inventories.rb
@@ -10,7 +10,7 @@
 #  managed_by  :uuid
 #  name        :string           not null
 #  slug        :string           not null
-#  visibility  :integer          default("members_only"), not null
+#  visibility  :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  fleet_id    :uuid             not null

--- a/test/factories/fleet_inventory_items.rb
+++ b/test/factories/fleet_inventory_items.rb
@@ -6,14 +6,14 @@
 #
 #  id                 :uuid             not null, primary key
 #  added_by           :uuid
-#  category           :integer          default("commodity"), not null
-#  entry_type         :integer          default("deposit"), not null
+#  category           :integer          default(0), not null
+#  entry_type         :integer          default(0), not null
 #  item_type          :string
 #  name               :string           not null
 #  notes              :text
 #  quality            :integer          default(0)
 #  quantity           :decimal(15, 2)   default(0.0), not null
-#  unit               :integer          default("scu"), not null
+#  unit               :integer          default(0), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  fleet_inventory_id :uuid             not null

--- a/test/factories/fleet_memberships.rb
+++ b/test/factories/fleet_memberships.rb
@@ -12,7 +12,7 @@
 #  invited_by        :uuid
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
-#  ships_filter      :integer          default("all")
+#  ships_filter      :integer          default(0)
 #  used_invite_token :string
 #  verified          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null

--- a/test/factories/model_positions.rb
+++ b/test/factories/model_positions.rb
@@ -8,7 +8,7 @@
 #  name          :string           not null
 #  position      :integer          default(0), not null
 #  position_type :integer          not null
-#  source        :integer          default("sc_data"), not null
+#  source        :integer          default(0), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  hardpoint_id  :uuid

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -97,6 +97,7 @@
 #  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
 #  scm_speed_decceleration           :decimal(15, 2)
+#  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
 #  store_images_updated_at           :datetime

--- a/test/factories/vehicles.rb
+++ b/test/factories/vehicles.rb
@@ -4,7 +4,7 @@
 #
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
-#  bought_via           :integer          default("pledge_store")
+#  bought_via           :integer          default(0)
 #  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -21,6 +21,20 @@ module ScData
           loader.one(model)
         end
       end
+
+      test "#load_model persists the parsed cross section signature" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Cross Section Test", in_game: true)
+        cross_section = {"x" => 12.5, "y" => 34.0, "z" => 56.25}
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "signature_cross_section" => cross_section}
+        )
+
+        loader.load_model(model)
+
+        assert_equal cross_section, model.reload.signature_cross_section
+      end
     end
   end
 end

--- a/test/models/fleet_membership_test.rb
+++ b/test/models/fleet_membership_test.rb
@@ -14,7 +14,7 @@
 #  invited_by        :uuid
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
-#  ships_filter      :integer          default("all")
+#  ships_filter      :integer          default(0)
 #  used_invite_token :string
 #  verified          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -101,6 +101,7 @@ require "test_helper"
 #  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
 #  scm_speed_decceleration           :decimal(15, 2)
+#  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
 #  store_images_updated_at           :datetime

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -6,7 +6,7 @@
 #
 #  id                   :uuid             not null, primary key
 #  alternative_names    :string
-#  bought_via           :integer          default("pledge_store")
+#  bought_via           :integer          default(0)
 #  bundled              :boolean          default(FALSE), not null
 #  flagship             :boolean          default(FALSE)
 #  hidden               :boolean          default(FALSE)


### PR DESCRIPTION
Adds the `signature_cross_section` jsonb column (migration) and loads the parsed per-axis ship cross-section through the models loader. Refreshes the schema and model annotations.

Stack (2 of 4): base `main`. Depends on data from the parse PR (#4311) at runtime, but is independent for CI. The api PR is based on this branch.

🤖