### PR TITLE
feat(api): expose component signatures, power ranges + cross-section

### DIFF
--- a/app/api_components/shared/v1/schemas/component.rb
+++ b/app/api_components/shared/v1/schemas/component.rb
@@ -65,8 +65,11 @@ module Shared
                 {"$ref": "#/components/schemas/FuelTank"},
                 {"$ref": "#/components/schemas/ComponentThruster"},
                 {"$ref": "#/components/schemas/ComponentWeapon"},
+                {"$ref": "#/components/schemas/ComponentTractorBeam"},
                 {"$ref": "#/components/schemas/ComponentShield"},
                 {"$ref": "#/components/schemas/ComponentCooler"},
+                {"$ref": "#/components/schemas/ComponentRadar"},
+                {"$ref": "#/components/schemas/ComponentController"},
                 {"$ref": "#/components/schemas/ComponentPowerPlant"}
               ]
             },

--- a/app/api_components/shared/v1/schemas/component_controller.rb
+++ b/app/api_components/shared/v1/schemas/component_controller.rb
@@ -3,8 +3,18 @@
 module Shared
   module V1
     module Schemas
-      class ComponentCooler
+      class ComponentController
         include OpenapiRuby::Components::Base
+
+        ANGULAR_VELOCITY = {
+          type: :object,
+          properties: {
+            pitch: {type: :number},
+            yaw: {type: :number},
+            roll: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
 
         POWER_RANGE_ENTRY = {
           type: :object,
@@ -28,15 +38,18 @@ module Shared
         schema({
           type: :object,
           properties: {
-            coolingRate: {type: :number},
+            scmSpeed: {type: :number},
+            scmSpeedBoosted: {type: :number},
+            reverseSpeedBoosted: {type: :number},
+            maxSpeed: {type: :number},
+            angularVelocity: ANGULAR_VELOCITY,
+            boostedAngularVelocity: ANGULAR_VELOCITY,
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
             powerRanges: POWER_RANGES,
-            signatureEm: {type: :number},
-            signatureIr: {type: :number}
+            signatureEm: {type: :number}
           },
-          additionalProperties: false,
-          required: %w[coolingRate]
+          additionalProperties: false
         })
       end
     end

--- a/app/api_components/shared/v1/schemas/component_power_plant.rb
+++ b/app/api_components/shared/v1/schemas/component_power_plant.rb
@@ -6,11 +6,32 @@ module Shared
       class ComponentPowerPlant
         include OpenapiRuby::Components::Base
 
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
         schema({
           type: :object,
           properties: {
             powerBase: {type: :number},
-            powerDraw: {type: :number}
+            powerDraw: {type: :number},
+            powerRanges: POWER_RANGES,
+            signatureEm: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_quantum_drive.rb
+++ b/app/api_components/shared/v1/schemas/component_quantum_drive.rb
@@ -6,6 +6,25 @@ module Shared
       class ComponentQuantumDrive
         include OpenapiRuby::Components::Base
 
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
         schema({
           type: :object,
           properties: {
@@ -30,7 +49,11 @@ module Shared
             },
             quantumBoostParams: {
               "$ref": "#/components/schemas/ComponentQuantumDriveBoost"
-            }
+            },
+            powerConsumption: {type: :number},
+            powerMinimumFraction: {type: :number},
+            powerRanges: POWER_RANGES,
+            signatureEm: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_radar.rb
+++ b/app/api_components/shared/v1/schemas/component_radar.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentRadar
+        include OpenapiRuby::Components::Base
+
+        SIGNATURE_SENSITIVITY = {
+          type: :object,
+          properties: {
+            sensitivity: {type: :number},
+            piercing: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
+        schema({
+          type: :object,
+          properties: {
+            signatureDetection: {
+              type: :object,
+              properties: {
+                ir: SIGNATURE_SENSITIVITY,
+                em: SIGNATURE_SENSITIVITY,
+                cs: SIGNATURE_SENSITIVITY,
+                rs: SIGNATURE_SENSITIVITY
+              },
+              additionalProperties: false
+            },
+            pingProperties: {
+              type: :object,
+              properties: {
+                cooldownTime: {type: :number}
+              },
+              additionalProperties: false
+            },
+            aimAssistRange: {type: :number},
+            aimAssistMin: {type: :number},
+            sensitivityModifiers: {
+              type: :object,
+              properties: {
+                sensitivityAddition: {type: :number}
+              },
+              additionalProperties: false
+            },
+            powerConsumption: {type: :number},
+            powerMinimumFraction: {type: :number},
+            powerRanges: POWER_RANGES,
+            signatureEm: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_shield.rb
+++ b/app/api_components/shared/v1/schemas/component_shield.rb
@@ -28,6 +28,25 @@ module Shared
           additionalProperties: false
         }.freeze
 
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
         schema({
           type: :object,
           properties: {
@@ -37,7 +56,11 @@ module Shared
             downedRegenDelay: {type: :number},
             damagedRegenDelay: {type: :number},
             resistance: DAMAGE_TYPE_MAP,
-            absorption: DAMAGE_TYPE_MAP
+            absorption: DAMAGE_TYPE_MAP,
+            powerConsumption: {type: :number},
+            powerMinimumFraction: {type: :number},
+            powerRanges: POWER_RANGES,
+            signatureEm: {type: :number}
           },
           additionalProperties: false,
           required: %w[maxHealth maxRegen]

--- a/app/api_components/shared/v1/schemas/component_tractor_beam.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentTractorBeam
+        include OpenapiRuby::Components::Base
+
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
+        schema({
+          type: :object,
+          properties: {
+            tractorBeam: {type: :boolean},
+            minForce: {type: :number},
+            maxForce: {type: :number},
+            minDistance: {type: :number},
+            maxDistance: {type: :number},
+            fullStrengthDistance: {type: :number},
+            maxAngle: {type: :number},
+            maxVolume: {type: :number},
+            volumeForceCoefficient: {type: :number},
+            tetherBreakTime: {type: :number},
+            heatPerSecond: {type: :number},
+            rotation: {
+              type: :object,
+              properties: {
+                maxAngularVelocity: {type: :number},
+                degreesPerAction: {type: :number}
+              },
+              additionalProperties: false
+            },
+            movement: {
+              type: :object,
+              properties: {
+                maxSpeed: {type: :number},
+                maxAcceleration: {type: :number}
+              },
+              additionalProperties: false
+            },
+            cargoMode: {
+              type: :object,
+              properties: {
+                maxForce: {type: :number},
+                minDistance: {type: :number},
+                maxDistance: {type: :number},
+                fullStrengthDistance: {type: :number}
+              },
+              additionalProperties: false
+            },
+            towing: {
+              type: :object,
+              properties: {
+                towingForce: {type: :number},
+                towingMaxDistance: {type: :number},
+                towingMaxAcceleration: {type: :number},
+                quantumTowMassLimit: {type: :number}
+              },
+              additionalProperties: false
+            },
+            powerConsumption: {type: :number},
+            powerMinimumFraction: {type: :number},
+            powerRanges: POWER_RANGES
+          },
+          additionalProperties: false,
+          required: %w[tractorBeam]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_weapon.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon.rb
@@ -6,6 +6,25 @@ module Shared
       class ComponentWeapon
         include OpenapiRuby::Components::Base
 
+        POWER_RANGE_ENTRY = {
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        }.freeze
+
+        POWER_RANGES = {
+          type: :object,
+          properties: {
+            low: POWER_RANGE_ENTRY,
+            medium: POWER_RANGE_ENTRY,
+            high: POWER_RANGE_ENTRY
+          },
+          additionalProperties: false
+        }.freeze
+
         schema({
           type: :object,
           properties: {
@@ -13,6 +32,8 @@ module Shared
             fireRate: {type: :number},
             heatPerShot: {type: :number},
             powerConsumption: {type: :number},
+            powerRanges: POWER_RANGES,
+            signatureEm: {type: :number},
             damagePerShot: {
               type: :object,
               properties: {

--- a/app/api_components/v1/schemas/models/model.rb
+++ b/app/api_components/v1/schemas/models/model.rb
@@ -159,6 +159,15 @@ module V1
                 },
                 quantumFuelTankSize: {type: :number},
                 weaponPoolSize: {type: :number},
+                signatureCrossSection: {
+                  type: :object,
+                  properties: {
+                    x: {type: :number},
+                    y: {type: :number},
+                    z: {type: :number}
+                  },
+                  additionalProperties: false
+                },
                 size: {type: :string},
                 sizeLabel: {type: :string},
                 dockSize: {type: :string}

--- a/app/frontend/frontend/components/Compare/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Compare/Models/Hardpoints/index.vue
@@ -37,6 +37,7 @@ const groups = [
   HardpointGroupEnum.PROPULSION,
   HardpointGroupEnum.THRUSTER,
   HardpointGroupEnum.WEAPON,
+  HardpointGroupEnum.DEFENSE,
   HardpointGroupEnum.AUXILIARY,
   HardpointGroupEnum.OTHER,
 ];
@@ -50,6 +51,8 @@ const propulsionVisible = ref(false);
 const thrusterVisible = ref(false);
 
 const weaponVisible = ref(false);
+
+const defenseVisible = ref(false);
 
 const auxiliaryVisible = ref(false);
 
@@ -95,6 +98,7 @@ const setupVisibles = () => {
   propulsionVisible.value = props.models.length > 0;
   thrusterVisible.value = props.models.length > 0;
   weaponVisible.value = props.models.length > 0;
+  defenseVisible.value = props.models.length > 0;
   auxiliaryVisible.value = props.models.length > 0;
   otherVisible.value = props.models.length > 0;
 };
@@ -114,6 +118,9 @@ const isVisible = (group: HardpointGroupEnum) => {
   }
   if (group === HardpointGroupEnum.WEAPON) {
     return weaponVisible.value;
+  }
+  if (group === HardpointGroupEnum.DEFENSE) {
+    return defenseVisible.value;
   }
   if (group === HardpointGroupEnum.AUXILIARY) {
     return auxiliaryVisible.value;
@@ -140,6 +147,9 @@ const toggle = (group: HardpointGroupEnum) => {
   }
   if (group === HardpointGroupEnum.WEAPON) {
     weaponVisible.value = !weaponVisible.value;
+  }
+  if (group === HardpointGroupEnum.DEFENSE) {
+    defenseVisible.value = !defenseVisible.value;
   }
   if (group === HardpointGroupEnum.AUXILIARY) {
     auxiliaryVisible.value = !auxiliaryVisible.value;

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -242,6 +242,7 @@ const shieldStats = useShieldStats(
           <HardpointGroup
             v-for="group in [
               HardpointGroupEnum.WEAPON,
+              HardpointGroupEnum.DEFENSE,
               HardpointGroupEnum.AUXILIARY,
             ]"
             :key="group"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -936,6 +936,7 @@
           "propulsion": "Propulsion",
           "thruster": "Thruster",
           "weapon": "Weapons",
+          "defense": "Defense",
           "other": "Other",
           "auxiliary": "Auxiliary",
           "seat": "Seats",

--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -90,11 +90,13 @@ class Hardpoint < ApplicationRecord
       :thruster
     when "seat"
       :seat
-    when "lifesupport", "armor", "countermeasures", "utility" # , "salvagemunching"
+    when "utility" # , "salvagemunching"
       :auxiliary
+    when "armor", "countermeasures"
+      :defense
     when "radar", "computers", "scanners"
       :avionic
-    when "powerplant", "cooler", "shieldgenerator"
+    when "powerplant", "cooler", "shieldgenerator", "lifesupport"
       :system
     when "turret", "weapon_mounts", "weapons", "missile_racks", "bombcompartments",
       "quantumenforcementdevice"

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -154,6 +154,13 @@ json.metrics do
   end
   json.quantum_fuel_tank_size model.quantum_fuel_tank_size&.to_f
   json.weapon_pool_size model.weapon_pool_size if model.weapon_pool_size.present?
+  if model.signature_cross_section.present?
+    json.signature_cross_section do
+      json.x model.signature_cross_section["x"].to_f
+      json.y model.signature_cross_section["y"].to_f
+      json.z model.signature_cross_section["z"].to_f
+    end
+  end
   json.size model.size
   json.size_label model.size&.humanize
   json.dock_size model.dock_size

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7016,8 +7016,11 @@ components:
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
           - "$ref": "#/components/schemas/ComponentWeapon"
+          - "$ref": "#/components/schemas/ComponentTractorBeam"
           - "$ref": "#/components/schemas/ComponentShield"
           - "$ref": "#/components/schemas/ComponentCooler"
+          - "$ref": "#/components/schemas/ComponentRadar"
+          - "$ref": "#/components/schemas/ComponentController"
           - "$ref": "#/components/schemas/ComponentPowerPlant"
         hardpoints:
           type: array
@@ -7096,10 +7099,113 @@ components:
       - RSI_PROPULSION
       - RSI_THRUSTER
       title: ComponentClassEnum
+    ComponentController:
+      type: object
+      properties:
+        scmSpeed:
+          type: number
+        scmSpeedBoosted:
+          type: number
+        reverseSpeedBoosted:
+          type: number
+        maxSpeed:
+          type: number
+        angularVelocity:
+          type: object
+          properties:
+            pitch:
+              type: number
+            yaw:
+              type: number
+            roll:
+              type: number
+          additionalProperties: false
+        boostedAngularVelocity:
+          type: object
+          properties:
+            pitch:
+              type: number
+            yaw:
+              type: number
+            roll:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+      additionalProperties: false
+      title: ComponentController
     ComponentCooler:
       type: object
       properties:
         coolingRate:
+          type: number
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+        signatureIr:
           type: number
       additionalProperties: false
       required:
@@ -7178,6 +7284,36 @@ components:
           type: number
         powerDraw:
           type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       title: ComponentPowerPlant
     ComponentQuantumDrive:
@@ -7219,6 +7355,40 @@ components:
           "$ref": "#/components/schemas/ComponentQuantumDriveJump"
         quantumBoostParams:
           "$ref": "#/components/schemas/ComponentQuantumDriveBoost"
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       title: ComponentQuantumDrive
     ComponentQuantumDriveBoost:
@@ -7311,6 +7481,97 @@ components:
       additionalProperties: false
       example: {}
       title: ComponentQuery
+    ComponentRadar:
+      type: object
+      properties:
+        signatureDetection:
+          type: object
+          properties:
+            ir:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            em:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            cs:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            rs:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        pingProperties:
+          type: object
+          properties:
+            cooldownTime:
+              type: number
+          additionalProperties: false
+        aimAssistRange:
+          type: number
+        aimAssistMin:
+          type: number
+        sensitivityModifiers:
+          type: object
+          properties:
+            sensitivityAddition:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+      additionalProperties: false
+      title: ComponentRadar
     ComponentShield:
       type: object
       properties:
@@ -7428,6 +7689,40 @@ components:
                   type: number
               additionalProperties: false
           additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       required:
       - maxHealth
@@ -7463,6 +7758,107 @@ components:
       - thrusterType
       - fuelBurnRatePer10KNewton
       title: ComponentThruster
+    ComponentTractorBeam:
+      type: object
+      properties:
+        tractorBeam:
+          type: boolean
+        minForce:
+          type: number
+        maxForce:
+          type: number
+        minDistance:
+          type: number
+        maxDistance:
+          type: number
+        fullStrengthDistance:
+          type: number
+        maxAngle:
+          type: number
+        maxVolume:
+          type: number
+        volumeForceCoefficient:
+          type: number
+        tetherBreakTime:
+          type: number
+        heatPerSecond:
+          type: number
+        rotation:
+          type: object
+          properties:
+            maxAngularVelocity:
+              type: number
+            degreesPerAction:
+              type: number
+          additionalProperties: false
+        movement:
+          type: object
+          properties:
+            maxSpeed:
+              type: number
+            maxAcceleration:
+              type: number
+          additionalProperties: false
+        cargoMode:
+          type: object
+          properties:
+            maxForce:
+              type: number
+            minDistance:
+              type: number
+            maxDistance:
+              type: number
+            fullStrengthDistance:
+              type: number
+          additionalProperties: false
+        towing:
+          type: object
+          properties:
+            towingForce:
+              type: number
+            towingMaxDistance:
+              type: number
+            towingMaxAcceleration:
+              type: number
+            quantumTowMassLimit:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+      additionalProperties: false
+      required:
+      - tractorBeam
+      title: ComponentTractorBeam
     ComponentTypeEnum:
       type: string
       enum:
@@ -7624,6 +8020,36 @@ components:
         heatPerShot:
           type: number
         powerConsumption:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
           type: number
         damagePerShot:
           type: object
@@ -9680,6 +10106,16 @@ components:
               type: number
             weaponPoolSize:
               type: number
+            signatureCrossSection:
+              type: object
+              properties:
+                x:
+                  type: number
+                "y":
+                  type: number
+                z:
+                  type: number
+              additionalProperties: false
             size:
               type: string
             sizeLabel:
@@ -10141,6 +10577,16 @@ components:
               type: number
             weaponPoolSize:
               type: number
+            signatureCrossSection:
+              type: object
+              properties:
+                x:
+                  type: number
+                "y":
+                  type: number
+                z:
+                  type: number
+              additionalProperties: false
             size:
               type: string
             sizeLabel:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -6980,8 +6980,11 @@ components:
           - "$ref": "#/components/schemas/FuelTank"
           - "$ref": "#/components/schemas/ComponentThruster"
           - "$ref": "#/components/schemas/ComponentWeapon"
+          - "$ref": "#/components/schemas/ComponentTractorBeam"
           - "$ref": "#/components/schemas/ComponentShield"
           - "$ref": "#/components/schemas/ComponentCooler"
+          - "$ref": "#/components/schemas/ComponentRadar"
+          - "$ref": "#/components/schemas/ComponentController"
           - "$ref": "#/components/schemas/ComponentPowerPlant"
         hardpoints:
           type: array
@@ -7060,10 +7063,113 @@ components:
       - RSI_PROPULSION
       - RSI_THRUSTER
       title: ComponentClassEnum
+    ComponentController:
+      type: object
+      properties:
+        scmSpeed:
+          type: number
+        scmSpeedBoosted:
+          type: number
+        reverseSpeedBoosted:
+          type: number
+        maxSpeed:
+          type: number
+        angularVelocity:
+          type: object
+          properties:
+            pitch:
+              type: number
+            yaw:
+              type: number
+            roll:
+              type: number
+          additionalProperties: false
+        boostedAngularVelocity:
+          type: object
+          properties:
+            pitch:
+              type: number
+            yaw:
+              type: number
+            roll:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+      additionalProperties: false
+      title: ComponentController
     ComponentCooler:
       type: object
       properties:
         coolingRate:
+          type: number
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+        signatureIr:
           type: number
       additionalProperties: false
       required:
@@ -7106,6 +7212,36 @@ components:
           type: number
         powerDraw:
           type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       title: ComponentPowerPlant
     ComponentQuantumDrive:
@@ -7147,6 +7283,40 @@ components:
           "$ref": "#/components/schemas/ComponentQuantumDriveJump"
         quantumBoostParams:
           "$ref": "#/components/schemas/ComponentQuantumDriveBoost"
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       title: ComponentQuantumDrive
     ComponentQuantumDriveBoost:
@@ -7224,6 +7394,97 @@ components:
       additionalProperties: false
       example: {}
       title: ComponentQuery
+    ComponentRadar:
+      type: object
+      properties:
+        signatureDetection:
+          type: object
+          properties:
+            ir:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            em:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            cs:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+            rs:
+              type: object
+              properties:
+                sensitivity:
+                  type: number
+                piercing:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        pingProperties:
+          type: object
+          properties:
+            cooldownTime:
+              type: number
+          additionalProperties: false
+        aimAssistRange:
+          type: number
+        aimAssistMin:
+          type: number
+        sensitivityModifiers:
+          type: object
+          properties:
+            sensitivityAddition:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
+      additionalProperties: false
+      title: ComponentRadar
     ComponentShield:
       type: object
       properties:
@@ -7341,6 +7602,40 @@ components:
                   type: number
               additionalProperties: false
           additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
+          type: number
       additionalProperties: false
       required:
       - maxHealth
@@ -7376,6 +7671,107 @@ components:
       - thrusterType
       - fuelBurnRatePer10KNewton
       title: ComponentThruster
+    ComponentTractorBeam:
+      type: object
+      properties:
+        tractorBeam:
+          type: boolean
+        minForce:
+          type: number
+        maxForce:
+          type: number
+        minDistance:
+          type: number
+        maxDistance:
+          type: number
+        fullStrengthDistance:
+          type: number
+        maxAngle:
+          type: number
+        maxVolume:
+          type: number
+        volumeForceCoefficient:
+          type: number
+        tetherBreakTime:
+          type: number
+        heatPerSecond:
+          type: number
+        rotation:
+          type: object
+          properties:
+            maxAngularVelocity:
+              type: number
+            degreesPerAction:
+              type: number
+          additionalProperties: false
+        movement:
+          type: object
+          properties:
+            maxSpeed:
+              type: number
+            maxAcceleration:
+              type: number
+          additionalProperties: false
+        cargoMode:
+          type: object
+          properties:
+            maxForce:
+              type: number
+            minDistance:
+              type: number
+            maxDistance:
+              type: number
+            fullStrengthDistance:
+              type: number
+          additionalProperties: false
+        towing:
+          type: object
+          properties:
+            towingForce:
+              type: number
+            towingMaxDistance:
+              type: number
+            towingMaxAcceleration:
+              type: number
+            quantumTowMassLimit:
+              type: number
+          additionalProperties: false
+        powerConsumption:
+          type: number
+        powerMinimumFraction:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+      additionalProperties: false
+      required:
+      - tractorBeam
+      title: ComponentTractorBeam
     ComponentTypeEnum:
       type: string
       enum:
@@ -7537,6 +7933,36 @@ components:
         heatPerShot:
           type: number
         powerConsumption:
+          type: number
+        powerRanges:
+          type: object
+          properties:
+            low:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            medium:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+            high:
+              type: object
+              properties:
+                start:
+                  type: number
+                modifier:
+                  type: number
+              additionalProperties: false
+          additionalProperties: false
+        signatureEm:
           type: number
         damagePerShot:
           type: object
@@ -10448,6 +10874,16 @@ components:
               type: number
             weaponPoolSize:
               type: number
+            signatureCrossSection:
+              type: object
+              properties:
+                x:
+                  type: number
+                "y":
+                  type: number
+                z:
+                  type: number
+              additionalProperties: false
             size:
               type: string
             sizeLabel:
@@ -10791,6 +11227,16 @@ components:
               type: number
             weaponPoolSize:
               type: number
+            signatureCrossSection:
+              type: object
+              properties:
+                x:
+                  type: number
+                "y":
+                  type: number
+                z:
+                  type: number
+              additionalProperties: false
             size:
               type: string
             sizeLabel:


### PR DESCRIPTION
Adds EM/IR signature nominals and power-range breakpoints to the component schemas (cooler, shield, radar, weapon, quantum drive, controller, power plant, tractor beam), the ship's per-axis `signatureCrossSection` to the model schema, and regroups hardpoints (armor/countermeasures → **Defense**, life support → **Systems**). Regenerated swagger schema.

Stack (3 of 4): **base `feat/scdata-load-signatures`** (needs the `signature_cross_section` column). The frontend PR is based on this branch.

🤖