### PR TITLE
feat(loadout): interactive power-distribution UI + metrics cards

### DIFF
--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
@@ -115,6 +115,27 @@ describe("ModelAvailabilityModal", () => {
     ]);
   });
 
+  it("links the shop when the location url is a web link", () => {
+    const wrapper = mountWith({
+      soldAt: [itemPrice({ locationUrl: "https://example.test/shop" })],
+    });
+
+    expect(wrapper.get("a.availability__shop").attributes("href")).toBe(
+      "https://example.test/shop",
+    );
+  });
+
+  // A location url is admin-writable and third-party fed; in an href a
+  // `javascript:` value would run on click.
+  it("refuses to link a location url that is not a web link", () => {
+    const wrapper = mountWith({
+      soldAt: [itemPrice({ locationUrl: "javascript:alert(1)" })],
+    });
+
+    expect(wrapper.find("a.availability__shop").exists()).toBe(false);
+    expect(wrapper.get(".availability__shop").text()).toBe("Astro Armada");
+  });
+
   it("splits the terminal name into shop and place", () => {
     const wrapper = mountWith({
       soldAt: [

--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
@@ -5,8 +5,9 @@ import Component from "./index.vue";
 
 vi.mock("@/shared/composables/useI18n", () => ({
   useI18n: () => ({
-    t: (key: string) => key,
-    toUEC: (value: unknown) => String(value),
+    t: (key: string, options?: { count?: number }) =>
+      options?.count === undefined ? key : `${key}:${options.count}`,
+    toNumber: (value: unknown) => String(value),
   }),
 }));
 
@@ -23,6 +24,11 @@ const mountWith = (props: { soldAt?: ItemPrice[]; rentalAt?: ItemPrice[] }) =>
     props,
     global: { stubs: { Modal: { template: "<div><slot /></div>" } } },
   });
+
+const texts = (
+  wrapper: ReturnType<typeof mountWith>,
+  selector: string,
+): string[] => wrapper.findAll(selector).map((node) => node.text());
 
 describe("ModelAvailabilityModal", () => {
   it("credits UEX when a sale location is shown", () => {
@@ -46,6 +52,81 @@ describe("ModelAvailabilityModal", () => {
 
     expect(wrapper.find('a[href="https://uexcorp.space"]').exists()).toBe(
       false,
+    );
+  });
+
+  it("leads with the cheapest price per section and counts its locations", () => {
+    const wrapper = mountWith({
+      soldAt: [
+        itemPrice({ id: "buy-1", price: 1358280 }),
+        itemPrice({ id: "buy-2", price: 1290370 }),
+      ],
+      rentalAt: [itemPrice({ id: "rent-1", price: 27165 })],
+    });
+
+    expect(texts(wrapper, ".availability__tile__value")).toEqual([
+      "1290370 number.units.uec",
+      "27165 number.units.uec",
+    ]);
+    expect(texts(wrapper, ".availability__tile__sub")).toEqual([
+      "labels.availability.locations:2",
+      "labels.availability.locations:1",
+    ]);
+  });
+
+  it("marks the cheapest row and prices the rest as a premium over it", () => {
+    const wrapper = mountWith({
+      soldAt: [
+        itemPrice({ id: "buy-1", price: 1358280 }),
+        itemPrice({ id: "buy-2", price: 1290370 }),
+      ],
+    });
+
+    expect(texts(wrapper, ".availability__price")).toEqual([
+      "1290370",
+      "1358280",
+    ]);
+    expect(texts(wrapper, ".availability__price--best")).toEqual(["1290370"]);
+    // 1,358,280 / 1,290,370 - 1 = 5.3%
+    expect(texts(wrapper, ".availability__premium")).toEqual(["+5%"]);
+  });
+
+  it("gives rows a rental period only once the periods differ", () => {
+    const oneDay = [
+      itemPrice({ id: "rent-1", price: 27165, timeRange: "1-day" }),
+      itemPrice({ id: "rent-2", price: 28350, timeRange: "1-day" }),
+    ];
+
+    expect(
+      texts(mountWith({ rentalAt: oneDay }), ".availability__range"),
+    ).toEqual([]);
+
+    const mixed = [
+      ...oneDay,
+      itemPrice({ id: "rent-3", price: 509344, timeRange: "30-days" }),
+    ];
+
+    expect(
+      texts(mountWith({ rentalAt: mixed }), ".availability__range"),
+    ).toEqual([
+      "labels.availability.timeRange.1-day",
+      "labels.availability.timeRange.1-day",
+      "labels.availability.timeRange.30-days",
+    ]);
+  });
+
+  it("splits the terminal name into shop and place", () => {
+    const wrapper = mountWith({
+      soldAt: [
+        itemPrice({
+          location: "Traveler Rentals - Cargo Center - Terra Gateway",
+        }),
+      ],
+    });
+
+    expect(wrapper.get(".availability__shop").text()).toBe("Traveler Rentals");
+    expect(wrapper.get(".availability__place").text()).toBe(
+      "Cargo Center · Terra Gateway",
     );
   });
 });

--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.spec.ts
@@ -1,13 +1,11 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
-import type { Model, ItemPrice } from "@/services/fyApi";
+import type { ItemPrice } from "@/services/fyApi";
 import Component from "./index.vue";
 
 vi.mock("@/shared/composables/useI18n", () => ({
   useI18n: () => ({
     t: (key: string) => key,
-    toNumber: (value: unknown) => String(value),
-    toDollar: (value: unknown) => String(value),
     toUEC: (value: unknown) => String(value),
   }),
 }));
@@ -15,24 +13,18 @@ vi.mock("@/shared/composables/useI18n", () => ({
 const itemPrice = (attributes: Partial<ItemPrice>) =>
   ({
     id: "price-1",
+    price: 100,
     location: "Astro Armada - Area 18",
     ...attributes,
   }) as ItemPrice;
 
-const model = (availability: Partial<Model["availability"]>) =>
-  ({
-    availability: { boughtAt: [], soldAt: [], rentalAt: [], ...availability },
-    classificationLabel: "Multi-Role",
-    metrics: {},
-  }) as unknown as Model;
-
-const mountWith = (availability: Partial<Model["availability"]>) =>
+const mountWith = (props: { soldAt?: ItemPrice[]; rentalAt?: ItemPrice[] }) =>
   mount(Component, {
-    props: { model: model(availability) },
-    global: { directives: { tooltip: () => {} } },
+    props,
+    global: { stubs: { Modal: { template: "<div><slot /></div>" } } },
   });
 
-describe("ModelBaseMetrics", () => {
+describe("ModelAvailabilityModal", () => {
   it("credits UEX when a sale location is shown", () => {
     const link = mountWith({ soldAt: [itemPrice({})] }).get(
       'a[href="https://uexcorp.space"]',

--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
@@ -1,0 +1,183 @@
+<script lang="ts">
+export default {
+  name: "ModelAvailabilityModal",
+};
+</script>
+
+<script lang="ts" setup>
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import type { ItemPrice } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  soldAt?: ItemPrice[];
+  rentalAt?: ItemPrice[];
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  soldAt: () => [],
+  rentalAt: () => [],
+});
+
+const { t, toUEC } = useI18n();
+
+const byPrice = (prices: ItemPrice[]) =>
+  [...prices].sort((a, b) => a.price - b.price);
+
+const buyPrices = computed(() => byPrice(props.soldAt));
+const rentalPrices = computed(() => byPrice(props.rentalAt));
+
+const hasData = computed(
+  () => !!buyPrices.value.length || !!rentalPrices.value.length,
+);
+
+// Rentals are quoted per period, so the same location appears once per range.
+const timeRangeLabel = (price: ItemPrice) =>
+  price.timeRange ? t(`labels.availability.timeRange.${price.timeRange}`) : "";
+</script>
+
+<template>
+  <Modal :title="t('labels.availability.title')">
+    <div class="availability">
+      <p v-if="!hasData" class="availability__empty">
+        {{ t("labels.availability.empty") }}
+      </p>
+
+      <template v-if="buyPrices.length">
+        <div class="availability__label">
+          {{ t("labels.availability.buy") }}
+        </div>
+        <ul class="availability__list">
+          <li
+            v-for="price in buyPrices"
+            :key="price.id"
+            class="availability__item"
+          >
+            <a
+              v-if="price.locationUrl"
+              :href="price.locationUrl"
+              class="availability__location"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ price.location }}
+            </a>
+            <span v-else class="availability__location">
+              {{ price.location }}
+            </span>
+            <!-- eslint-disable vue/no-v-html -->
+            <span class="availability__price" v-html="toUEC(price.price)" />
+            <!-- eslint-enable vue/no-v-html -->
+          </li>
+        </ul>
+      </template>
+
+      <template v-if="rentalPrices.length">
+        <div class="availability__label">
+          {{ t("labels.availability.rent") }}
+        </div>
+        <ul class="availability__list">
+          <li
+            v-for="price in rentalPrices"
+            :key="price.id"
+            class="availability__item"
+          >
+            <a
+              v-if="price.locationUrl"
+              :href="price.locationUrl"
+              class="availability__location"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ price.location }}
+            </a>
+            <span v-else class="availability__location">
+              {{ price.location }}
+            </span>
+            <span v-if="price.timeRange" class="availability__range">
+              {{ timeRangeLabel(price) }}
+            </span>
+            <!-- eslint-disable vue/no-v-html -->
+            <span class="availability__price" v-html="toUEC(price.price)" />
+            <!-- eslint-enable vue/no-v-html -->
+          </li>
+        </ul>
+      </template>
+
+      <div v-if="hasData" class="metrics-attribution">
+        <a href="https://uexcorp.space" target="_blank" rel="noopener">
+          {{ t("model.poweredByUex") }}
+        </a>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<style lang="scss" scoped>
+.availability {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.availability__empty {
+  margin: 0;
+  color: $gray-light;
+}
+
+.availability__label {
+  font-family: "Orbitron", tahoma, sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: $gray-light;
+  margin: 14px 0 6px;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.availability__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.availability__item {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba($gray-light, 0.16);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+}
+
+.availability__location {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.availability__range {
+  flex: none;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: $gray-light;
+}
+
+.availability__price {
+  flex: none;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: lighten($text-color, 15%);
+}
+</style>

--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
@@ -67,6 +67,12 @@ const shopName = (price: ItemPrice) => price.location.split(" - ")[0];
 const placeName = (price: ItemPrice) =>
   price.location.split(" - ").slice(1).join(" · ");
 
+// A location url is admin-writable and third-party fed, and this one lands in an
+// `href`: a `javascript:` value would run on click. Rows written before the
+// model validation can still hold one, so the scheme is checked here too.
+const linkUrl = (price: ItemPrice) =>
+  /^https?:\/\//i.test(price.locationUrl ?? "") ? price.locationUrl : undefined;
+
 // Vehicle prices barely move between shops — a few percent — so bars scaled to
 // the dearest would all read full. The premium over the cheapest is the part
 // worth showing.
@@ -123,8 +129,8 @@ const premium = (price: ItemPrice, cheapest: ItemPrice) =>
               >
                 <span class="availability__loc">
                   <a
-                    v-if="price.locationUrl"
-                    :href="price.locationUrl"
+                    v-if="linkUrl(price)"
+                    :href="linkUrl(price)"
                     class="availability__shop"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
+++ b/app/frontend/frontend/components/Models/AvailabilityModal/index.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
   rentalAt: () => [],
 });
 
-const { t, toUEC } = useI18n();
+const { t, toNumber } = useI18n();
 
 const byPrice = (prices: ItemPrice[]) =>
   [...prices].sort((a, b) => a.price - b.price);
@@ -27,13 +27,51 @@ const byPrice = (prices: ItemPrice[]) =>
 const buyPrices = computed(() => byPrice(props.soldAt));
 const rentalPrices = computed(() => byPrice(props.rentalAt));
 
-const hasData = computed(
-  () => !!buyPrices.value.length || !!rentalPrices.value.length,
+const sections = computed(() =>
+  [
+    {
+      key: "buy",
+      label: t("labels.availability.buy"),
+      prices: buyPrices.value,
+    },
+    {
+      key: "rent",
+      label: t("labels.availability.rent"),
+      prices: rentalPrices.value,
+    },
+  ]
+    .filter((section) => section.prices.length)
+    .map((section) => ({
+      ...section,
+      // Today every rental is quoted for the same period, and repeating "1 day"
+      // down thirty rows says nothing the tile has not — it earns its column
+      // only once the periods actually differ.
+      mixedPeriods:
+        new Set(section.prices.map((price) => price.timeRange)).size > 1,
+    })),
 );
+
+const hasData = computed(() => !!sections.value.length);
+
+const uec = computed(() => t("number.units.uec"));
 
 // Rentals are quoted per period, so the same location appears once per range.
 const timeRangeLabel = (price: ItemPrice) =>
   price.timeRange ? t(`labels.availability.timeRange.${price.timeRange}`) : "";
+
+// UEX names a terminal "shop - spaceport - city": the shop is what people look
+// for and the rest is where to fly, so they get separate weights instead of one
+// long run of text that ellipsises mid-place.
+const shopName = (price: ItemPrice) => price.location.split(" - ")[0];
+
+const placeName = (price: ItemPrice) =>
+  price.location.split(" - ").slice(1).join(" · ");
+
+// Vehicle prices barely move between shops — a few percent — so bars scaled to
+// the dearest would all read full. The premium over the cheapest is the part
+// worth showing.
+const premium = (price: ItemPrice, cheapest: ItemPrice) =>
+  cheapest.price ? Math.round((price.price / cheapest.price - 1) * 100) : 0;
 </script>
 
 <template>
@@ -43,81 +81,107 @@ const timeRangeLabel = (price: ItemPrice) =>
         {{ t("labels.availability.empty") }}
       </p>
 
-      <template v-if="buyPrices.length">
-        <div class="availability__label">
-          {{ t("labels.availability.buy") }}
-        </div>
-        <ul class="availability__list">
-          <li
-            v-for="price in buyPrices"
-            :key="price.id"
-            class="availability__item"
+      <template v-else>
+        <div class="availability__tiles">
+          <div
+            v-for="(section, index) in sections"
+            :key="section.key"
+            class="availability__tile"
+            :class="{ 'availability__tile--primary': index === 0 }"
           >
-            <a
-              v-if="price.locationUrl"
-              :href="price.locationUrl"
-              class="availability__location"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ price.location }}
-            </a>
-            <span v-else class="availability__location">
-              {{ price.location }}
-            </span>
-            <!-- eslint-disable vue/no-v-html -->
-            <span class="availability__price" v-html="toUEC(price.price)" />
-            <!-- eslint-enable vue/no-v-html -->
-          </li>
-        </ul>
-      </template>
-
-      <template v-if="rentalPrices.length">
-        <div class="availability__label">
-          {{ t("labels.availability.rent") }}
+            <div class="availability__tile__label">
+              {{ t(`labels.availability.cheapest.${section.key}`) }}
+            </div>
+            <div class="availability__tile__value">
+              {{ toNumber(section.prices[0].price, "integer") }}
+              <span class="availability__tile__unit">{{ uec }}</span>
+            </div>
+            <div class="availability__tile__sub">
+              <template v-if="timeRangeLabel(section.prices[0])">
+                {{ timeRangeLabel(section.prices[0]) }} ·
+              </template>
+              {{
+                t("labels.availability.locations", {
+                  count: section.prices.length,
+                })
+              }}
+            </div>
+          </div>
         </div>
-        <ul class="availability__list">
-          <li
-            v-for="price in rentalPrices"
-            :key="price.id"
-            class="availability__item"
-          >
-            <a
-              v-if="price.locationUrl"
-              :href="price.locationUrl"
-              class="availability__location"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ price.location }}
-            </a>
-            <span v-else class="availability__location">
-              {{ price.location }}
-            </span>
-            <span v-if="price.timeRange" class="availability__range">
-              {{ timeRangeLabel(price) }}
-            </span>
-            <!-- eslint-disable vue/no-v-html -->
-            <span class="availability__price" v-html="toUEC(price.price)" />
-            <!-- eslint-enable vue/no-v-html -->
-          </li>
-        </ul>
-      </template>
 
-      <div v-if="hasData" class="metrics-attribution">
-        <a href="https://uexcorp.space" target="_blank" rel="noopener">
-          {{ t("model.poweredByUex") }}
-        </a>
-      </div>
+        <div class="availability__scroll">
+          <template v-for="section in sections" :key="section.key">
+            <div class="availability__head">
+              <span>{{ section.label }}</span>
+              <span class="availability__head__unit">{{ uec }}</span>
+            </div>
+            <ul class="availability__list">
+              <li
+                v-for="price in section.prices"
+                :key="price.id"
+                class="availability__item"
+              >
+                <span class="availability__loc">
+                  <a
+                    v-if="price.locationUrl"
+                    :href="price.locationUrl"
+                    class="availability__shop"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {{ shopName(price) }}
+                  </a>
+                  <span v-else class="availability__shop">
+                    {{ shopName(price) }}
+                  </span>
+                  <span v-if="placeName(price)" class="availability__place">
+                    {{ placeName(price) }}
+                  </span>
+                </span>
+                <span
+                  v-if="section.mixedPeriods && price.timeRange"
+                  class="availability__range"
+                >
+                  {{ timeRangeLabel(price) }}
+                </span>
+                <span
+                  v-if="premium(price, section.prices[0]) > 0"
+                  class="availability__premium"
+                >
+                  +{{ premium(price, section.prices[0]) }}%
+                </span>
+                <span
+                  class="availability__price"
+                  :class="{
+                    'availability__price--best':
+                      price.id === section.prices[0].id,
+                  }"
+                >
+                  {{ toNumber(price.price, "integer") }}
+                </span>
+              </li>
+            </ul>
+          </template>
+        </div>
+
+        <div class="availability__footer">
+          <a href="https://uexcorp.space" target="_blank" rel="noopener">
+            {{ t("model.poweredByUex") }}
+          </a>
+        </div>
+      </template>
     </div>
   </Modal>
 </template>
 
 <style lang="scss" scoped>
+// The modal body scrolls on its own, so an inner scroller with its own
+// max-height would nest two scrollbars. Capping the whole card at that height
+// instead keeps the tiles and the UEX credit put while only the lists move.
 .availability {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  max-height: calc(100vh - 16rem);
 }
 
 .availability__empty {
@@ -125,16 +189,101 @@ const timeRangeLabel = (price: ItemPrice) =>
   color: $gray-light;
 }
 
-.availability__label {
-  font-family: "Orbitron", tahoma, sans-serif;
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: $gray-light;
-  margin: 14px 0 6px;
+.availability__tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
 
-  &:first-child {
-    margin-top: 0;
+.availability__tile {
+  flex: 1 1 150px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 11px 14px;
+  min-width: 0;
+  overflow: hidden;
+  container-type: inline-size;
+  background: $gray-black;
+  border: 1px solid rgba($gray-light, 0.28);
+  border-radius: 6px;
+
+  &--primary {
+    border-color: rgba($gold, 0.5);
+
+    .availability__tile__value {
+      color: $gold;
+    }
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray;
+  }
+
+  &__value {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-weight: 700;
+    // Capitals run to eight figures, so the value scales with the tile rather
+    // than outgrowing it.
+    font-size: clamp(14px, 13cqw, 22px);
+    line-height: 1;
+    color: lighten($text-color, 15%);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  &__unit {
+    font-family: "Open Sans", sans-serif;
+    font-weight: 600;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: $gray-light;
+  }
+
+  &__sub {
+    font-size: 11px;
+    color: $gray;
+  }
+}
+
+.availability__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.availability__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: "Orbitron", tahoma, sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: $gray;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba($gray-light, 0.28);
+
+  &:not(:first-child) {
+    margin-top: 22px;
+  }
+
+  &__unit {
+    font-family: "Open Sans", sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: none;
+    color: $gray;
   }
 }
 
@@ -142,8 +291,6 @@ const timeRangeLabel = (price: ItemPrice) =>
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
 }
 
 .availability__item {
@@ -151,33 +298,65 @@ const timeRangeLabel = (price: ItemPrice) =>
   align-items: baseline;
   gap: 12px;
   padding: 8px 0;
-  border-bottom: 1px solid rgba($gray-light, 0.16);
+  border-bottom: 1px solid rgba($gray-light, 0.18);
 
   &:last-child {
     border-bottom: 0;
   }
 }
 
-.availability__location {
+.availability__loc {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.availability__shop,
+.availability__place {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.availability__range {
-  flex: none;
+.availability__shop {
+  font-size: 13px;
+  color: lighten($text-color, 15%);
+}
+
+.availability__place {
   font-size: 11px;
-  letter-spacing: 0.08em;
+  color: $gray;
+}
+
+.availability__range,
+.availability__premium {
+  flex: none;
+  font-family: "Orbitron", tahoma, sans-serif;
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: $gray-light;
+  color: $gray;
+  white-space: nowrap;
 }
 
 .availability__price {
   flex: none;
+  font-size: 13px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: lighten($text-color, 15%);
+  white-space: nowrap;
+
+  &--best {
+    color: $gold;
+  }
+}
+
+.availability__footer {
+  margin-top: 14px;
+  font-size: 11px;
+  color: $gray;
 }
 </style>

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -5,6 +5,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
+import Collapsed from "@/shared/components/Collapsed.vue";
 import type { Model } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 
@@ -49,147 +51,168 @@ const displayHeight = computed(() => {
 
   return props.model.metrics.height;
 });
+
+const hasPrice = computed(
+  () => !!props.model.price || !!props.model.pledgePrice,
+);
+
+const hasFuel = computed(
+  () =>
+    !!props.model.metrics.hydrogenFuelTankSize ||
+    !!props.model.metrics.quantumFuelTankSize,
+);
+
+const hasAvailability = computed(
+  () => !!soldAt.value?.length || !!rentalAt.value?.length,
+);
+
+const availabilityVisible = ref(false);
 </script>
 
 <template>
-  <div class="row base-metrics metrics-padding">
-    <div class="col-12 col-lg-3">
-      <div class="metrics-title">
-        {{ t("labels.metrics.base") }}
+  <MetricsCard :title="t('labels.metrics.base')" class="base-panel">
+    <template #head>
+      <span v-if="model.classificationLabel" class="base-panel__chip">
+        {{ model.classificationLabel }}
+      </span>
+    </template>
+
+    <div class="metrics-card__hero metrics-card__hero--grid">
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.length") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(displayLength || "", "distance") }}
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.beam") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(displayBeam || "", "distance") }}
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.height") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(displayHeight || "", "distance") }}
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.mass") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(model.metrics.mass || "", "weight") }}
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.cargo") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(model.metrics.cargo || "", "integer") }}
+          <span class="metrics-card__tile__unit">SCU</span>
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.size") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ model.metrics.sizeLabel }}
+        </div>
       </div>
     </div>
-    <div class="col-12 col-lg-9 metrics-block">
-      <div class="row">
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">{{ t("model.length") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(displayLength || "", "distance") }}
-          </div>
-          <div class="metrics-label">{{ t("model.beam") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(displayBeam || "", "distance") }}
-          </div>
+
+    <template v-if="hasPrice">
+      <div class="metrics-card__section-label">
+        {{ t("labels.base.price") }}
+      </div>
+      <div class="metrics-card__rows metrics-card__rows--split">
+        <div v-if="model.price" class="metrics-card__row">
+          <span class="metrics-card__row__label">
+            {{ t("labels.base.priceInGame") }}
+          </span>
+          <!-- eslint-disable vue/no-v-html -->
+          <span
+            v-tooltip="{ content: toUEC(model.price), html: true }"
+            class="metrics-card__row__value"
+            v-html="toUEC(model.price)"
+          />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">{{ t("model.height") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(displayHeight || "", "distance") }}
-          </div>
-          <div class="metrics-label">{{ t("model.mass") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(model.metrics.mass || "", "weight") }}
-          </div>
-        </div>
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">{{ t("model.cargo") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(model.metrics.cargo || "", "cargo") }}
-          </div>
+        <div v-if="model.pledgePrice" class="metrics-card__row">
+          <span class="metrics-card__row__label">
+            {{ t("labels.base.pricePledge") }}
+          </span>
+          <span class="metrics-card__row__value">
+            {{ toDollar(model.pledgePrice) }}
+          </span>
         </div>
       </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="seperator" />
+    </template>
+
+    <template v-if="hasFuel">
+      <div v-if="hasPrice" class="metrics-card__divider" />
+      <div class="metrics-card__section-label">
+        {{ t("labels.base.fuel") }}
+      </div>
+      <div class="metrics-card__rows metrics-card__rows--split">
+        <div
+          v-if="model.metrics.hydrogenFuelTankSize"
+          class="metrics-card__row"
+        >
+          <span class="metrics-card__row__label">
+            {{ t("labels.base.fuelHydrogen") }}
+          </span>
+          <span class="metrics-card__row__value">
+            {{ toNumber(model.metrics.hydrogenFuelTankSize, "cargo") }}
+          </span>
+        </div>
+        <div v-if="model.metrics.quantumFuelTankSize" class="metrics-card__row">
+          <span class="metrics-card__row__label">
+            {{ t("labels.base.fuelQuantum") }}
+          </span>
+          <span class="metrics-card__row__value">
+            {{ toNumber(model.metrics.quantumFuelTankSize, "cargo") }}
+          </span>
         </div>
       </div>
-      <div class="row">
-        <div class="col-lg-12">
-          <div class="row">
-            <div class="col-6">
-              <div class="metrics-label">{{ t("model.classification") }}:</div>
-              <div class="metrics-value">
-                {{ model.classificationLabel }}
-              </div>
-            </div>
-            <div class="col-6">
-              <div class="metrics-label">{{ t("model.size") }}:</div>
-              <div class="metrics-value">
-                {{ model.metrics.sizeLabel }}
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col-lg-12">
-          <div class="row">
-            <div v-if="model.price" class="col-6">
-              <div class="metrics-label">{{ t("model.price") }}:</div>
-              <!-- eslint-disable vue/no-v-html -->
-              <div
-                v-tooltip="{ content: toUEC(model.price), html: true }"
-                class="metrics-value"
-                v-html="toUEC(model.price)"
-              />
-              <!-- eslint-enable vue/no-v-html -->
-            </div>
-            <div v-if="model.pledgePrice" class="col-6">
-              <div class="metrics-label">{{ t("model.pledgePrice") }}:</div>
-              <div class="metrics-value">
-                {{ toDollar(model.pledgePrice) }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="seperator" />
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-lg-12">
-          <div class="row">
-            <div v-if="model.metrics.hydrogenFuelTankSize" class="col-6">
-              <div class="metrics-label">
-                {{ t("model.hydrogenFuelTankSize") }}:
-              </div>
-              <div class="metrics-value">
-                {{ toNumber(model.metrics.hydrogenFuelTankSize, "cargo") }}
-              </div>
-            </div>
-            <div v-if="model.metrics.quantumFuelTankSize" class="col-6">
-              <div class="metrics-label">
-                {{ t("model.quantumFuelTankSize") }}:
-              </div>
-              <div class="metrics-value">
-                {{ toNumber(model.metrics.quantumFuelTankSize, "cargo") }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="seperator" />
-        </div>
-      </div>
-      <div class="row">
-        <div v-if="model.lastUpdatedAt" class="col-lg-12">
-          <div class="metrics-label">{{ t("model.lastUpdatedAt") }}:</div>
-          <div class="metrics-value">
-            {{ model.lastUpdatedAtLabel }}
-          </div>
-        </div>
-        <div class="col-12">
-          <div class="row">
-            <div v-if="soldAt && soldAt.length" class="col-12">
-              <div class="metrics-label">{{ t("model.soldAt") }}:</div>
-              <div class="metrics-value">
-                <ul class="list-unstyled">
+    </template>
+
+    <div v-if="hasAvailability" class="metrics-card__actions">
+      <button
+        type="button"
+        class="metrics-card__toggle"
+        @click="availabilityVisible = !availabilityVisible"
+      >
+        {{ t("labels.base.availability") }}
+      </button>
+      <Collapsed :visible="availabilityVisible">
+        <div class="metrics-card__breakdown">
+          <div class="metrics-card__rows metrics-card__rows--split">
+            <div
+              v-if="soldAt && soldAt.length"
+              class="metrics-card__row metrics-card__row--stack"
+            >
+              <span class="metrics-card__row__label">
+                {{ t("model.soldAt") }}
+              </span>
+              <span class="metrics-card__row__value">
+                <ul class="base-panel__locations">
                   <li v-for="modelPrice in soldAt" :key="modelPrice.id">
                     {{ modelPrice.location }}
                   </li>
                 </ul>
-              </div>
+              </span>
             </div>
-            <div v-if="rentalAt && rentalAt.length" class="col-12">
-              <div class="metrics-label">{{ t("model.rentalAt") }}:</div>
-              <div class="metrics-value">
-                <ul class="list-unstyled">
+            <div
+              v-if="rentalAt && rentalAt.length"
+              class="metrics-card__row metrics-card__row--stack"
+            >
+              <span class="metrics-card__row__label">
+                {{ t("model.rentalAt") }}
+              </span>
+              <span class="metrics-card__row__value">
+                <ul class="base-panel__locations">
                   <li v-for="modelPrice in rentalAt" :key="modelPrice.id">
                     {{ modelPrice.location }}
                   </li>
                 </ul>
-              </div>
+              </span>
             </div>
             <div v-if="hasAvailability" class="col-12">
               <div class="metrics-attribution">
@@ -200,7 +223,46 @@ const displayHeight = computed(() => {
             </div>
           </div>
         </div>
-      </div>
+      </Collapsed>
     </div>
-  </div>
+
+    <div v-if="model.lastUpdatedAt" class="metrics-card__footer">
+      <span class="metrics-card__hint">
+        {{ t("model.lastUpdatedAt") }} {{ model.lastUpdatedAtLabel }}
+      </span>
+    </div>
+  </MetricsCard>
 </template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+.base-panel {
+  &__chip {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray-light;
+    border: 1px solid rgba($gray-light, 0.4);
+    border-radius: 999px;
+    padding: 4px 11px;
+    white-space: nowrap;
+  }
+
+  &__locations {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 13px;
+    font-weight: 400;
+    color: $text-color;
+
+    li {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -6,11 +6,13 @@ export default {
 
 <script lang="ts" setup>
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
-import Collapsed from "@/shared/components/Collapsed.vue";
 import type { Model } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useComlink } from "@/shared/composables/useComlink";
 
 const { t, toNumber, toDollar, toUEC } = useI18n();
+
+const comlink = useComlink();
 
 type Props = {
   model: Model;
@@ -23,10 +25,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 const soldAt = computed(() => props.model.availability.soldAt);
 const rentalAt = computed(() => props.model.availability.rentalAt);
-
-const hasAvailability = computed(
-  () => !!soldAt.value?.length || !!rentalAt.value?.length,
-);
 
 const displayLength = computed(() => {
   if (props.extended && props.model.metrics.extendedLength) {
@@ -56,17 +54,16 @@ const hasPrice = computed(
   () => !!props.model.price || !!props.model.pledgePrice,
 );
 
-const hasFuel = computed(
-  () =>
-    !!props.model.metrics.hydrogenFuelTankSize ||
-    !!props.model.metrics.quantumFuelTankSize,
-);
-
-const hasAvailability = computed(
-  () => !!soldAt.value?.length || !!rentalAt.value?.length,
-);
-
-const availabilityVisible = ref(false);
+const openAvailability = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/frontend/components/Models/AvailabilityModal/index.vue"),
+    props: {
+      soldAt: soldAt.value,
+      rentalAt: rentalAt.value,
+    },
+  });
+};
 </script>
 
 <template>
@@ -145,90 +142,22 @@ const availabilityVisible = ref(false);
       </div>
     </template>
 
-    <template v-if="hasFuel">
-      <div v-if="hasPrice" class="metrics-card__divider" />
-      <div class="metrics-card__section-label">
-        {{ t("labels.base.fuel") }}
-      </div>
-      <div class="metrics-card__rows metrics-card__rows--split">
-        <div
-          v-if="model.metrics.hydrogenFuelTankSize"
-          class="metrics-card__row"
-        >
-          <span class="metrics-card__row__label">
-            {{ t("labels.base.fuelHydrogen") }}
-          </span>
-          <span class="metrics-card__row__value">
-            {{ toNumber(model.metrics.hydrogenFuelTankSize, "cargo") }}
-          </span>
-        </div>
-        <div v-if="model.metrics.quantumFuelTankSize" class="metrics-card__row">
-          <span class="metrics-card__row__label">
-            {{ t("labels.base.fuelQuantum") }}
-          </span>
-          <span class="metrics-card__row__value">
-            {{ toNumber(model.metrics.quantumFuelTankSize, "cargo") }}
-          </span>
-        </div>
-      </div>
-    </template>
-
-    <div v-if="hasAvailability" class="metrics-card__actions">
+    <div class="metrics-card__actions">
       <button
         type="button"
         class="metrics-card__toggle"
-        @click="availabilityVisible = !availabilityVisible"
+        @click="openAvailability"
       >
         {{ t("labels.base.availability") }}
       </button>
-      <Collapsed :visible="availabilityVisible">
-        <div class="metrics-card__breakdown">
-          <div class="metrics-card__rows metrics-card__rows--split">
-            <div
-              v-if="soldAt && soldAt.length"
-              class="metrics-card__row metrics-card__row--stack"
-            >
-              <span class="metrics-card__row__label">
-                {{ t("model.soldAt") }}
-              </span>
-              <span class="metrics-card__row__value">
-                <ul class="base-panel__locations">
-                  <li v-for="modelPrice in soldAt" :key="modelPrice.id">
-                    {{ modelPrice.location }}
-                  </li>
-                </ul>
-              </span>
-            </div>
-            <div
-              v-if="rentalAt && rentalAt.length"
-              class="metrics-card__row metrics-card__row--stack"
-            >
-              <span class="metrics-card__row__label">
-                {{ t("model.rentalAt") }}
-              </span>
-              <span class="metrics-card__row__value">
-                <ul class="base-panel__locations">
-                  <li v-for="modelPrice in rentalAt" :key="modelPrice.id">
-                    {{ modelPrice.location }}
-                  </li>
-                </ul>
-              </span>
-            </div>
-            <div v-if="hasAvailability" class="col-12">
-              <div class="metrics-attribution">
-                <a href="https://uexcorp.space" target="_blank" rel="noopener">
-                  {{ t("model.poweredByUex") }}
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Collapsed>
     </div>
 
     <div v-if="model.lastUpdatedAt" class="metrics-card__footer">
-      <span class="metrics-card__hint">
-        {{ t("model.lastUpdatedAt") }} {{ model.lastUpdatedAtLabel }}
+      <span class="base-panel__updated">
+        <span class="base-panel__updated-label">
+          {{ t("model.lastUpdatedAt") }}
+        </span>
+        {{ model.lastUpdatedAtLabel }}
       </span>
     </div>
   </MetricsCard>
@@ -250,18 +179,15 @@ const availabilityVisible = ref(false);
     white-space: nowrap;
   }
 
-  &__locations {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  // Not `__hint`: that is sized for the explanatory sentences the other cards
+  // end on, and this is a value people actually read off the card.
+  &__updated {
     font-size: 13px;
-    font-weight: 400;
     color: $text-color;
+    font-variant-numeric: tabular-nums;
 
-    li {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    &-label {
+      color: $gray-light;
     }
   }
 }

--- a/app/frontend/frontend/components/Models/CargoMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CargoMetrics/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model, CargoHold } from "@/services/fyApi";
 import {
   CONTAINER_DEFS,
@@ -68,64 +69,152 @@ function computeMaxPerSize(holds: CargoHold[]): ContainerCapacity[] {
   return results;
 }
 
-const containerCapacities = computed(() => {
-  if (!holds.value.length) return [];
-  return computeMaxPerSize(holds.value);
-});
-
 const totalCargo = computed(() => {
   return holds.value.reduce((sum, h) => sum + (h.capacity || 0), 0);
+});
+
+const containerCapacities = computed(() => {
+  if (!holds.value.length) return [];
+
+  const total = totalCargo.value || props.model.metrics.cargo || 0;
+
+  return computeMaxPerSize(holds.value).map((capacity) => {
+    const scu = capacity.size * capacity.maxQuantity;
+
+    return {
+      ...capacity,
+      scu,
+      // Boxes of one size rarely tile the grid perfectly, so this is the share
+      // of the hold that size can actually fill.
+      share: total ? Math.min(100, Math.round((scu / total) * 100)) : 0,
+    };
+  });
 });
 
 const maxContainerSize = computed(() => {
   if (!holds.value.length) return null;
   return Math.max(...holds.value.map((h) => h.maxContainerSize?.size || 0));
 });
+
+const hasData = computed(() => containerCapacities.value.length > 0);
 </script>
 
 <template>
-  <div
-    v-if="containerCapacities.length"
-    class="row cargo-metrics metrics-padding"
+  <MetricsCard
+    v-if="hasData"
+    :title="t('labels.cargo.title')"
+    class="cargo-panel"
   >
-    <div class="col-12 col-lg-3">
-      <div class="metrics-title">
-        {{ t("labels.cargoGridViewer.capacity") }}
-      </div>
-    </div>
-    <div class="col-12 col-lg-9 metrics-block">
-      <div class="row">
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">{{ t("model.cargo") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(totalCargo || model.metrics.cargo || "", "cargo") }}
-          </div>
+    <div class="metrics-card__hero">
+      <div class="metrics-card__tile metrics-card__tile--primary">
+        <div class="metrics-card__tile__label">{{ t("model.cargo") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(totalCargo || model.metrics.cargo || "", "integer") }}
+          <span class="metrics-card__tile__unit">SCU</span>
         </div>
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.cargoGridViewer.maxContainerSize") }}:
-          </div>
-          <div class="metrics-value">
-            {{ maxContainerSize || "-" }}
-            {{ maxContainerSize ? "SCU" : "" }}
-          </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.cargo.holdsSub", { count: holds.length }) }}
         </div>
       </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="seperator" />
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.cargoGridViewer.maxContainerSize") }}
         </div>
-      </div>
-      <div class="row">
-        <div
-          v-for="cap in containerCapacities"
-          :key="cap.size"
-          class="col-6 col-lg-3"
-        >
-          <div class="metrics-label">{{ cap.size }} SCU:</div>
-          <div class="metrics-value">{{ cap.maxQuantity }}x</div>
+        <div class="metrics-card__tile__value">
+          {{ maxContainerSize || "-" }}
+          <span v-if="maxContainerSize" class="metrics-card__tile__unit">
+            SCU
+          </span>
+        </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.cargo.maxContainerSub") }}
         </div>
       </div>
     </div>
-  </div>
+
+    <div class="metrics-card__section-label">
+      {{ t("labels.cargo.containers") }}
+    </div>
+    <div class="cargo-caps">
+      <div v-for="cap in containerCapacities" :key="cap.size" class="cargo-cap">
+        <div class="cargo-cap__head">
+          <span class="cargo-cap__label">{{ cap.size }} SCU</span>
+          <span class="cargo-cap__value">{{ cap.maxQuantity }}x</span>
+          <span class="cargo-cap__share">
+            {{ toNumber(cap.scu, "integer") }} SCU · {{ cap.share }}%
+          </span>
+        </div>
+        <div class="cargo-cap__bar">
+          <div
+            class="cargo-cap__bar-fill"
+            :style="{ width: `${cap.share}%` }"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="metrics-card__footer">
+      <span class="metrics-card__hint">{{ t("labels.cargo.hint") }}</span>
+    </div>
+  </MetricsCard>
 </template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+.cargo-caps {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cargo-cap {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  &__head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: $gray-light;
+    min-width: 52px;
+  }
+
+  &__value {
+    font-size: 13px;
+    font-weight: 600;
+    color: $text-color;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__share {
+    margin-left: auto;
+    font-size: 11px;
+    color: $gray;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  &__bar {
+    height: 6px;
+    border-radius: 3px;
+    background: rgba($gray-light, 0.16);
+    overflow: hidden;
+  }
+
+  &__bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: linear-gradient(90deg, rgba($primary, 0.55), $primary);
+    transition: width 0.3s ease;
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -13,7 +13,7 @@ import {
   useLoadoutStats,
   type DamageBreakdown,
 } from "@/frontend/composables/useLoadoutStats";
-import type { FamilyOverrides } from "@/frontend/composables/useLoadoutSim";
+import type { PortOverrides } from "@/frontend/composables/useLoadoutSim";
 
 type Props = {
   hardpoints?: Hardpoint[];
@@ -31,7 +31,7 @@ const weaponPoolSize = inject<Ref<number | undefined>>(
 );
 
 // The Power Distribution control's pip choices; absent (standalone use) → auto.
-const powerOverrides = inject<Ref<FamilyOverrides | undefined>>(
+const powerOverrides = inject<Ref<PortOverrides | undefined>>(
   "powerOverrides",
   ref(undefined),
 );

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -44,6 +44,11 @@ const stats = useLoadoutStats(
 
 const round = (value: number) => Math.round(value);
 
+// toNumber renders 0 as "N/A"; here a zeroed value is a real 0 (e.g. weapons
+// unpowered), so show "0" instead.
+const dmg = (value: number) =>
+  round(value) > 0 ? toNumber(round(value), "integer") : "0";
+
 const hoveredType = ref<string | null>(null);
 
 const damageTypes: {
@@ -86,7 +91,7 @@ const composition = computed(() =>
           {{ t("labels.combat.dps") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ toNumber(round(stats.dps.total), "integer") }}
+          {{ dmg(stats.dps.total) }}
           <span class="metrics-card__tile__unit">DPS</span>
         </div>
         <div class="metrics-card__tile__sub">
@@ -98,7 +103,7 @@ const composition = computed(() =>
           {{ t("labels.combat.sustained") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ toNumber(round(stats.sustainedDps.total), "integer") }}
+          {{ dmg(stats.sustainedDps.total) }}
           <span class="metrics-card__tile__unit">DPS</span>
         </div>
         <div class="metrics-card__tile__sub">
@@ -110,7 +115,7 @@ const composition = computed(() =>
           {{ t("labels.combat.alpha") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ toNumber(round(stats.alpha.total), "integer") }}
+          {{ dmg(stats.alpha.total) }}
           <span class="metrics-card__tile__unit">DMG</span>
         </div>
         <div class="metrics-card__tile__sub">

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import { useTransition, TransitionPresets } from "@vueuse/core";
 import type { Hardpoint } from "@/services/fyApi";
 import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vue";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
@@ -49,6 +50,15 @@ const round = (value: number) => Math.round(value);
 const dmg = (value: number) =>
   round(value) > 0 ? toNumber(round(value), "integer") : "0";
 
+// Animate the power-reactive damage totals as the pip allocation changes.
+const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
+const animatedDps = useTransition(() => stats.value.dps.total, animate);
+const animatedSustained = useTransition(
+  () => stats.value.sustainedDps.total,
+  animate,
+);
+const animatedAlpha = useTransition(() => stats.value.alpha.total, animate);
+
 const hoveredType = ref<string | null>(null);
 
 const damageTypes: {
@@ -91,7 +101,7 @@ const composition = computed(() =>
           {{ t("labels.combat.dps") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ dmg(stats.dps.total) }}
+          {{ dmg(animatedDps) }}
           <span class="metrics-card__tile__unit">DPS</span>
         </div>
         <div class="metrics-card__tile__sub">
@@ -103,7 +113,7 @@ const composition = computed(() =>
           {{ t("labels.combat.sustained") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ dmg(stats.sustainedDps.total) }}
+          {{ dmg(animatedSustained) }}
           <span class="metrics-card__tile__unit">DPS</span>
         </div>
         <div class="metrics-card__tile__sub">
@@ -115,7 +125,7 @@ const composition = computed(() =>
           {{ t("labels.combat.alpha") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ dmg(stats.alpha.total) }}
+          {{ dmg(animatedAlpha) }}
           <span class="metrics-card__tile__unit">DMG</span>
         </div>
         <div class="metrics-card__tile__sub">

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -13,6 +13,7 @@ import {
   useLoadoutStats,
   type DamageBreakdown,
 } from "@/frontend/composables/useLoadoutStats";
+import type { FamilyOverrides } from "@/frontend/composables/useLoadoutSim";
 
 type Props = {
   hardpoints?: Hardpoint[];
@@ -29,9 +30,16 @@ const weaponPoolSize = inject<Ref<number | undefined>>(
   ref(undefined),
 );
 
+// The Power Distribution control's pip choices; absent (standalone use) → auto.
+const powerOverrides = inject<Ref<FamilyOverrides | undefined>>(
+  "powerOverrides",
+  ref(undefined),
+);
+
 const stats = useLoadoutStats(
   () => props.hardpoints,
   () => toValue(weaponPoolSize),
+  () => toValue(powerOverrides),
 );
 
 const round = (value: number) => Math.round(value);

--- a/app/frontend/frontend/components/Models/CombatMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CombatMetrics/index.vue
@@ -18,10 +18,12 @@ import type { PortOverrides } from "@/frontend/composables/useLoadoutSim";
 
 type Props = {
   hardpoints?: Hardpoint[];
+  loading?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   hardpoints: () => [],
+  loading: false,
 });
 
 const { t, toNumber } = useI18n();
@@ -91,8 +93,9 @@ const composition = computed(() =>
 
 <template>
   <MetricsCard
-    v-if="stats.hasData"
+    v-if="loading || stats.hasData"
     :title="t('labels.combat.title')"
+    :loading="loading"
     class="combat-panel"
   >
     <div class="metrics-card__hero">

--- a/app/frontend/frontend/components/Models/CompositionBar/index.vue
+++ b/app/frontend/frontend/components/Models/CompositionBar/index.vue
@@ -90,7 +90,9 @@ const rows = computed(() => {
 
   &__seg {
     height: 100%;
-    transition: opacity 0.18s ease;
+    transition:
+      width 0.35s ease,
+      opacity 0.18s ease;
   }
 
   &__bar--dimmed &__seg:not(&__seg--active) {

--- a/app/frontend/frontend/components/Models/CrewMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/CrewMetrics/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import type { Model } from "@/services/fyApi";
 
@@ -18,27 +19,26 @@ const { t, toNumber } = useI18n();
 </script>
 
 <template>
-  <div class="row metrics-padding">
-    <div class="col-12 col-lg-3">
-      <div class="metrics-title">
-        {{ t("labels.metrics.crew") }}
-      </div>
-    </div>
-    <div class="col-12 col-lg-9 metrics-block">
-      <div class="row">
-        <div class="col-6 col-md-6">
-          <div class="metrics-label">{{ t("model.minCrew") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(model.crew.min, "people") }}
-          </div>
+  <MetricsCard :title="t('labels.metrics.crew')">
+    <div
+      class="metrics-card__hero metrics-card__hero--grid metrics-card__hero--grid-2"
+    >
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.minCrew") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(model.crew.min, "people") }}
         </div>
-        <div class="col-6 col-md-6">
-          <div class="metrics-label">{{ t("model.maxCrew") }}:</div>
-          <div class="metrics-value">
-            {{ toNumber(model.crew.max, "people") }}
-          </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">{{ t("model.maxCrew") }}</div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(model.crew.max, "people") }}
         </div>
       </div>
     </div>
-  </div>
+  </MetricsCard>
 </template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+</style>

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -26,7 +26,17 @@ const { t, toNumber } = useI18n();
 
 const comlink = useComlink();
 
-const shield = useShieldStats(() => props.hardpoints);
+// Shield power allocation from the Power Distribution control (1 = full when
+// standalone); scales shield HP + regen.
+const shieldPoolRatio = inject<Ref<number | undefined>>(
+  "shieldPoolRatio",
+  ref(undefined),
+);
+
+const shield = useShieldStats(
+  () => props.hardpoints,
+  () => toValue(shieldPoolRatio),
+);
 const armor = useArmorStats(() => props.hardpoints);
 
 const round = (value: number) => Math.round(value);

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -16,11 +16,13 @@ import { useArmorStats } from "@/frontend/composables/useArmorStats";
 type Props = {
   hardpoints?: Hardpoint[];
   modelName?: string;
+  loading?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   hardpoints: () => [],
   modelName: "",
+  loading: false,
 });
 
 const { t, toNumber } = useI18n();
@@ -82,8 +84,9 @@ const openDeflectionCheck = () => {
 
 <template>
   <MetricsCard
-    v-if="hasData"
+    v-if="loading || hasData"
     :title="t('labels.defense.title')"
+    :loading="loading"
     class="defense-panel"
   >
     <div v-if="shield.hasData" class="metrics-card__hero">

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -7,7 +7,6 @@ export default {
 <script lang="ts" setup>
 import { useTransition, TransitionPresets } from "@vueuse/core";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
-import ProgressBar from "@/shared/components/ProgressBar/index.vue";
 import type { Hardpoint } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
@@ -107,7 +106,15 @@ const openDeflectionCheck = () => {
           {{ num(round(shieldRegen)) }}
           <span class="metrics-card__tile__unit">HP/s</span>
         </div>
-        <ProgressBar :progress="regenPercent" class="shield-regen-bar" />
+        <div
+          class="regen-bar"
+          role="progressbar"
+          :aria-valuenow="regenPercent"
+          :aria-valuemin="0"
+          :aria-valuemax="100"
+        >
+          <div class="regen-bar__fill" :style="{ width: `${regenPercent}%` }" />
+        </div>
         <div class="metrics-card__tile__sub">
           {{ t("labels.defense.shieldRegenSub") }}
         </div>
@@ -246,8 +253,21 @@ const openDeflectionCheck = () => {
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
 
-.shield-regen-bar {
-  margin: 6px 0 2px;
+// Matches the composition bar's pill look, as a single animated fill.
+.regen-bar {
+  height: 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: $gray-black;
+  border: 1px solid rgba($gray-light, 0.28);
+  margin: 8px 0 2px;
+
+  &__fill {
+    height: 100%;
+    background: $primary;
+    border-radius: 999px;
+    transition: width 0.4s ease;
+  }
 }
 
 .stat-rows {

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -5,7 +5,9 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import { useTransition, TransitionPresets } from "@vueuse/core";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
+import ProgressBar from "@/shared/components/ProgressBar/index.vue";
 import type { Hardpoint } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
@@ -44,6 +46,15 @@ const round = (value: number) => Math.round(value);
 // zero — nothing absorbed is a real result, not missing data.
 const num = (value: number) => (value ? toNumber(value, "integer") : "0");
 
+// Shield HP/regen animate as the pip allocation changes; the regen bar fills to
+// the share of full regen the shield currently gets (its power ratio).
+const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
+const shieldHp = useTransition(() => shield.value.totalHp, animate);
+const shieldRegen = useTransition(() => shield.value.totalRegen, animate);
+const regenPercent = computed(() =>
+  Math.round((toValue(shieldPoolRatio) ?? 1) * 100),
+);
+
 const hasData = computed(() => shield.value.hasData || armor.value.hasData);
 
 const percent = (value: number) => `${Math.round(value * 100)}%`;
@@ -81,7 +92,7 @@ const openDeflectionCheck = () => {
           {{ t("labels.defense.shieldHp") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ num(round(shield.totalHp)) }}
+          {{ num(round(shieldHp)) }}
           <span class="metrics-card__tile__unit">HP</span>
         </div>
         <div class="metrics-card__tile__sub">
@@ -93,9 +104,10 @@ const openDeflectionCheck = () => {
           {{ t("labels.defense.shieldRegen") }}
         </div>
         <div class="metrics-card__tile__value">
-          {{ num(round(shield.totalRegen)) }}
+          {{ num(round(shieldRegen)) }}
           <span class="metrics-card__tile__unit">HP/s</span>
         </div>
+        <ProgressBar :progress="regenPercent" class="shield-regen-bar" />
         <div class="metrics-card__tile__sub">
           {{ t("labels.defense.shieldRegenSub") }}
         </div>
@@ -233,6 +245,10 @@ const openDeflectionCheck = () => {
 
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
+
+.shield-regen-bar {
+  margin: 6px 0 2px;
+}
 
 .stat-rows {
   display: grid;

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -45,14 +45,16 @@ const round = (value: number) => Math.round(value);
 // zero — nothing absorbed is a real result, not missing data.
 const num = (value: number) => (value ? toNumber(value, "integer") : "0");
 
-// Shield HP/regen animate as the pip allocation changes; the regen bar fills to
-// the share of full regen the shield currently gets (its power ratio).
+// Shield HP/regen animate as the pip allocation changes; the regen bar shows
+// regen as a share of the full shield HP (how much of the shield refills per
+// second — always well under 100%).
 const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
 const shieldHp = useTransition(() => shield.value.totalHp, animate);
 const shieldRegen = useTransition(() => shield.value.totalRegen, animate);
-const regenPercent = computed(() =>
-  Math.round((toValue(shieldPoolRatio) ?? 1) * 100),
-);
+const regenPercent = computed(() => {
+  const hp = shield.value.totalHp;
+  return hp > 0 ? Math.round((toValue(shieldRegen) / hp) * 100) : 0;
+});
 
 const hasData = computed(() => shield.value.hasData || armor.value.hasData);
 
@@ -106,17 +108,20 @@ const openDeflectionCheck = () => {
           {{ num(round(shieldRegen)) }}
           <span class="metrics-card__tile__unit">HP/s</span>
         </div>
-        <div
-          class="regen-bar"
-          role="progressbar"
-          :aria-valuenow="regenPercent"
-          :aria-valuemin="0"
-          :aria-valuemax="100"
-        >
-          <div class="regen-bar__fill" :style="{ width: `${regenPercent}%` }" />
-        </div>
-        <div class="metrics-card__tile__sub">
-          {{ t("labels.defense.shieldRegenSub") }}
+        <div class="regen-bar">
+          <div
+            class="regen-bar__track"
+            role="progressbar"
+            :aria-valuenow="regenPercent"
+            :aria-valuemin="0"
+            :aria-valuemax="100"
+          >
+            <div
+              class="regen-bar__fill"
+              :style="{ width: `${regenPercent}%` }"
+            />
+          </div>
+          <span class="regen-bar__pct">{{ regenPercent }} %</span>
         </div>
       </div>
     </div>
@@ -253,20 +258,35 @@ const openDeflectionCheck = () => {
 <style lang="scss" scoped>
 @import "@/frontend/components/Models/metricsCard";
 
-// Matches the composition bar's pill look, as a single animated fill.
+// Matches the composition bar's pill look, as a single animated fill + percent.
 .regen-bar {
-  height: 8px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: $gray-black;
-  border: 1px solid rgba($gray-light, 0.28);
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 8px 0 2px;
+
+  &__track {
+    flex: 1;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: $gray-black;
+    border: 1px solid rgba($gray-light, 0.28);
+  }
 
   &__fill {
     height: 100%;
     background: $primary;
     border-radius: 999px;
     transition: width 0.4s ease;
+  }
+
+  &__pct {
+    font-size: 11px;
+    color: $gray;
+    font-variant-numeric: tabular-nums;
+    min-width: 34px;
+    text-align: right;
   }
 }
 

--- a/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/DefenseMetrics/index.vue
@@ -46,15 +46,14 @@ const round = (value: number) => Math.round(value);
 const num = (value: number) => (value ? toNumber(value, "integer") : "0");
 
 // Shield HP/regen animate as the pip allocation changes; the regen bar shows
-// regen as a share of the full shield HP (how much of the shield refills per
-// second — always well under 100%).
+// regen as a share of the shield's max regen (its power ratio) — 100% at full
+// shield power, 0% when unpowered.
 const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
 const shieldHp = useTransition(() => shield.value.totalHp, animate);
 const shieldRegen = useTransition(() => shield.value.totalRegen, animate);
-const regenPercent = computed(() => {
-  const hp = shield.value.totalHp;
-  return hp > 0 ? Math.round((toValue(shieldRegen) / hp) * 100) : 0;
-});
+const regenPercent = computed(() =>
+  Math.round((toValue(shieldPoolRatio) ?? 1) * 100),
+);
 
 const hasData = computed(() => shield.value.hasData || armor.value.hasData);
 

--- a/app/frontend/frontend/components/Models/ExternalFuelTanks/index.vue
+++ b/app/frontend/frontend/components/Models/ExternalFuelTanks/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model, ExternalFuelTank } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 
@@ -28,13 +29,16 @@ type Group = {
   componentName: string;
   count: number;
   perTankCapacity: number;
+  share: number;
 };
 
 const groups = computed<Group[]>(() => {
   const map = new Map<string, Group>();
+
   for (const tank of tanks.value) {
     const key = tank.componentName || "—";
     const existing = map.get(key);
+
     if (existing) {
       existing.count += 1;
     } else {
@@ -42,59 +46,135 @@ const groups = computed<Group[]>(() => {
         componentName: key,
         count: 1,
         perTankCapacity: tank.capacity || 0,
+        share: 0,
       });
     }
   }
-  return [...map.values()];
+
+  const total = totalCapacity.value;
+
+  return [...map.values()]
+    .map((group) => ({
+      ...group,
+      share: total
+        ? Math.round(((group.perTankCapacity * group.count) / total) * 100)
+        : 0,
+    }))
+    .sort((a, b) => b.perTankCapacity * b.count - a.perTankCapacity * a.count);
 });
 </script>
 
 <template>
-  <div
+  <MetricsCard
     v-if="tanks.length"
-    class="row external-fuel-tanks metrics-padding"
+    :title="t('labels.model.externalFuelTanks')"
+    class="fuel-tanks-panel"
     data-test="external-fuel-tanks"
   >
-    <div class="col-12 col-lg-3">
-      <div class="metrics-title">
-        {{ t("labels.model.externalFuelTanks") }}
+    <div class="metrics-card__hero">
+      <div class="metrics-card__tile metrics-card__tile--primary">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.model.externalFuelTanksTotal") }}
+        </div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(totalCapacity, "cargo") }}
+        </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.fuelTanks.capacitySub", { count: tanks.length }) }}
+        </div>
+      </div>
+      <div class="metrics-card__tile">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.model.externalFuelTanksCount") }}
+        </div>
+        <div class="metrics-card__tile__value">{{ tanks.length }}x</div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.fuelTanks.podsSub") }}
+        </div>
       </div>
     </div>
-    <div class="col-12 col-lg-9 metrics-block">
-      <div class="row">
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.model.externalFuelTanksTotal") }}:
-          </div>
-          <div class="metrics-value">
-            {{ toNumber(totalCapacity, "cargo") }}
-          </div>
-        </div>
-        <div class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.model.externalFuelTanksCount") }}:
-          </div>
-          <div class="metrics-value">{{ tanks.length }}x</div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="seperator" />
-        </div>
-      </div>
-      <div class="row">
-        <div
-          v-for="group in groups"
-          :key="group.componentName"
-          class="col-6 col-lg-4"
-        >
-          <div class="metrics-label">{{ group.componentName }}:</div>
-          <div class="metrics-value">
-            {{ group.count }}x &middot;
+
+    <div class="metrics-card__section-label">
+      {{ t("labels.fuelTanks.components") }}
+    </div>
+    <div class="fuel-tanks">
+      <div
+        v-for="group in groups"
+        :key="group.componentName"
+        class="fuel-tank"
+        :title="group.componentName"
+      >
+        <div class="fuel-tank__head">
+          <span class="fuel-tank__name">{{ group.componentName }}</span>
+          <span class="fuel-tank__count">{{ group.count }}x</span>
+          <span class="fuel-tank__share">
             {{ toNumber(group.perTankCapacity, "cargo") }}
-          </div>
+            {{ t("labels.fuelTanks.perPod") }}
+          </span>
+        </div>
+        <div class="fuel-tank__bar">
+          <div
+            class="fuel-tank__bar-fill"
+            :style="{ width: `${group.share}%` }"
+          />
         </div>
       </div>
     </div>
-  </div>
+
+    <div class="metrics-card__footer">
+      <span class="metrics-card__hint">{{ t("labels.fuelTanks.hint") }}</span>
+    </div>
+  </MetricsCard>
 </template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+.fuel-tanks {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fuel-tank__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+
+.fuel-tank__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: lighten($text-color, 15%);
+}
+
+.fuel-tank__count {
+  font-family: "Orbitron", tahoma, sans-serif;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: lighten($text-color, 15%);
+}
+
+.fuel-tank__share {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: $gray;
+}
+
+.fuel-tank__bar {
+  height: 5px;
+  border-radius: 3px;
+  background: rgba($gray-light, 0.28);
+  overflow: hidden;
+}
+
+.fuel-tank__bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, $primary, rgba($primary, 0.5));
+}
+</style>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
@@ -43,17 +43,21 @@ const model = () =>
     metrics: { isGroundVehicle: false },
   }) as never;
 
-function mountFlight(ratio: number) {
+function mountFlight(ratio: number, powered = true) {
   const enginePowerRatio = ref(ratio);
+  const enginePowered = ref(powered);
   const wrapper = mount(FlightMetrics, {
     props: { model: model() },
     global: {
-      provide: { enginePowerRatio },
+      provide: { enginePowerRatio, enginePowered },
       stubs: { MetricsCard: { template: "<div><slot /></div>" } },
     },
   });
-  return { wrapper, enginePowerRatio };
+  return { wrapper, enginePowerRatio, enginePowered };
 }
+
+const values = (wrapper: ReturnType<typeof mountFlight>["wrapper"]) =>
+  wrapper.findAll(".flight-rot__value").map((n) => n.text());
 
 const boosts = (wrapper: ReturnType<typeof mountFlight>["wrapper"]) =>
   wrapper.findAll(".flight-rot__boost").map((n) => n.text());
@@ -74,15 +78,24 @@ describe("FlightMetrics engine reactivity", () => {
 
   it("keeps base handling and hides the boost at the engine floor (ratio 0)", async () => {
     // The IFCS speeds/base handling are constant game figures; at the mandatory
-    // engine floor there's simply no afterburner boost to show.
+    // engine floor (still powered) there's simply no afterburner boost to show.
     const { wrapper, enginePowerRatio } = mountFlight(1);
     enginePowerRatio.value = 0;
     await nextTick();
-    expect(wrapper.findAll(".flight-rot__value").map((n) => n.text())).toEqual([
-      "10",
-      "10",
-      "17",
-    ]);
+    expect(values(wrapper)).toEqual(["10", "10", "17"]);
     expect(wrapper.findAll(".flight-rot__boost")).toHaveLength(0);
+  });
+
+  it("zeroes every flight figure when the engine is fully unpowered", async () => {
+    // Last pip pulled → no power to the engine → dead in the water.
+    const { wrapper, enginePowered } = mountFlight(1);
+    enginePowered.value = false;
+    await nextTick();
+    expect(values(wrapper)).toEqual(["0", "0", "0"]);
+    expect(wrapper.findAll(".flight-rot__boost")).toHaveLength(0);
+    // SCM / Boost / Max hero tiles all read 0 as well.
+    expect(
+      wrapper.findAll(".metrics-card__tile__value").map((n) => n.text()),
+    ).toEqual(["0", "0", "0"]);
   });
 });

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
@@ -72,14 +72,17 @@ describe("FlightMetrics engine reactivity", () => {
     expect(boosts(wrapper)).toEqual(["→ 11", "→ 11", "→ 19"]);
   });
 
-  it("zeroes the handling when the engine is unpowered", async () => {
+  it("keeps base handling and hides the boost at the engine floor (ratio 0)", async () => {
+    // The IFCS speeds/base handling are constant game figures; at the mandatory
+    // engine floor there's simply no afterburner boost to show.
     const { wrapper, enginePowerRatio } = mountFlight(1);
     enginePowerRatio.value = 0;
     await nextTick();
     expect(wrapper.findAll(".flight-rot__value").map((n) => n.text())).toEqual([
-      "0",
-      "0",
-      "0",
+      "10",
+      "10",
+      "17",
     ]);
+    expect(wrapper.findAll(".flight-rot__boost")).toHaveLength(0);
   });
 });

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref, computed, nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    toNumber: (value: number) => String(value),
+  }),
+}));
+
+// Passthrough useTransition so we assert the target value without waiting on the
+// animation clock — the point of the test is the reactivity, not the tween.
+vi.mock("@vueuse/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vueuse/core")>();
+  return {
+    ...actual,
+    useTransition: (source: unknown) =>
+      computed(() =>
+        typeof source === "function"
+          ? (source as () => number)()
+          : (source as { value: number }).value,
+      ),
+    TransitionPresets: { easeOutCubic: [] },
+  };
+});
+
+import FlightMetrics from "./index.vue";
+
+const model = () =>
+  ({
+    speeds: {
+      scmSpeed: 110,
+      scmSpeedBoosted: 290,
+      maxSpeed: 1000,
+      pitch: 10,
+      pitchBoosted: 12,
+      yaw: 10,
+      yawBoosted: 12,
+      roll: 17,
+      rollBoosted: 20,
+    },
+    metrics: { isGroundVehicle: false },
+  }) as never;
+
+function mountFlight(ratio: number) {
+  const enginePowerRatio = ref(ratio);
+  const wrapper = mount(FlightMetrics, {
+    props: { model: model() },
+    global: {
+      provide: { enginePowerRatio },
+      stubs: { MetricsCard: { template: "<div><slot /></div>" } },
+    },
+  });
+  return { wrapper, enginePowerRatio };
+}
+
+const boosts = (wrapper: ReturnType<typeof mountFlight>["wrapper"]) =>
+  wrapper.findAll(".flight-rot__boost").map((n) => n.text());
+
+describe("FlightMetrics engine reactivity", () => {
+  it("shows the rated boosted handling at full engine power", () => {
+    const { wrapper } = mountFlight(1);
+    expect(boosts(wrapper)).toEqual(["→ 12", "→ 12", "→ 20"]);
+  });
+
+  it("interpolates boosted handling down as engine pips drop", async () => {
+    const { wrapper, enginePowerRatio } = mountFlight(1);
+    enginePowerRatio.value = 0.5;
+    await nextTick();
+    // pitch 10 + (12-10)*0.5 = 11, yaw 11, roll 17 + (20-17)*0.5 = 18.5 → 19
+    expect(boosts(wrapper)).toEqual(["→ 11", "→ 11", "→ 19"]);
+  });
+
+  it("zeroes the handling when the engine is unpowered", async () => {
+    const { wrapper, enginePowerRatio } = mountFlight(1);
+    enginePowerRatio.value = 0;
+    await nextTick();
+    expect(wrapper.findAll(".flight-rot__value").map((n) => n.text())).toEqual([
+      "0",
+      "0",
+      "0",
+    ]);
+  });
+});

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -8,6 +8,7 @@ export default {
 import { useTransition, TransitionPresets } from "@vueuse/core";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model } from "@/services/fyApi";
+import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useI18n } from "@/shared/composables/useI18n";
 
 type Props = {
@@ -18,13 +19,20 @@ const props = defineProps<Props>();
 
 const { t, toNumber } = useI18n();
 
-// Engine power relative to the default distribution (provided by Hardpoints).
-// Scales the flight figures with the thruster pips; 1 when standalone.
+// Engine power relative to the default distribution (from Hardpoints): it only
+// scales the *boosted* handling — never the speeds or base handling, matching
+// erkul. 1 (full boost) when standalone.
 const enginePowerRatio = inject<Ref<number | undefined>>(
   "enginePowerRatio",
   ref(1),
 );
-const ratio = computed(() => toValue(enginePowerRatio) ?? 1);
+const boostFactor = computed(() =>
+  Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
+);
+
+// SCM / NAV mode swaps the headline speed (from Hardpoints; SCM standalone).
+const flightMode = inject<Ref<FlightMode>>("flightMode", ref("SCM"));
+const isNav = computed(() => toValue(flightMode) === "NAV");
 
 const speeds = computed(() => props.model.speeds);
 const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
@@ -35,39 +43,51 @@ const hasData = computed(() =>
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
 
-const scaled = (value?: number) => (value ?? 0) * ratio.value;
-
-const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
-const scmSpeed = useTransition(() => scaled(speeds.value.scmSpeed), animate);
-const scmBoost = useTransition(
-  () => scaled(speeds.value.scmSpeedBoosted),
-  animate,
-);
-
-const speed = (value: number) => toNumber(Math.round(value), "speed");
+const speed = (value?: number) => toNumber(Math.round(value ?? 0), "speed");
 const rotation = (value: number) => toNumber(Math.round(value), "rotation");
 
-// Handling axes (°/s), base → boosted, scaled by engine power — only meaningful
-// for spaceflight.
+// Boosted handling interpolates from the base rate (no engine power) up to the
+// rated boosted rate (full engine power).
+const boosted = (base?: number, max?: number) =>
+  (base ?? 0) + ((max ?? base ?? 0) - (base ?? 0)) * boostFactor.value;
+
 const rotations = computed(() => [
   {
     label: t("model.pitch"),
     base: speeds.value.pitch,
-    boost: speeds.value.pitchBoosted,
+    max: speeds.value.pitchBoosted,
   },
   {
     label: t("model.yaw"),
     base: speeds.value.yaw,
-    boost: speeds.value.yawBoosted,
+    max: speeds.value.yawBoosted,
   },
   {
     label: t("model.roll"),
     base: speeds.value.roll,
-    boost: speeds.value.rollBoosted,
+    max: speeds.value.rollBoosted,
   },
 ]);
 
-const reverseSpeed = computed(() => scaled(speeds.value.reverseSpeedBoosted));
+const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
+const pitchBoost = useTransition(
+  () => boosted(speeds.value.pitch, speeds.value.pitchBoosted),
+  animate,
+);
+const yawBoost = useTransition(
+  () => boosted(speeds.value.yaw, speeds.value.yawBoosted),
+  animate,
+);
+const rollBoost = useTransition(
+  () => boosted(speeds.value.roll, speeds.value.rollBoosted),
+  animate,
+);
+const boostAnim = computed<Record<string, number>>(() => ({
+  [t("model.pitch")]: pitchBoost.value,
+  [t("model.yaw")]: yawBoost.value,
+  [t("model.roll")]: rollBoost.value,
+}));
+
 const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
 </script>
 
@@ -84,7 +104,7 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
             {{ t("model.groundMaxSpeed") }}
           </div>
           <div class="metrics-card__tile__value">
-            {{ toNumber(speeds.groundMaxSpeed, "speed") }}
+            {{ speed(speeds.groundMaxSpeed) }}
           </div>
         </div>
         <div class="metrics-card__tile">
@@ -92,23 +112,29 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
             {{ t("model.groundReverseSpeed") }}
           </div>
           <div class="metrics-card__tile__value">
-            {{ toNumber(speeds.groundReverseSpeed, "speed") }}
+            {{ speed(speeds.groundReverseSpeed) }}
           </div>
         </div>
       </template>
       <template v-else>
         <div class="metrics-card__tile metrics-card__tile--primary">
-          <div class="metrics-card__tile__label">{{ t("model.scmSpeed") }}</div>
-          <div class="metrics-card__tile__value">{{ speed(scmSpeed) }}</div>
+          <div class="metrics-card__tile__label">
+            {{ isNav ? t("model.maxSpeed") : t("model.scmSpeed") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ speed(isNav ? speeds.maxSpeed : speeds.scmSpeed) }}
+          </div>
           <div class="metrics-card__tile__sub">
-            {{ t("labels.flight.scm") }}
+            {{ isNav ? t("labels.flight.nav") : t("labels.flight.scm") }}
           </div>
         </div>
         <div class="metrics-card__tile">
           <div class="metrics-card__tile__label">
             {{ t("labels.flight.boost") }}
           </div>
-          <div class="metrics-card__tile__value">{{ speed(scmBoost) }}</div>
+          <div class="metrics-card__tile__value">
+            {{ speed(speeds.scmSpeedBoosted) }}
+          </div>
           <div class="metrics-card__tile__sub">
             {{ t("labels.flight.boostSub") }}
           </div>
@@ -117,7 +143,9 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           <div class="metrics-card__tile__label">
             {{ t("labels.flight.reverse") }}
           </div>
-          <div class="metrics-card__tile__value">{{ speed(reverseSpeed) }}</div>
+          <div class="metrics-card__tile__value">
+            {{ speed(speeds.reverseSpeedBoosted) }}
+          </div>
         </div>
       </template>
     </div>
@@ -133,9 +161,9 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           class="flight-rot__item"
         >
           <span class="flight-rot__value">
-            {{ rotation(scaled(axis.base)) }}
-            <span v-if="axis.boost" class="flight-rot__boost">
-              → {{ rotation(scaled(axis.boost)) }}
+            {{ rotation(axis.base ?? 0) }}
+            <span v-if="axis.max" class="flight-rot__boost">
+              → {{ rotation(boostAnim[axis.label]) }}
             </span>
           </span>
           <span class="flight-rot__label">{{ axis.label }}</span>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -1,0 +1,141 @@
+<script lang="ts">
+export default {
+  name: "ModelFlightMetrics",
+};
+</script>
+
+<script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
+import type { Model } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  model: Model;
+};
+
+const props = defineProps<Props>();
+
+const { t, toNumber } = useI18n();
+
+const speeds = computed(() => props.model.speeds);
+const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
+
+const hasData = computed(() =>
+  isGroundVehicle.value
+    ? !!speeds.value.groundMaxSpeed
+    : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
+);
+
+// The handling axes (°/s) — only meaningful for spaceflight.
+const rotations = computed(() => [
+  { label: t("model.pitch"), value: speeds.value.pitch },
+  { label: t("model.yaw"), value: speeds.value.yaw },
+  { label: t("model.roll"), value: speeds.value.roll },
+]);
+</script>
+
+<template>
+  <MetricsCard
+    v-if="hasData"
+    :title="t('labels.flight.title')"
+    class="flight-panel"
+  >
+    <div class="metrics-card__hero">
+      <template v-if="isGroundVehicle">
+        <div class="metrics-card__tile metrics-card__tile--primary">
+          <div class="metrics-card__tile__label">
+            {{ t("model.groundMaxSpeed") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(speeds.groundMaxSpeed, "speed") }}
+          </div>
+        </div>
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">
+            {{ t("model.groundReverseSpeed") }}
+          </div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(speeds.groundReverseSpeed, "speed") }}
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div class="metrics-card__tile metrics-card__tile--primary">
+          <div class="metrics-card__tile__label">{{ t("model.scmSpeed") }}</div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(speeds.scmSpeed, "speed") }}
+          </div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.flight.scm") }}
+          </div>
+        </div>
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">{{ t("model.maxSpeed") }}</div>
+          <div class="metrics-card__tile__value">
+            {{ toNumber(speeds.maxSpeed, "speed") }}
+          </div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.flight.nav") }}
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <template v-if="!isGroundVehicle">
+      <div class="metrics-card__section-label">
+        {{ t("labels.flight.maneuverability") }}
+      </div>
+      <div class="flight-rot">
+        <div
+          v-for="axis in rotations"
+          :key="axis.label"
+          class="flight-rot__item"
+        >
+          <span class="flight-rot__value">
+            {{ toNumber(axis.value, "rotation") }}
+          </span>
+          <span class="flight-rot__label">{{ axis.label }}</span>
+        </div>
+      </div>
+    </template>
+
+    <div class="metrics-card__footer">
+      <span class="metrics-card__hint">{{ t("labels.flight.hint") }}</span>
+    </div>
+  </MetricsCard>
+</template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+.flight-rot {
+  display: flex;
+  gap: 10px;
+
+  &__item {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 10px 6px;
+    border: 1px solid rgba($gray-light, 0.16);
+    border-radius: 4px;
+  }
+
+  &__value {
+    font-size: 15px;
+    font-weight: 600;
+    color: $text-color;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 8.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: $gray;
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -26,9 +26,9 @@ const enginePowerRatio = inject<Ref<number | undefined>>(
   ref(1),
 );
 const powered = computed(() => ((toValue(enginePowerRatio) ?? 1) > 0 ? 1 : 0));
-// How much of the rated boost the thrusters can currently deliver (engine power
-// relative to its default fill). Only the *boosted* handling scales with this;
-// the speeds and base handling don't.
+// How much of the rated boost the thrusters can currently deliver — the game's
+// IFCS afterburner ratio (engine power above its floor, up to full pips). Only
+// the *boosted* handling scales with this; the speeds and base handling don't.
 const boostFactor = computed(() =>
   Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
 );

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -19,16 +19,14 @@ const props = defineProps<Props>();
 
 const { t, toNumber } = useI18n();
 
-// Engine power relative to the default distribution (from Hardpoints): it only
-// scales the *boosted* handling — never the speeds or base handling, matching
-// erkul. 1 (full boost) when standalone.
+// Engine power from the pip UI (Hardpoints). erkul: with the engine unpowered
+// (0 pips) the ship is dead in the water — every flight figure reads 0; any
+// power at all restores the rated figures. 1 (powered) when standalone.
 const enginePowerRatio = inject<Ref<number | undefined>>(
   "enginePowerRatio",
   ref(1),
 );
-const boostFactor = computed(() =>
-  Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
-);
+const powered = computed(() => ((toValue(enginePowerRatio) ?? 1) > 0 ? 1 : 0));
 
 // SCM / NAV mode swaps the headline speed (from Hardpoints; SCM standalone).
 const flightMode = inject<Ref<FlightMode>>("flightMode", ref("SCM"));
@@ -43,50 +41,56 @@ const hasData = computed(() =>
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
 
-const speed = (value?: number) => toNumber(Math.round(value ?? 0), "speed");
+const gate = (value?: number) => (value ?? 0) * powered.value;
+const speed = (value: number) => toNumber(Math.round(value), "speed");
 const rotation = (value: number) => toNumber(Math.round(value), "rotation");
 
-// Boosted handling interpolates from the base rate (no engine power) up to the
-// rated boosted rate (full engine power).
-const boosted = (base?: number, max?: number) =>
-  (base ?? 0) + ((max ?? base ?? 0) - (base ?? 0)) * boostFactor.value;
+const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
+const headline = useTransition(
+  () => gate(isNav.value ? speeds.value.maxSpeed : speeds.value.scmSpeed),
+  animate,
+);
+const boostSpeed = useTransition(
+  () => gate(speeds.value.scmSpeedBoosted),
+  animate,
+);
+const reverseSpeed = useTransition(
+  () => gate(speeds.value.reverseSpeedBoosted),
+  animate,
+);
+const groundMax = useTransition(
+  () => gate(speeds.value.groundMaxSpeed),
+  animate,
+);
+const groundReverse = useTransition(
+  () => gate(speeds.value.groundReverseSpeed),
+  animate,
+);
+
+const pitchBoost = useTransition(
+  () => gate(speeds.value.pitchBoosted),
+  animate,
+);
+const yawBoost = useTransition(() => gate(speeds.value.yawBoosted), animate);
+const rollBoost = useTransition(() => gate(speeds.value.rollBoosted), animate);
 
 const rotations = computed(() => [
   {
     label: t("model.pitch"),
-    base: speeds.value.pitch,
-    max: speeds.value.pitchBoosted,
+    base: gate(speeds.value.pitch),
+    boost: pitchBoost.value,
   },
   {
     label: t("model.yaw"),
-    base: speeds.value.yaw,
-    max: speeds.value.yawBoosted,
+    base: gate(speeds.value.yaw),
+    boost: yawBoost.value,
   },
   {
     label: t("model.roll"),
-    base: speeds.value.roll,
-    max: speeds.value.rollBoosted,
+    base: gate(speeds.value.roll),
+    boost: rollBoost.value,
   },
 ]);
-
-const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
-const pitchBoost = useTransition(
-  () => boosted(speeds.value.pitch, speeds.value.pitchBoosted),
-  animate,
-);
-const yawBoost = useTransition(
-  () => boosted(speeds.value.yaw, speeds.value.yawBoosted),
-  animate,
-);
-const rollBoost = useTransition(
-  () => boosted(speeds.value.roll, speeds.value.rollBoosted),
-  animate,
-);
-const boostAnim = computed<Record<string, number>>(() => ({
-  [t("model.pitch")]: pitchBoost.value,
-  [t("model.yaw")]: yawBoost.value,
-  [t("model.roll")]: rollBoost.value,
-}));
 
 const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
 </script>
@@ -103,16 +107,14 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           <div class="metrics-card__tile__label">
             {{ t("model.groundMaxSpeed") }}
           </div>
-          <div class="metrics-card__tile__value">
-            {{ speed(speeds.groundMaxSpeed) }}
-          </div>
+          <div class="metrics-card__tile__value">{{ speed(groundMax) }}</div>
         </div>
         <div class="metrics-card__tile">
           <div class="metrics-card__tile__label">
             {{ t("model.groundReverseSpeed") }}
           </div>
           <div class="metrics-card__tile__value">
-            {{ speed(speeds.groundReverseSpeed) }}
+            {{ speed(groundReverse) }}
           </div>
         </div>
       </template>
@@ -121,9 +123,7 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           <div class="metrics-card__tile__label">
             {{ isNav ? t("model.maxSpeed") : t("model.scmSpeed") }}
           </div>
-          <div class="metrics-card__tile__value">
-            {{ speed(isNav ? speeds.maxSpeed : speeds.scmSpeed) }}
-          </div>
+          <div class="metrics-card__tile__value">{{ speed(headline) }}</div>
           <div class="metrics-card__tile__sub">
             {{ isNav ? t("labels.flight.nav") : t("labels.flight.scm") }}
           </div>
@@ -132,9 +132,7 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           <div class="metrics-card__tile__label">
             {{ t("labels.flight.boost") }}
           </div>
-          <div class="metrics-card__tile__value">
-            {{ speed(speeds.scmSpeedBoosted) }}
-          </div>
+          <div class="metrics-card__tile__value">{{ speed(boostSpeed) }}</div>
           <div class="metrics-card__tile__sub">
             {{ t("labels.flight.boostSub") }}
           </div>
@@ -143,9 +141,7 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           <div class="metrics-card__tile__label">
             {{ t("labels.flight.reverse") }}
           </div>
-          <div class="metrics-card__tile__value">
-            {{ speed(speeds.reverseSpeedBoosted) }}
-          </div>
+          <div class="metrics-card__tile__value">{{ speed(reverseSpeed) }}</div>
         </div>
       </template>
     </div>
@@ -161,9 +157,9 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
           class="flight-rot__item"
         >
           <span class="flight-rot__value">
-            {{ rotation(axis.base ?? 0) }}
-            <span v-if="axis.max" class="flight-rot__boost">
-              → {{ rotation(boostAnim[axis.label]) }}
+            {{ rotation(axis.base) }}
+            <span v-if="axis.boost" class="flight-rot__boost">
+              → {{ rotation(axis.boost) }}
             </span>
           </span>
           <span class="flight-rot__label">{{ axis.label }}</span>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import { useTransition, TransitionPresets } from "@vueuse/core";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -17,6 +18,14 @@ const props = defineProps<Props>();
 
 const { t, toNumber } = useI18n();
 
+// Engine power relative to the default distribution (provided by Hardpoints).
+// Scales the flight figures with the thruster pips; 1 when standalone.
+const enginePowerRatio = inject<Ref<number | undefined>>(
+  "enginePowerRatio",
+  ref(1),
+);
+const ratio = computed(() => toValue(enginePowerRatio) ?? 1);
+
 const speeds = computed(() => props.model.speeds);
 const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
 
@@ -26,12 +35,40 @@ const hasData = computed(() =>
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
 
-// The handling axes (°/s) — only meaningful for spaceflight.
+const scaled = (value?: number) => (value ?? 0) * ratio.value;
+
+const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
+const scmSpeed = useTransition(() => scaled(speeds.value.scmSpeed), animate);
+const scmBoost = useTransition(
+  () => scaled(speeds.value.scmSpeedBoosted),
+  animate,
+);
+
+const speed = (value: number) => toNumber(Math.round(value), "speed");
+const rotation = (value: number) => toNumber(Math.round(value), "rotation");
+
+// Handling axes (°/s), base → boosted, scaled by engine power — only meaningful
+// for spaceflight.
 const rotations = computed(() => [
-  { label: t("model.pitch"), value: speeds.value.pitch },
-  { label: t("model.yaw"), value: speeds.value.yaw },
-  { label: t("model.roll"), value: speeds.value.roll },
+  {
+    label: t("model.pitch"),
+    base: speeds.value.pitch,
+    boost: speeds.value.pitchBoosted,
+  },
+  {
+    label: t("model.yaw"),
+    base: speeds.value.yaw,
+    boost: speeds.value.yawBoosted,
+  },
+  {
+    label: t("model.roll"),
+    base: speeds.value.roll,
+    boost: speeds.value.rollBoosted,
+  },
 ]);
+
+const reverseSpeed = computed(() => scaled(speeds.value.reverseSpeedBoosted));
+const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
 </script>
 
 <template>
@@ -62,21 +99,25 @@ const rotations = computed(() => [
       <template v-else>
         <div class="metrics-card__tile metrics-card__tile--primary">
           <div class="metrics-card__tile__label">{{ t("model.scmSpeed") }}</div>
-          <div class="metrics-card__tile__value">
-            {{ toNumber(speeds.scmSpeed, "speed") }}
-          </div>
+          <div class="metrics-card__tile__value">{{ speed(scmSpeed) }}</div>
           <div class="metrics-card__tile__sub">
             {{ t("labels.flight.scm") }}
           </div>
         </div>
         <div class="metrics-card__tile">
-          <div class="metrics-card__tile__label">{{ t("model.maxSpeed") }}</div>
-          <div class="metrics-card__tile__value">
-            {{ toNumber(speeds.maxSpeed, "speed") }}
+          <div class="metrics-card__tile__label">
+            {{ t("labels.flight.boost") }}
           </div>
+          <div class="metrics-card__tile__value">{{ speed(scmBoost) }}</div>
           <div class="metrics-card__tile__sub">
-            {{ t("labels.flight.nav") }}
+            {{ t("labels.flight.boostSub") }}
           </div>
+        </div>
+        <div v-if="hasReverse" class="metrics-card__tile">
+          <div class="metrics-card__tile__label">
+            {{ t("labels.flight.reverse") }}
+          </div>
+          <div class="metrics-card__tile__value">{{ speed(reverseSpeed) }}</div>
         </div>
       </template>
     </div>
@@ -92,7 +133,10 @@ const rotations = computed(() => [
           class="flight-rot__item"
         >
           <span class="flight-rot__value">
-            {{ toNumber(axis.value, "rotation") }}
+            {{ rotation(scaled(axis.base)) }}
+            <span v-if="axis.boost" class="flight-rot__boost">
+              → {{ rotation(scaled(axis.boost)) }}
+            </span>
           </span>
           <span class="flight-rot__label">{{ axis.label }}</span>
         </div>
@@ -124,10 +168,16 @@ const rotations = computed(() => [
   }
 
   &__value {
-    font-size: 15px;
+    font-size: 14px;
     font-weight: 600;
     color: $text-color;
     font-variant-numeric: tabular-nums;
+  }
+
+  &__boost {
+    font-size: 11px;
+    font-weight: 600;
+    color: $primary;
   }
 
   &__label {

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -30,6 +30,11 @@ const boostFactor = computed(() =>
   Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
 );
 
+// The ship can only fly while the engine has power; with every engine pip
+// pulled it's dead in the water and every flight figure reads 0.
+const enginePowered = inject<Ref<boolean>>("enginePowered", ref(true));
+const powered = computed(() => (toValue(enginePowered) ? 1 : 0));
+
 const speeds = computed(() => props.model.speeds);
 const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
 
@@ -39,10 +44,12 @@ const hasData = computed(() =>
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
 
+// A dead engine zeroes every flight figure; otherwise they're the game values.
+const gate = (value?: number) => (value ?? 0) * powered.value;
 // Boosted handling interpolates from the base rate up to the rated boosted rate
 // by how much boost the engine power supports (0 → base, 1 → rated).
 const boosted = (base?: number, rated?: number) =>
-  (base ?? 0) + ((rated ?? base ?? 0) - (base ?? 0)) * boostFactor.value;
+  gate((base ?? 0) + ((rated ?? base ?? 0) - (base ?? 0)) * boostFactor.value);
 // toNumber renders 0 as "N/A"; a real zero flight figure should read "0".
 const speed = (value: number) =>
   Math.round(value) > 0 ? toNumber(Math.round(value), "speed") : "0";
@@ -50,18 +57,18 @@ const rotation = (value: number) =>
   Math.round(value) > 0 ? toNumber(Math.round(value), "rotation") : "0";
 
 const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
-const scmSpeed = useTransition(() => speeds.value.scmSpeed ?? 0, animate);
+const scmSpeed = useTransition(() => gate(speeds.value.scmSpeed), animate);
 const boostSpeed = useTransition(
-  () => speeds.value.scmSpeedBoosted ?? 0,
+  () => gate(speeds.value.scmSpeedBoosted),
   animate,
 );
-const maxSpeed = useTransition(() => speeds.value.maxSpeed ?? 0, animate);
+const maxSpeed = useTransition(() => gate(speeds.value.maxSpeed), animate);
 const groundMax = useTransition(
-  () => speeds.value.groundMaxSpeed ?? 0,
+  () => gate(speeds.value.groundMaxSpeed),
   animate,
 );
 const groundReverse = useTransition(
-  () => speeds.value.groundReverseSpeed ?? 0,
+  () => gate(speeds.value.groundReverseSpeed),
   animate,
 );
 
@@ -84,11 +91,11 @@ const rotations = computed(() =>
   [
     {
       label: t("model.pitch"),
-      base: speeds.value.pitch ?? 0,
+      base: gate(speeds.value.pitch),
       boost: pitchBoost,
     },
-    { label: t("model.yaw"), base: speeds.value.yaw ?? 0, boost: yawBoost },
-    { label: t("model.roll"), base: speeds.value.roll ?? 0, boost: rollBoost },
+    { label: t("model.yaw"), base: gate(speeds.value.yaw), boost: yawBoost },
+    { label: t("model.roll"), base: gate(speeds.value.roll), boost: rollBoost },
   ].map((axis) => ({
     label: axis.label,
     base: axis.base,

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -8,7 +8,6 @@ export default {
 import { useTransition, TransitionPresets } from "@vueuse/core";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model } from "@/services/fyApi";
-import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useI18n } from "@/shared/composables/useI18n";
 
 type Props = {
@@ -27,10 +26,12 @@ const enginePowerRatio = inject<Ref<number | undefined>>(
   ref(1),
 );
 const powered = computed(() => ((toValue(enginePowerRatio) ?? 1) > 0 ? 1 : 0));
-
-// SCM / NAV mode swaps the headline speed (from Hardpoints; SCM standalone).
-const flightMode = inject<Ref<FlightMode>>("flightMode", ref("SCM"));
-const isNav = computed(() => toValue(flightMode) === "NAV");
+// How much of the rated boost the thrusters can currently deliver (engine power
+// relative to its default fill). Only the *boosted* handling scales with this;
+// the speeds and base handling don't.
+const boostFactor = computed(() =>
+  Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
+);
 
 const speeds = computed(() => props.model.speeds);
 const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
@@ -42,22 +43,23 @@ const hasData = computed(() =>
 );
 
 const gate = (value?: number) => (value ?? 0) * powered.value;
-const speed = (value: number) => toNumber(Math.round(value), "speed");
-const rotation = (value: number) => toNumber(Math.round(value), "rotation");
+// Boosted handling interpolates from the base rate up to the rated boosted rate
+// by how much boost the engine power supports.
+const boosted = (base?: number, rated?: number) =>
+  gate((base ?? 0) + ((rated ?? base ?? 0) - (base ?? 0)) * boostFactor.value);
+// toNumber renders 0 as "N/A"; a gated-to-zero flight figure is a real 0.
+const speed = (value: number) =>
+  Math.round(value) > 0 ? toNumber(Math.round(value), "speed") : "0";
+const rotation = (value: number) =>
+  Math.round(value) > 0 ? toNumber(Math.round(value), "rotation") : "0";
 
 const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
-const headline = useTransition(
-  () => gate(isNav.value ? speeds.value.maxSpeed : speeds.value.scmSpeed),
-  animate,
-);
+const scmSpeed = useTransition(() => gate(speeds.value.scmSpeed), animate);
 const boostSpeed = useTransition(
   () => gate(speeds.value.scmSpeedBoosted),
   animate,
 );
-const reverseSpeed = useTransition(
-  () => gate(speeds.value.reverseSpeedBoosted),
-  animate,
-);
+const maxSpeed = useTransition(() => gate(speeds.value.maxSpeed), animate);
 const groundMax = useTransition(
   () => gate(speeds.value.groundMaxSpeed),
   animate,
@@ -68,11 +70,17 @@ const groundReverse = useTransition(
 );
 
 const pitchBoost = useTransition(
-  () => gate(speeds.value.pitchBoosted),
+  () => boosted(speeds.value.pitch, speeds.value.pitchBoosted),
   animate,
 );
-const yawBoost = useTransition(() => gate(speeds.value.yawBoosted), animate);
-const rollBoost = useTransition(() => gate(speeds.value.rollBoosted), animate);
+const yawBoost = useTransition(
+  () => boosted(speeds.value.yaw, speeds.value.yawBoosted),
+  animate,
+);
+const rollBoost = useTransition(
+  () => boosted(speeds.value.roll, speeds.value.rollBoosted),
+  animate,
+);
 
 const rotations = computed(() => [
   {
@@ -91,8 +99,6 @@ const rotations = computed(() => [
     boost: rollBoost.value,
   },
 ]);
-
-const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
 </script>
 
 <template>
@@ -120,12 +126,10 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
       </template>
       <template v-else>
         <div class="metrics-card__tile metrics-card__tile--primary">
-          <div class="metrics-card__tile__label">
-            {{ isNav ? t("model.maxSpeed") : t("model.scmSpeed") }}
-          </div>
-          <div class="metrics-card__tile__value">{{ speed(headline) }}</div>
+          <div class="metrics-card__tile__label">{{ t("model.scmSpeed") }}</div>
+          <div class="metrics-card__tile__value">{{ speed(scmSpeed) }}</div>
           <div class="metrics-card__tile__sub">
-            {{ isNav ? t("labels.flight.nav") : t("labels.flight.scm") }}
+            {{ t("labels.flight.scm") }}
           </div>
         </div>
         <div class="metrics-card__tile">
@@ -137,11 +141,12 @@ const hasReverse = computed(() => !!speeds.value.reverseSpeedBoosted);
             {{ t("labels.flight.boostSub") }}
           </div>
         </div>
-        <div v-if="hasReverse" class="metrics-card__tile">
-          <div class="metrics-card__tile__label">
-            {{ t("labels.flight.reverse") }}
+        <div class="metrics-card__tile">
+          <div class="metrics-card__tile__label">{{ t("model.maxSpeed") }}</div>
+          <div class="metrics-card__tile__value">{{ speed(maxSpeed) }}</div>
+          <div class="metrics-card__tile__sub">
+            {{ t("labels.flight.nav") }}
           </div>
-          <div class="metrics-card__tile__value">{{ speed(reverseSpeed) }}</div>
         </div>
       </template>
     </div>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -38,11 +38,21 @@ const powered = computed(() => (toValue(enginePowered) ? 1 : 0));
 const speeds = computed(() => props.model.speeds);
 const isGroundVehicle = computed(() => props.model.metrics.isGroundVehicle);
 
-const hasData = computed(() =>
+const hasSpeeds = computed(() =>
   isGroundVehicle.value
     ? !!speeds.value.groundMaxSpeed
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
+
+const hasFuel = computed(
+  () =>
+    !!props.model.metrics.hydrogenFuelTankSize ||
+    !!props.model.metrics.quantumFuelTankSize,
+);
+
+// Fuel is what the speeds are spent on, so it reads here rather than among the
+// base dimensions — and a ship with tanks but no recorded speeds still shows it.
+const hasData = computed(() => hasSpeeds.value || hasFuel.value);
 
 // A dead engine zeroes every flight figure; otherwise they're the game values.
 const gate = (value?: number) => (value ?? 0) * powered.value;
@@ -111,7 +121,7 @@ const rotations = computed(() =>
     :title="t('labels.flight.title')"
     class="flight-panel"
   >
-    <div class="metrics-card__hero">
+    <div v-if="hasSpeeds" class="metrics-card__hero">
       <template v-if="isGroundVehicle">
         <div class="metrics-card__tile metrics-card__tile--primary">
           <div class="metrics-card__tile__label">
@@ -155,7 +165,7 @@ const rotations = computed(() =>
       </template>
     </div>
 
-    <template v-if="!isGroundVehicle">
+    <template v-if="!isGroundVehicle && hasSpeeds">
       <div class="metrics-card__section-label">
         {{ t("labels.flight.maneuverability") }}
       </div>
@@ -176,7 +186,35 @@ const rotations = computed(() =>
       </div>
     </template>
 
-    <div class="metrics-card__footer">
+    <template v-if="hasFuel">
+      <div v-if="hasSpeeds" class="metrics-card__divider" />
+      <div class="metrics-card__section-label">
+        {{ t("labels.flight.fuel") }}
+      </div>
+      <div class="metrics-card__rows metrics-card__rows--split">
+        <div
+          v-if="model.metrics.hydrogenFuelTankSize"
+          class="metrics-card__row"
+        >
+          <span class="metrics-card__row__label">
+            {{ t("labels.flight.fuelHydrogen") }}
+          </span>
+          <span class="metrics-card__row__value">
+            {{ toNumber(model.metrics.hydrogenFuelTankSize, "cargo") }}
+          </span>
+        </div>
+        <div v-if="model.metrics.quantumFuelTankSize" class="metrics-card__row">
+          <span class="metrics-card__row__label">
+            {{ t("labels.flight.fuelQuantum") }}
+          </span>
+          <span class="metrics-card__row__value">
+            {{ toNumber(model.metrics.quantumFuelTankSize, "cargo") }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <div v-if="hasSpeeds" class="metrics-card__footer">
       <span class="metrics-card__hint">{{ t("labels.flight.hint") }}</span>
     </div>
   </MetricsCard>

--- a/app/frontend/frontend/components/Models/FlightMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/FlightMetrics/index.vue
@@ -18,17 +18,14 @@ const props = defineProps<Props>();
 
 const { t, toNumber } = useI18n();
 
-// Engine power from the pip UI (Hardpoints). erkul: with the engine unpowered
-// (0 pips) the ship is dead in the water — every flight figure reads 0; any
-// power at all restores the rated figures. 1 (powered) when standalone.
+// Engine power from the pip UI (Hardpoints) — the game's IFCS afterburner ratio
+// (engine power above its floor, up to full pips). Only the *boosted* handling
+// scales with it; the speeds and base handling are constant game figures, as in
+// the IFCS flight model. 1 (full boost) when standalone / no engine family.
 const enginePowerRatio = inject<Ref<number | undefined>>(
   "enginePowerRatio",
   ref(1),
 );
-const powered = computed(() => ((toValue(enginePowerRatio) ?? 1) > 0 ? 1 : 0));
-// How much of the rated boost the thrusters can currently deliver — the game's
-// IFCS afterburner ratio (engine power above its floor, up to full pips). Only
-// the *boosted* handling scales with this; the speeds and base handling don't.
 const boostFactor = computed(() =>
   Math.min(1, Math.max(0, toValue(enginePowerRatio) ?? 1)),
 );
@@ -42,30 +39,29 @@ const hasData = computed(() =>
     : !!(speeds.value.scmSpeed || speeds.value.maxSpeed),
 );
 
-const gate = (value?: number) => (value ?? 0) * powered.value;
 // Boosted handling interpolates from the base rate up to the rated boosted rate
-// by how much boost the engine power supports.
+// by how much boost the engine power supports (0 → base, 1 → rated).
 const boosted = (base?: number, rated?: number) =>
-  gate((base ?? 0) + ((rated ?? base ?? 0) - (base ?? 0)) * boostFactor.value);
-// toNumber renders 0 as "N/A"; a gated-to-zero flight figure is a real 0.
+  (base ?? 0) + ((rated ?? base ?? 0) - (base ?? 0)) * boostFactor.value;
+// toNumber renders 0 as "N/A"; a real zero flight figure should read "0".
 const speed = (value: number) =>
   Math.round(value) > 0 ? toNumber(Math.round(value), "speed") : "0";
 const rotation = (value: number) =>
   Math.round(value) > 0 ? toNumber(Math.round(value), "rotation") : "0";
 
 const animate = { duration: 400, transition: TransitionPresets.easeOutCubic };
-const scmSpeed = useTransition(() => gate(speeds.value.scmSpeed), animate);
+const scmSpeed = useTransition(() => speeds.value.scmSpeed ?? 0, animate);
 const boostSpeed = useTransition(
-  () => gate(speeds.value.scmSpeedBoosted),
+  () => speeds.value.scmSpeedBoosted ?? 0,
   animate,
 );
-const maxSpeed = useTransition(() => gate(speeds.value.maxSpeed), animate);
+const maxSpeed = useTransition(() => speeds.value.maxSpeed ?? 0, animate);
 const groundMax = useTransition(
-  () => gate(speeds.value.groundMaxSpeed),
+  () => speeds.value.groundMaxSpeed ?? 0,
   animate,
 );
 const groundReverse = useTransition(
-  () => gate(speeds.value.groundReverseSpeed),
+  () => speeds.value.groundReverseSpeed ?? 0,
   animate,
 );
 
@@ -82,23 +78,24 @@ const rollBoost = useTransition(
   animate,
 );
 
-const rotations = computed(() => [
-  {
-    label: t("model.pitch"),
-    base: gate(speeds.value.pitch),
-    boost: pitchBoost.value,
-  },
-  {
-    label: t("model.yaw"),
-    base: gate(speeds.value.yaw),
-    boost: yawBoost.value,
-  },
-  {
-    label: t("model.roll"),
-    base: gate(speeds.value.roll),
-    boost: rollBoost.value,
-  },
-]);
+// Only surface the boosted rate when the engine power actually lifts it above
+// the base handling; at the mandatory floor there's no afterburner to show.
+const rotations = computed(() =>
+  [
+    {
+      label: t("model.pitch"),
+      base: speeds.value.pitch ?? 0,
+      boost: pitchBoost,
+    },
+    { label: t("model.yaw"), base: speeds.value.yaw ?? 0, boost: yawBoost },
+    { label: t("model.roll"), base: speeds.value.roll ?? 0, boost: rollBoost },
+  ].map((axis) => ({
+    label: axis.label,
+    base: axis.base,
+    boost: axis.boost.value,
+    showBoost: Math.round(axis.boost.value) > Math.round(axis.base),
+  })),
+);
 </script>
 
 <template>
@@ -163,7 +160,7 @@ const rotations = computed(() => [
         >
           <span class="flight-rot__value">
             {{ rotation(axis.base) }}
-            <span v-if="axis.boost" class="flight-rot__boost">
+            <span v-if="axis.showBoost" class="flight-rot__boost">
               → {{ rotation(axis.boost) }}
             </span>
           </span>

--- a/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
@@ -94,16 +94,23 @@ const detailStats = useHardpointStats(
 const primaryStat = computed(() => detailStats.value.find((s) => s.primary));
 const inlineStats = computed(() => detailStats.value.filter((s) => !s.primary));
 
+// Cosmetic geometry (turret shells, weapon shrouds, wingtip covers) sits on
+// child ports as nameless `Misc`/`AttachedPart` items that stay uncategorised —
+// they'd render as bare "TBD" rows, unlike a genuinely empty slot, which keeps
+// its category.
+const isCosmetic = (hp: Hardpoint) =>
+  hp.category === HardpointCategoryEnum.UNKNOWN && !hp.component?.name;
+
 const loadout = computed(() => {
   if (hardpoint.value.hardpoints?.length) {
-    return hardpoint.value.hardpoints;
+    return hardpoint.value.hardpoints.filter((hp) => !isCosmetic(hp));
   }
 
   if (
     hardpoint.value.component?.hardpoints?.length &&
     hardpoint.value.component.hardpoints[0].component
   ) {
-    return hardpoint.value.component.hardpoints;
+    return hardpoint.value.component.hardpoints.filter((hp) => !isCosmetic(hp));
   }
 
   return [];

--- a/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Category/index.vue
@@ -147,7 +147,7 @@ const icons = {
         v-else-if="category === HardpointCategoryEnum.LIFESUPPORT"
         class="hardpoint-category__icon"
       >
-        <i class="fa-duotone fa-star-of-life fa-lg" />
+        <i class="fa-duotone fa-heart-pulse fa-lg" />
       </span>
       <span
         v-else-if="category === HardpointCategoryEnum.RELAY"

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -73,9 +73,10 @@
   gap: 20px;
   margin-bottom: 20px;
 
-  // Two independent columns (Combat/Power · Defense/Hull) that pack their cards
-  // tightly, so a shorter card leaves no row-alignment whitespace beside it.
-  @media (min-width: 768px) {
+  // Three independent columns (Combat/Power · Defense/Hull · Flight) that pack
+  // their cards tightly, so a shorter card leaves no row-alignment whitespace
+  // beside it. Stacked on narrow screens, three-up once there's room.
+  @media (min-width: 992px) {
     flex-direction: row;
     align-items: flex-start;
   }

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -68,18 +68,27 @@
 // alignment keeps each card at its natural height instead of stretching it to
 // the tallest in the row, which is where the empty space came from.
 .metrics-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
   gap: 20px;
   margin-bottom: 20px;
 
-  // Combat / Defense / Hull / Power as a 2×2 grid on wider screens.
+  // Two independent columns (Combat/Power · Defense/Hull) that pack their cards
+  // tightly, so a shorter card leaves no row-alignment whitespace beside it.
   @media (min-width: 768px) {
-    grid-template-columns: repeat(2, 1fr);
+    flex-direction: row;
+    align-items: flex-start;
   }
 
-  > * {
-    margin: 0;
+  &__col {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    flex: 1 1 0;
+    min-width: 0;
+
+    > * {
+      margin: 0;
+    }
   }
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -74,19 +74,12 @@
   gap: 20px;
   margin-bottom: 20px;
 
+  // Combat / Defense / Hull / Power as a 2×2 grid on wider screens.
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (min-width: 1200px) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
   > * {
     margin: 0;
-  }
-
-  &__full {
-    grid-column: 1 / -1;
   }
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -16,32 +16,28 @@
   }
 }
 
-// Metrics cards flow in a dense grid rather than Bootstrap columns: `start`
-// alignment keeps each card at its natural height instead of stretching it to
-// the tallest in the row, which is where the empty space came from.
+// Metrics cards are packed rather than assigned to fixed columns: each spans a
+// measured number of 4px rows (see useMetricsMasonry) and `dense` flow lets a
+// later card backfill a column another card left short. Stacked on narrow
+// screens, three-up once there's room.
 .metrics-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-bottom: 20px;
-
-  // Three independent columns (Combat/Power · Defense/Hull · Flight) that pack
-  // their cards tightly, so a shorter card leaves no row-alignment whitespace
-  // beside it. Stacked on narrow screens, three-up once there's room.
-  @media (min-width: 992px) {
-    flex-direction: row;
-    align-items: flex-start;
+  > * {
+    margin: 0 0 20px;
   }
 
-  &__col {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    flex: 1 1 0;
-    min-width: 0;
+  @media (min-width: 992px) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-rows: 4px;
+    grid-auto-flow: row dense;
+    column-gap: 20px;
 
     > * {
       margin: 0;
+      grid-row: span var(--metrics-card-span, 60);
+      // The span includes the gap below the card, so it must sit at its natural
+      // height instead of stretching into that trailing space.
+      align-self: start;
     }
   }
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -6,61 +6,13 @@
     flex-wrap: wrap;
   }
 
-  // Density toggle sits with the hardpoint groups it controls; a pill segmented
-  // control in the metrics-card HUD language.
+  // Density toggle sits with the hardpoint groups it controls, aligned with the
+  // source toggle above it.
   &__viewbar {
     display: flex;
     align-items: center;
-    gap: 12px;
+    justify-content: flex-end;
     margin: 4px 0 16px;
-  }
-
-  &__viewbar-label {
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 10.5px;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: $gray-light;
-  }
-
-  &__seg {
-    display: inline-flex;
-    padding: 3px;
-    border: 1px solid rgba($gray-light, 0.5);
-    border-radius: 999px;
-    background: rgba(0, 0, 0, 0.25);
-  }
-
-  &__seg-btn {
-    padding: 7px 16px;
-    border: none;
-    border-radius: 999px;
-    background: transparent;
-    color: $gray-light;
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 10.5px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    cursor: pointer;
-    transition:
-      color 0.15s ease,
-      background 0.15s ease;
-
-    &:hover {
-      color: lighten($text-color, 15%);
-    }
-
-    &--active {
-      color: #171a1d;
-      background: $gold;
-      box-shadow: 0 0 12px -2px rgba($gold, 0.5);
-
-      // Keep the dark label readable on the gold pill when hovered (otherwise
-      // the base hover colour — light grey — washes out against the gold).
-      &:hover {
-        color: #171a1d;
-      }
-    }
   }
 }
 

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -85,4 +85,8 @@
   > * {
     margin: 0;
   }
+
+  &__full {
+    grid-column: 1 / -1;
+  }
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -138,6 +138,12 @@ provide(
   computed(() => powerSim.value.shieldPoolRatio),
 );
 
+// Engine power → Flight card scales speed/handling with the thruster pips.
+provide(
+  "enginePowerRatio",
+  computed(() => powerSim.value.enginePowerRatio),
+);
+
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same
 // sustained factor the Combat card totals from.
 provide(

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -16,7 +16,10 @@ import ModelPowerDistribution from "@/frontend/components/Models/PowerDistributi
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
-import type { PortOverrides } from "@/frontend/composables/useLoadoutSim";
+import {
+  useLoadoutSim,
+  type PortOverrides,
+} from "@/frontend/composables/useLoadoutSim";
 import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useShieldStats } from "@/frontend/composables/useShieldStats";
 import {
@@ -121,6 +124,18 @@ provide(
 // The user's pip choices, so the Combat card totals recompute from the same
 // distribution the control shows.
 provide("powerOverrides", powerOverrides);
+
+// Shield power allocation → Defense card scales shield HP/regen with the pips.
+const powerSim = useLoadoutSim(
+  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
+  () => props.model.metrics?.weaponPoolSize,
+  flightMode,
+  powerOverrides,
+);
+provide(
+  "shieldPoolRatio",
+  computed(() => powerSim.value.shieldPoolRatio),
+);
 
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same
 // sustained factor the Combat card totals from.

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -144,9 +144,6 @@ provide(
   computed(() => powerSim.value.enginePowerRatio),
 );
 
-// SCM / NAV mode → Flight card swaps the headline speed (SCM ↔ max).
-provide("flightMode", flightMode);
-
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same
 // sustained factor the Combat card totals from.
 provide(

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -201,6 +201,7 @@ const shieldStats = useShieldStats(
           v-model:mode="flightMode"
           :hardpoints="hardpoints as Hardpoint[]"
           :weapon-pool-size="model.metrics?.weaponPoolSize"
+          class="metrics-grid__full"
         />
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -12,9 +12,12 @@ import HardpointGroup from "./Group/index.vue";
 import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index.vue";
 import ModelDefenseMetrics from "@/frontend/components/Models/DefenseMetrics/index.vue";
 import ModelHullMetrics from "@/frontend/components/Models/HullMetrics/index.vue";
+import ModelPowerDistribution from "@/frontend/components/Models/PowerDistribution/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
+import type { FamilyOverrides } from "@/frontend/composables/useLoadoutSim";
+import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useShieldStats } from "@/frontend/composables/useShieldStats";
 import {
   useModelHardpoints as useModelHardpointsQuery,
@@ -95,9 +98,19 @@ const {
   query: { enabled: !!props.model },
 });
 
+// User pip choices from the Power Distribution control; empty = auto (default).
+const powerOverrides = ref<FamilyOverrides>({});
+const flightMode = ref<FlightMode>("SCM");
+
+// Reset overrides when the ship (or hardpoint source) changes.
+watch([() => props.model.slug, source], () => {
+  powerOverrides.value = {};
+});
+
 const combatStats = useLoadoutStats(
   () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
   () => props.model.metrics?.weaponPoolSize,
+  powerOverrides,
 );
 
 provide(
@@ -178,6 +191,12 @@ const shieldStats = useShieldStats(
           :hull-health="model.metrics.hullHealth"
           :hull-parts="model.metrics.hullParts"
           :hull-doors="model.metrics.hullDoors"
+        />
+        <ModelPowerDistribution
+          v-model="powerOverrides"
+          v-model:mode="flightMode"
+          :hardpoints="hardpoints as Hardpoint[]"
+          :weapon-pool-size="model.metrics?.weaponPoolSize"
         />
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -138,11 +138,14 @@ provide(
   computed(() => powerSim.value.shieldPoolRatio),
 );
 
-// Engine power → Flight card scales speed/handling with the thruster pips.
+// Engine power → Flight card scales boosted handling with the thruster pips.
 provide(
   "enginePowerRatio",
   computed(() => powerSim.value.enginePowerRatio),
 );
+
+// SCM / NAV mode → Flight card swaps the headline speed (SCM ↔ max).
+provide("flightMode", flightMode);
 
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same
 // sustained factor the Combat card totals from.

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -202,6 +202,7 @@ const showLoadoutMetrics = computed(
       <div class="flex justify-end hardpoints__toolbar">
         <BtnGroup>
           <Btn
+            size="small"
             :active="source === HardpointSourceEnum.GAME_FILES"
             :disabled="!model.inGame"
             @click="source = HardpointSourceEnum.GAME_FILES"
@@ -211,6 +212,7 @@ const showLoadoutMetrics = computed(
             }}
           </Btn>
           <Btn
+            size="small"
             :active="source === HardpointSourceEnum.SHIP_MATRIX"
             @click="source = HardpointSourceEnum.SHIP_MATRIX"
           >
@@ -251,37 +253,24 @@ const showLoadoutMetrics = computed(
         </div>
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">
-        <span class="hardpoints__viewbar-label">
-          {{ t("labels.hardpoint.density.title") }}
-        </span>
-        <div
-          class="hardpoints__seg"
-          role="tablist"
-          :aria-label="t('labels.hardpoint.density.title')"
-        >
-          <button
-            type="button"
-            class="hardpoints__seg-btn"
-            :class="{
-              'hardpoints__seg-btn--active': density === 'compact',
-            }"
+        <BtnGroup inline :aria-label="t('labels.hardpoint.density.title')">
+          <Btn
+            size="small"
+            :active="density === 'compact'"
             :aria-pressed="density === 'compact'"
             @click="density = 'compact'"
           >
             {{ t("labels.hardpoint.density.compact") }}
-          </button>
-          <button
-            type="button"
-            class="hardpoints__seg-btn"
-            :class="{
-              'hardpoints__seg-btn--active': density === 'expanded',
-            }"
+          </Btn>
+          <Btn
+            size="small"
+            :active="density === 'expanded'"
             :aria-pressed="density === 'expanded'"
             @click="density = 'expanded'"
           >
             {{ t("labels.hardpoint.density.expanded") }}
-          </button>
-        </div>
+          </Btn>
+        </BtnGroup>
       </div>
       <div v-if="hardpoints?.length" class="row">
         <div class="col-12 col-md-6 col-lg-4">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -201,7 +201,6 @@ const shieldStats = useShieldStats(
           v-model:mode="flightMode"
           :hardpoints="hardpoints as Hardpoint[]"
           :weapon-pool-size="model.metrics?.weaponPoolSize"
-          class="metrics-grid__full"
         />
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -16,7 +16,7 @@ import ModelPowerDistribution from "@/frontend/components/Models/PowerDistributi
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
-import type { FamilyOverrides } from "@/frontend/composables/useLoadoutSim";
+import type { PortOverrides } from "@/frontend/composables/useLoadoutSim";
 import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useShieldStats } from "@/frontend/composables/useShieldStats";
 import {
@@ -99,7 +99,7 @@ const {
 });
 
 // User pip choices from the Power Distribution control; empty = auto (default).
-const powerOverrides = ref<FamilyOverrides>({});
+const powerOverrides = ref<PortOverrides>({});
 const flightMode = ref<FlightMode>("SCM");
 
 // Reset overrides when the ship (or hardpoint source) changes.

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -186,22 +186,26 @@ const shieldStats = useShieldStats(
         "
         class="metrics-grid"
       >
-        <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
-        <ModelDefenseMetrics
-          :hardpoints="hardpoints as Hardpoint[]"
-          :model-name="model.name"
-        />
-        <ModelHullMetrics
-          :hull-health="model.metrics.hullHealth"
-          :hull-parts="model.metrics.hullParts"
-          :hull-doors="model.metrics.hullDoors"
-        />
-        <ModelPowerDistribution
-          v-model="powerOverrides"
-          v-model:mode="flightMode"
-          :hardpoints="hardpoints as Hardpoint[]"
-          :weapon-pool-size="model.metrics?.weaponPoolSize"
-        />
+        <div class="metrics-grid__col">
+          <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
+          <ModelPowerDistribution
+            v-model="powerOverrides"
+            v-model:mode="flightMode"
+            :hardpoints="hardpoints as Hardpoint[]"
+            :weapon-pool-size="model.metrics?.weaponPoolSize"
+          />
+        </div>
+        <div class="metrics-grid__col">
+          <ModelDefenseMetrics
+            :hardpoints="hardpoints as Hardpoint[]"
+            :model-name="model.name"
+          />
+          <ModelHullMetrics
+            :hull-health="model.metrics.hullHealth"
+            :hull-parts="model.metrics.hullParts"
+            :hull-doors="model.metrics.hullDoors"
+          />
+        </div>
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">
         <span class="hardpoints__viewbar-label">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -23,7 +23,6 @@ import {
   type PortOverrides,
 } from "@/frontend/composables/useLoadoutSim";
 import type { FlightMode } from "@/frontend/composables/powerSim";
-import { useShieldStats } from "@/frontend/composables/useShieldStats";
 import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
@@ -107,6 +106,10 @@ const {
   query: { enabled: !!props.model },
 });
 
+// Cards that read the hardpoints query render right away and spin while it is
+// in flight, so they never pop into the layout once the data lands.
+const loadingHardpoints = computed(() => isLoading.value || isFetching.value);
+
 // User pip choices from the Power Distribution control; empty = auto (default).
 const powerOverrides = ref<PortOverrides>({});
 const flightMode = ref<FlightMode>("SCM");
@@ -161,20 +164,10 @@ provide(
   computed(() => combatStats.value.weaponPowerRatio),
 );
 
-const shieldStats = useShieldStats(
-  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
-);
-
-// Everything but the cargo card is derived from the game-files loadout, so the
-// ship-matrix source has nothing to show there.
-const showLoadoutMetrics = computed(
-  () =>
-    source.value === HardpointSourceEnum.GAME_FILES &&
-    (combatStats.value.hasData ||
-      shieldStats.value.hasData ||
-      !!props.model.metrics.hullHealth ||
-      !!props.model.speeds?.scmSpeed ||
-      !!props.model.speeds?.groundMaxSpeed),
+// Every metrics card is derived from the game-files loadout, which only
+// flight-ready ships have — those always carry stats, so no per-card guard.
+const showMetrics = computed(
+  () => props.model.inGame && source.value === HardpointSourceEnum.GAME_FILES,
 );
 </script>
 
@@ -222,33 +215,36 @@ const showLoadoutMetrics = computed(
           </Btn>
         </BtnGroup>
       </div>
-      <ModelRefuelBoom :model="model" />
-      <div v-if="showLoadoutMetrics || cargoHolds.length" class="metrics-grid">
-        <template v-if="showLoadoutMetrics">
-          <div class="metrics-grid__col">
-            <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
-            <ModelPowerDistribution
-              v-model="powerOverrides"
-              v-model:mode="flightMode"
-              :hardpoints="hardpoints as Hardpoint[]"
-              :weapon-pool-size="model.metrics?.weaponPoolSize"
-              :cross-section="model.metrics?.signatureCrossSection"
-            />
-          </div>
-          <div class="metrics-grid__col">
-            <ModelDefenseMetrics
-              :hardpoints="hardpoints as Hardpoint[]"
-              :model-name="model.name"
-            />
-            <ModelHullMetrics
-              :hull-health="model.metrics.hullHealth"
-              :hull-parts="model.metrics.hullParts"
-              :hull-doors="model.metrics.hullDoors"
-            />
-          </div>
-        </template>
+      <ModelRefuelBoom v-if="showMetrics" :model="model" />
+      <div v-if="showMetrics" class="metrics-grid">
         <div class="metrics-grid__col">
-          <ModelFlightMetrics v-if="showLoadoutMetrics" :model="model" />
+          <ModelCombatMetrics
+            :hardpoints="hardpoints as Hardpoint[]"
+            :loading="loadingHardpoints"
+          />
+          <ModelPowerDistribution
+            v-model="powerOverrides"
+            v-model:mode="flightMode"
+            :hardpoints="hardpoints as Hardpoint[]"
+            :weapon-pool-size="model.metrics?.weaponPoolSize"
+            :cross-section="model.metrics?.signatureCrossSection"
+            :loading="loadingHardpoints"
+          />
+        </div>
+        <div class="metrics-grid__col">
+          <ModelDefenseMetrics
+            :hardpoints="hardpoints as Hardpoint[]"
+            :model-name="model.name"
+            :loading="loadingHardpoints"
+          />
+          <ModelHullMetrics
+            :hull-health="model.metrics.hullHealth"
+            :hull-parts="model.metrics.hullParts"
+            :hull-doors="model.metrics.hullDoors"
+          />
+        </div>
+        <div class="metrics-grid__col">
+          <ModelFlightMetrics :model="model" />
           <ModelCargoMetrics :model="model" :cargo-holds="cargoHolds" />
         </div>
       </div>

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -208,6 +208,7 @@ const shieldStats = useShieldStats(
             v-model:mode="flightMode"
             :hardpoints="hardpoints as Hardpoint[]"
             :weapon-pool-size="model.metrics?.weaponPoolSize"
+            :cross-section="model.metrics?.signatureCrossSection"
           />
         </div>
         <div class="metrics-grid__col">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -143,10 +143,15 @@ provide(
   computed(() => powerSim.value.shieldPoolRatio),
 );
 
-// Engine power → Flight card scales boosted handling with the thruster pips.
+// Engine power → Flight card scales boosted handling with the thruster pips,
+// and zeroes every flight figure when the engine is fully unpowered.
 provide(
   "enginePowerRatio",
   computed(() => powerSim.value.enginePowerRatio),
+);
+provide(
+  "enginePowered",
+  computed(() => powerSim.value.engineActive),
 );
 
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -24,6 +24,7 @@ import {
   type PortOverrides,
 } from "@/frontend/composables/useLoadoutSim";
 import type { FlightMode } from "@/frontend/composables/powerSim";
+import { useMetricsMasonry } from "@/frontend/composables/useMetricsMasonry";
 import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
@@ -170,6 +171,10 @@ provide(
 const showMetrics = computed(
   () => props.model.inGame && source.value === HardpointSourceEnum.GAME_FILES,
 );
+
+const metricsGrid = ref<HTMLElement>();
+
+useMetricsMasonry(metricsGrid);
 </script>
 
 <template>
@@ -216,39 +221,33 @@ const showMetrics = computed(
           </Btn>
         </BtnGroup>
       </div>
-      <div v-if="showMetrics" class="metrics-grid">
-        <div class="metrics-grid__col">
-          <ModelCombatMetrics
-            :hardpoints="hardpoints as Hardpoint[]"
-            :loading="loadingHardpoints"
-          />
-          <ModelPowerDistribution
-            v-model="powerOverrides"
-            v-model:mode="flightMode"
-            :hardpoints="hardpoints as Hardpoint[]"
-            :weapon-pool-size="model.metrics?.weaponPoolSize"
-            :cross-section="model.metrics?.signatureCrossSection"
-            :loading="loadingHardpoints"
-          />
-        </div>
-        <div class="metrics-grid__col">
-          <ModelDefenseMetrics
-            :hardpoints="hardpoints as Hardpoint[]"
-            :model-name="model.name"
-            :loading="loadingHardpoints"
-          />
-          <ModelHullMetrics
-            :hull-health="model.metrics.hullHealth"
-            :hull-parts="model.metrics.hullParts"
-            :hull-doors="model.metrics.hullDoors"
-          />
-        </div>
-        <div class="metrics-grid__col">
-          <ModelFlightMetrics :model="model" />
-          <ModelCargoMetrics :model="model" :cargo-holds="cargoHolds" />
-          <ModelExternalFuelTanks :model="model" />
-          <ModelRefuelBoom :model="model" />
-        </div>
+      <div v-if="showMetrics" ref="metricsGrid" class="metrics-grid">
+        <ModelCombatMetrics
+          :hardpoints="hardpoints as Hardpoint[]"
+          :loading="loadingHardpoints"
+        />
+        <ModelPowerDistribution
+          v-model="powerOverrides"
+          v-model:mode="flightMode"
+          :hardpoints="hardpoints as Hardpoint[]"
+          :weapon-pool-size="model.metrics?.weaponPoolSize"
+          :cross-section="model.metrics?.signatureCrossSection"
+          :loading="loadingHardpoints"
+        />
+        <ModelDefenseMetrics
+          :hardpoints="hardpoints as Hardpoint[]"
+          :model-name="model.name"
+          :loading="loadingHardpoints"
+        />
+        <ModelHullMetrics
+          :hull-health="model.metrics.hullHealth"
+          :hull-parts="model.metrics.hullParts"
+          :hull-doors="model.metrics.hullDoors"
+        />
+        <ModelFlightMetrics :model="model" />
+        <ModelCargoMetrics :model="model" :cargo-holds="cargoHolds" />
+        <ModelExternalFuelTanks :model="model" />
+        <ModelRefuelBoom :model="model" />
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">
         <BtnGroup inline :aria-label="t('labels.hardpoint.density.title')">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -12,6 +12,7 @@ import HardpointGroup from "./Group/index.vue";
 import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index.vue";
 import ModelDefenseMetrics from "@/frontend/components/Models/DefenseMetrics/index.vue";
 import ModelHullMetrics from "@/frontend/components/Models/HullMetrics/index.vue";
+import ModelFlightMetrics from "@/frontend/components/Models/FlightMetrics/index.vue";
 import ModelPowerDistribution from "@/frontend/components/Models/PowerDistribution/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -197,7 +198,9 @@ const shieldStats = useShieldStats(
           source === HardpointSourceEnum.GAME_FILES &&
           (combatStats.hasData ||
             shieldStats.hasData ||
-            model.metrics.hullHealth)
+            model.metrics.hullHealth ||
+            model.speeds?.scmSpeed ||
+            model.speeds?.groundMaxSpeed)
         "
         class="metrics-grid"
       >
@@ -221,6 +224,9 @@ const shieldStats = useShieldStats(
             :hull-parts="model.metrics.hullParts"
             :hull-doors="model.metrics.hullDoors"
           />
+        </div>
+        <div class="metrics-grid__col">
+          <ModelFlightMetrics :model="model" />
         </div>
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -13,6 +13,7 @@ import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index
 import ModelDefenseMetrics from "@/frontend/components/Models/DefenseMetrics/index.vue";
 import ModelHullMetrics from "@/frontend/components/Models/HullMetrics/index.vue";
 import ModelFlightMetrics from "@/frontend/components/Models/FlightMetrics/index.vue";
+import ModelCargoMetrics from "@/frontend/components/Models/CargoMetrics/index.vue";
 import ModelPowerDistribution from "@/frontend/components/Models/PowerDistribution/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -27,6 +28,7 @@ import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
   HardpointSourceEnum,
+  type CargoHold,
   type Hardpoint,
   type Model,
 } from "@/services/fyApi";
@@ -34,9 +36,12 @@ import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
 
 type Props = {
   model: Model;
+  cargoHolds?: CargoHold[];
 };
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  cargoHolds: () => [],
+});
 
 provide(
   "modelSlug",
@@ -154,6 +159,18 @@ provide(
 const shieldStats = useShieldStats(
   () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
 );
+
+// Everything but the cargo card is derived from the game-files loadout, so the
+// ship-matrix source has nothing to show there.
+const showLoadoutMetrics = computed(
+  () =>
+    source.value === HardpointSourceEnum.GAME_FILES &&
+    (combatStats.value.hasData ||
+      shieldStats.value.hasData ||
+      !!props.model.metrics.hullHealth ||
+      !!props.model.speeds?.scmSpeed ||
+      !!props.model.speeds?.groundMaxSpeed),
+);
 </script>
 
 <template>
@@ -199,40 +216,33 @@ const shieldStats = useShieldStats(
         </BtnGroup>
       </div>
       <ModelRefuelBoom :model="model" />
-      <div
-        v-if="
-          source === HardpointSourceEnum.GAME_FILES &&
-          (combatStats.hasData ||
-            shieldStats.hasData ||
-            model.metrics.hullHealth ||
-            model.speeds?.scmSpeed ||
-            model.speeds?.groundMaxSpeed)
-        "
-        class="metrics-grid"
-      >
+      <div v-if="showLoadoutMetrics || cargoHolds.length" class="metrics-grid">
+        <template v-if="showLoadoutMetrics">
+          <div class="metrics-grid__col">
+            <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
+            <ModelPowerDistribution
+              v-model="powerOverrides"
+              v-model:mode="flightMode"
+              :hardpoints="hardpoints as Hardpoint[]"
+              :weapon-pool-size="model.metrics?.weaponPoolSize"
+              :cross-section="model.metrics?.signatureCrossSection"
+            />
+          </div>
+          <div class="metrics-grid__col">
+            <ModelDefenseMetrics
+              :hardpoints="hardpoints as Hardpoint[]"
+              :model-name="model.name"
+            />
+            <ModelHullMetrics
+              :hull-health="model.metrics.hullHealth"
+              :hull-parts="model.metrics.hullParts"
+              :hull-doors="model.metrics.hullDoors"
+            />
+          </div>
+        </template>
         <div class="metrics-grid__col">
-          <ModelCombatMetrics :hardpoints="hardpoints as Hardpoint[]" />
-          <ModelPowerDistribution
-            v-model="powerOverrides"
-            v-model:mode="flightMode"
-            :hardpoints="hardpoints as Hardpoint[]"
-            :weapon-pool-size="model.metrics?.weaponPoolSize"
-            :cross-section="model.metrics?.signatureCrossSection"
-          />
-        </div>
-        <div class="metrics-grid__col">
-          <ModelDefenseMetrics
-            :hardpoints="hardpoints as Hardpoint[]"
-            :model-name="model.name"
-          />
-          <ModelHullMetrics
-            :hull-health="model.metrics.hullHealth"
-            :hull-parts="model.metrics.hullParts"
-            :hull-doors="model.metrics.hullDoors"
-          />
-        </div>
-        <div class="metrics-grid__col">
-          <ModelFlightMetrics :model="model" />
+          <ModelFlightMetrics v-if="showLoadoutMetrics" :model="model" />
+          <ModelCargoMetrics :model="model" :cargo-holds="cargoHolds" />
         </div>
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -118,6 +118,10 @@ provide(
   computed(() => props.model.metrics?.weaponPoolSize),
 );
 
+// The user's pip choices, so the Combat card totals recompute from the same
+// distribution the control shows.
+provide("powerOverrides", powerOverrides);
+
 // The loadout-wide weapon-power throttle, so per-weapon rows show the same
 // sustained factor the Combat card totals from.
 provide(

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -16,6 +16,7 @@ import ModelFlightMetrics from "@/frontend/components/Models/FlightMetrics/index
 import ModelCargoMetrics from "@/frontend/components/Models/CargoMetrics/index.vue";
 import ModelPowerDistribution from "@/frontend/components/Models/PowerDistribution/index.vue";
 import ModelRefuelBoom from "@/frontend/components/Models/RefuelBoom/index.vue";
+import ModelExternalFuelTanks from "@/frontend/components/Models/ExternalFuelTanks/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useLoadoutStats } from "@/frontend/composables/useLoadoutStats";
 import {
@@ -215,7 +216,6 @@ const showMetrics = computed(
           </Btn>
         </BtnGroup>
       </div>
-      <ModelRefuelBoom v-if="showMetrics" :model="model" />
       <div v-if="showMetrics" class="metrics-grid">
         <div class="metrics-grid__col">
           <ModelCombatMetrics
@@ -246,6 +246,8 @@ const showMetrics = computed(
         <div class="metrics-grid__col">
           <ModelFlightMetrics :model="model" />
           <ModelCargoMetrics :model="model" :cargo-holds="cargoHolds" />
+          <ModelExternalFuelTanks :model="model" />
+          <ModelRefuelBoom :model="model" />
         </div>
       </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">

--- a/app/frontend/frontend/components/Models/MetricsCard/index.vue
+++ b/app/frontend/frontend/components/Models/MetricsCard/index.vue
@@ -5,13 +5,17 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import SmallLoader from "@/shared/components/SmallLoader/index.vue";
+
 type Props = {
   title: string;
   variant?: "default" | "slim";
+  loading?: boolean;
 };
 
 withDefaults(defineProps<Props>(), {
   variant: "default",
+  loading: false,
 });
 </script>
 
@@ -22,6 +26,7 @@ withDefaults(defineProps<Props>(), {
         <span class="metrics-card__dot" />
         {{ title }}
       </span>
+      <SmallLoader :loading="loading" alignment="right" />
       <slot name="head" />
     </div>
     <div class="metrics-card__body">
@@ -59,7 +64,17 @@ withDefaults(defineProps<Props>(), {
   bottom: -2px;
 }
 
+// Relative so a slotted loader is contained to the header strip rather than
+// spanning (and overlapping) the whole card. Laid out as a row so `head` slot
+// content sits opposite the title; the loader is absolute, so it stays out of
+// the flow and an empty slot leaves the title as the only child.
 .metrics-card__head {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
   padding: 16px 18px 12px;
 }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -17,6 +17,14 @@ import {
   type FlightMode,
   type PowerFamily,
 } from "@/frontend/composables/powerSim";
+import weaponsIconUrl from "@/images/hardpoints/weapons.svg";
+import shieldGeneratorsIconUrl from "@/images/hardpoints/shield_generators.svg";
+import coolersIconUrl from "@/images/hardpoints/coolers.svg";
+import radarIconUrl from "@/images/hardpoints/radar.svg";
+import quantumDrivesIconUrl from "@/images/hardpoints/quantum_drives.svg";
+import qedIconUrl from "@/images/hardpoints/qed.svg";
+import empIconUrl from "@/images/hardpoints/emp.svg";
+import mainThrustersIconUrl from "@/images/hardpoints/main_thrusters.svg";
 
 type Props = {
   hardpoints?: Hardpoint[];
@@ -39,7 +47,19 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-// Short column labels (erkul-style compact glyphs under each pip bar).
+// The hardpoint icon per family (engine falls back to the thruster glyph); a
+// short text label covers families without a dedicated icon.
+const FAMILY_ICON: Partial<Record<PowerFamily, string>> = {
+  weapon: weaponsIconUrl,
+  shield: shieldGeneratorsIconUrl,
+  coolers: coolersIconUrl,
+  radar: radarIconUrl,
+  qdrive: quantumDrivesIconUrl,
+  qed: qedIconUrl,
+  emp: empIconUrl,
+  engine: mainThrustersIconUrl,
+};
+
 const SHORT_LABEL: Record<PowerFamily, string> = {
   weapon: "WPN",
   engine: "ENG",
@@ -73,8 +93,10 @@ const columnLabel = (column: PowerColumn) =>
   column.label ?? t(`labels.power.families.${column.family}`);
 
 // Click pip cell at `level` (1-based, bottom-up): jump the component to that
-// level, or step it down one when clicking the current top cell.
+// level, or step it down one when clicking the current top cell. Locked
+// (all-critical) components can't be changed.
 const setLevel = (column: PowerColumn, level: number) => {
+  if (column.locked) return;
   const target = Math.max(
     0,
     Math.min(column.capacity, level === column.allocated ? level - 1 : level),
@@ -124,7 +146,10 @@ const reset = () => emit("update:modelValue", {});
         v-for="column in columns"
         :key="column.portPath"
         class="power-col"
-        :class="{ 'power-col--weapon': column.family === 'weapon' }"
+        :class="{
+          'power-col--weapon': column.family === 'weapon',
+          'power-col--locked': column.locked,
+        }"
       >
         <div class="power-col__count">{{ column.allocated }}</div>
         <div
@@ -144,12 +169,19 @@ const reset = () => emit("update:modelValue", {});
               'power-col__pip--on': level <= column.allocated,
               'power-col__pip--top': level === column.allocated,
             }"
+            :disabled="column.locked"
             :aria-label="`${columnLabel(column)}: ${level}`"
             @click="setLevel(column, level)"
           />
         </div>
         <div class="power-col__label" :title="columnLabel(column)">
-          {{ SHORT_LABEL[column.family] }}
+          <img
+            v-if="FAMILY_ICON[column.family]"
+            :src="FAMILY_ICON[column.family]"
+            :alt="columnLabel(column)"
+            class="power-col__icon"
+          />
+          <span v-else>{{ SHORT_LABEL[column.family] }}</span>
         </div>
       </div>
     </div>
@@ -282,6 +314,20 @@ const reset = () => emit("update:modelValue", {});
     letter-spacing: 0.08em;
     color: $gray;
     text-transform: uppercase;
+    height: 16px;
+    display: flex;
+    align-items: center;
+  }
+
+  &__icon {
+    width: 15px;
+    height: 15px;
+    opacity: 0.75;
+  }
+
+  &--locked &__pip {
+    pointer-events: none;
+    opacity: 0.55;
   }
 }
 </style>

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -123,10 +123,11 @@ const applyTarget = (column: PowerColumn, desired: number) => {
   emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
 };
 
-// Click pip cell at `level` (bottom-up): jump to that level, or step down one
-// when clicking the current top cell.
+// Click pip cell at `level` (bottom-up): allocate exactly that many segments —
+// click a lower pip to reduce, the same pip does nothing. (Turn fully off via
+// the icon.)
 const setLevel = (column: PowerColumn, level: number) =>
-  applyTarget(column, level === column.allocated ? level - 1 : level);
+  applyTarget(column, level);
 
 // Click the icon: drain the column to 0 if it has any pips, else fill it from
 // the pool — erkul's icon toggle.

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -547,13 +547,13 @@ const cellHeight = (span: number) =>
   &__icon {
     width: 15px;
     height: 15px;
-    opacity: 0.9;
+    opacity: 1;
   }
 
   &__fa {
     font-size: 13px;
     color: $primary;
-    opacity: 0.9;
+    opacity: 1;
   }
 
   // A column with no pips reads as "off" — dim its count and icon. A powered

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -60,6 +60,16 @@ const FAMILY_ICON: Partial<Record<PowerFamily, string>> = {
   engine: mainThrustersIconUrl,
 };
 
+// FontAwesome fallback for families without a hardpoint SVG (mirroring the
+// glyphs the Hardpoints view uses).
+const FAMILY_FA_ICON: Partial<Record<PowerFamily, string>> = {
+  lifeSupport: "fa-star-of-life",
+  salvage: "fa-bin-recycle",
+  miningLaser: "fa-gem",
+  tractorBeam: "fa-magnet",
+  towingbeam: "fa-link",
+};
+
 const SHORT_LABEL: Record<PowerFamily, string> = {
   weapon: "WPN",
   engine: "ENG",
@@ -92,25 +102,55 @@ const hasOverrides = computed(() => Object.keys(props.modelValue).length > 0);
 const columnLabel = (column: PowerColumn) =>
   column.label ?? t(`labels.power.families.${column.family}`);
 
-// Click pip cell at `level` (1-based, bottom-up): jump the component to that
-// level, or step it down one when clicking the current top cell. A component is
-// either off (0) or on at ≥ its mandatory floor, so a target below the floor
-// snaps to off (turning all-critical systems like the QD into an on/off toggle).
-const setLevel = (column: PowerColumn, level: number) => {
-  let target = level === column.allocated ? level - 1 : level;
+// Set a column toward `desired` segments, honoring the rules: a component is
+// off (0) or on at ≥ its mandatory floor, and an increase can't exceed the pips
+// available in the pool (so clicking with an empty pool does nothing).
+const applyTarget = (column: PowerColumn, desired: number) => {
+  let target = Math.max(0, Math.min(column.capacity, desired));
   if (target > 0 && target < column.min) target = 0;
-  target = Math.max(0, Math.min(column.capacity, target));
+
+  if (target > column.allocated) {
+    const available = sim.value.remaining;
+    if (column.allocated === 0) {
+      if (available < column.min) return; // can't afford to turn it on
+      target = Math.min(target, available);
+    } else {
+      target = Math.min(target, column.allocated + available);
+    }
+  }
+
+  if (target === column.allocated) return;
   emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
 };
 
-// Click the icon: drain the column to 0 if it has any pips, else fill it up
-// (bounded by the available pool) — erkul's icon toggle.
-const toggleColumn = (column: PowerColumn) => {
-  const target = column.allocated > 0 ? 0 : column.capacity;
-  emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
-};
+// Click pip cell at `level` (bottom-up): jump to that level, or step down one
+// when clicking the current top cell.
+const setLevel = (column: PowerColumn, level: number) =>
+  applyTarget(column, level === column.allocated ? level - 1 : level);
+
+// Click the icon: drain the column to 0 if it has any pips, else fill it from
+// the pool — erkul's icon toggle.
+const toggleColumn = (column: PowerColumn) =>
+  applyTarget(column, column.allocated > 0 ? 0 : column.capacity);
 
 const reset = () => emit("update:modelValue", {});
+
+// Pip cells for a column: the mandatory floor renders as one taller block, then
+// each optional segment as its own cell. `level` is the allocation this cell
+// represents (its top).
+const cells = (column: PowerColumn) => {
+  const list: { level: number; span: number }[] = [];
+  if (column.min > 0) list.push({ level: column.min, span: column.min });
+  for (let level = column.min + 1; level <= column.capacity; level += 1) {
+    list.push({ level, span: 1 });
+  }
+  return list;
+};
+
+const PIP_HEIGHT = 9;
+const PIP_GAP = 2;
+const cellHeight = (span: number) =>
+  `${span * PIP_HEIGHT + (span - 1) * PIP_GAP}px`;
 </script>
 
 <template>
@@ -167,16 +207,18 @@ const reset = () => emit("update:modelValue", {});
           :aria-valuemax="column.capacity"
         >
           <button
-            v-for="level in column.capacity"
-            :key="level"
+            v-for="cell in cells(column)"
+            :key="cell.level"
             type="button"
             class="power-col__pip"
             :class="{
-              'power-col__pip--on': level <= column.allocated,
-              'power-col__pip--top': level === column.allocated,
+              'power-col__pip--on': cell.level <= column.allocated,
+              'power-col__pip--top': cell.level === column.allocated,
+              'power-col__pip--block': cell.span > 1,
             }"
-            :aria-label="`${columnLabel(column)}: ${level}`"
-            @click="setLevel(column, level)"
+            :style="{ height: cellHeight(cell.span) }"
+            :aria-label="`${columnLabel(column)}: ${cell.level}`"
+            @click="setLevel(column, cell.level)"
           />
         </div>
         <button
@@ -191,6 +233,11 @@ const reset = () => emit("update:modelValue", {});
             :src="FAMILY_ICON[column.family]"
             :alt="columnLabel(column)"
             class="power-col__icon"
+          />
+          <i
+            v-else-if="FAMILY_FA_ICON[column.family]"
+            class="fa-duotone power-col__fa"
+            :class="FAMILY_FA_ICON[column.family]"
           />
           <span v-else>{{ SHORT_LABEL[column.family] }}</span>
         </button>
@@ -338,6 +385,12 @@ const reset = () => emit("update:modelValue", {});
     width: 15px;
     height: 15px;
     opacity: 0.75;
+  }
+
+  &__fa {
+    font-size: 13px;
+    color: $gray;
+    opacity: 0.85;
   }
 
   // A column with no pips reads as "off" — dim its count and icon.

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -10,10 +10,10 @@ import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useLoadoutSim,
-  type FamilyOverrides,
+  type PortOverrides,
+  type PowerColumn,
 } from "@/frontend/composables/useLoadoutSim";
 import {
-  POWER_FAMILIES,
   type FlightMode,
   type PowerFamily,
 } from "@/frontend/composables/powerSim";
@@ -21,7 +21,7 @@ import {
 type Props = {
   hardpoints?: Hardpoint[];
   weaponPoolSize?: number;
-  modelValue?: FamilyOverrides;
+  modelValue?: PortOverrides;
   mode?: FlightMode;
 };
 
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-  "update:modelValue": [value: FamilyOverrides];
+  "update:modelValue": [value: PortOverrides];
   "update:mode": [value: FlightMode];
 }>();
 
@@ -63,34 +63,23 @@ const sim = useLoadoutSim(
   () => props.modelValue,
 );
 
-const families = computed(() =>
-  POWER_FAMILIES.filter((family) => sim.value.familyCapacity[family] > 0).map(
-    (family) => ({
-      family,
-      label: t(`labels.power.families.${family}`),
-      short: SHORT_LABEL[family],
-      allocated: sim.value.perFamily[family],
-      capacity: sim.value.familyCapacity[family],
-    }),
-  ),
-);
-
+const columns = computed(() => sim.value.columns);
 const usedSegments = computed(
   () => sim.value.totalSegments - sim.value.remaining,
 );
-
 const hasOverrides = computed(() => Object.keys(props.modelValue).length > 0);
 
-// Click pip cell at `level` (1-based, bottom-up): jump the family to that level,
-// or step it down one when clicking the current top cell (so weapons can reach 0).
-const setLevel = (family: PowerFamily, level: number) => {
-  const current = sim.value.perFamily[family];
-  const capacity = sim.value.familyCapacity[family];
+const columnLabel = (column: PowerColumn) =>
+  column.label ?? t(`labels.power.families.${column.family}`);
+
+// Click pip cell at `level` (1-based, bottom-up): jump the component to that
+// level, or step it down one when clicking the current top cell.
+const setLevel = (column: PowerColumn, level: number) => {
   const target = Math.max(
     0,
-    Math.min(capacity, level === current ? level - 1 : level),
+    Math.min(column.capacity, level === column.allocated ? level - 1 : level),
   );
-  emit("update:modelValue", { ...props.modelValue, [family]: target });
+  emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
 };
 
 const reset = () => emit("update:modelValue", {});
@@ -98,7 +87,7 @@ const reset = () => emit("update:modelValue", {});
 
 <template>
   <MetricsCard
-    v-if="families.length && sim.totalSegments > 0"
+    v-if="columns.length && sim.totalSegments > 0"
     :title="t('labels.power.title')"
     class="power-panel"
   >
@@ -132,35 +121,35 @@ const reset = () => emit("update:modelValue", {});
 
     <div class="power-bars">
       <div
-        v-for="entry in families"
-        :key="entry.family"
+        v-for="column in columns"
+        :key="column.portPath"
         class="power-col"
-        :class="{ 'power-col--weapon': entry.family === 'weapon' }"
+        :class="{ 'power-col--weapon': column.family === 'weapon' }"
       >
-        <div class="power-col__count">{{ entry.allocated }}</div>
+        <div class="power-col__count">{{ column.allocated }}</div>
         <div
           class="power-col__stack"
           role="slider"
-          :aria-label="entry.label"
-          :aria-valuenow="entry.allocated"
+          :aria-label="columnLabel(column)"
+          :aria-valuenow="column.allocated"
           :aria-valuemin="0"
-          :aria-valuemax="entry.capacity"
+          :aria-valuemax="column.capacity"
         >
           <button
-            v-for="level in entry.capacity"
+            v-for="level in column.capacity"
             :key="level"
             type="button"
             class="power-col__pip"
             :class="{
-              'power-col__pip--on': level <= entry.allocated,
-              'power-col__pip--top': level === entry.allocated,
+              'power-col__pip--on': level <= column.allocated,
+              'power-col__pip--top': level === column.allocated,
             }"
-            :aria-label="`${entry.label}: ${level}`"
-            @click="setLevel(entry.family, level)"
+            :aria-label="`${columnLabel(column)}: ${level}`"
+            @click="setLevel(column, level)"
           />
         </div>
-        <div class="power-col__label" :title="entry.label">
-          {{ entry.short }}
+        <div class="power-col__label" :title="columnLabel(column)">
+          {{ SHORT_LABEL[column.family] }}
         </div>
       </div>
     </div>
@@ -229,8 +218,8 @@ const reset = () => emit("update:modelValue", {});
 .power-bars {
   display: flex;
   align-items: flex-end;
-  justify-content: space-between;
-  gap: 8px;
+  justify-content: flex-start;
+  gap: 6px;
   min-height: 180px;
   overflow-x: auto;
 }
@@ -239,8 +228,8 @@ const reset = () => emit("update:modelValue", {});
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 0;
-  min-width: 34px;
+  flex: 0 0 auto;
+  min-width: 30px;
   gap: 6px;
 
   &__count {
@@ -254,8 +243,7 @@ const reset = () => emit("update:modelValue", {});
     display: flex;
     flex-direction: column-reverse;
     gap: 2px;
-    width: 100%;
-    max-width: 40px;
+    width: 26px;
   }
 
   &__pip {

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -1,0 +1,303 @@
+<script lang="ts">
+export default {
+  name: "ModelPowerDistribution",
+};
+</script>
+
+<script lang="ts" setup>
+import type { Hardpoint } from "@/services/fyApi";
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useLoadoutSim,
+  type FamilyOverrides,
+} from "@/frontend/composables/useLoadoutSim";
+import {
+  POWER_FAMILIES,
+  type FlightMode,
+  type PowerFamily,
+} from "@/frontend/composables/powerSim";
+
+type Props = {
+  hardpoints?: Hardpoint[];
+  weaponPoolSize?: number;
+  modelValue?: FamilyOverrides;
+  mode?: FlightMode;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  hardpoints: () => [],
+  weaponPoolSize: undefined,
+  modelValue: () => ({}),
+  mode: "SCM",
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [value: FamilyOverrides];
+  "update:mode": [value: FlightMode];
+}>();
+
+const { t } = useI18n();
+
+const sim = useLoadoutSim(
+  () => props.hardpoints,
+  () => props.weaponPoolSize,
+  () => props.mode,
+  () => props.modelValue,
+);
+
+const families = computed(() =>
+  POWER_FAMILIES.filter((family) => sim.value.familyCapacity[family] > 0).map(
+    (family) => ({
+      family,
+      label: t(`labels.power.families.${family}`),
+      allocated: sim.value.perFamily[family],
+      capacity: sim.value.familyCapacity[family],
+    }),
+  ),
+);
+
+const usedSegments = computed(
+  () => sim.value.totalSegments - sim.value.remaining,
+);
+
+const hasOverrides = computed(() => Object.keys(props.modelValue).length > 0);
+
+const setTarget = (family: PowerFamily, target: number) => {
+  const capacity = sim.value.familyCapacity[family];
+  const clamped = Math.max(0, Math.min(capacity, target));
+  emit("update:modelValue", { ...props.modelValue, [family]: clamped });
+};
+
+const step = (family: PowerFamily, delta: number) => {
+  setTarget(family, sim.value.perFamily[family] + delta);
+};
+
+const reset = () => emit("update:modelValue", {});
+</script>
+
+<template>
+  <MetricsCard
+    v-if="families.length && sim.totalSegments > 0"
+    :title="t('labels.power.title')"
+    class="power-panel"
+  >
+    <div class="power-panel__toolbar">
+      <div
+        class="power-panel__seg"
+        role="tablist"
+        :aria-label="t('labels.power.title')"
+      >
+        <button
+          v-for="flightMode in ['SCM', 'NAV'] as FlightMode[]"
+          :key="flightMode"
+          type="button"
+          class="power-panel__seg-btn"
+          :class="{ 'power-panel__seg-btn--active': mode === flightMode }"
+          :aria-pressed="mode === flightMode"
+          @click="emit('update:mode', flightMode)"
+        >
+          {{ t(`labels.power.${flightMode.toLowerCase()}`) }}
+        </button>
+      </div>
+      <div class="power-panel__budget">
+        {{
+          t("labels.power.segmentsUsed", {
+            used: usedSegments,
+            total: sim.totalSegments,
+          })
+        }}
+      </div>
+    </div>
+
+    <ul class="power-panel__families">
+      <li
+        v-for="entry in families"
+        :key="entry.family"
+        class="power-family"
+        :class="{ 'power-family--weapon': entry.family === 'weapon' }"
+      >
+        <div class="power-family__head">
+          <span class="power-family__label">{{ entry.label }}</span>
+          <span class="power-family__count">
+            {{ entry.allocated
+            }}<span class="power-family__count-max">/{{ entry.capacity }}</span>
+          </span>
+        </div>
+        <div class="power-family__control">
+          <button
+            type="button"
+            class="power-family__step"
+            :disabled="entry.allocated <= 0"
+            :aria-label="`- ${entry.label}`"
+            @click="step(entry.family, -1)"
+          >
+            −
+          </button>
+          <div
+            class="power-family__bar"
+            role="progressbar"
+            :aria-valuenow="entry.allocated"
+            :aria-valuemax="entry.capacity"
+          >
+            <span
+              v-for="n in entry.capacity"
+              :key="n"
+              class="power-family__pip"
+              :class="{ 'power-family__pip--on': n <= entry.allocated }"
+            />
+          </div>
+          <button
+            type="button"
+            class="power-family__step"
+            :disabled="entry.allocated >= entry.capacity"
+            :aria-label="`+ ${entry.label}`"
+            @click="step(entry.family, 1)"
+          >
+            +
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <div class="metrics-card__actions">
+      <button
+        type="button"
+        class="metrics-card__toggle"
+        :disabled="!hasOverrides"
+        @click="reset"
+      >
+        {{ t("labels.power.reset") }}
+      </button>
+    </div>
+
+    <div class="metrics-card__footer">
+      <span class="metrics-card__hint">{{ t("labels.power.hint") }}</span>
+    </div>
+  </MetricsCard>
+</template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+.power-panel {
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  &__seg {
+    display: inline-flex;
+    border: 1px solid rgba($gray-light, 0.28);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  &__seg-btn {
+    padding: 5px 14px;
+    background: transparent;
+    border: 0;
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray;
+    cursor: pointer;
+
+    &--active {
+      background: rgba($primary, 0.18);
+      color: $text-color;
+    }
+  }
+
+  &__budget {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: $gray;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__families {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+}
+
+.power-family {
+  &__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 5px;
+  }
+
+  &__label {
+    font-size: 12px;
+    color: lighten($text-color, 15%);
+  }
+
+  &__count {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: $text-color;
+  }
+
+  &__count-max {
+    color: $gray;
+  }
+
+  &__control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__step {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    border: 1px solid rgba($gray-light, 0.28);
+    border-radius: 4px;
+    background: transparent;
+    color: $text-color;
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.35;
+      cursor: default;
+    }
+  }
+
+  &__bar {
+    flex: 1 1 auto;
+    display: flex;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__pip {
+    flex: 1 1 0;
+    height: 10px;
+    border-radius: 2px;
+    background: rgba($gray-light, 0.22);
+    transition: background 0.12s ease;
+
+    &--on {
+      background: rgba($primary, 0.55);
+    }
+  }
+
+  &--weapon .power-family__pip--on {
+    background: rgba(#fa6800, 0.7);
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -123,7 +123,7 @@ const memberLabel = (column: PowerColumn, member: PowerColumnMember) =>
 // and an increase can't exceed the pips available in the pool (so clicking with
 // an empty pool does nothing).
 const applyTarget = (member: PowerColumnMember, desired: number) => {
-  let target = Math.max(0, Math.min(member.capacity, desired));
+  let target = Math.max(0, Math.min(member.fillable, desired));
   if (target > 0 && target < member.min) target = 0;
 
   if (target > member.allocated) {
@@ -148,8 +148,9 @@ const onCellClick = (
   member: PowerColumnMember,
   level: number,
 ) => {
+  if (level > member.fillable) return; // headroom slot — not fillable
   if (column.members.length > 1 && level === member.min) {
-    applyTarget(member, member.allocated > 0 ? 0 : member.capacity);
+    applyTarget(member, member.allocated > 0 ? 0 : member.fillable);
   } else {
     applyTarget(member, level);
   }
@@ -161,7 +162,7 @@ const toggleColumn = (column: PowerColumn) => {
   const anyOn = column.members.some((member) => member.allocated > 0);
   const next: PortOverrides = { ...props.modelValue };
   for (const member of column.members) {
-    next[member.portPath] = anyOn ? 0 : member.capacity;
+    next[member.portPath] = anyOn ? 0 : member.fillable;
   }
   emit("update:modelValue", next);
 };
@@ -174,6 +175,7 @@ const reset = () => emit("update:modelValue", {});
 const hoveredPort = ref<string | null>(null);
 const hoveredLevel = ref(0);
 const onPipHover = (member: PowerColumnMember, level: number) => {
+  if (level > member.fillable) return; // don't preview unfillable headroom
   hoveredPort.value = member.portPath;
   hoveredLevel.value = level;
 };
@@ -260,7 +262,9 @@ const cellHeight = (span: number) =>
           'power-col--off': column.allocated === 0,
         }"
       >
-        <div class="power-col__count">{{ column.allocated }}</div>
+        <div class="power-col__count">
+          {{ column.allocated }} / {{ column.capacity }}
+        </div>
         <div
           class="power-col__stack"
           role="group"
@@ -285,6 +289,7 @@ const cellHeight = (span: number) =>
                 'power-col__pip--top': cell.level === shownLevel(member),
                 'power-col__pip--block': cell.span > 1,
                 'power-col__pip--preview': hoveredPort === member.portPath,
+                'power-col__pip--headroom': cell.level > member.fillable,
                 'power-col__pip--memberoff':
                   column.members.length > 1 && member.allocated === 0,
               }"
@@ -490,6 +495,13 @@ const cellHeight = (span: number) =>
     &--memberoff {
       background: rgba($gray-light, 0.1);
     }
+
+    // Weapon-pool headroom: shown for scale but not fillable.
+    &--headroom {
+      background: transparent;
+      border: 1px solid rgba($gray-light, 0.16);
+      cursor: not-allowed;
+    }
   }
 
   // erkul-style count inside a merged (span > 1) block.
@@ -540,7 +552,7 @@ const cellHeight = (span: number) =>
 
   &__fa {
     font-size: 13px;
-    color: $text-color;
+    color: $primary;
     opacity: 0.9;
   }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -136,6 +136,21 @@ const toggleColumn = (column: PowerColumn) =>
 
 const reset = () => emit("update:modelValue", {});
 
+// Hover preview: while hovering a pip, the column renders as if allocated to the
+// hovered level (fills up going higher, empties going lower) so the click result
+// is visible before committing.
+const hoveredPort = ref<string | null>(null);
+const hoveredLevel = ref(0);
+const onPipHover = (column: PowerColumn, level: number) => {
+  hoveredPort.value = column.portPath;
+  hoveredLevel.value = level;
+};
+const clearHover = () => {
+  hoveredPort.value = null;
+};
+const shownLevel = (column: PowerColumn) =>
+  hoveredPort.value === column.portPath ? hoveredLevel.value : column.allocated;
+
 // Pip cells for a column: the mandatory floor renders as one taller block, then
 // each optional segment as its own cell. `level` is the allocation this cell
 // represents (its top).
@@ -213,12 +228,17 @@ const cellHeight = (span: number) =>
             type="button"
             class="power-col__pip"
             :class="{
-              'power-col__pip--on': cell.level <= column.allocated,
-              'power-col__pip--top': cell.level === column.allocated,
+              'power-col__pip--on': cell.level <= shownLevel(column),
+              'power-col__pip--top': cell.level === shownLevel(column),
               'power-col__pip--block': cell.span > 1,
+              'power-col__pip--preview': hoveredPort === column.portPath,
             }"
             :style="{ height: cellHeight(cell.span) }"
             :aria-label="`${columnLabel(column)}: ${cell.level}`"
+            @mouseenter="onPipHover(column, cell.level)"
+            @focus="onPipHover(column, cell.level)"
+            @mouseleave="clearHover"
+            @blur="clearHover"
             @click="setLevel(column, cell.level)"
           />
         </div>
@@ -346,7 +366,8 @@ const cellHeight = (span: number) =>
     padding: 0;
     transition: background 0.1s ease;
 
-    &:hover {
+    // Ordered so on/top override the preview tint (later rule wins).
+    &--preview {
       background: rgba($gray-light, 0.32);
     }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
   "update:mode": [value: FlightMode];
 }>();
 
-const { t } = useI18n();
+const { t, toNumber } = useI18n();
 
 // The hardpoint icon per family (engine falls back to the thruster glyph); a
 // short text label covers families without a dedicated icon.
@@ -98,6 +98,14 @@ const usedSegments = computed(
   () => sim.value.totalSegments - sim.value.remaining,
 );
 const hasOverrides = computed(() => Object.keys(props.modelValue).length > 0);
+
+// Aim-assist readout for the power pane: effective range + how full it is
+// relative to the radar's max (grows as the radar gets more power).
+const aimAssistPercent = computed(() =>
+  sim.value.aimAssistMax > 0
+    ? Math.round((sim.value.aimAssist / sim.value.aimAssistMax) * 100)
+    : 0,
+);
 
 const columnLabel = (column: PowerColumn) =>
   column.label ?? t(`labels.power.families.${column.family}`);
@@ -201,6 +209,21 @@ const cellHeight = (span: number) =>
           })
         }}
       </div>
+    </div>
+
+    <div v-if="sim.aimAssistMax > 0" class="power-readout">
+      <span class="power-readout__label">{{
+        t("labels.power.aimAssist")
+      }}</span>
+      <div class="power-readout__track">
+        <div
+          class="power-readout__fill"
+          :style="{ width: `${aimAssistPercent}%` }"
+        />
+      </div>
+      <span class="power-readout__value">
+        {{ sim.aimAssist ? toNumber(sim.aimAssist, "integer") : 0 }} m
+      </span>
     </div>
 
     <div class="power-bars">
@@ -323,6 +346,46 @@ const cellHeight = (span: number) =>
     letter-spacing: 0.08em;
     color: $gray;
     font-variant-numeric: tabular-nums;
+  }
+}
+
+.power-readout {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 9.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray;
+    min-width: 76px;
+  }
+
+  &__track {
+    flex: 1;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: $gray-black;
+    border: 1px solid rgba($gray-light, 0.28);
+  }
+
+  &__fill {
+    height: 100%;
+    background: $primary;
+    border-radius: 999px;
+    transition: width 0.4s ease;
+  }
+
+  &__value {
+    font-size: 12px;
+    color: $text-color;
+    font-variant-numeric: tabular-nums;
+    min-width: 64px;
+    text-align: right;
   }
 }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -109,6 +109,14 @@ const aimAssistPercent = computed(() =>
     : 0,
 );
 
+// Cooling load: heat generated as a share of the coolant the active coolers
+// provide (erkul's coolingRatio). Can exceed 100% when the ship is under-cooled;
+// 0 with no active cooler. Only shown when the ship actually has coolers.
+const hasCoolers = computed(() => sim.value.coolingMaxPerSec > 0);
+const coolingPercent = computed(() => Math.round(sim.value.coolingRatio * 100));
+const coolingFill = computed(() => Math.min(coolingPercent.value, 100));
+const coolingOver = computed(() => coolingPercent.value > 100);
+
 const familyLabel = (family: PowerFamily) =>
   t(`labels.power.families.${family}`);
 const columnLabel = (column: PowerColumn) =>
@@ -237,6 +245,21 @@ const cellHeight = (span: number) =>
           })
         }}
       </div>
+    </div>
+
+    <div
+      v-if="hasCoolers"
+      class="power-readout"
+      :class="{ 'power-readout--over': coolingOver }"
+    >
+      <span class="power-readout__label">{{ t("labels.power.cooling") }}</span>
+      <div class="power-readout__track">
+        <div
+          class="power-readout__fill"
+          :style="{ width: `${coolingFill}%` }"
+        />
+      </div>
+      <span class="power-readout__value">{{ coolingPercent }}%</span>
     </div>
 
     <div v-if="sim.aimAssistMax > 0" class="power-readout">
@@ -431,6 +454,15 @@ const cellHeight = (span: number) =>
     font-variant-numeric: tabular-nums;
     min-width: 64px;
     text-align: right;
+  }
+
+  // Under-cooled: heat load exceeds the coolers' output.
+  &--over &__fill {
+    background: $danger;
+  }
+
+  &--over &__value {
+    color: $danger;
   }
 }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -93,14 +93,20 @@ const columnLabel = (column: PowerColumn) =>
   column.label ?? t(`labels.power.families.${column.family}`);
 
 // Click pip cell at `level` (1-based, bottom-up): jump the component to that
-// level, or step it down one when clicking the current top cell. Locked
-// (all-critical) components can't be changed.
+// level, or step it down one when clicking the current top cell. A component is
+// either off (0) or on at ≥ its mandatory floor, so a target below the floor
+// snaps to off (turning all-critical systems like the QD into an on/off toggle).
 const setLevel = (column: PowerColumn, level: number) => {
-  if (column.locked) return;
-  const target = Math.max(
-    0,
-    Math.min(column.capacity, level === column.allocated ? level - 1 : level),
-  );
+  let target = level === column.allocated ? level - 1 : level;
+  if (target > 0 && target < column.min) target = 0;
+  target = Math.max(0, Math.min(column.capacity, target));
+  emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
+};
+
+// Click the icon: drain the column to 0 if it has any pips, else fill it up
+// (bounded by the available pool) — erkul's icon toggle.
+const toggleColumn = (column: PowerColumn) => {
+  const target = column.allocated > 0 ? 0 : column.capacity;
   emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
 };
 
@@ -148,7 +154,7 @@ const reset = () => emit("update:modelValue", {});
         class="power-col"
         :class="{
           'power-col--weapon': column.family === 'weapon',
-          'power-col--locked': column.locked,
+          'power-col--off': column.allocated === 0,
         }"
       >
         <div class="power-col__count">{{ column.allocated }}</div>
@@ -169,12 +175,17 @@ const reset = () => emit("update:modelValue", {});
               'power-col__pip--on': level <= column.allocated,
               'power-col__pip--top': level === column.allocated,
             }"
-            :disabled="column.locked"
             :aria-label="`${columnLabel(column)}: ${level}`"
             @click="setLevel(column, level)"
           />
         </div>
-        <div class="power-col__label" :title="columnLabel(column)">
+        <button
+          type="button"
+          class="power-col__label"
+          :title="columnLabel(column)"
+          :aria-label="columnLabel(column)"
+          @click="toggleColumn(column)"
+        >
           <img
             v-if="FAMILY_ICON[column.family]"
             :src="FAMILY_ICON[column.family]"
@@ -182,7 +193,7 @@ const reset = () => emit("update:modelValue", {});
             class="power-col__icon"
           />
           <span v-else>{{ SHORT_LABEL[column.family] }}</span>
-        </div>
+        </button>
       </div>
     </div>
 
@@ -317,6 +328,10 @@ const reset = () => emit("update:modelValue", {});
     height: 16px;
     display: flex;
     align-items: center;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
   }
 
   &__icon {
@@ -325,9 +340,20 @@ const reset = () => emit("update:modelValue", {});
     opacity: 0.75;
   }
 
-  &--locked &__pip {
-    pointer-events: none;
-    opacity: 0.55;
+  // A column with no pips reads as "off" — dim its count and icon.
+  &--off {
+    .power-col__count {
+      color: $gray;
+      opacity: 0.5;
+    }
+
+    .power-col__icon {
+      opacity: 0.3;
+    }
+
+    .power-col__label {
+      opacity: 0.6;
+    }
   }
 }
 </style>

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -276,7 +276,7 @@ const cellHeight = (span: number) =>
 
     <div v-if="hasSignatures" class="power-sigs">
       <div class="power-sigs__item" :title="t('labels.power.ir')">
-        <i class="fa-duotone fa-fire-flame-simple power-sigs__icon" />
+        <i class="fa-duotone fa-heat power-sigs__icon" />
         <span class="power-sigs__value">{{ compact(emittedIr) }}</span>
       </div>
       <div class="power-sigs__item" :title="t('labels.power.em')">
@@ -495,7 +495,6 @@ const cellHeight = (span: number) =>
   &__icon {
     font-size: 14px;
     color: $primary;
-    opacity: 0.9;
   }
 
   &__value {

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -329,7 +329,7 @@ const cellHeight = (span: number) =>
 .power-bars {
   display: flex;
   align-items: flex-end;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 6px;
   min-height: 180px;
   overflow-x: auto;
@@ -339,7 +339,7 @@ const cellHeight = (span: number) =>
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 0 0 auto;
+  flex: 1 1 0;
   min-width: 30px;
   gap: 6px;
 
@@ -354,7 +354,8 @@ const cellHeight = (span: number) =>
     display: flex;
     flex-direction: column-reverse;
     gap: 2px;
-    width: 26px;
+    width: 100%;
+    max-width: 44px;
   }
 
   &__pip {

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -329,9 +329,10 @@ const cellHeight = (span: number) =>
 .power-bars {
   display: flex;
   align-items: flex-end;
-  justify-content: space-between;
-  gap: 6px;
-  min-height: 180px;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  min-height: 170px;
   overflow-x: auto;
 }
 
@@ -339,8 +340,8 @@ const cellHeight = (span: number) =>
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 0;
-  min-width: 30px;
+  flex: 0 0 auto;
+  width: 40px;
   gap: 6px;
 
   &__count {

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -33,6 +33,7 @@ type Props = {
   crossSection?: { x?: number; y?: number; z?: number };
   modelValue?: PortOverrides;
   mode?: FlightMode;
+  loading?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -41,6 +42,7 @@ const props = withDefaults(defineProps<Props>(), {
   crossSection: undefined,
   modelValue: () => ({}),
   mode: "SCM",
+  loading: false,
 });
 
 const emit = defineEmits<{
@@ -242,8 +244,9 @@ const cellHeight = (span: number) =>
 
 <template>
   <MetricsCard
-    v-if="columns.length && sim.totalSegments > 0"
+    v-if="loading || (columns.length && sim.totalSegments > 0)"
     :title="t('labels.power.title')"
+    :loading="loading"
     class="power-panel"
   >
     <div class="power-panel__toolbar">

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -39,6 +39,23 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
+// Short column labels (erkul-style compact glyphs under each pip bar).
+const SHORT_LABEL: Record<PowerFamily, string> = {
+  weapon: "WPN",
+  engine: "ENG",
+  shield: "SHD",
+  qdrive: "QD",
+  radar: "RAD",
+  lifeSupport: "LS",
+  coolers: "COOL",
+  qed: "QED",
+  emp: "EMP",
+  miningLaser: "MIN",
+  salvage: "SLV",
+  tractorBeam: "TRC",
+  towingbeam: "TOW",
+};
+
 const sim = useLoadoutSim(
   () => props.hardpoints,
   () => props.weaponPoolSize,
@@ -51,6 +68,7 @@ const families = computed(() =>
     (family) => ({
       family,
       label: t(`labels.power.families.${family}`),
+      short: SHORT_LABEL[family],
       allocated: sim.value.perFamily[family],
       capacity: sim.value.familyCapacity[family],
     }),
@@ -63,14 +81,16 @@ const usedSegments = computed(
 
 const hasOverrides = computed(() => Object.keys(props.modelValue).length > 0);
 
-const setTarget = (family: PowerFamily, target: number) => {
+// Click pip cell at `level` (1-based, bottom-up): jump the family to that level,
+// or step it down one when clicking the current top cell (so weapons can reach 0).
+const setLevel = (family: PowerFamily, level: number) => {
+  const current = sim.value.perFamily[family];
   const capacity = sim.value.familyCapacity[family];
-  const clamped = Math.max(0, Math.min(capacity, target));
-  emit("update:modelValue", { ...props.modelValue, [family]: clamped });
-};
-
-const step = (family: PowerFamily, delta: number) => {
-  setTarget(family, sim.value.perFamily[family] + delta);
+  const target = Math.max(
+    0,
+    Math.min(capacity, level === current ? level - 1 : level),
+  );
+  emit("update:modelValue", { ...props.modelValue, [family]: target });
 };
 
 const reset = () => emit("update:modelValue", {});
@@ -110,55 +130,40 @@ const reset = () => emit("update:modelValue", {});
       </div>
     </div>
 
-    <ul class="power-panel__families">
-      <li
+    <div class="power-bars">
+      <div
         v-for="entry in families"
         :key="entry.family"
-        class="power-family"
-        :class="{ 'power-family--weapon': entry.family === 'weapon' }"
+        class="power-col"
+        :class="{ 'power-col--weapon': entry.family === 'weapon' }"
       >
-        <div class="power-family__head">
-          <span class="power-family__label">{{ entry.label }}</span>
-          <span class="power-family__count">
-            {{ entry.allocated
-            }}<span class="power-family__count-max">/{{ entry.capacity }}</span>
-          </span>
-        </div>
-        <div class="power-family__control">
+        <div class="power-col__count">{{ entry.allocated }}</div>
+        <div
+          class="power-col__stack"
+          role="slider"
+          :aria-label="entry.label"
+          :aria-valuenow="entry.allocated"
+          :aria-valuemin="0"
+          :aria-valuemax="entry.capacity"
+        >
           <button
+            v-for="level in entry.capacity"
+            :key="level"
             type="button"
-            class="power-family__step"
-            :disabled="entry.allocated <= 0"
-            :aria-label="`- ${entry.label}`"
-            @click="step(entry.family, -1)"
-          >
-            −
-          </button>
-          <div
-            class="power-family__bar"
-            role="progressbar"
-            :aria-valuenow="entry.allocated"
-            :aria-valuemax="entry.capacity"
-          >
-            <span
-              v-for="n in entry.capacity"
-              :key="n"
-              class="power-family__pip"
-              :class="{ 'power-family__pip--on': n <= entry.allocated }"
-            />
-          </div>
-          <button
-            type="button"
-            class="power-family__step"
-            :disabled="entry.allocated >= entry.capacity"
-            :aria-label="`+ ${entry.label}`"
-            @click="step(entry.family, 1)"
-          >
-            +
-          </button>
+            class="power-col__pip"
+            :class="{
+              'power-col__pip--on': level <= entry.allocated,
+              'power-col__pip--top': level === entry.allocated,
+            }"
+            :aria-label="`${entry.label}: ${level}`"
+            @click="setLevel(entry.family, level)"
+          />
         </div>
-      </li>
-    </ul>
+        <div class="power-col__label" :title="entry.label">
+          {{ entry.short }}
+        </div>
+      </div>
+    </div>
 
     <div class="metrics-card__actions">
       <button
@@ -186,7 +191,7 @@ const reset = () => emit("update:modelValue", {});
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    margin-bottom: 16px;
+    margin-bottom: 18px;
   }
 
   &__seg {
@@ -219,85 +224,76 @@ const reset = () => emit("update:modelValue", {});
     color: $gray;
     font-variant-numeric: tabular-nums;
   }
-
-  &__families {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
 }
 
-.power-family {
-  &__head {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    margin-bottom: 5px;
-  }
+.power-bars {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 180px;
+  overflow-x: auto;
+}
 
-  &__label {
-    font-size: 12px;
-    color: lighten($text-color, 15%);
-  }
+.power-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1 1 0;
+  min-width: 34px;
+  gap: 6px;
 
   &__count {
-    font-size: 12px;
+    font-size: 13px;
     font-variant-numeric: tabular-nums;
     color: $text-color;
+    min-height: 16px;
   }
 
-  &__count-max {
-    color: $gray;
-  }
-
-  &__control {
+  &__stack {
     display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  &__step {
-    flex: 0 0 auto;
-    width: 24px;
-    height: 24px;
-    border: 1px solid rgba($gray-light, 0.28);
-    border-radius: 4px;
-    background: transparent;
-    color: $text-color;
-    font-size: 15px;
-    line-height: 1;
-    cursor: pointer;
-
-    &:disabled {
-      opacity: 0.35;
-      cursor: default;
-    }
-  }
-
-  &__bar {
-    flex: 1 1 auto;
-    display: flex;
+    flex-direction: column-reverse;
     gap: 2px;
-    min-width: 0;
+    width: 100%;
+    max-width: 40px;
   }
 
   &__pip {
-    flex: 1 1 0;
-    height: 10px;
+    height: 9px;
+    border: 0;
     border-radius: 2px;
-    background: rgba($gray-light, 0.22);
-    transition: background 0.12s ease;
+    background: rgba($gray-light, 0.18);
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.1s ease;
+
+    &:hover {
+      background: rgba($gray-light, 0.32);
+    }
 
     &--on {
-      background: rgba($primary, 0.55);
+      background: rgba($primary, 0.4);
+    }
+
+    &--top {
+      background: $primary;
     }
   }
 
-  &--weapon .power-family__pip--on {
-    background: rgba(#fa6800, 0.7);
+  &--weapon &__pip--on {
+    background: rgba(#fa6800, 0.45);
+  }
+
+  &--weapon &__pip--top {
+    background: #fa6800;
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 8.5px;
+    letter-spacing: 0.08em;
+    color: $gray;
+    text-transform: uppercase;
   }
 }
 </style>

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -140,9 +140,11 @@ const applyTarget = (member: PowerColumnMember, desired: number) => {
   emit("update:modelValue", { ...props.modelValue, [member.portPath]: target });
 };
 
-// Click a pip cell at `level` (bottom-up). In a grouped column the mandatory
-// base block of a member is its on/off toggle (erkul's "click the generator");
-// otherwise allocate exactly `level` segments to the member.
+// Click a pip cell at `level` (bottom-up). In a stacked column the merged base
+// block sets that generator/beam to its minimum, or toggles it off when it is
+// already at the minimum — so a member with headroom (e.g. 4 + 1) can still be
+// reduced to 4 or switched off without jumping straight to full. Every other
+// pip allocates exactly `level` segments to that member.
 const onCellClick = (
   column: PowerColumn,
   member: PowerColumnMember,
@@ -150,7 +152,7 @@ const onCellClick = (
 ) => {
   if (level > member.fillable) return; // headroom slot — not fillable
   if (column.members.length > 1 && level === member.min) {
-    applyTarget(member, member.allocated > 0 ? 0 : member.fillable);
+    applyTarget(member, member.allocated === member.min ? 0 : member.min);
   } else {
     applyTarget(member, level);
   }

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -30,7 +30,7 @@ import mainThrustersIconUrl from "@/images/hardpoints/main_thrusters.svg";
 type Props = {
   hardpoints?: Hardpoint[];
   weaponPoolSize?: number;
-  crossSection?: number;
+  crossSection?: { x?: number; y?: number; z?: number };
   modelValue?: PortOverrides;
   mode?: FlightMode;
 };
@@ -118,15 +118,30 @@ const coolingPercent = computed(() => Math.round(sim.value.coolingRatio * 100));
 const coolingFill = computed(() => Math.min(coolingPercent.value, 100));
 const coolingOver = computed(() => coolingPercent.value > 100);
 
-// Signature readouts (erkul's IR / CS numbers). IR is power-reactive (from the
-// active coolers); CS is the ship's fixed cross-section. Compact-formatted
-// (e.g. "9.8k") like erkul. EM is not modelled yet.
+// Signature readouts (erkul's IR / EM / CS numbers). IR + EM are power-reactive;
+// CS is the ship's fixed cross-section per axis. Compact-formatted ("9.8k").
 const compact = (value: number) =>
   value >= 1000 ? `${(value / 1000).toFixed(1)}k` : `${Math.round(value)}`;
 const emittedIr = computed(() => sim.value.emittedIr);
-const crossSection = computed(() => props.crossSection ?? 0);
+const emittedEm = computed(() => sim.value.emittedEm);
+
+// Cross-section: erkul shows one axis at a time with a clickable label to cycle
+// x → y → z. Default to the largest axis.
+const CS_AXES = ["x", "y", "z"] as const;
+type CsAxis = (typeof CS_AXES)[number];
+const csValue = (axis: CsAxis) => Math.round(props.crossSection?.[axis] ?? 0);
+const csAxis = ref<CsAxis>(
+  CS_AXES.reduce((best, axis) => (csValue(axis) > csValue(best) ? axis : best)),
+);
+const cycleCsAxis = () => {
+  csAxis.value = CS_AXES[(CS_AXES.indexOf(csAxis.value) + 1) % CS_AXES.length];
+};
+const crossSection = computed(() => csValue(csAxis.value));
+const hasCrossSection = computed(() =>
+  CS_AXES.some((axis) => csValue(axis) > 0),
+);
 const hasSignatures = computed(
-  () => emittedIr.value > 0 || crossSection.value > 0,
+  () => emittedIr.value > 0 || emittedEm.value > 0 || hasCrossSection.value,
 );
 
 const familyLabel = (family: PowerFamily) =>
@@ -260,14 +275,27 @@ const cellHeight = (span: number) =>
     </div>
 
     <div v-if="hasSignatures" class="power-sigs">
-      <div class="power-sigs__item">
-        <span class="power-sigs__label">{{ t("labels.power.ir") }}</span>
+      <div class="power-sigs__item" :title="t('labels.power.ir')">
+        <i class="fa-duotone fa-fire-flame-simple power-sigs__icon" />
         <span class="power-sigs__value">{{ compact(emittedIr) }}</span>
       </div>
-      <div v-if="crossSection > 0" class="power-sigs__item">
-        <span class="power-sigs__label">{{ t("labels.power.cs") }}</span>
-        <span class="power-sigs__value">{{ compact(crossSection) }}</span>
+      <div class="power-sigs__item" :title="t('labels.power.em')">
+        <i class="fa-duotone fa-bolt power-sigs__icon" />
+        <span class="power-sigs__value">{{ compact(emittedEm) }}</span>
       </div>
+      <button
+        v-if="hasCrossSection"
+        type="button"
+        class="power-sigs__item power-sigs__item--toggle"
+        :title="t('labels.power.csAxisHint')"
+        @click="cycleCsAxis"
+      >
+        <i class="fa-duotone fa-diamond power-sigs__icon" />
+        <span class="power-sigs__value">
+          {{ compact(crossSection) }}
+          <span class="power-sigs__axis">{{ csAxis.toUpperCase() }}</span>
+        </span>
+      </button>
     </div>
 
     <div
@@ -442,21 +470,32 @@ const cellHeight = (span: number) =>
 
 .power-sigs {
   display: flex;
-  gap: 28px;
+  justify-content: center;
+  gap: 32px;
   margin-bottom: 16px;
 
   &__item {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 8px;
+
+    &--toggle {
+      border: 0;
+      background: transparent;
+      padding: 0;
+      cursor: pointer;
+
+      &:hover .power-sigs__value,
+      &:hover .power-sigs__icon {
+        color: $primary;
+      }
+    }
   }
 
-  &__label {
-    font-family: "Orbitron", tahoma, sans-serif;
-    font-size: 9.5px;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: $gray;
+  &__icon {
+    font-size: 14px;
+    color: $primary;
+    opacity: 0.9;
   }
 
   &__value {
@@ -464,6 +503,13 @@ const cellHeight = (span: number) =>
     font-weight: 600;
     color: $text-color;
     font-variant-numeric: tabular-nums;
+  }
+
+  &__axis {
+    font-size: 10px;
+    font-weight: 600;
+    color: $gray;
+    margin-left: 2px;
   }
 }
 

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -26,11 +26,11 @@ import quantumDrivesIconUrl from "@/images/hardpoints/quantum_drives.svg";
 import qedIconUrl from "@/images/hardpoints/qed.svg";
 import empIconUrl from "@/images/hardpoints/emp.svg";
 import mainThrustersIconUrl from "@/images/hardpoints/main_thrusters.svg";
-import utilityItemsIconUrl from "@/images/hardpoints/utility_items.svg";
 
 type Props = {
   hardpoints?: Hardpoint[];
   weaponPoolSize?: number;
+  crossSection?: number;
   modelValue?: PortOverrides;
   mode?: FlightMode;
 };
@@ -38,6 +38,7 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), {
   hardpoints: () => [],
   weaponPoolSize: undefined,
+  crossSection: undefined,
   modelValue: () => ({}),
   mode: "SCM",
 });
@@ -60,16 +61,16 @@ const FAMILY_ICON: Partial<Record<PowerFamily, string>> = {
   qed: qedIconUrl,
   emp: empIconUrl,
   engine: mainThrustersIconUrl,
-  tractorBeam: utilityItemsIconUrl,
-  towingbeam: utilityItemsIconUrl,
 };
 
-// FontAwesome fallback for families without a hardpoint SVG (mirroring the
-// glyphs the Hardpoints view uses).
+// FontAwesome fallback for families without a hardpoint SVG. Life support and
+// the beams follow erkul's glyphs (a pulse heart, arrows pulling to a center).
 const FAMILY_FA_ICON: Partial<Record<PowerFamily, string>> = {
-  lifeSupport: "fa-star-of-life",
+  lifeSupport: "fa-heart-pulse",
   salvage: "fa-bin-recycle",
   miningLaser: "fa-gem",
+  tractorBeam: "fa-arrows-to-circle",
+  towingbeam: "fa-arrows-to-circle",
 };
 
 const SHORT_LABEL: Record<PowerFamily, string> = {
@@ -117,12 +118,23 @@ const coolingPercent = computed(() => Math.round(sim.value.coolingRatio * 100));
 const coolingFill = computed(() => Math.min(coolingPercent.value, 100));
 const coolingOver = computed(() => coolingPercent.value > 100);
 
+// Signature readouts (erkul's IR / CS numbers). IR is power-reactive (from the
+// active coolers); CS is the ship's fixed cross-section. Compact-formatted
+// (e.g. "9.8k") like erkul. EM is not modelled yet.
+const compact = (value: number) =>
+  value >= 1000 ? `${(value / 1000).toFixed(1)}k` : `${Math.round(value)}`;
+const emittedIr = computed(() => sim.value.emittedIr);
+const crossSection = computed(() => props.crossSection ?? 0);
+const hasSignatures = computed(
+  () => emittedIr.value > 0 || crossSection.value > 0,
+);
+
 const familyLabel = (family: PowerFamily) =>
   t(`labels.power.families.${family}`);
-const columnLabel = (column: PowerColumn) =>
-  column.members.length > 1
-    ? familyLabel(column.family)
-    : (column.label ?? familyLabel(column.family));
+// A column is identified by its family ("Shields", "Coolers", …); the mounted
+// component's own name stays on its pips, where it identifies which member of a
+// stacked column a pip belongs to.
+const columnLabel = (column: PowerColumn) => familyLabel(column.family);
 const memberLabel = (column: PowerColumn, member: PowerColumnMember) =>
   member.label ?? familyLabel(column.family);
 
@@ -244,6 +256,17 @@ const cellHeight = (span: number) =>
             total: sim.totalSegments,
           })
         }}
+      </div>
+    </div>
+
+    <div v-if="hasSignatures" class="power-sigs">
+      <div class="power-sigs__item">
+        <span class="power-sigs__label">{{ t("labels.power.ir") }}</span>
+        <span class="power-sigs__value">{{ compact(emittedIr) }}</span>
+      </div>
+      <div v-if="crossSection > 0" class="power-sigs__item">
+        <span class="power-sigs__label">{{ t("labels.power.cs") }}</span>
+        <span class="power-sigs__value">{{ compact(crossSection) }}</span>
       </div>
     </div>
 
@@ -417,6 +440,33 @@ const cellHeight = (span: number) =>
   }
 }
 
+.power-sigs {
+  display: flex;
+  gap: 28px;
+  margin-bottom: 16px;
+
+  &__item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  &__label {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 9.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray;
+  }
+
+  &__value {
+    font-size: 15px;
+    font-weight: 600;
+    color: $text-color;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
 .power-readout {
   display: flex;
   align-items: center;
@@ -466,6 +516,9 @@ const cellHeight = (span: number) =>
   }
 }
 
+// The columns wrap, so the row never needs to scroll — and an `overflow-x`
+// scroll container here also turns overflow-y into `auto`, which put scrollbars
+// on the pane as soon as a ship had enough columns to wrap.
 .power-bars {
   display: flex;
   align-items: flex-end;
@@ -473,7 +526,6 @@ const cellHeight = (span: number) =>
   flex-wrap: wrap;
   gap: 14px 10px;
   min-height: 170px;
-  overflow-x: auto;
 }
 
 .power-col {
@@ -584,8 +636,11 @@ const cellHeight = (span: number) =>
     opacity: 1;
   }
 
+  // FA glyphs only fill ~0.875em of their line box, so they need a larger font
+  // size than the SVG icons' 15px to read at the same weight next to them.
   &__fa {
-    font-size: 13px;
+    font-size: 17px;
+    line-height: 15px;
     color: $primary;
     opacity: 1;
   }

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -12,6 +12,7 @@ import {
   useLoadoutSim,
   type PortOverrides,
   type PowerColumn,
+  type PowerColumnMember,
 } from "@/frontend/composables/useLoadoutSim";
 import {
   type FlightMode,
@@ -25,6 +26,7 @@ import quantumDrivesIconUrl from "@/images/hardpoints/quantum_drives.svg";
 import qedIconUrl from "@/images/hardpoints/qed.svg";
 import empIconUrl from "@/images/hardpoints/emp.svg";
 import mainThrustersIconUrl from "@/images/hardpoints/main_thrusters.svg";
+import utilityItemsIconUrl from "@/images/hardpoints/utility_items.svg";
 
 type Props = {
   hardpoints?: Hardpoint[];
@@ -58,6 +60,8 @@ const FAMILY_ICON: Partial<Record<PowerFamily, string>> = {
   qed: qedIconUrl,
   emp: empIconUrl,
   engine: mainThrustersIconUrl,
+  tractorBeam: utilityItemsIconUrl,
+  towingbeam: utilityItemsIconUrl,
 };
 
 // FontAwesome fallback for families without a hardpoint SVG (mirroring the
@@ -66,8 +70,6 @@ const FAMILY_FA_ICON: Partial<Record<PowerFamily, string>> = {
   lifeSupport: "fa-star-of-life",
   salvage: "fa-bin-recycle",
   miningLaser: "fa-gem",
-  tractorBeam: "fa-magnet",
-  towingbeam: "fa-link",
 };
 
 const SHORT_LABEL: Record<PowerFamily, string> = {
@@ -107,65 +109,87 @@ const aimAssistPercent = computed(() =>
     : 0,
 );
 
+const familyLabel = (family: PowerFamily) =>
+  t(`labels.power.families.${family}`);
 const columnLabel = (column: PowerColumn) =>
-  column.label ?? t(`labels.power.families.${column.family}`);
+  column.members.length > 1
+    ? familyLabel(column.family)
+    : (column.label ?? familyLabel(column.family));
+const memberLabel = (column: PowerColumn, member: PowerColumnMember) =>
+  member.label ?? familyLabel(column.family);
 
-// Set a column toward `desired` segments, honoring the rules: a component is
-// off (0) or on at ≥ its mandatory floor, and an increase can't exceed the pips
-// available in the pool (so clicking with an empty pool does nothing).
-const applyTarget = (column: PowerColumn, desired: number) => {
-  let target = Math.max(0, Math.min(column.capacity, desired));
-  if (target > 0 && target < column.min) target = 0;
+// Set a member (a single component or the weapon pool) toward `desired`
+// segments, honoring the rules: it is off (0) or on at ≥ its mandatory floor,
+// and an increase can't exceed the pips available in the pool (so clicking with
+// an empty pool does nothing).
+const applyTarget = (member: PowerColumnMember, desired: number) => {
+  let target = Math.max(0, Math.min(member.capacity, desired));
+  if (target > 0 && target < member.min) target = 0;
 
-  if (target > column.allocated) {
+  if (target > member.allocated) {
     const available = sim.value.remaining;
-    if (column.allocated === 0) {
-      if (available < column.min) return; // can't afford to turn it on
+    if (member.allocated === 0) {
+      if (available < member.min) return; // can't afford to turn it on
       target = Math.min(target, available);
     } else {
-      target = Math.min(target, column.allocated + available);
+      target = Math.min(target, member.allocated + available);
     }
   }
 
-  if (target === column.allocated) return;
-  emit("update:modelValue", { ...props.modelValue, [column.portPath]: target });
+  if (target === member.allocated) return;
+  emit("update:modelValue", { ...props.modelValue, [member.portPath]: target });
 };
 
-// Click pip cell at `level` (bottom-up): allocate exactly that many segments —
-// click a lower pip to reduce, the same pip does nothing. (Turn fully off via
-// the icon.)
-const setLevel = (column: PowerColumn, level: number) =>
-  applyTarget(column, level);
+// Click a pip cell at `level` (bottom-up). In a grouped column the mandatory
+// base block of a member is its on/off toggle (erkul's "click the generator");
+// otherwise allocate exactly `level` segments to the member.
+const onCellClick = (
+  column: PowerColumn,
+  member: PowerColumnMember,
+  level: number,
+) => {
+  if (column.members.length > 1 && level === member.min) {
+    applyTarget(member, member.allocated > 0 ? 0 : member.capacity);
+  } else {
+    applyTarget(member, level);
+  }
+};
 
-// Click the icon: drain the column to 0 if it has any pips, else fill it from
-// the pool — erkul's icon toggle.
-const toggleColumn = (column: PowerColumn) =>
-  applyTarget(column, column.allocated > 0 ? 0 : column.capacity);
+// Click the icon: drain the whole column to 0 if any member has pips, else fill
+// every member from the pool — erkul's icon toggle.
+const toggleColumn = (column: PowerColumn) => {
+  const anyOn = column.members.some((member) => member.allocated > 0);
+  const next: PortOverrides = { ...props.modelValue };
+  for (const member of column.members) {
+    next[member.portPath] = anyOn ? 0 : member.capacity;
+  }
+  emit("update:modelValue", next);
+};
 
 const reset = () => emit("update:modelValue", {});
 
-// Hover preview: while hovering a pip, the column renders as if allocated to the
+// Hover preview: while hovering a pip, the member renders as if allocated to the
 // hovered level (fills up going higher, empties going lower) so the click result
 // is visible before committing.
 const hoveredPort = ref<string | null>(null);
 const hoveredLevel = ref(0);
-const onPipHover = (column: PowerColumn, level: number) => {
-  hoveredPort.value = column.portPath;
+const onPipHover = (member: PowerColumnMember, level: number) => {
+  hoveredPort.value = member.portPath;
   hoveredLevel.value = level;
 };
 const clearHover = () => {
   hoveredPort.value = null;
 };
-const shownLevel = (column: PowerColumn) =>
-  hoveredPort.value === column.portPath ? hoveredLevel.value : column.allocated;
+const shownLevel = (member: PowerColumnMember) =>
+  hoveredPort.value === member.portPath ? hoveredLevel.value : member.allocated;
 
-// Pip cells for a column: the mandatory floor renders as one taller block, then
+// Pip cells for a member: the mandatory floor renders as one taller block, then
 // each optional segment as its own cell. `level` is the allocation this cell
 // represents (its top).
-const cells = (column: PowerColumn) => {
+const cells = (member: PowerColumnMember) => {
   const list: { level: number; span: number }[] = [];
-  if (column.min > 0) list.push({ level: column.min, span: column.min });
-  for (let level = column.min + 1; level <= column.capacity; level += 1) {
+  if (member.min > 0) list.push({ level: member.min, span: member.min });
+  for (let level = member.min + 1; level <= member.capacity; level += 1) {
     list.push({ level, span: 1 });
   }
   return list;
@@ -239,31 +263,45 @@ const cellHeight = (span: number) =>
         <div class="power-col__count">{{ column.allocated }}</div>
         <div
           class="power-col__stack"
-          role="slider"
+          role="group"
           :aria-label="columnLabel(column)"
-          :aria-valuenow="column.allocated"
-          :aria-valuemin="0"
-          :aria-valuemax="column.capacity"
         >
-          <button
-            v-for="cell in cells(column)"
-            :key="cell.level"
-            type="button"
-            class="power-col__pip"
-            :class="{
-              'power-col__pip--on': cell.level <= shownLevel(column),
-              'power-col__pip--top': cell.level === shownLevel(column),
-              'power-col__pip--block': cell.span > 1,
-              'power-col__pip--preview': hoveredPort === column.portPath,
-            }"
-            :style="{ height: cellHeight(cell.span) }"
-            :aria-label="`${columnLabel(column)}: ${cell.level}`"
-            @mouseenter="onPipHover(column, cell.level)"
-            @focus="onPipHover(column, cell.level)"
-            @mouseleave="clearHover"
-            @blur="clearHover"
-            @click="setLevel(column, cell.level)"
-          />
+          <template
+            v-for="(member, memberIndex) in column.members"
+            :key="member.portPath"
+          >
+            <div
+              v-if="memberIndex > 0"
+              class="power-col__divider"
+              aria-hidden="true"
+            />
+            <button
+              v-for="cell in cells(member)"
+              :key="`${member.portPath}-${cell.level}`"
+              type="button"
+              class="power-col__pip"
+              :class="{
+                'power-col__pip--on': cell.level <= shownLevel(member),
+                'power-col__pip--top': cell.level === shownLevel(member),
+                'power-col__pip--block': cell.span > 1,
+                'power-col__pip--preview': hoveredPort === member.portPath,
+                'power-col__pip--memberoff':
+                  column.members.length > 1 && member.allocated === 0,
+              }"
+              :style="{ height: cellHeight(cell.span) }"
+              :title="memberLabel(column, member)"
+              :aria-label="`${memberLabel(column, member)}: ${cell.level}`"
+              @mouseenter="onPipHover(member, cell.level)"
+              @focus="onPipHover(member, cell.level)"
+              @mouseleave="clearHover"
+              @blur="clearHover"
+              @click="onCellClick(column, member, cell.level)"
+            >
+              <span v-if="cell.span > 1" class="power-col__pip-label">{{
+                cell.span
+              }}</span>
+            </button>
+          </template>
         </div>
         <button
           type="button"
@@ -392,9 +430,9 @@ const cellHeight = (span: number) =>
 .power-bars {
   display: flex;
   align-items: flex-end;
-  justify-content: center;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: 10px 18px;
+  gap: 14px 10px;
   min-height: 170px;
   overflow-x: auto;
 }
@@ -403,8 +441,9 @@ const cellHeight = (span: number) =>
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 0 0 auto;
-  width: 40px;
+  flex: 1 1 0;
+  min-width: 34px;
+  max-width: 72px;
   gap: 6px;
 
   &__count {
@@ -429,6 +468,9 @@ const cellHeight = (span: number) =>
     background: rgba($gray-light, 0.18);
     cursor: pointer;
     padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: background 0.1s ease;
 
     // Ordered so on/top override the preview tint (later rule wins).
@@ -443,6 +485,28 @@ const cellHeight = (span: number) =>
     &--top {
       background: $primary;
     }
+
+    // A generator/beam turned off inside a stacked column reads as empty.
+    &--memberoff {
+      background: rgba($gray-light, 0.1);
+    }
+  }
+
+  // erkul-style count inside a merged (span > 1) block.
+  &__pip-label {
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    color: $text-color;
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+  }
+
+  // Separates the stacked members (generators / beams) of a grouped column.
+  &__divider {
+    height: 0;
+    margin: 1px 0;
+    border-top: 1px dashed rgba($gray-light, 0.35);
   }
 
   &--weapon &__pip--on {
@@ -471,16 +535,17 @@ const cellHeight = (span: number) =>
   &__icon {
     width: 15px;
     height: 15px;
-    opacity: 0.75;
+    opacity: 0.9;
   }
 
   &__fa {
     font-size: 13px;
-    color: $gray;
-    opacity: 0.85;
+    color: $text-color;
+    opacity: 0.9;
   }
 
-  // A column with no pips reads as "off" — dim its count and icon.
+  // A column with no pips reads as "off" — dim its count and icon. A powered
+  // column (any pip, including a single critical one) stays at full strength.
   &--off {
     .power-col__count {
       color: $gray;
@@ -489,6 +554,11 @@ const cellHeight = (span: number) =>
 
     .power-col__icon {
       opacity: 0.3;
+    }
+
+    .power-col__fa {
+      color: $gray;
+      opacity: 0.4;
     }
 
     .power-col__label {

--- a/app/frontend/frontend/components/Models/RefuelBoom/index.vue
+++ b/app/frontend/frontend/components/Models/RefuelBoom/index.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import type { Model } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 
@@ -36,65 +37,85 @@ const nozzleLabel = computed(() => {
 </script>
 
 <template>
-  <div
+  <MetricsCard
     v-if="boom"
-    class="row refuel-boom metrics-padding"
+    :title="t('labels.model.refuelBoom')"
+    class="refuel-boom-panel"
     data-test="refuel-boom"
   >
-    <div class="col-12 col-lg-3">
-      <div class="metrics-title">
-        {{ t("labels.model.refuelBoom") }}
-      </div>
-    </div>
-    <div class="col-12 col-lg-9 metrics-block">
-      <div class="row">
-        <div v-if="armLabel" class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.model.refuelBoomArm") }}:
-          </div>
-          <div class="metrics-value">{{ armLabel }}</div>
-        </div>
-        <div v-if="nozzleLabel" class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.model.refuelBoomNozzle") }}:
-          </div>
-          <div class="metrics-value">{{ nozzleLabel }}</div>
-        </div>
-        <div v-if="boom.captureRadius != null" class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.hardpoint.refuelBoom.captureRadius") }}:
-          </div>
-          <div class="metrics-value">
-            {{ toNumber(boom.captureRadius, "integer") }} m
-          </div>
-        </div>
-      </div>
+    <div class="metrics-card__hero">
       <div
-        v-if="boom.fuelFlowRate != null || boom.quantumFuelFlowRate != null"
-        class="row"
+        v-if="boom.fuelFlowRate != null"
+        class="metrics-card__tile metrics-card__tile--primary"
       >
-        <div class="col-12">
-          <div class="seperator" />
+        <div class="metrics-card__tile__label">
+          {{ t("labels.hardpoint.refuelBoom.fuelFlowRate") }}
+        </div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(boom.fuelFlowRate, "cargo") }}
+          <span class="metrics-card__tile__unit">/s</span>
+        </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.refuelBoom.fuelFlowSub") }}
         </div>
       </div>
-      <div class="row">
-        <div v-if="boom.fuelFlowRate != null" class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.hardpoint.refuelBoom.fuelFlowRate") }}:
-          </div>
-          <div class="metrics-value">
-            {{ toNumber(boom.fuelFlowRate, "cargo") }}/s
-          </div>
+      <div v-if="boom.quantumFuelFlowRate != null" class="metrics-card__tile">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.hardpoint.refuelBoom.quantumFuelFlowRate") }}
         </div>
-        <div v-if="boom.quantumFuelFlowRate != null" class="col-6 col-lg-4">
-          <div class="metrics-label">
-            {{ t("labels.hardpoint.refuelBoom.quantumFuelFlowRate") }}:
-          </div>
-          <div class="metrics-value">
-            {{ toNumber(boom.quantumFuelFlowRate, "cargo") }}/s
-          </div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(boom.quantumFuelFlowRate, "cargo") }}
+          <span class="metrics-card__tile__unit">/s</span>
+        </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.refuelBoom.quantumFlowSub") }}
+        </div>
+      </div>
+      <div v-if="boom.captureRadius != null" class="metrics-card__tile">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.hardpoint.refuelBoom.captureRadius") }}
+        </div>
+        <div class="metrics-card__tile__value">
+          {{ toNumber(boom.captureRadius, "integer") }}
+          <span class="metrics-card__tile__unit">m</span>
+        </div>
+        <div class="metrics-card__tile__sub">
+          {{ t("labels.refuelBoom.captureRadiusSub") }}
         </div>
       </div>
     </div>
-  </div>
+
+    <template v-if="armLabel || nozzleLabel">
+      <div class="metrics-card__section-label">
+        {{ t("labels.refuelBoom.equipment") }}
+      </div>
+      <div v-if="armLabel" class="metrics-card__aux">
+        <span class="metrics-card__aux-label">
+          {{ t("labels.model.refuelBoomArm") }}
+        </span>
+        <span class="metrics-card__aux-value">{{ armLabel }}</span>
+      </div>
+      <div v-if="nozzleLabel" class="metrics-card__aux">
+        <span class="metrics-card__aux-label">
+          {{ t("labels.model.refuelBoomNozzle") }}
+        </span>
+        <span class="metrics-card__aux-value">{{ nozzleLabel }}</span>
+      </div>
+    </template>
+
+    <div class="metrics-card__footer">
+      <span class="metrics-card__hint">{{ t("labels.refuelBoom.hint") }}</span>
+    </div>
+  </MetricsCard>
 </template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+
+// The equipment rows carry component names rather than figures, so they wrap
+// instead of holding the baseline row the numeric aux stats use.
+.metrics-card__aux {
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+</style>

--- a/app/frontend/frontend/components/Models/metricsCard.scss
+++ b/app/frontend/frontend/components/Models/metricsCard.scss
@@ -23,7 +23,7 @@
     // Fixed tracks instead of flex basis + grow: every tile keeps the same width
     // across both rows however long its value runs, which the flex hero cannot
     // guarantee. For cards whose figures are all peers — no headline stat to
-    // give `--primary` to — so the values also sit a step smaller.
+    // give `--primary` to — so the values sit a step smaller and at one size.
     &--grid {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
@@ -36,8 +36,12 @@
         padding: 12px 14px;
       }
 
+      // Flat, not the flex hero's container-relative scale. Track count differs
+      // per card, so sizing off the tile would set a two-track card's values
+      // noticeably larger than a three-track one's and the rail would read as
+      // two different type scales. `overflow: hidden` stays the backstop.
       .metrics-card__tile__value {
-        font-size: clamp(13px, 11cqw, 18px);
+        font-size: 15px;
       }
     }
   }

--- a/app/frontend/frontend/components/Models/metricsCard.scss
+++ b/app/frontend/frontend/components/Models/metricsCard.scss
@@ -15,6 +15,31 @@
     border-radius: 8px;
     overflow: hidden;
     margin-bottom: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    // Fixed tracks instead of flex basis + grow: every tile keeps the same width
+    // across both rows however long its value runs, which the flex hero cannot
+    // guarantee. For cards whose figures are all peers — no headline stat to
+    // give `--primary` to — so the values also sit a step smaller.
+    &--grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+
+      &-2 {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      .metrics-card__tile {
+        padding: 12px 14px;
+      }
+
+      .metrics-card__tile__value {
+        font-size: clamp(13px, 11cqw, 18px);
+      }
+    }
   }
 
   &__section-label {
@@ -48,6 +73,72 @@
       font-weight: 600;
       font-variant-numeric: tabular-nums;
       color: lighten($text-color, 15%);
+    }
+  }
+
+  // A list of secondary stats. `__aux` covers a single one-line stat and carries
+  // its own bottom margin, so it cannot serve a card that has five or more of
+  // them; these stack, and pair up two-per-line where the card is wide enough.
+  &__rows {
+    display: flex;
+    flex-direction: column;
+
+    &--split {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: 26px;
+
+      // Both cells of the final line, since `:last-child` only reaches one of
+      // them. Assumes an even cell count — an odd trailing cell keeps its rule.
+      .metrics-card__row:nth-last-child(-n + 2) {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  &__row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 0;
+    border-bottom: 1px solid rgba($gray-light, 0.16);
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    // For values too long to sit beside their label — a list of locations, say.
+    &--stack {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 4px;
+
+      .metrics-card__row__value {
+        text-align: left;
+        white-space: normal;
+      }
+    }
+
+    &__label {
+      font-family: "Orbitron", tahoma, sans-serif;
+      font-size: 10px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: $gray-light;
+      flex: none;
+    }
+
+    &__value {
+      min-width: 0;
+      overflow: hidden;
+      font-size: 13.5px;
+      font-weight: 600;
+      color: lighten($text-color, 15%);
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 

--- a/app/frontend/frontend/composables/powerSim.spec.ts
+++ b/app/frontend/frontend/composables/powerSim.spec.ts
@@ -8,11 +8,11 @@ import {
   type PowerPort,
 } from "./powerSim";
 
-// erkul's `ue`: the weapon pool is `poolSize` size-1 blocks, of which the first
-// `consumption` are enabled (the rest disabled).
+// erkul's `ue`: the weapon pool is `poolSize` size-1 blocks (all sharing one
+// portPath), of which the first `consumption` are enabled (the rest disabled).
 function weaponBlocks(poolSize: number, consumption: number): PowerPort[] {
   return Array.from({ length: poolSize }, (_, i) => ({
-    portPath: `w${i}`,
+    portPath: "weaponPool",
     family: "weapon" as const,
     size: 1,
     disabled: i >= consumption,

--- a/app/frontend/frontend/composables/powerSim.spec.ts
+++ b/app/frontend/frontend/composables/powerSim.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { allocatePower, weaponPoolRatio, type PowerPort } from "./powerSim";
+import {
+  allocatePower,
+  componentBlocks,
+  totalSegments,
+  weaponPoolBlocks,
+  weaponPoolRatio,
+  type PowerPort,
+} from "./powerSim";
 
 // erkul's `ue`: the weapon pool is `poolSize` size-1 blocks, of which the first
 // `consumption` are enabled (the rest disabled).
@@ -78,5 +85,79 @@ describe("allocatePower", () => {
 
     expect(state.perFamily.weapon).toBe(1);
     expect(state.perFamily.shield).toBe(0);
+  });
+});
+
+describe("componentBlocks (le)", () => {
+  it("returns nothing for a component with no power draw", () => {
+    expect(componentBlocks("p", "radar", undefined)).toEqual([]);
+    expect(componentBlocks("p", "radar", { units: 0 })).toEqual([]);
+  });
+
+  it("defaults to one critical block plus regular size-1 blocks (no minimum)", () => {
+    // units 3, no minimumFraction → critical = round(3 × 1/3) = 1, regular = 2.
+    const blocks = componentBlocks("rad", "radar", { units: 3 });
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toMatchObject({ size: 1, critical: true });
+    expect(blocks.slice(1).every((b) => b.size === 1 && !b.critical)).toBe(
+      true,
+    );
+    expect(blocks.reduce((s, b) => s + b.size, 0)).toBe(3);
+  });
+
+  it("sizes the critical block from an explicit minimum fraction", () => {
+    // units 4, minimumFraction 0.5 → critical = round(4 × 0.5) = 2, regular = 2.
+    const blocks = componentBlocks("ls", "lifeSupport", {
+      units: 4,
+      minimumFraction: 0.5,
+    });
+    expect(blocks[0]).toMatchObject({ size: 2, critical: true });
+    expect(blocks.filter((b) => !b.critical)).toHaveLength(2);
+    expect(blocks.reduce((s, b) => s + b.size, 0)).toBe(4);
+  });
+});
+
+describe("weaponPoolBlocks (ue)", () => {
+  it("builds poolSize blocks, enabling the first ceil(Σ units)", () => {
+    // Asgard: pool 4, summed weapon units 7.8 → ceil = 8, all 4 enabled.
+    const blocks = weaponPoolBlocks("wpn", 7.8, 4);
+    expect(blocks).toHaveLength(4);
+    expect(blocks.every((b) => !b.disabled)).toBe(true);
+  });
+
+  it("disables blocks beyond the summed consumption", () => {
+    const blocks = weaponPoolBlocks("wpn", 2.4, 6);
+    // ceil(2.4) = 3 enabled, 3 disabled.
+    expect(blocks.filter((b) => !b.disabled)).toHaveLength(3);
+    expect(blocks.filter((b) => b.disabled)).toHaveLength(3);
+  });
+});
+
+describe("totalSegments (Et)", () => {
+  it("returns the plant's units for a single powered plant", () => {
+    expect(totalSegments([{ units: 20, size: 2, poweredOn: true }])).toBe(20);
+  });
+
+  it("ignores unpowered plants", () => {
+    expect(
+      totalSegments([
+        { units: 20, size: 2, poweredOn: true },
+        { units: 15, size: 2, poweredOn: false },
+      ]),
+    ).toBe(20);
+  });
+
+  it("adds the multi-plant coupling bonus ((count − 1) × Σ size)", () => {
+    // two plants: round(20/2)+round(16/2) = 10+8 = 18, plus (2−1)×(2+2) = 4 → 22.
+    expect(
+      totalSegments([
+        { units: 20, size: 2, poweredOn: true },
+        { units: 16, size: 2, poweredOn: true },
+      ]),
+    ).toBe(22);
+  });
+
+  it("returns 0 when no plant is powered", () => {
+    expect(totalSegments([{ units: 20, size: 2, poweredOn: false }])).toBe(0);
   });
 });

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -151,6 +151,17 @@ const NAV_PRIORITY: PowerFamily[] = [
   "towingbeam",
 ];
 
+// Quantum drive draws no power in SCM — it's a NAV-mode system.
+const NAV_ONLY_FAMILIES: PowerFamily[] = ["qdrive"];
+
+// Families the default auto-distribution fills beyond their critical minimum;
+// every other family sits at its critical floor until the user assigns pips
+// (matching erkul's default, e.g. life support at 1, engine at its minimum).
+const PRIMARY_FILL: Record<FlightMode, PowerFamily[]> = {
+  SCM: ["weapon", "shield", "radar"],
+  NAV: ["qdrive", "engine", "radar"],
+};
+
 // co(): the auto-distribution — mandatory criticals first, then each component
 // filled toward its target (a per-port override, else its natural maximum) in
 // family-priority order. The cooler heat-balancing pass is not yet ported.
@@ -166,20 +177,46 @@ export function allocatePower(
   const weaponCap = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
   const priority = mode === "SCM" ? SCM_PRIORITY : NAV_PRIORITY;
 
-  // Base pass: mandatory critical blocks per family, in priority order.
-  for (const family of priority) allocCritical(of(family), state);
+  // Skip a component when it's turned off (target 0), or when it's a NAV-only
+  // system (quantum drive) in SCM that the user hasn't explicitly powered.
+  const skip = (family: PowerFamily, portPath: string) => {
+    if (overrides[portPath] === 0) return true;
+    return (
+      mode === "SCM" &&
+      NAV_ONLY_FAMILIES.includes(family) &&
+      overrides[portPath] === undefined
+    );
+  };
 
-  // Fill pass: each distinct component (portPath) up to its target.
+  // Base pass: mandatory critical blocks per family, in priority order.
+  for (const family of priority) {
+    allocCritical(
+      of(family).filter((port) => !skip(family, port.portPath)),
+      state,
+    );
+  }
+
+  // Fill pass: each component to its target. An explicit override wins; else a
+  // primary family fills to its max, and every other family stays at its
+  // critical floor (its pips return to the pool).
+  const primary = PRIMARY_FILL[mode];
   for (const family of priority) {
     const familyPorts = of(family);
+    const isWeapon = family === "weapon";
+    const isPrimary = primary.includes(family);
     const seen = new Set<string>();
     for (const port of familyPorts) {
       if (seen.has(port.portPath)) continue;
       seen.add(port.portPath);
-      const isWeapon = family === "weapon";
-      const target =
-        overrides[port.portPath] ??
-        (isWeapon ? weaponCap : Number.POSITIVE_INFINITY);
+      if (skip(family, port.portPath)) continue;
+
+      const override = overrides[port.portPath];
+      let target: number;
+      if (override !== undefined) target = override;
+      else if (isPrimary)
+        target = isWeapon ? weaponCap : Number.POSITIVE_INFINITY;
+      else continue; // non-primary, no override → criticals only
+
       fillPortTo(
         familyPorts,
         port.portPath,

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -180,25 +180,55 @@ export function allocatePower(
   allocCritical(of("radar"), state);
   allocCritical(of("engine"), state);
 
-  // Jn — fill.
-  fill("miningLaser");
-  fill("salvage");
-  if (mode === "SCM") {
-    const weaponDefault = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
-    const weaponTarget = opts.overrides?.weapon ?? weaponDefault;
+  // Jn — fill every family in priority order (weapons capped at their pool);
+  // a family with a user override fills to that target, otherwise greedily. All
+  // families are covered so the pip UI can allocate to any of them.
+  const weaponDefault = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
+  const weaponTarget = opts.overrides?.weapon ?? weaponDefault;
+  const fillWeapon = () =>
     fillTo(
       of("weapon"),
       "weapon",
       Math.min(weaponTarget, opts.weaponPoolSize, opts.weaponConsumption),
       state,
     );
-    fill("shield");
-    fill("radar");
-    fill("engine");
-  } else {
-    fill("qdrive");
-    fill("radar");
-    fill("engine");
+
+  const priority: PowerFamily[] =
+    mode === "SCM"
+      ? [
+          "miningLaser",
+          "salvage",
+          "weapon",
+          "shield",
+          "radar",
+          "engine",
+          "coolers",
+          "qdrive",
+          "qed",
+          "emp",
+          "tractorBeam",
+          "towingbeam",
+          "lifeSupport",
+        ]
+      : [
+          "miningLaser",
+          "salvage",
+          "qdrive",
+          "radar",
+          "engine",
+          "shield",
+          "coolers",
+          "weapon",
+          "qed",
+          "emp",
+          "tractorBeam",
+          "towingbeam",
+          "lifeSupport",
+        ];
+
+  for (const family of priority) {
+    if (family === "weapon") fillWeapon();
+    else fill(family);
   }
 
   return state;

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -155,10 +155,11 @@ const NAV_PRIORITY: PowerFamily[] = [
 const NAV_ONLY_FAMILIES: PowerFamily[] = ["qdrive"];
 
 // Families the default auto-distribution fills beyond their critical minimum;
-// every other family sits at its critical floor until the user assigns pips
-// (matching erkul's default, e.g. life support at 1, engine at its minimum).
+// every other family sits at its critical floor until the user assigns pips.
+// Mirrors erkul's `Jn` fill order — weapon/shield/radar/engine in SCM — so the
+// engine gets its rated pips by default (which drives the flight figures).
 const PRIMARY_FILL: Record<FlightMode, PowerFamily[]> = {
-  SCM: ["weapon", "shield", "radar"],
+  SCM: ["weapon", "shield", "radar", "engine"],
   NAV: ["qdrive", "engine", "radar"],
 };
 

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -166,7 +166,13 @@ export function allocatePower(
   allocCritical(of("salvage"), state);
   if (mode === "SCM") {
     allocCritical(of("emp"), state);
-    weaponBase(of("weapon"), 1, state);
+    // Weapons get a 1-segment base, unless the user explicitly overrides them
+    // to fewer (letting the pip UI take weapons down to 0).
+    const weaponBaseCap =
+      opts.overrides?.weapon === undefined
+        ? 1
+        : Math.min(1, opts.overrides.weapon);
+    weaponBase(of("weapon"), weaponBaseCap, state);
     allocCritical(of("shield"), state);
   } else {
     allocCritical(of("qdrive"), state);

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -195,3 +195,78 @@ export function weaponPoolRatio(
   if (weaponConsumption <= 0) return 1;
   return Math.min(1, state.perFamily.weapon / weaponConsumption);
 }
+
+// --- Port construction (erkul `z`/`K`/`le`/`ue`/`Et`) --------------------
+// Builds the `PowerPort[]` blocks a loadout feeds to `allocatePower`, from each
+// component's Power draw. A component drawing `units` power becomes ~`round(units)`
+// size-1 blocks, of which the minimum (`round(units × minimumFraction)`, or 1
+// when there is no explicit minimum) is a single `critical` block that must stay
+// powered. Weapons are special-cased into the shared weapon pool (`ue`).
+
+// A component's Power consumption, as read from parsed `power_consumption` /
+// `power_ranges`. `minimumFraction` is the flow's `minimumConsumptionFraction`
+// (0 for almost every component today).
+export type PowerDraw = {
+  units: number;
+  minimumFraction?: number;
+};
+
+// K: the size of the mandatory (critical) block. Defaults to 1 segment when the
+// component declares no minimum fraction (`minimumFraction || 1/units`).
+function criticalSize(units: number, minimumFraction?: number): number {
+  if (units <= 0) return 0;
+  const fraction = minimumFraction || 1 / units;
+  return Math.round(units * fraction);
+}
+
+// le: a single non-weapon component's blocks — one `critical` block sized `K`,
+// then `round(units − K)` regular size-1 blocks.
+export function componentBlocks(
+  portPath: string,
+  family: PowerFamily,
+  draw: PowerDraw | undefined,
+): PowerPort[] {
+  if (!draw || draw.units <= 0) return [];
+  const critical = criticalSize(draw.units, draw.minimumFraction);
+  const regular = Math.max(0, Math.round(draw.units - critical));
+  const blocks: PowerPort[] = [];
+  if (critical > 0) {
+    blocks.push({ portPath, family, size: critical, critical: true });
+  }
+  for (let i = 0; i < regular; i++) {
+    blocks.push({ portPath, family, size: 1 });
+  }
+  return blocks;
+}
+
+// ue: the shared weapon pool — `poolSize` size-1 blocks, of which the first
+// `ceil(Σ units)` (the summed weapon consumption) are enabled.
+export function weaponPoolBlocks(
+  portPathPrefix: string,
+  weaponUnitsSum: number,
+  poolSize: number,
+): PowerPort[] {
+  const consumption = Math.ceil(weaponUnitsSum);
+  return Array.from({ length: poolSize }, (_, i) => ({
+    portPath: `${portPathPrefix}#${i}`,
+    family: "weapon" as const,
+    size: 1,
+    disabled: i >= consumption,
+  }));
+}
+
+// Et: total available segments from the powered plants. A single plant yields
+// its `units`; multiple plants add a `(count − 1) × Σ size` coupling bonus.
+export function totalSegments(
+  plants: { units: number; size: number; poweredOn: boolean }[],
+): number {
+  const powered = plants.filter((p) => p.poweredOn);
+  if (powered.length === 0) return 0;
+  let units = 0;
+  let sizeSum = 0;
+  for (const p of powered) {
+    units += Math.round(p.units / powered.length);
+    sizeSum += p.size;
+  }
+  return units + (powered.length - 1) * sizeSum;
+}

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -173,6 +173,9 @@ export function allocatePower(
   const mode = opts.mode ?? "SCM";
   const state = emptyState(totalSegments);
   const overrides = opts.overrides ?? {};
+  // Reset selection so the same ports can be re-allocated (e.g. baseline pass
+  // then override pass).
+  for (const port of ports) port.selected = false;
   const of = (f: PowerFamily) => ports.filter((p) => p.family === f);
   const weaponCap = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
   const priority = mode === "SCM" ? SCM_PRIORITY : NAV_PRIORITY;

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -86,64 +86,74 @@ function allocCritical(ports: PowerPort[], state: AllocationState): void {
   }
 }
 
-// $: greedily fill a family until a block doesn't fit.
-function fillGreedy(ports: PowerPort[], state: AllocationState): void {
-  for (const p of ports) {
-    if (p.disabled || p.selected) continue;
-    if (p.size > state.remaining) break;
-    alloc(state, p);
-  }
-}
-
-// nt: allocate weapon blocks up to `cap` segments (the weapon base).
-function weaponBase(
+// Fill a single port (component) toward `target` total segments for that port,
+// taking blocks that still fit. The shared weapon pool is one port; every other
+// component is its own port.
+function fillPortTo(
   ports: PowerPort[],
-  cap: number,
-  state: AllocationState,
-): void {
-  const target = Math.min(cap, state.remaining);
-  let taken = 0;
-  for (const p of ports) {
-    if (taken >= target) break;
-    if (p.disabled || p.selected) continue;
-    if (p.size > state.remaining) break;
-    alloc(state, p);
-    taken += p.size;
-  }
-}
-
-// et/ot: fill a family up to `target` total segments for that family.
-function fillTo(
-  ports: PowerPort[],
-  family: PowerFamily,
+  portPath: string,
   target: number,
   state: AllocationState,
 ): void {
-  const need = target - state.perFamily[family];
-  if (need <= 0) return;
-  let taken = 0;
   for (const p of ports) {
-    if (p.disabled || p.selected) continue;
-    if (taken + p.size > need || p.size > state.remaining) break;
+    if (p.portPath !== portPath || p.disabled || p.selected) continue;
+    if ((state.perPort[portPath] ?? 0) >= target) break;
+    if (p.size > state.remaining) break;
     alloc(state, p);
-    taken += p.size;
-    if (taken >= need) break;
   }
 }
+
+// The shared weapon-pool port. All weapon blocks share this portPath so the pool
+// is one column in the UI and one override key.
+export const WEAPON_POOL_PORT = "weaponPool";
+
+// User pip choices: target segments per component (by portPath), the weapon pool
+// keyed by WEAPON_POOL_PORT.
+export type PortOverrides = Record<string, number>;
 
 export type AllocateOptions = {
   mode?: FlightMode;
   // Weapon fill target = min(weaponConsumptionPoints, weaponPoolSize).
   weaponConsumption: number;
   weaponPoolSize: number;
-  // User pip choices: target segments per family. A family with an override is
-  // filled to that target instead of greedily — the interactive pip UI's input.
-  overrides?: Partial<Record<PowerFamily, number>>;
+  overrides?: PortOverrides;
 };
 
-// co(): the default auto-distribution (base pass Zn, then fill pass Jn), with an
-// optional per-family override target (the pip UI). The cooler heat-balancing
-// pass and refinements are not yet ported.
+const SCM_PRIORITY: PowerFamily[] = [
+  "lifeSupport",
+  "miningLaser",
+  "salvage",
+  "emp",
+  "weapon",
+  "shield",
+  "radar",
+  "engine",
+  "coolers",
+  "qdrive",
+  "qed",
+  "tractorBeam",
+  "towingbeam",
+];
+
+const NAV_PRIORITY: PowerFamily[] = [
+  "lifeSupport",
+  "miningLaser",
+  "salvage",
+  "qdrive",
+  "radar",
+  "engine",
+  "shield",
+  "coolers",
+  "weapon",
+  "emp",
+  "qed",
+  "tractorBeam",
+  "towingbeam",
+];
+
+// co(): the auto-distribution — mandatory criticals first, then each component
+// filled toward its target (a per-port override, else its natural maximum) in
+// family-priority order. The cooler heat-balancing pass is not yet ported.
 export function allocatePower(
   ports: PowerPort[],
   totalSegments: number,
@@ -151,84 +161,32 @@ export function allocatePower(
 ): AllocationState {
   const mode = opts.mode ?? "SCM";
   const state = emptyState(totalSegments);
+  const overrides = opts.overrides ?? {};
   const of = (f: PowerFamily) => ports.filter((p) => p.family === f);
+  const weaponCap = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
+  const priority = mode === "SCM" ? SCM_PRIORITY : NAV_PRIORITY;
 
-  // Fill a family to its override target if the user set one, else greedily.
-  const fill = (f: PowerFamily) => {
-    const target = opts.overrides?.[f];
-    if (target === undefined) fillGreedy(of(f), state);
-    else fillTo(of(f), f, target, state);
-  };
+  // Base pass: mandatory critical blocks per family, in priority order.
+  for (const family of priority) allocCritical(of(family), state);
 
-  // Zn — base: critical blocks per family in priority order, weapon base 1.
-  allocCritical(of("lifeSupport"), state);
-  allocCritical(of("miningLaser"), state);
-  allocCritical(of("salvage"), state);
-  if (mode === "SCM") {
-    allocCritical(of("emp"), state);
-    // Weapons get a 1-segment base, unless the user explicitly overrides them
-    // to fewer (letting the pip UI take weapons down to 0).
-    const weaponBaseCap =
-      opts.overrides?.weapon === undefined
-        ? 1
-        : Math.min(1, opts.overrides.weapon);
-    weaponBase(of("weapon"), weaponBaseCap, state);
-    allocCritical(of("shield"), state);
-  } else {
-    allocCritical(of("qdrive"), state);
-  }
-  allocCritical(of("radar"), state);
-  allocCritical(of("engine"), state);
-
-  // Jn — fill every family in priority order (weapons capped at their pool);
-  // a family with a user override fills to that target, otherwise greedily. All
-  // families are covered so the pip UI can allocate to any of them.
-  const weaponDefault = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
-  const weaponTarget = opts.overrides?.weapon ?? weaponDefault;
-  const fillWeapon = () =>
-    fillTo(
-      of("weapon"),
-      "weapon",
-      Math.min(weaponTarget, opts.weaponPoolSize, opts.weaponConsumption),
-      state,
-    );
-
-  const priority: PowerFamily[] =
-    mode === "SCM"
-      ? [
-          "miningLaser",
-          "salvage",
-          "weapon",
-          "shield",
-          "radar",
-          "engine",
-          "coolers",
-          "qdrive",
-          "qed",
-          "emp",
-          "tractorBeam",
-          "towingbeam",
-          "lifeSupport",
-        ]
-      : [
-          "miningLaser",
-          "salvage",
-          "qdrive",
-          "radar",
-          "engine",
-          "shield",
-          "coolers",
-          "weapon",
-          "qed",
-          "emp",
-          "tractorBeam",
-          "towingbeam",
-          "lifeSupport",
-        ];
-
+  // Fill pass: each distinct component (portPath) up to its target.
   for (const family of priority) {
-    if (family === "weapon") fillWeapon();
-    else fill(family);
+    const familyPorts = of(family);
+    const seen = new Set<string>();
+    for (const port of familyPorts) {
+      if (seen.has(port.portPath)) continue;
+      seen.add(port.portPath);
+      const isWeapon = family === "weapon";
+      const target =
+        overrides[port.portPath] ??
+        (isWeapon ? weaponCap : Number.POSITIVE_INFINITY);
+      fillPortTo(
+        familyPorts,
+        port.portPath,
+        isWeapon ? Math.min(target, weaponCap) : target,
+        state,
+      );
+    }
   }
 
   return state;
@@ -289,15 +247,16 @@ export function componentBlocks(
 }
 
 // ue: the shared weapon pool — `poolSize` size-1 blocks, of which the first
-// `ceil(Σ units)` (the summed weapon consumption) are enabled.
+// `ceil(Σ units)` (the summed weapon consumption) are enabled. All blocks share
+// one portPath so the pool is a single column / override key.
 export function weaponPoolBlocks(
-  portPathPrefix: string,
+  portPath: string,
   weaponUnitsSum: number,
   poolSize: number,
 ): PowerPort[] {
   const consumption = Math.ceil(weaponUnitsSum);
   return Array.from({ length: poolSize }, (_, i) => ({
-    portPath: `${portPathPrefix}#${i}`,
+    portPath,
     family: "weapon" as const,
     size: 1,
     disabled: i >= consumption,

--- a/app/frontend/frontend/composables/powerSim.ts
+++ b/app/frontend/frontend/composables/powerSim.ts
@@ -136,10 +136,14 @@ export type AllocateOptions = {
   // Weapon fill target = min(weaponConsumptionPoints, weaponPoolSize).
   weaponConsumption: number;
   weaponPoolSize: number;
+  // User pip choices: target segments per family. A family with an override is
+  // filled to that target instead of greedily — the interactive pip UI's input.
+  overrides?: Partial<Record<PowerFamily, number>>;
 };
 
-// co(): the default auto-distribution (base pass Zn, then fill pass Jn).
-// The cooler heat-balancing pass and refinements are not yet ported.
+// co(): the default auto-distribution (base pass Zn, then fill pass Jn), with an
+// optional per-family override target (the pip UI). The cooler heat-balancing
+// pass and refinements are not yet ported.
 export function allocatePower(
   ports: PowerPort[],
   totalSegments: number,
@@ -148,6 +152,13 @@ export function allocatePower(
   const mode = opts.mode ?? "SCM";
   const state = emptyState(totalSegments);
   const of = (f: PowerFamily) => ports.filter((p) => p.family === f);
+
+  // Fill a family to its override target if the user set one, else greedily.
+  const fill = (f: PowerFamily) => {
+    const target = opts.overrides?.[f];
+    if (target === undefined) fillGreedy(of(f), state);
+    else fillTo(of(f), f, target, state);
+  };
 
   // Zn — base: critical blocks per family in priority order, weapon base 1.
   allocCritical(of("lifeSupport"), state);
@@ -164,22 +175,24 @@ export function allocatePower(
   allocCritical(of("engine"), state);
 
   // Jn — fill.
-  fillGreedy(of("miningLaser"), state);
-  fillGreedy(of("salvage"), state);
+  fill("miningLaser");
+  fill("salvage");
   if (mode === "SCM") {
+    const weaponDefault = Math.min(opts.weaponConsumption, opts.weaponPoolSize);
+    const weaponTarget = opts.overrides?.weapon ?? weaponDefault;
     fillTo(
       of("weapon"),
       "weapon",
-      Math.min(opts.weaponConsumption, opts.weaponPoolSize),
+      Math.min(weaponTarget, opts.weaponPoolSize, opts.weaponConsumption),
       state,
     );
-    fillGreedy(of("shield"), state);
-    fillGreedy(of("radar"), state);
-    fillGreedy(of("engine"), state);
+    fill("shield");
+    fill("radar");
+    fill("engine");
   } else {
-    fillGreedy(of("qdrive"), state);
-    fillGreedy(of("radar"), state);
-    fillGreedy(of("engine"), state);
+    fill("qdrive");
+    fill("radar");
+    fill("engine");
   }
 
   return state;

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -10,6 +10,7 @@ import {
   type ComponentJumpDrive,
   type ComponentThruster,
   type ComponentArmor,
+  type ComponentTractorBeam,
 } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { sustainedRatio } from "@/frontend/composables/useLoadoutStats";
@@ -108,7 +109,126 @@ export const useHardpointStats = (
     const category = hp.category;
     const result: HardpointStat[] = [];
 
-    if (category === HardpointCategoryEnum.WEAPONS) {
+    // Tractor and towing beams mount in the weapons category but share none of a
+    // gun's stats, so the parsed `tractorBeam` flag is the signal to use — the
+    // game files even type some of them as SalvageHead.
+    if ("tractorBeam" in typeData) {
+      const tractor = typeData as ComponentTractorBeam;
+      const towing = tractor.towing;
+      // Beams pull together, so the force figures sum across a collapsed stack
+      // (like weapon DPS does). Reach, cone, tether and handling are per-beam
+      // ratings and stay as they are.
+      const stackCount = Math.max(1, Math.round(Number(toValue(count) ?? 1)));
+
+      // Reach reads as the falloff span erkul shows (its "75 → 150 m"): full
+      // force out to `fullStrengthDistance`, then fading to nothing at
+      // `maxDistance`. `minDistance` is not part of it — that is the 0.5 m every
+      // beam grabs from. Beams with no falloff point just show their max.
+      const rangeStat = (
+        labelKey: string,
+        fullStrength: number | undefined,
+        max: number,
+      ): HardpointStat => ({
+        label: t(`labels.hardpoint.${labelKey}`),
+        value: fullStrength
+          ? `${String(toNumber(fullStrength))} - ${String(toNumber(max, "weaponRange"))}`
+          : String(toNumber(max, "weaponRange")),
+      });
+
+      // A towing beam's own maxForce is a 5e9 "unlimited" sentinel, so its tow
+      // force is the figure that actually describes it (erkul does the same).
+      if (towing?.towingForce) {
+        result.push(
+          stat(
+            "tractorBeams.towForce",
+            towing.towingForce * stackCount,
+            "newton",
+            true,
+          ),
+        );
+      } else if (tractor.maxForce) {
+        result.push(
+          stat(
+            "tractorBeams.maxForce",
+            tractor.maxForce * stackCount,
+            "newton",
+            true,
+          ),
+        );
+      }
+      if (tractor.maxDistance) {
+        result.push(
+          rangeStat(
+            "tractorBeams.range",
+            tractor.fullStrengthDistance,
+            tractor.maxDistance,
+          ),
+        );
+      }
+      if (tractor.maxAngle) {
+        result.push(stat("tractorBeams.cone", tractor.maxAngle, "degrees"));
+      }
+      if (tractor.minForce) {
+        result.push(stat("tractorBeams.minForce", tractor.minForce, "newton"));
+      }
+      // Cargo mode swaps in far stronger overrides for hauling boxes.
+      if (tractor.cargoMode?.maxForce) {
+        result.push(
+          stat(
+            "tractorBeams.cargoForce",
+            tractor.cargoMode.maxForce * stackCount,
+            "newton",
+          ),
+        );
+      }
+      if (tractor.cargoMode?.maxDistance) {
+        result.push(
+          rangeStat(
+            "tractorBeams.cargoRange",
+            tractor.cargoMode.fullStrengthDistance,
+            tractor.cargoMode.maxDistance,
+          ),
+        );
+      }
+      if (towing?.towingMaxDistance) {
+        result.push(
+          stat(
+            "tractorBeams.towDistance",
+            towing.towingMaxDistance,
+            "weaponRange",
+          ),
+        );
+      }
+      if (towing?.quantumTowMassLimit) {
+        result.push(
+          stat(
+            "tractorBeams.quantumTowMass",
+            towing.quantumTowMassLimit,
+            "weight",
+          ),
+        );
+      }
+      if (tractor.tetherBreakTime) {
+        result.push({
+          label: t("labels.hardpoint.tractorBeams.tetherBreak"),
+          value: String(toNumber(tractor.tetherBreakTime, "seconds")),
+        });
+      }
+      if (tractor.rotation?.maxAngularVelocity) {
+        result.push(
+          stat(
+            "tractorBeams.rotationSpeed",
+            tractor.rotation.maxAngularVelocity,
+            "rotation",
+          ),
+        );
+      }
+      if (tractor.movement?.maxSpeed) {
+        result.push(
+          stat("tractorBeams.moveSpeed", tractor.movement.maxSpeed, "speed"),
+        );
+      }
+    } else if (category === HardpointCategoryEnum.WEAPONS) {
       const weapon = typeData as ComponentWeapon;
       // Sustainable-fire fraction (erkul's "efficiency"): the duty-cycle share
       // of burst the weapon can hold. Only meaningful when < 100%.

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -300,6 +300,17 @@ describe("shield active cap", () => {
   });
 });
 
+describe("weapon pool headroom", () => {
+  it("renders the full pool but is only fillable up to weapon demand", () => {
+    // One energy weapon drawing 2 (consumption 2) with a pool of 10 → the
+    // column shows all 10 slots, but only 2 can take power.
+    const sim = simulateLoadoutPower([plant(40, 2), ...weapons(1, 2)], 10);
+    const wpn = sim.columns.find((c) => c.portPath === WEAPON_POOL_PORT);
+    expect(wpn?.capacity).toBe(10);
+    expect(wpn?.fillable).toBe(2);
+  });
+});
+
 describe("tractor beams", () => {
   it("groups tractor beams into their own column, not the weapon pool", () => {
     const tractorA = hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 });

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -364,6 +364,23 @@ describe("heat (cooling ratio)", () => {
     expect(coolerOff.emittedIr).toBe(0);
   });
 
+  it("computes an EM signature from plants and powered components", () => {
+    const emPlant = hp(
+      HardpointCategoryEnum.POWERPLANT,
+      { powerBase: 40, signatureEm: 6000 },
+      { size: 2 },
+    );
+    const shield = hp(HardpointCategoryEnum.SHIELDGENERATOR, {
+      powerConsumption: 4,
+      signatureEm: 1600,
+    });
+    const sim = simulateLoadoutPower([emPlant, shield], 0);
+    expect(sim.emittedEm).toBeGreaterThan(0);
+    // No plant / nothing powered → no EM.
+    const dark = simulateLoadoutPower([shield], 0);
+    expect(dark.emittedEm).toBe(0);
+  });
+
   it("exceeds 1 when the coolers can't keep up (under-cooled)", () => {
     // A tiny cooler against a fully-powered shield generates far more heat than
     // it can dissipate → cooling load well above 1.

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -186,6 +186,17 @@ describe("overrides (pip UI)", () => {
     const coolerCol = sim.columns.find((c) => c.portPath === cooler.id);
     expect(coolerCol?.allocated).toBe(2);
   });
+
+  it("locks an all-critical component (quantum drive, min fraction 1)", () => {
+    const qd = hp(HardpointCategoryEnum.QUANTUMDRIVE, {
+      powerConsumption: 3,
+      powerMinimumFraction: 1,
+    });
+    const sim = simulateLoadoutPower([plant(40, 2), qd], 0);
+    const col = sim.columns.find((c) => c.portPath === qd.id);
+    expect(col?.locked).toBe(true);
+    expect(col?.allocated).toBe(col?.capacity);
+  });
 });
 
 describe("shield active cap", () => {
@@ -196,8 +207,8 @@ describe("shield active cap", () => {
 
   it("powers only the first 2 shields by default (rest are backups)", () => {
     const sim = simulateLoadoutPower([plant(40, 2), ...shields(3)], 0);
-    // 2 columns of 4 cells; the 3rd shield draws no power (no column).
-    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(2);
+    // Shields aggregate into ONE column; 2 active × 4 cells = 8, 3rd is backup.
+    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(1);
     expect(familyCapacity(sim, "shield")).toBe(8);
   });
 
@@ -209,7 +220,7 @@ describe("shield active cap", () => {
       undefined,
       3,
     );
-    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(3);
+    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(1);
     expect(familyCapacity(sim, "shield")).toBe(12);
   });
 });

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -5,6 +5,7 @@ import {
   simulateLoadoutPower,
   useLoadoutSim,
   WEAPON_POOL_PORT,
+  SHIELD_POOL_PORT,
   type LoadoutSimResult,
 } from "./useLoadoutSim";
 import type { PowerFamily } from "./powerSim";
@@ -187,15 +188,40 @@ describe("overrides (pip UI)", () => {
     expect(coolerCol?.allocated).toBe(2);
   });
 
-  it("locks an all-critical component (quantum drive, min fraction 1)", () => {
+  it("leaves the quantum drive unpowered in SCM but powered in NAV", () => {
     const qd = hp(HardpointCategoryEnum.QUANTUMDRIVE, {
       powerConsumption: 3,
       powerMinimumFraction: 1,
     });
-    const sim = simulateLoadoutPower([plant(40, 2), qd], 0);
-    const col = sim.columns.find((c) => c.portPath === qd.id);
-    expect(col?.locked).toBe(true);
-    expect(col?.allocated).toBe(col?.capacity);
+    const ports = [plant(40, 2), qd];
+    const scm = simulateLoadoutPower(ports, 0, "SCM");
+    expect(scm.columns.find((c) => c.portPath === qd.id)?.allocated).toBe(0);
+    const nav = simulateLoadoutPower(ports, 0, "NAV");
+    expect(nav.columns.find((c) => c.portPath === qd.id)?.allocated).toBe(3);
+  });
+
+  it("defaults a non-primary system to its critical floor (life support 1)", () => {
+    // LS: units 2 @ 0.5 min fraction → critical 1; not greedily filled.
+    const ls = hp(HardpointCategoryEnum.LIFESUPPORT, {
+      powerConsumption: 2,
+      powerMinimumFraction: 0.5,
+    });
+    const col = simulateLoadoutPower([plant(40, 2), ls], 0).columns.find(
+      (c) => c.portPath === ls.id,
+    );
+    expect(col?.allocated).toBe(1);
+    expect(col?.capacity).toBe(2);
+  });
+
+  it("returns freed pips to the pool instead of redistributing", () => {
+    const ports = asgardLike();
+    const base = simulateLoadoutPower(ports, 4);
+    const reduced = simulateLoadoutPower(ports, 4, "SCM", {
+      [SHIELD_POOL_PORT]: 1,
+    });
+    // Dropping shields frees segments into `remaining`, not into other families.
+    expect(reduced.remaining).toBeGreaterThan(base.remaining);
+    expect(reduced.perFamily.weapon).toBe(base.perFamily.weapon);
   });
 });
 

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -155,6 +155,12 @@ describe("overrides (pip UI)", () => {
     expect(sim.familyCapacity.weapon).toBe(4);
     expect(sim.familyCapacity.shield).toBe(4);
   });
+
+  it("lets the user take weapons all the way to 0 (no forced base)", () => {
+    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", { weapon: 0 });
+    expect(sim.perFamily.weapon).toBe(0);
+    expect(sim.weaponPoolRatio).toBe(0);
+  });
 });
 
 describe("POWER_FAMILY_BY_CATEGORY", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -5,7 +5,6 @@ import {
   simulateLoadoutPower,
   useLoadoutSim,
   WEAPON_POOL_PORT,
-  SHIELD_POOL_PORT,
   type LoadoutSimResult,
 } from "./useLoadoutSim";
 import type { PowerFamily } from "./powerSim";
@@ -215,9 +214,12 @@ describe("overrides (pip UI)", () => {
 
   it("returns freed pips to the pool instead of redistributing", () => {
     const ports = asgardLike();
+    const shieldId = ports.find(
+      (h) => h.category === HardpointCategoryEnum.SHIELDGENERATOR,
+    )!.id;
     const base = simulateLoadoutPower(ports, 4);
     const reduced = simulateLoadoutPower(ports, 4, "SCM", {
-      [SHIELD_POOL_PORT]: 1,
+      [shieldId]: 1,
     });
     // Dropping shields frees segments into `remaining`, not into other families.
     expect(reduced.remaining).toBeGreaterThan(base.remaining);
@@ -225,9 +227,13 @@ describe("overrides (pip UI)", () => {
   });
 
   it("exposes a shieldPoolRatio that drops to 0 when shields are unpowered", () => {
-    expect(simulateLoadoutPower(asgardLike(), 4).shieldPoolRatio).toBe(1);
-    const off = simulateLoadoutPower(asgardLike(), 4, "SCM", {
-      [SHIELD_POOL_PORT]: 0,
+    const ports = asgardLike();
+    const shieldId = ports.find(
+      (h) => h.category === HardpointCategoryEnum.SHIELDGENERATOR,
+    )!.id;
+    expect(simulateLoadoutPower(ports, 4).shieldPoolRatio).toBe(1);
+    const off = simulateLoadoutPower(ports, 4, "SCM", {
+      [shieldId]: 0,
     });
     expect(off.shieldPoolRatio).toBe(0);
   });
@@ -258,8 +264,11 @@ describe("shield active cap", () => {
 
   it("powers only the first 2 shields by default (rest are backups)", () => {
     const sim = simulateLoadoutPower([plant(40, 2), ...shields(3)], 0);
-    // Shields aggregate into ONE column; 2 active × 4 cells = 8, 3rd is backup.
-    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(1);
+    // Shields stack into ONE column with a member per active generator
+    // (2 active × 4 cells = 8), the 3rd is a backup.
+    const shieldCols = sim.columns.filter((c) => c.family === "shield");
+    expect(shieldCols).toHaveLength(1);
+    expect(shieldCols[0].members).toHaveLength(2);
     expect(familyCapacity(sim, "shield")).toBe(8);
   });
 
@@ -271,8 +280,38 @@ describe("shield active cap", () => {
       undefined,
       3,
     );
-    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(1);
+    const shieldCols = sim.columns.filter((c) => c.family === "shield");
+    expect(shieldCols).toHaveLength(1);
+    expect(shieldCols[0].members).toHaveLength(3);
     expect(familyCapacity(sim, "shield")).toBe(12);
+  });
+
+  it("lets a single generator be disabled independently", () => {
+    const gens = shields(2);
+    const ports = [plant(40, 2), ...gens];
+    const full = simulateLoadoutPower(ports, 0);
+    expect(full.shieldPoolRatio).toBe(1);
+    // Turning off just one of two equal generators halves the shield ratio,
+    // while the stacked column keeps both members.
+    const one = simulateLoadoutPower(ports, 0, "SCM", { [gens[0].id]: 0 });
+    expect(one.shieldPoolRatio).toBeCloseTo(0.5);
+    const shieldCol = one.columns.find((c) => c.family === "shield");
+    expect(shieldCol?.members).toHaveLength(2);
+  });
+});
+
+describe("tractor beams", () => {
+  it("groups tractor beams into their own column, not the weapon pool", () => {
+    const tractorA = hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 });
+    tractorA.component!.type = "TractorBeam";
+    const tractorB = hp(HardpointCategoryEnum.TURRET, { powerConsumption: 3 });
+    tractorB.component!.type = "TractorBeam";
+    const sim = simulateLoadoutPower([plant(40, 2), tractorA, tractorB], 4);
+    // They must not inflate weapon consumption / the weapon pool.
+    expect(sim.perFamily.weapon).toBe(0);
+    const col = sim.columns.find((c) => c.family === "tractorBeam");
+    expect(col?.members).toHaveLength(2);
+    expect(col?.capacity).toBe(5);
   });
 });
 

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -323,6 +323,56 @@ describe("shield active cap", () => {
   });
 });
 
+describe("heat (cooling ratio)", () => {
+  const cooler = () =>
+    hp(HardpointCategoryEnum.COOLER, {
+      powerConsumption: 3,
+      coolingRate: 30,
+      powerRanges: {
+        low: { start: 1, modifier: 0.7 },
+        medium: { start: 2, modifier: 0.85 },
+        high: { start: 3, modifier: 1 },
+      },
+    });
+
+  it("derives a cooling load from coolers vs heat generated", () => {
+    const ls = hp(HardpointCategoryEnum.LIFESUPPORT, {
+      powerConsumption: 2,
+      powerMinimumFraction: 0.5,
+    });
+    const sim = simulateLoadoutPower([plant(40, 2), cooler(), ls], 0);
+    expect(sim.coolingPerSec).toBeGreaterThan(0);
+    expect(sim.coolingMaxPerSec).toBeGreaterThan(0);
+    expect(sim.heatGeneration).toBeGreaterThan(0);
+    expect(sim.coolingRatio).toBeCloseTo(
+      sim.heatGeneration / sim.coolingPerSec,
+      5,
+    );
+  });
+
+  it("exceeds 1 when the coolers can't keep up (under-cooled)", () => {
+    // A tiny cooler against a fully-powered shield generates far more heat than
+    // it can dissipate → cooling load well above 1.
+    const tinyCooler = hp(HardpointCategoryEnum.COOLER, {
+      powerConsumption: 2,
+      coolingRate: 4,
+    });
+    const shield = hp(HardpointCategoryEnum.SHIELDGENERATOR, {
+      powerConsumption: 12,
+    });
+    const sim = simulateLoadoutPower([plant(40, 2), tinyCooler, shield], 0);
+    expect(sim.coolingRatio).toBeGreaterThan(1);
+  });
+
+  it("has no heat or cooling when nothing is powered", () => {
+    // No plant → no segments → nothing active.
+    const sim = simulateLoadoutPower([cooler()], 0);
+    expect(sim.heatGeneration).toBe(0);
+    expect(sim.coolingPerSec).toBe(0);
+    expect(sim.coolingRatio).toBe(0);
+  });
+});
+
 describe("weapon pool headroom", () => {
   it("renders the full pool but is only fillable up to weapon demand", () => {
     // One energy weapon drawing 2 (consumption 2) with a pool of 10 → the

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -371,6 +371,22 @@ describe("heat (cooling ratio)", () => {
     expect(sim.coolingPerSec).toBe(0);
     expect(sim.coolingRatio).toBe(0);
   });
+
+  it("does not count tractor beams toward the heat load (matches erkul)", () => {
+    const base = [
+      plant(40, 2),
+      cooler(),
+      hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+    ];
+    const tractor = hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 4 });
+    tractor.component!.type = "TractorBeam";
+
+    const without = simulateLoadoutPower(base, 0);
+    const withBeam = simulateLoadoutPower([...base, tractor], 0);
+    // Powering the tractor beam must not change the cooling load.
+    expect(withBeam.heatGeneration).toBeCloseTo(without.heatGeneration, 5);
+    expect(withBeam.coolingRatio).toBeCloseTo(without.coolingRatio, 5);
+  });
 });
 
 describe("weapon pool headroom", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -163,6 +163,30 @@ describe("overrides (pip UI)", () => {
   });
 });
 
+describe("shield active cap", () => {
+  const shields = (count: number) =>
+    Array.from({ length: count }, () =>
+      hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+    );
+
+  it("powers only the first 2 shields by default (rest are backups)", () => {
+    const sim = simulateLoadoutPower([plant(40, 2), ...shields(3)], 0);
+    // Each shield = 4 cells; only 2 active → 8; the 3rd draws no power.
+    expect(sim.familyCapacity.shield).toBe(8);
+  });
+
+  it("respects a ship's own shield cap", () => {
+    const sim = simulateLoadoutPower(
+      [plant(40, 2), ...shields(3)],
+      0,
+      "SCM",
+      undefined,
+      3,
+    );
+    expect(sim.familyCapacity.shield).toBe(12);
+  });
+});
+
 describe("POWER_FAMILY_BY_CATEGORY", () => {
   it("maps the power-drawing families and leaves the rest unmapped", () => {
     expect(POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.WEAPONS]).toBe(

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -231,6 +231,23 @@ describe("overrides (pip UI)", () => {
     });
     expect(off.shieldPoolRatio).toBe(0);
   });
+
+  it("interpolates aim-assist range by radar power", () => {
+    const radar = hp(HardpointCategoryEnum.RADAR, {
+      powerConsumption: 5,
+      aimAssistMin: 1200,
+      aimAssistRange: 1925,
+    });
+    const ports = [plant(40, 2), radar];
+    // Radar is a primary family → fully powered → aim-assist reaches its max.
+    const full = simulateLoadoutPower(ports, 0);
+    expect(full.aimAssistMax).toBe(1925);
+    expect(full.aimAssist).toBe(1925);
+
+    // Radar off → no aim assist.
+    const off = simulateLoadoutPower(ports, 0, "SCM", { [radar.id]: 0 });
+    expect(off.aimAssist).toBe(0);
+  });
 });
 
 describe("shield active cap", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { HardpointCategoryEnum, type Hardpoint } from "@/services/fyApi";
-import { POWER_FAMILY_BY_CATEGORY, useLoadoutSim } from "./useLoadoutSim";
+import {
+  POWER_FAMILY_BY_CATEGORY,
+  simulateLoadoutPower,
+  useLoadoutSim,
+} from "./useLoadoutSim";
 
 let seq = 0;
 
@@ -96,6 +100,53 @@ describe("useLoadoutSim", () => {
     // Two nested weapons drawing 2 each → consumption 4, pool 2 → ratio 0.5.
     expect(sim.perFamily.weapon).toBe(2);
     expect(sim.weaponPoolRatio).toBeCloseTo(0.5);
+  });
+});
+
+describe("weaponMaxRatio (sustained-DPS input)", () => {
+  const weapons = (n: number, draw: number) =>
+    Array.from({ length: n }, () =>
+      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: draw }),
+    );
+
+  it("equals min(1, pool/consumption) when the plant has ample power", () => {
+    const hardpoints = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 40 }, {
+        component: { size: 2, typeData: { powerBase: 40 } },
+      } as Partial<Hardpoint>),
+      ...weapons(4, 2), // consumption 8, pool 4 → 0.5
+      hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+    ];
+    expect(simulateLoadoutPower(hardpoints, 4).weaponMaxRatio).toBeCloseTo(0.5);
+  });
+
+  it("caps below the uncapped ratio when the plant is segment-starved", () => {
+    const hardpoints = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 3 }, {
+        component: { size: 1, typeData: { powerBase: 3 } },
+      } as Partial<Hardpoint>),
+      hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 2 }),
+      ...weapons(4, 2), // consumption 8, pool 4 → uncapped 0.5
+    ];
+    // 3 segments, 1 reserved as life-support critical → weapons max 2 of pool 4.
+    const ratio = simulateLoadoutPower(hardpoints, 4).weaponMaxRatio;
+    expect(ratio).toBeLessThan(0.5);
+    expect(ratio).toBeCloseTo(2 / 8);
+  });
+
+  it("falls back to the uncapped ratio when there is no plant data (no regression)", () => {
+    const hardpoints = [...weapons(4, 2)]; // no power plant at all
+    expect(simulateLoadoutPower(hardpoints, 4).weaponMaxRatio).toBeCloseTo(0.5);
+  });
+
+  it("is 1 for a ship without a weapon pool", () => {
+    const hardpoints = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 5 }, {
+        component: { size: 1, typeData: { powerBase: 5 } },
+      } as Partial<Hardpoint>),
+      ...weapons(2, 2),
+    ];
+    expect(simulateLoadoutPower(hardpoints, 0).weaponMaxRatio).toBe(1);
   });
 });
 

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -421,7 +421,9 @@ describe("heat (cooling ratio)", () => {
 });
 
 describe("engine power ratio (flight scaling)", () => {
-  it("is 1 at the default and drops as engine pips are pulled", () => {
+  it("is 1 when the engine fills to capacity and 0 when unpowered", () => {
+    // Ample power fills every engine pip → full boost; pulling the pips to 0
+    // leaves the ship dead in the water (ratio 0).
     const engine = hp(HardpointCategoryEnum.CONTROLLER, {
       powerConsumption: 8,
       powerMinimumFraction: 0.125,
@@ -432,18 +434,38 @@ describe("engine power ratio (flight scaling)", () => {
     expect(off.enginePowerRatio).toBe(0);
   });
 
-  it("scales between 0 and 1 as engine pips are pulled part-way", () => {
-    // Engine fills to its capacity (8) by default; halving its pips halves the
-    // ratio that drives the boosted handling.
+  it("scales as engine pips are pulled part-way ((alloc − min) / (cap − min))", () => {
+    // Consumption 10, minimum 20% → a mandatory floor of 2. Full fills all 10
+    // → ratio 1; at 6 segments the boost ratio is (6 − 2) / (10 − 2) = 0.5.
     const engine = hp(HardpointCategoryEnum.CONTROLLER, {
-      powerConsumption: 8,
-      powerMinimumFraction: 0.25,
+      powerConsumption: 10,
+      powerMinimumFraction: 0.2,
     });
     const ports = [plant(60, 2), engine];
     const full = simulateLoadoutPower(ports, 0);
     expect(full.enginePowerRatio).toBe(1);
-    const half = simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 4 });
+    const half = simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 6 });
     expect(half.enginePowerRatio).toBeCloseTo(0.5);
+  });
+
+  it("is below 1 at the default when the engine can't fill to capacity", () => {
+    // The engine fills last, so a segment-starved plant leaves it part-filled
+    // at the default — a partial boost, like erkul's default 3/6 engine pips,
+    // rather than the fully-rated boost.
+    const engine = hp(HardpointCategoryEnum.CONTROLLER, {
+      powerConsumption: 8,
+      powerMinimumFraction: 0.125,
+    });
+    const ports = [
+      plant(6, 1),
+      hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+      engine,
+    ];
+    const sim = simulateLoadoutPower(ports, 0);
+    const col = sim.columns.find((c) => c.family === "engine")!;
+    expect(col.allocated).toBeLessThan(col.capacity);
+    expect(sim.enginePowerRatio).toBeGreaterThan(0);
+    expect(sim.enginePowerRatio).toBeLessThan(1);
   });
 
   it("is 1 when the ship has no engine power family", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -161,6 +161,16 @@ describe("overrides (pip UI)", () => {
     expect(sim.perFamily.weapon).toBe(0);
     expect(sim.weaponPoolRatio).toBe(0);
   });
+
+  it("allocates to any non-weapon family the user boosts (coolers/qdrive)", () => {
+    const hardpoints = [
+      plant(40, 2),
+      ...weapons(4, 2),
+      hp(HardpointCategoryEnum.COOLER, { powerConsumption: 3 }),
+    ];
+    const sim = simulateLoadoutPower(hardpoints, 4, "SCM", { coolers: 2 });
+    expect(sim.perFamily.coolers).toBe(2);
+  });
 });
 
 describe("shield active cap", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -298,6 +298,29 @@ describe("shield active cap", () => {
     const shieldCol = one.columns.find((c) => c.family === "shield");
     expect(shieldCol?.members).toHaveLength(2);
   });
+
+  it("allocates each generator independently when they have headroom", () => {
+    // Each generator: crit round(5 × 0.8) = 4, plus 1 regular → capacity 5.
+    const genA = hp(HardpointCategoryEnum.SHIELDGENERATOR, {
+      powerConsumption: 5,
+      powerMinimumFraction: 0.8,
+    });
+    const genB = hp(HardpointCategoryEnum.SHIELDGENERATOR, {
+      powerConsumption: 5,
+      powerMinimumFraction: 0.8,
+    });
+    const sim = simulateLoadoutPower([plant(40, 2), genA, genB], 0, "SCM", {
+      [genA.id]: 4,
+      [genB.id]: 5,
+    });
+    const col = sim.columns.find((c) => c.family === "shield");
+    const a = col?.members.find((m) => m.portPath === genA.id);
+    const b = col?.members.find((m) => m.portPath === genB.id);
+    expect(a?.capacity).toBe(5);
+    expect(a?.min).toBe(4);
+    expect(a?.allocated).toBe(4);
+    expect(b?.allocated).toBe(5);
+  });
 });
 
 describe("weapon pool headroom", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { HardpointCategoryEnum, type Hardpoint } from "@/services/fyApi";
+import { POWER_FAMILY_BY_CATEGORY, useLoadoutSim } from "./useLoadoutSim";
+
+let seq = 0;
+
+function hp(
+  category: HardpointCategoryEnum,
+  typeData: Record<string, unknown>,
+  extra: Partial<Hardpoint> = {},
+): Hardpoint {
+  seq += 1;
+  return {
+    id: `hp-${seq}`,
+    name: category,
+    category,
+    component: { size: 1, typeData } as Hardpoint["component"],
+    ...extra,
+  } as Hardpoint;
+}
+
+describe("useLoadoutSim", () => {
+  it("reproduces the max-power weapon ratio when segments are ample (Asgard)", () => {
+    // One plant of 20 segments, 4 weapons drawing 2 each (consumption 8), a
+    // shield and life support. Weapon pool 4 → weapon fills to 4 → ratio 0.5.
+    const hardpoints: Hardpoint[] = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
+        component: { size: 2, typeData: { powerBase: 20 } },
+      } as Partial<Hardpoint>),
+      ...Array.from({ length: 4 }, () =>
+        hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+      ),
+      hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 3 }),
+      hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 1 }),
+    ];
+
+    const sim = useLoadoutSim(hardpoints, 4).value;
+
+    expect(sim.totalSegments).toBe(20);
+    expect(sim.perFamily.weapon).toBe(4);
+    expect(sim.weaponPoolRatio).toBeCloseTo(0.5);
+    // Ample power leaves the non-weapon families fully fed.
+    expect(sim.perFamily.shield).toBeGreaterThan(0);
+    expect(sim.perFamily.lifeSupport).toBeGreaterThan(0);
+  });
+
+  it("throttles the weapon pool when the plant is segment-starved", () => {
+    const hardpoints: Hardpoint[] = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 3 }, {
+        component: { size: 1, typeData: { powerBase: 3 } },
+      } as Partial<Hardpoint>),
+      hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 2 }),
+      ...Array.from({ length: 4 }, () =>
+        hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+      ),
+    ];
+
+    const sim = useLoadoutSim(hardpoints, 4).value;
+
+    // 3 segments: life support keeps its critical block, weapons get the rest —
+    // below the pool of 4, so the ratio drops under the max-power 0.5.
+    expect(sim.totalSegments).toBe(3);
+    expect(sim.weaponPoolRatio).toBeLessThan(0.5);
+  });
+
+  it("treats a ship without a weapon pool as power-unlimited (ratio 1)", () => {
+    const hardpoints: Hardpoint[] = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 10 }, {
+        component: { size: 1, typeData: { powerBase: 10 } },
+      } as Partial<Hardpoint>),
+      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+    ];
+
+    expect(useLoadoutSim(hardpoints, 0).value.weaponPoolRatio).toBe(1);
+    expect(useLoadoutSim(hardpoints, undefined).value.weaponPoolRatio).toBe(1);
+  });
+
+  it("descends into nested hardpoints (weapons under a mount)", () => {
+    const hardpoints: Hardpoint[] = [
+      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
+        component: { size: 1, typeData: { powerBase: 20 } },
+      } as Partial<Hardpoint>),
+      hp(
+        HardpointCategoryEnum.WEAPON_MOUNTS,
+        {},
+        {
+          hardpoints: [
+            hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+            hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+          ],
+        },
+      ),
+    ];
+
+    const sim = useLoadoutSim(hardpoints, 2).value;
+    // Two nested weapons drawing 2 each → consumption 4, pool 2 → ratio 0.5.
+    expect(sim.perFamily.weapon).toBe(2);
+    expect(sim.weaponPoolRatio).toBeCloseTo(0.5);
+  });
+});
+
+describe("POWER_FAMILY_BY_CATEGORY", () => {
+  it("maps the power-drawing families and leaves the rest unmapped", () => {
+    expect(POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.WEAPONS]).toBe(
+      "weapon",
+    );
+    expect(
+      POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.SHIELDGENERATOR],
+    ).toBe("shield");
+    expect(POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.CONTROLLER]).toBe(
+      "engine",
+    );
+    // Thrusters / fuel draw no power segments in erkul's model.
+    expect(
+      POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.MAIN_THRUSTERS],
+    ).toBeUndefined();
+    expect(
+      POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.FUELTANKS],
+    ).toBeUndefined();
+  });
+});

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -8,32 +8,47 @@ import {
 
 let seq = 0;
 
+// The component payload union, taken from the generated Hardpoint type. Each
+// member is all-optional, so a minimal `{ powerBase }` / `{ powerConsumption }`
+// fixture satisfies it without hand-rolling a shape.
+type ComponentTypeData = NonNullable<Hardpoint["component"]>["typeData"];
+
 function hp(
   category: HardpointCategoryEnum,
-  typeData: Record<string, unknown>,
-  extra: Partial<Hardpoint> = {},
+  typeData: ComponentTypeData,
+  opts: { size?: number; children?: Hardpoint[] } = {},
 ): Hardpoint {
   seq += 1;
   return {
     id: `hp-${seq}`,
     name: category,
     category,
-    component: { size: 1, typeData } as Hardpoint["component"],
-    ...extra,
+    component: {
+      name: category,
+      size: String(opts.size ?? 1),
+      typeData,
+    } as Hardpoint["component"],
+    hardpoints: opts.children ?? [],
+    createdAt: "",
+    updatedAt: "",
   } as Hardpoint;
 }
+
+const plant = (powerBase: number, size = 1) =>
+  hp(HardpointCategoryEnum.POWERPLANT, { powerBase }, { size });
+
+const weapons = (count: number, draw: number) =>
+  Array.from({ length: count }, () =>
+    hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: draw }),
+  );
 
 describe("useLoadoutSim", () => {
   it("reproduces the max-power weapon ratio when segments are ample (Asgard)", () => {
     // One plant of 20 segments, 4 weapons drawing 2 each (consumption 8), a
     // shield and life support. Weapon pool 4 → weapon fills to 4 → ratio 0.5.
-    const hardpoints: Hardpoint[] = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
-        component: { size: 2, typeData: { powerBase: 20 } },
-      } as Partial<Hardpoint>),
-      ...Array.from({ length: 4 }, () =>
-        hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-      ),
+    const hardpoints = [
+      plant(20, 2),
+      ...weapons(4, 2),
       hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 3 }),
       hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 1 }),
     ];
@@ -49,14 +64,10 @@ describe("useLoadoutSim", () => {
   });
 
   it("throttles the weapon pool when the plant is segment-starved", () => {
-    const hardpoints: Hardpoint[] = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 3 }, {
-        component: { size: 1, typeData: { powerBase: 3 } },
-      } as Partial<Hardpoint>),
+    const hardpoints = [
+      plant(3),
       hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 2 }),
-      ...Array.from({ length: 4 }, () =>
-        hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-      ),
+      ...weapons(4, 2),
     ];
 
     const sim = useLoadoutSim(hardpoints, 4).value;
@@ -68,32 +79,16 @@ describe("useLoadoutSim", () => {
   });
 
   it("treats a ship without a weapon pool as power-unlimited (ratio 1)", () => {
-    const hardpoints: Hardpoint[] = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 10 }, {
-        component: { size: 1, typeData: { powerBase: 10 } },
-      } as Partial<Hardpoint>),
-      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-    ];
+    const hardpoints = [plant(10), ...weapons(1, 2)];
 
     expect(useLoadoutSim(hardpoints, 0).value.weaponPoolRatio).toBe(1);
     expect(useLoadoutSim(hardpoints, undefined).value.weaponPoolRatio).toBe(1);
   });
 
   it("descends into nested hardpoints (weapons under a mount)", () => {
-    const hardpoints: Hardpoint[] = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
-        component: { size: 1, typeData: { powerBase: 20 } },
-      } as Partial<Hardpoint>),
-      hp(
-        HardpointCategoryEnum.WEAPON_MOUNTS,
-        {},
-        {
-          hardpoints: [
-            hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-            hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-          ],
-        },
-      ),
+    const hardpoints = [
+      plant(20),
+      hp(HardpointCategoryEnum.WEAPON_MOUNTS, {}, { children: weapons(2, 2) }),
     ];
 
     const sim = useLoadoutSim(hardpoints, 2).value;
@@ -104,16 +99,9 @@ describe("useLoadoutSim", () => {
 });
 
 describe("weaponMaxRatio (sustained-DPS input)", () => {
-  const weapons = (n: number, draw: number) =>
-    Array.from({ length: n }, () =>
-      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: draw }),
-    );
-
   it("equals min(1, pool/consumption) when the plant has ample power", () => {
     const hardpoints = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 40 }, {
-        component: { size: 2, typeData: { powerBase: 40 } },
-      } as Partial<Hardpoint>),
+      plant(40, 2),
       ...weapons(4, 2), // consumption 8, pool 4 → 0.5
       hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
     ];
@@ -122,9 +110,7 @@ describe("weaponMaxRatio (sustained-DPS input)", () => {
 
   it("caps below the uncapped ratio when the plant is segment-starved", () => {
     const hardpoints = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 3 }, {
-        component: { size: 1, typeData: { powerBase: 3 } },
-      } as Partial<Hardpoint>),
+      plant(3),
       hp(HardpointCategoryEnum.LIFESUPPORT, { powerConsumption: 2 }),
       ...weapons(4, 2), // consumption 8, pool 4 → uncapped 0.5
     ];
@@ -135,29 +121,22 @@ describe("weaponMaxRatio (sustained-DPS input)", () => {
   });
 
   it("falls back to the uncapped ratio when there is no plant data (no regression)", () => {
-    const hardpoints = [...weapons(4, 2)]; // no power plant at all
-    expect(simulateLoadoutPower(hardpoints, 4).weaponMaxRatio).toBeCloseTo(0.5);
+    expect(simulateLoadoutPower(weapons(4, 2), 4).weaponMaxRatio).toBeCloseTo(
+      0.5,
+    );
   });
 
   it("is 1 for a ship without a weapon pool", () => {
-    const hardpoints = [
-      hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 5 }, {
-        component: { size: 1, typeData: { powerBase: 5 } },
-      } as Partial<Hardpoint>),
-      ...weapons(2, 2),
-    ];
-    expect(simulateLoadoutPower(hardpoints, 0).weaponMaxRatio).toBe(1);
+    expect(
+      simulateLoadoutPower([plant(5), ...weapons(2, 2)], 0).weaponMaxRatio,
+    ).toBe(1);
   });
 });
 
 describe("overrides (pip UI)", () => {
   const asgardLike = (): Hardpoint[] => [
-    hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
-      component: { size: 2, typeData: { powerBase: 20 } },
-    } as Partial<Hardpoint>),
-    ...Array.from({ length: 4 }, () =>
-      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
-    ),
+    plant(20, 2),
+    ...weapons(4, 2),
     hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
   ];
 

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -420,6 +420,30 @@ describe("heat (cooling ratio)", () => {
   });
 });
 
+describe("engine power ratio (flight scaling)", () => {
+  it("is 1 at the default and drops as engine pips are pulled", () => {
+    const engine = hp(HardpointCategoryEnum.CONTROLLER, {
+      powerConsumption: 8,
+      powerMinimumFraction: 0.125,
+    });
+    const ports = [plant(40, 2), engine];
+    expect(simulateLoadoutPower(ports, 0).enginePowerRatio).toBe(1);
+    const off = simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 0 });
+    expect(off.enginePowerRatio).toBe(0);
+  });
+
+  it("is 1 when the ship has no engine power family", () => {
+    const sim = simulateLoadoutPower(
+      [
+        plant(40, 2),
+        hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+      ],
+      0,
+    );
+    expect(sim.enginePowerRatio).toBe(1);
+  });
+});
+
 describe("weapon pool headroom", () => {
   it("renders the full pool but is only fillable up to weapon demand", () => {
     // One energy weapon drawing 2 (consumption 2) with a pool of 10 → the

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -4,7 +4,16 @@ import {
   POWER_FAMILY_BY_CATEGORY,
   simulateLoadoutPower,
   useLoadoutSim,
+  WEAPON_POOL_PORT,
+  type LoadoutSimResult,
 } from "./useLoadoutSim";
+import type { PowerFamily } from "./powerSim";
+
+// Sum a family's per-component column capacities.
+const familyCapacity = (sim: LoadoutSimResult, family: PowerFamily) =>
+  sim.columns
+    .filter((column) => column.family === family)
+    .reduce((sum, column) => sum + column.capacity, 0);
 
 let seq = 0;
 
@@ -141,7 +150,9 @@ describe("overrides (pip UI)", () => {
   ];
 
   it("throttles weapons down to the override target", () => {
-    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", { weapon: 2 });
+    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", {
+      [WEAPON_POOL_PORT]: 2,
+    });
     expect(sim.perFamily.weapon).toBe(2);
     // consumption 8, weapon segments 2 → ratio 0.25 (below the 0.5 max).
     expect(sim.weaponPoolRatio).toBeCloseTo(0.25);
@@ -149,27 +160,31 @@ describe("overrides (pip UI)", () => {
     expect(sim.weaponMaxRatio).toBeCloseTo(0.5);
   });
 
-  it("reports each family's capacity for the slider bounds", () => {
+  it("exposes one column per component with its capacity", () => {
     const sim = simulateLoadoutPower(asgardLike(), 4);
-    // weapon pool 4, consumption 8 → 4 enabled blocks.
-    expect(sim.familyCapacity.weapon).toBe(4);
-    expect(sim.familyCapacity.shield).toBe(4);
+    const weaponCol = sim.columns.find((c) => c.portPath === WEAPON_POOL_PORT);
+    expect(weaponCol?.capacity).toBe(4);
+    expect(familyCapacity(sim, "shield")).toBe(4);
   });
 
   it("lets the user take weapons all the way to 0 (no forced base)", () => {
-    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", { weapon: 0 });
+    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", {
+      [WEAPON_POOL_PORT]: 0,
+    });
     expect(sim.perFamily.weapon).toBe(0);
     expect(sim.weaponPoolRatio).toBe(0);
   });
 
-  it("allocates to any non-weapon family the user boosts (coolers/qdrive)", () => {
-    const hardpoints = [
-      plant(40, 2),
-      ...weapons(4, 2),
-      hp(HardpointCategoryEnum.COOLER, { powerConsumption: 3 }),
-    ];
-    const sim = simulateLoadoutPower(hardpoints, 4, "SCM", { coolers: 2 });
-    expect(sim.perFamily.coolers).toBe(2);
+  it("allocates to a specific non-weapon component the user boosts", () => {
+    const cooler = hp(HardpointCategoryEnum.COOLER, { powerConsumption: 3 });
+    const sim = simulateLoadoutPower(
+      [plant(40, 2), ...weapons(4, 2), cooler],
+      4,
+      "SCM",
+      { [cooler.id]: 2 },
+    );
+    const coolerCol = sim.columns.find((c) => c.portPath === cooler.id);
+    expect(coolerCol?.allocated).toBe(2);
   });
 });
 
@@ -181,8 +196,9 @@ describe("shield active cap", () => {
 
   it("powers only the first 2 shields by default (rest are backups)", () => {
     const sim = simulateLoadoutPower([plant(40, 2), ...shields(3)], 0);
-    // Each shield = 4 cells; only 2 active → 8; the 3rd draws no power.
-    expect(sim.familyCapacity.shield).toBe(8);
+    // 2 columns of 4 cells; the 3rd shield draws no power (no column).
+    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(2);
+    expect(familyCapacity(sim, "shield")).toBe(8);
   });
 
   it("respects a ship's own shield cap", () => {
@@ -193,7 +209,8 @@ describe("shield active cap", () => {
       undefined,
       3,
     );
-    expect(sim.familyCapacity.shield).toBe(12);
+    expect(sim.columns.filter((c) => c.family === "shield")).toHaveLength(3);
+    expect(familyCapacity(sim, "shield")).toBe(12);
   });
 });
 

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -478,6 +478,23 @@ describe("engine power ratio (flight scaling)", () => {
     );
     expect(sim.enginePowerRatio).toBe(1);
   });
+
+  it("reports the engine inactive only when every engine pip is pulled", () => {
+    const engine = hp(HardpointCategoryEnum.CONTROLLER, {
+      powerConsumption: 8,
+      powerMinimumFraction: 0.125,
+    });
+    const ports = [plant(40, 2), engine];
+    // Default (engine powered) and at the floor → still active.
+    expect(simulateLoadoutPower(ports, 0).engineActive).toBe(true);
+    expect(
+      simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 1 }).engineActive,
+    ).toBe(true);
+    // Every pip pulled → dead in the water.
+    expect(
+      simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 0 }).engineActive,
+    ).toBe(false);
+  });
 });
 
 describe("weapon pool headroom", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -432,6 +432,20 @@ describe("engine power ratio (flight scaling)", () => {
     expect(off.enginePowerRatio).toBe(0);
   });
 
+  it("scales between 0 and 1 as engine pips are pulled part-way", () => {
+    // Engine fills to its capacity (8) by default; halving its pips halves the
+    // ratio that drives the boosted handling.
+    const engine = hp(HardpointCategoryEnum.CONTROLLER, {
+      powerConsumption: 8,
+      powerMinimumFraction: 0.25,
+    });
+    const ports = [plant(60, 2), engine];
+    const full = simulateLoadoutPower(ports, 0);
+    expect(full.enginePowerRatio).toBe(1);
+    const half = simulateLoadoutPower(ports, 0, "SCM", { [engine.id]: 4 });
+    expect(half.enginePowerRatio).toBeCloseTo(0.5);
+  });
+
   it("is 1 when the ship has no engine power family", () => {
     const sim = simulateLoadoutPower(
       [

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -150,6 +150,34 @@ describe("weaponMaxRatio (sustained-DPS input)", () => {
   });
 });
 
+describe("overrides (pip UI)", () => {
+  const asgardLike = (): Hardpoint[] => [
+    hp(HardpointCategoryEnum.POWERPLANT, { powerBase: 20 }, {
+      component: { size: 2, typeData: { powerBase: 20 } },
+    } as Partial<Hardpoint>),
+    ...Array.from({ length: 4 }, () =>
+      hp(HardpointCategoryEnum.WEAPONS, { powerConsumption: 2 }),
+    ),
+    hp(HardpointCategoryEnum.SHIELDGENERATOR, { powerConsumption: 4 }),
+  ];
+
+  it("throttles weapons down to the override target", () => {
+    const sim = simulateLoadoutPower(asgardLike(), 4, "SCM", { weapon: 2 });
+    expect(sim.perFamily.weapon).toBe(2);
+    // consumption 8, weapon segments 2 → ratio 0.25 (below the 0.5 max).
+    expect(sim.weaponPoolRatio).toBeCloseTo(0.25);
+    // The max-power baseline is unaffected by the override.
+    expect(sim.weaponMaxRatio).toBeCloseTo(0.5);
+  });
+
+  it("reports each family's capacity for the slider bounds", () => {
+    const sim = simulateLoadoutPower(asgardLike(), 4);
+    // weapon pool 4, consumption 8 → 4 enabled blocks.
+    expect(sim.familyCapacity.weapon).toBe(4);
+    expect(sim.familyCapacity.shield).toBe(4);
+  });
+});
+
 describe("POWER_FAMILY_BY_CATEGORY", () => {
   it("maps the power-drawing families and leaves the rest unmapped", () => {
     expect(POWER_FAMILY_BY_CATEGORY[HardpointCategoryEnum.WEAPONS]).toBe(

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -223,6 +223,14 @@ describe("overrides (pip UI)", () => {
     expect(reduced.remaining).toBeGreaterThan(base.remaining);
     expect(reduced.perFamily.weapon).toBe(base.perFamily.weapon);
   });
+
+  it("exposes a shieldPoolRatio that drops to 0 when shields are unpowered", () => {
+    expect(simulateLoadoutPower(asgardLike(), 4).shieldPoolRatio).toBe(1);
+    const off = simulateLoadoutPower(asgardLike(), 4, "SCM", {
+      [SHIELD_POOL_PORT]: 0,
+    });
+    expect(off.shieldPoolRatio).toBe(0);
+  });
 });
 
 describe("shield active cap", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.spec.ts
@@ -328,6 +328,7 @@ describe("heat (cooling ratio)", () => {
     hp(HardpointCategoryEnum.COOLER, {
       powerConsumption: 3,
       coolingRate: 30,
+      signatureIr: 7000,
       powerRanges: {
         low: { start: 1, modifier: 0.7 },
         medium: { start: 2, modifier: 0.85 },
@@ -348,6 +349,19 @@ describe("heat (cooling ratio)", () => {
       sim.heatGeneration / sim.coolingPerSec,
       5,
     );
+  });
+
+  it("emits IR from the active coolers, scaled by the cooling ratio", () => {
+    const ls = hp(HardpointCategoryEnum.LIFESUPPORT, {
+      powerConsumption: 2,
+      powerMinimumFraction: 0.5,
+    });
+    const sim = simulateLoadoutPower([plant(40, 2), cooler(), ls], 0);
+    expect(sim.emittedIr).toBeGreaterThan(0);
+
+    // No plant → no active cooling → no IR emission.
+    const coolerOff = simulateLoadoutPower([cooler(), ls], 0);
+    expect(coolerOff.emittedIr).toBe(0);
   });
 
   it("exceeds 1 when the coolers can't keep up (under-cooled)", () => {

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -7,10 +7,25 @@ import {
   totalSegments,
   weaponPoolBlocks,
   weaponPoolRatio,
+  WEAPON_POOL_PORT,
+  type AllocationState,
   type FlightMode,
+  type PortOverrides,
   type PowerFamily,
   type PowerPort,
 } from "./powerSim";
+
+export { WEAPON_POOL_PORT, type PortOverrides } from "./powerSim";
+
+// A single power column in the pip UI — one component, or the shared weapon
+// pool. `label` is the component name (undefined for the weapon pool).
+export type PowerColumn = {
+  portPath: string;
+  family: PowerFamily;
+  label?: string;
+  allocated: number;
+  capacity: number;
+};
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
 // feeds power segments to are mapped; every other category (thrusters, fuel,
@@ -33,15 +48,12 @@ export const POWER_FAMILY_BY_CATEGORY: Partial<
   [HardpointCategoryEnum.SALVAGEMUNCHING]: "salvage",
 };
 
-export type FamilyOverrides = Partial<Record<PowerFamily, number>>;
-
 export type LoadoutSimResult = {
   totalSegments: number;
   remaining: number;
   perFamily: Record<PowerFamily, number>;
-  // Max segments each family could hold (for the pip UI slider bounds): the sum
-  // of its enabled port sizes.
-  familyCapacity: Record<PowerFamily, number>;
+  // Per-component (+ weapon pool) columns for the pip UI, in display order.
+  columns: PowerColumn[];
   // Weapon sustained-DPS ratio at the *current* allocation (reflects overrides).
   weaponPoolRatio: number;
   // Weapon sustained-DPS ratio with weapons at maximum pips (other families
@@ -59,6 +71,7 @@ type Collected = {
   plants: { units: number; size: number; poweredOn: boolean }[];
   weaponUnits: number;
   otherPorts: PowerPort[];
+  portLabels: Record<string, string>;
   shieldsSeen: number;
 };
 
@@ -111,6 +124,9 @@ function collectPorts(
                 minimumFraction,
               }),
             );
+            if (hardpoint.component?.name) {
+              acc.portLabels[hardpoint.id] = hardpoint.component.name;
+            }
           }
         }
       }
@@ -150,14 +166,55 @@ function computeWeaponMaxRatio(
   return Math.min(uncapped, weaponMax / consumption);
 }
 
+// Group the allocation into display columns: one per component (+ the shared
+// weapon pool), ordered by family, dropping ports with no capacity.
+function buildColumns(
+  ports: PowerPort[],
+  portLabels: Record<string, string>,
+  state: AllocationState,
+): PowerColumn[] {
+  const byPort = new Map<string, { family: PowerFamily; capacity: number }>();
+  const order: string[] = [];
+  for (const port of ports) {
+    let entry = byPort.get(port.portPath);
+    if (!entry) {
+      entry = { family: port.family, capacity: 0 };
+      byPort.set(port.portPath, entry);
+      order.push(port.portPath);
+    }
+    if (!port.disabled) entry.capacity += port.size;
+  }
+
+  const columns = order
+    .map((portPath) => {
+      const entry = byPort.get(portPath) as {
+        family: PowerFamily;
+        capacity: number;
+      };
+      return {
+        portPath,
+        family: entry.family,
+        label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
+        allocated: state.perPort[portPath] ?? 0,
+        capacity: entry.capacity,
+      };
+    })
+    .filter((column) => column.capacity > 0);
+
+  return columns.sort(
+    (a, b) =>
+      POWER_FAMILIES.indexOf(a.family) - POWER_FAMILIES.indexOf(b.family),
+  );
+}
+
 // Pure core: build the family ports from a loadout, run erkul's allocation over
-// the plants' segments, and expose the per-family segments and the weapon
-// sustained-DPS ratios (default SCM split + max-weapon).
+// the plants' segments, and expose the per-component columns and the weapon
+// sustained-DPS ratios (current allocation + max-weapon).
 export function simulateLoadoutPower(
   hardpoints: Hardpoint[] | undefined,
   weaponPoolSize: number | undefined,
   mode: FlightMode = "SCM",
-  overrides?: FamilyOverrides,
+  overrides?: PortOverrides,
   shieldMaxItemCount: number = DEFAULT_SHIELD_MAX_ITEM_COUNT,
 ): LoadoutSimResult {
   const acc = collectPorts(
@@ -166,6 +223,7 @@ export function simulateLoadoutPower(
       plants: [],
       weaponUnits: 0,
       otherPorts: [],
+      portLabels: {},
       shieldsSeen: 0,
     },
     shieldMaxItemCount,
@@ -175,16 +233,9 @@ export function simulateLoadoutPower(
   const consumption = Math.ceil(acc.weaponUnits);
 
   const ports: PowerPort[] = [
-    ...weaponPoolBlocks("weaponPool", acc.weaponUnits, pool),
+    ...weaponPoolBlocks(WEAPON_POOL_PORT, acc.weaponUnits, pool),
     ...acc.otherPorts,
   ];
-
-  const familyCapacity = Object.fromEntries(
-    POWER_FAMILIES.map((f) => [f, 0]),
-  ) as Record<PowerFamily, number>;
-  for (const port of ports) {
-    if (!port.disabled) familyCapacity[port.family] += port.size;
-  }
 
   const state = allocatePower(ports, segments, {
     mode,
@@ -193,11 +244,13 @@ export function simulateLoadoutPower(
     overrides,
   });
 
+  const columns = buildColumns(ports, acc.portLabels, state);
+
   return {
     totalSegments: segments,
     remaining: state.remaining,
     perFamily: state.perFamily,
-    familyCapacity,
+    columns,
     // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
     weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
     weaponMaxRatio: computeWeaponMaxRatio(
@@ -214,7 +267,7 @@ export function useLoadoutSim(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
   weaponPoolSize: MaybeRefOrGetter<number | undefined>,
   mode: MaybeRefOrGetter<FlightMode> = () => "SCM",
-  overrides: MaybeRefOrGetter<FamilyOverrides | undefined> = () => undefined,
+  overrides: MaybeRefOrGetter<PortOverrides | undefined> = () => undefined,
   shieldMaxItemCount: MaybeRefOrGetter<number | undefined> = () => undefined,
 ) {
   return computed<LoadoutSimResult>(() =>

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -3,6 +3,7 @@ import { HardpointCategoryEnum, type Hardpoint } from "@/services/fyApi";
 import {
   allocatePower,
   componentBlocks,
+  POWER_FAMILIES,
   totalSegments,
   weaponPoolBlocks,
   weaponPoolRatio,
@@ -32,16 +33,21 @@ export const POWER_FAMILY_BY_CATEGORY: Partial<
   [HardpointCategoryEnum.SALVAGEMUNCHING]: "salvage",
 };
 
+export type FamilyOverrides = Partial<Record<PowerFamily, number>>;
+
 export type LoadoutSimResult = {
   totalSegments: number;
   remaining: number;
   perFamily: Record<PowerFamily, number>;
-  // Weapon sustained-DPS ratio in the *default* SCM auto-distribution.
+  // Max segments each family could hold (for the pip UI slider bounds): the sum
+  // of its enabled port sizes.
+  familyCapacity: Record<PowerFamily, number>;
+  // Weapon sustained-DPS ratio at the *current* allocation (reflects overrides).
   weaponPoolRatio: number;
   // Weapon sustained-DPS ratio with weapons at maximum pips (other families
   // dropped to their mandatory minimums) — the max-power model sustained DPS
-  // uses. Equals min(1, poolSize/consumption) unless the plant literally can't
-  // deliver enough segments to fill the pool.
+  // uses as its baseline. Equals min(1, poolSize/consumption) unless the plant
+  // literally can't deliver enough segments to fill the pool.
   weaponMaxRatio: number;
 };
 
@@ -139,6 +145,7 @@ export function simulateLoadoutPower(
   hardpoints: Hardpoint[] | undefined,
   weaponPoolSize: number | undefined,
   mode: FlightMode = "SCM",
+  overrides?: FamilyOverrides,
 ): LoadoutSimResult {
   const acc = collectPorts(hardpoints, {
     plants: [],
@@ -154,16 +161,25 @@ export function simulateLoadoutPower(
     ...acc.otherPorts,
   ];
 
+  const familyCapacity = Object.fromEntries(
+    POWER_FAMILIES.map((f) => [f, 0]),
+  ) as Record<PowerFamily, number>;
+  for (const port of ports) {
+    if (!port.disabled) familyCapacity[port.family] += port.size;
+  }
+
   const state = allocatePower(ports, segments, {
     mode,
     weaponConsumption: consumption,
     weaponPoolSize: pool,
+    overrides,
   });
 
   return {
     totalSegments: segments,
     remaining: state.remaining,
     perFamily: state.perFamily,
+    familyCapacity,
     // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
     weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
     weaponMaxRatio: computeWeaponMaxRatio(
@@ -180,12 +196,14 @@ export function useLoadoutSim(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
   weaponPoolSize: MaybeRefOrGetter<number | undefined>,
   mode: MaybeRefOrGetter<FlightMode> = () => "SCM",
+  overrides: MaybeRefOrGetter<FamilyOverrides | undefined> = () => undefined,
 ) {
   return computed<LoadoutSimResult>(() =>
     simulateLoadoutPower(
       toValue(hardpoints),
       toValue(weaponPoolSize),
       toValue(mode),
+      toValue(overrides),
     ),
   );
 }

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -258,12 +258,33 @@ export function simulateLoadoutPower(
     ...acc.otherPorts,
   ];
 
-  const state = allocatePower(ports, segments, {
+  const allocateOpts = {
     mode,
     weaponConsumption: consumption,
     weaponPoolSize: pool,
-    overrides,
-  });
+  };
+
+  // The default distribution (no user input).
+  const baseline = allocatePower(ports, segments, allocateOpts);
+
+  // Once the user assigns pips, pin every untouched component to its baseline
+  // and honor the overrides — so freed pips return to the pool rather than
+  // being greedily re-grabbed by another primary family (e.g. shields).
+  let state = baseline;
+  if (overrides && Object.keys(overrides).length > 0) {
+    const targets: PortOverrides = {};
+    const seen = new Set<string>();
+    for (const port of ports) {
+      if (seen.has(port.portPath)) continue;
+      seen.add(port.portPath);
+      targets[port.portPath] =
+        overrides[port.portPath] ?? baseline.perPort[port.portPath] ?? 0;
+    }
+    state = allocatePower(ports, segments, {
+      ...allocateOpts,
+      overrides: targets,
+    });
+  }
 
   const columns = buildColumns(ports, acc.portLabels, state);
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -96,7 +96,21 @@ type HeatComponent = {
   ranges: PowerRange[];
   coolingRate: number;
   irNominal: number;
+  emNominal: number;
 };
+
+// A power plant as an EM source (plants emit the most EM, weighted by ship-wide
+// power utilization) and a segment source.
+type PowerPlant = {
+  units: number;
+  size: number;
+  poweredOn: boolean;
+  emNominal: number;
+  ranges: PowerRange[];
+};
+
+// A weapon's EM contribution (per-weapon nominal + its power-range curve).
+type WeaponEmSource = { emNominal: number; ranges: PowerRange[] };
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
 // feeds power segments to are mapped; every other category (thrusters, fuel,
@@ -149,6 +163,8 @@ export type LoadoutSimResult = {
   coolingRatio: number;
   // Emitted infrared signature at the current allocation (scaled by cooling).
   emittedIr: number;
+  // Emitted electromagnetic signature at the current allocation.
+  emittedEm: number;
 };
 
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
@@ -156,8 +172,9 @@ export type LoadoutSimResult = {
 export const DEFAULT_SHIELD_MAX_ITEM_COUNT = 2;
 
 type Collected = {
-  plants: { units: number; size: number; poweredOn: boolean }[];
+  plants: PowerPlant[];
   weaponUnits: number;
+  weaponEmSources: WeaponEmSource[];
   otherPorts: PowerPort[];
   portLabels: Record<string, string>;
   shieldsSeen: number;
@@ -192,6 +209,8 @@ function collectPorts(
             units,
             size: numeric(hardpoint.component?.size),
             poweredOn: true,
+            emNominal: numeric(typeData.signatureEm),
+            ranges: toRanges(typeData.powerRanges),
           });
         }
       } else {
@@ -205,6 +224,13 @@ function collectPorts(
         const draw = numeric(typeData.powerConsumption);
         if (family === "weapon") {
           acc.weaponUnits += draw;
+          const emNominal = numeric(typeData.signatureEm);
+          if (emNominal > 0) {
+            acc.weaponEmSources.push({
+              emNominal,
+              ranges: toRanges(typeData.powerRanges),
+            });
+          }
         } else if (family && draw > 0) {
           // Shields past the active cap are unpowered backups.
           const isBackupShield =
@@ -230,6 +256,7 @@ function collectPorts(
               coolingRate:
                 family === "coolers" ? numeric(typeData.coolingRate) : 0,
               irNominal: numeric(typeData.signatureIr),
+              emNominal: numeric(typeData.signatureEm),
             });
             if (hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
@@ -428,6 +455,55 @@ function computeHeat(
   };
 }
 
+// EM signature (erkul's `yr`): power plants weighted by ship-wide power
+// utilization, weapons weighted by their pool fill ratio, and every other
+// powered component scaled by its active-segment fraction — each × its
+// power-range modifier and nominal EM emission.
+function computeEm(
+  plants: PowerPlant[],
+  weaponEmSources: WeaponEmSource[],
+  components: HeatComponent[],
+  perPort: Record<string, number>,
+  usedSegments: number,
+  totalSegments: number,
+  weaponAllocated: number,
+  weaponRatio: number,
+): number {
+  let em = 0;
+
+  const poweredPlants = plants.filter((plant) => plant.poweredOn);
+  if (poweredPlants.length > 0 && totalSegments > 0) {
+    const utilization = usedSegments / totalSegments;
+    const perPlant = Math.round(usedSegments) / poweredPlants.length;
+    const plantSum = poweredPlants.reduce(
+      (sum, plant) =>
+        sum + plant.emNominal * rangeModifier(plant.ranges, perPlant),
+      0,
+    );
+    em += plantSum * utilization;
+  }
+
+  if (weaponAllocated > 0 && weaponRatio > 0) {
+    const weaponSum = weaponEmSources.reduce(
+      (sum, weapon) =>
+        sum + weapon.emNominal * rangeModifier(weapon.ranges, weaponAllocated),
+      0,
+    );
+    em += weaponSum * weaponRatio;
+  }
+
+  for (const component of components) {
+    const active = perPort[component.portPath] ?? 0;
+    if (active <= 0 || component.units <= 0) continue;
+    em +=
+      component.emNominal *
+      rangeModifier(component.ranges, active) *
+      (active / component.units);
+  }
+
+  return em;
+}
+
 // Pure core: build the family ports from a loadout, run erkul's allocation over
 // the plants' segments, and expose the per-component columns and the weapon
 // sustained-DPS ratios (current allocation + max-weapon).
@@ -443,6 +519,7 @@ export function simulateLoadoutPower(
     {
       plants: [],
       weaponUnits: 0,
+      weaponEmSources: [],
       otherPorts: [],
       portLabels: {},
       shieldsSeen: 0,
@@ -517,10 +594,18 @@ export function simulateLoadoutPower(
         )
       : 0;
 
-  const heat = computeHeat(
+  const usedSegments = segments - state.remaining;
+  const heat = computeHeat(acc.components, usedSegments, state.perPort);
+  const weaponRatioValue = pool <= 0 ? 1 : weaponPoolRatio(state, consumption);
+  const emittedEm = computeEm(
+    acc.plants,
+    acc.weaponEmSources,
     acc.components,
-    segments - state.remaining,
     state.perPort,
+    usedSegments,
+    segments,
+    state.perPort[WEAPON_POOL_PORT] ?? 0,
+    weaponRatioValue,
   );
 
   return {
@@ -529,7 +614,7 @@ export function simulateLoadoutPower(
     perFamily: state.perFamily,
     columns,
     // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
-    weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
+    weaponPoolRatio: weaponRatioValue,
     weaponMaxRatio: computeWeaponMaxRatio(
       pool,
       consumption,
@@ -544,6 +629,7 @@ export function simulateLoadoutPower(
     heatGeneration: heat.heatGeneration,
     coolingRatio: heat.coolingRatio,
     emittedIr: heat.emittedIr,
+    emittedEm,
   };
 }
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -20,11 +20,15 @@ export { WEAPON_POOL_PORT, type PortOverrides } from "./powerSim";
 // One controllable unit inside a column: a single component (or the shared
 // weapon pool). `min` is the mandatory floor — the unit is either off (0) or on
 // at ≥ `min` segments (min === capacity for all-critical systems like the QD).
+// `capacity` is every rendered slot; `fillable` is how many can actually take
+// power (they differ only for the weapon pool, which shows its full pool but is
+// fillable only up to the mounted energy weapons' demand).
 export type PowerColumnMember = {
   portPath: string;
   label?: string;
   allocated: number;
   capacity: number;
+  fillable: number;
   min: number;
 };
 
@@ -221,18 +225,26 @@ function buildColumns(
 ): PowerColumn[] {
   const byPort = new Map<
     string,
-    { family: PowerFamily; capacity: number; critical: number }
+    {
+      family: PowerFamily;
+      capacity: number;
+      fillable: number;
+      critical: number;
+    }
   >();
   const order: string[] = [];
   for (const port of ports) {
     let entry = byPort.get(port.portPath);
     if (!entry) {
-      entry = { family: port.family, capacity: 0, critical: 0 };
+      entry = { family: port.family, capacity: 0, fillable: 0, critical: 0 };
       byPort.set(port.portPath, entry);
       order.push(port.portPath);
     }
+    // Every block is a rendered slot; only enabled ones can take power. They
+    // differ only for the weapon pool's headroom past the weapons' demand.
+    entry.capacity += port.size;
     if (!port.disabled) {
-      entry.capacity += port.size;
+      entry.fillable += port.size;
       if (port.critical) entry.critical += port.size;
     }
   }
@@ -247,6 +259,7 @@ function buildColumns(
       label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
       allocated: state.perPort[portPath] ?? 0,
       capacity: entry.capacity,
+      fillable: entry.fillable,
       // Mandatory floor: a component is either off or on at ≥ this many
       // segments (equals capacity for all-critical systems like the QD).
       min: entry.critical,
@@ -259,6 +272,7 @@ function buildColumns(
           ...member,
           allocated: 0,
           capacity: 0,
+          fillable: 0,
           min: 0,
           label: undefined,
           family: entry.family,
@@ -270,6 +284,7 @@ function buildColumns(
       column.members.push(member);
       column.allocated += member.allocated;
       column.capacity += member.capacity;
+      column.fillable += member.fillable;
       column.min += member.min;
     } else {
       columns.push({ ...member, family: entry.family, members: [member] });

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -36,7 +36,13 @@ export type LoadoutSimResult = {
   totalSegments: number;
   remaining: number;
   perFamily: Record<PowerFamily, number>;
+  // Weapon sustained-DPS ratio in the *default* SCM auto-distribution.
   weaponPoolRatio: number;
+  // Weapon sustained-DPS ratio with weapons at maximum pips (other families
+  // dropped to their mandatory minimums) — the max-power model sustained DPS
+  // uses. Equals min(1, poolSize/consumption) unless the plant literally can't
+  // deliver enough segments to fill the pool.
+  weaponMaxRatio: number;
 };
 
 type Collected = {
@@ -100,42 +106,86 @@ function collectPorts(
   return acc;
 }
 
-// The default power auto-distribution for a loadout: build the family ports from
-// the installed components, run erkul's allocation over the plants' segments,
-// and expose the per-family segments + the weapon sustained-DPS `poolRatio`.
-// This is the read-only default; the pip UI will later override the targets.
+// The weapon ratio with weapons maxed: after every family's mandatory (critical)
+// blocks are reserved, weapons fill their pool with what's left. Falls back to
+// the segment-independent min(1, poolSize/consumption) when there is no plant
+// data to cap against — so it never regresses ships whose plant power isn't
+// (yet) parsed.
+function computeWeaponMaxRatio(
+  pool: number,
+  consumption: number,
+  segments: number,
+  otherPorts: PowerPort[],
+): number {
+  if (pool <= 0 || consumption <= 0) return 1;
+  const uncapped = Math.min(1, pool / consumption);
+  if (segments <= 0) return uncapped;
+
+  const nonWeaponCritical = otherPorts
+    .filter((port) => port.critical)
+    .reduce((sum, port) => sum + port.size, 0);
+  const enabled = Math.min(pool, consumption);
+  const weaponMax = Math.max(
+    0,
+    Math.min(enabled, segments - nonWeaponCritical),
+  );
+  return Math.min(uncapped, weaponMax / consumption);
+}
+
+// Pure core: build the family ports from a loadout, run erkul's allocation over
+// the plants' segments, and expose the per-family segments and the weapon
+// sustained-DPS ratios (default SCM split + max-weapon).
+export function simulateLoadoutPower(
+  hardpoints: Hardpoint[] | undefined,
+  weaponPoolSize: number | undefined,
+  mode: FlightMode = "SCM",
+): LoadoutSimResult {
+  const acc = collectPorts(hardpoints, {
+    plants: [],
+    weaponUnits: 0,
+    otherPorts: [],
+  });
+  const pool = weaponPoolSize ?? 0;
+  const segments = totalSegments(acc.plants);
+  const consumption = Math.ceil(acc.weaponUnits);
+
+  const ports: PowerPort[] = [
+    ...weaponPoolBlocks("weaponPool", acc.weaponUnits, pool),
+    ...acc.otherPorts,
+  ];
+
+  const state = allocatePower(ports, segments, {
+    mode,
+    weaponConsumption: consumption,
+    weaponPoolSize: pool,
+  });
+
+  return {
+    totalSegments: segments,
+    remaining: state.remaining,
+    perFamily: state.perFamily,
+    // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
+    weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
+    weaponMaxRatio: computeWeaponMaxRatio(
+      pool,
+      consumption,
+      segments,
+      acc.otherPorts,
+    ),
+  };
+}
+
+// Reactive wrapper around simulateLoadoutPower for use in components.
 export function useLoadoutSim(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
   weaponPoolSize: MaybeRefOrGetter<number | undefined>,
   mode: MaybeRefOrGetter<FlightMode> = () => "SCM",
 ) {
-  return computed<LoadoutSimResult>(() => {
-    const acc = collectPorts(toValue(hardpoints), {
-      plants: [],
-      weaponUnits: 0,
-      otherPorts: [],
-    });
-    const pool = toValue(weaponPoolSize) ?? 0;
-    const segments = totalSegments(acc.plants);
-    const consumption = Math.ceil(acc.weaponUnits);
-
-    const ports: PowerPort[] = [
-      ...weaponPoolBlocks("weaponPool", acc.weaponUnits, pool),
-      ...acc.otherPorts,
-    ];
-
-    const state = allocatePower(ports, segments, {
-      mode: toValue(mode),
-      weaponConsumption: consumption,
-      weaponPoolSize: pool,
-    });
-
-    return {
-      totalSegments: segments,
-      remaining: state.remaining,
-      perFamily: state.perFamily,
-      // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
-      weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
-    };
-  });
+  return computed<LoadoutSimResult>(() =>
+    simulateLoadoutPower(
+      toValue(hardpoints),
+      toValue(weaponPoolSize),
+      toValue(mode),
+    ),
+  );
 }

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -67,6 +67,10 @@ export type LoadoutSimResult = {
   // Shield power ratio (allocated shield segments / capacity) — scales shield
   // HP/regen; 0 when shields are unpowered.
   shieldPoolRatio: number;
+  // Effective aim-assist range (m) at the current radar power, and the radar's
+  // max (for the bar's full scale). 0 when there's no radar / it's unpowered.
+  aimAssist: number;
+  aimAssistMax: number;
 };
 
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
@@ -83,6 +87,7 @@ type Collected = {
   otherPorts: PowerPort[];
   portLabels: Record<string, string>;
   shieldsSeen: number;
+  radarAim?: { min: number; max: number };
 };
 
 function numeric(value: unknown): number {
@@ -140,6 +145,17 @@ function collectPorts(
             );
             if (family !== "shield" && hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
+            }
+            // Capture the radar's aim-assist range for the power-pane readout.
+            if (
+              family === "radar" &&
+              !acc.radarAim &&
+              typeData.aimAssistRange
+            ) {
+              acc.radarAim = {
+                min: numeric(typeData.aimAssistMin),
+                max: numeric(typeData.aimAssistRange),
+              };
             }
           }
         }
@@ -299,6 +315,22 @@ export function simulateLoadoutPower(
       ? Math.min(1, shieldColumn.allocated / shieldColumn.capacity)
       : 1;
 
+  // Radar power ratio → effective aim-assist range (erkul's `or`): interpolated
+  // between the radar's min and max by radar power, 0 when the radar is off.
+  const radarColumn = columns.find((column) => column.family === "radar");
+  const radarPoolRatio =
+    radarColumn && radarColumn.capacity > 0
+      ? Math.min(1, radarColumn.allocated / radarColumn.capacity)
+      : 0;
+  const aimAssistMax = acc.radarAim?.max ?? 0;
+  const aimAssist =
+    acc.radarAim && radarPoolRatio > 0
+      ? Math.round(
+          acc.radarAim.min +
+            (acc.radarAim.max - acc.radarAim.min) * radarPoolRatio,
+        )
+      : 0;
+
   return {
     totalSegments: segments,
     remaining: state.remaining,
@@ -313,6 +345,8 @@ export function simulateLoadoutPower(
       acc.otherPorts,
     ),
     shieldPoolRatio,
+    aimAssist,
+    aimAssistMax,
   };
 }
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -149,6 +149,9 @@ export type LoadoutSimResult = {
   // Shield power ratio (allocated shield segments / capacity) — scales shield
   // HP/regen; 0 when shields are unpowered.
   shieldPoolRatio: number;
+  // Engine power relative to the default distribution — scales flight speed and
+  // handling; 1 at the default, 0 when the engine is fully unpowered.
+  enginePowerRatio: number;
   // Effective aim-assist range (m) at the current radar power, and the radar's
   // max (for the bar's full scale). 0 when there's no radar / it's unpowered.
   aimAssist: number;
@@ -578,6 +581,21 @@ export function simulateLoadoutPower(
   const shieldPoolRatio =
     shieldCapacity > 0 ? Math.min(1, shieldAllocated / shieldCapacity) : 1;
 
+  // Engine (thruster) power relative to the default distribution — scales the
+  // flight stats. 1 at the default allocation (the ship's rated figures already
+  // reflect it), lower as the user pulls engine pips, higher as they add them.
+  // 1 when the ship has no engine power family (nothing to scale against).
+  const hasEngine = columns.some((column) => column.family === "engine");
+  const engineBaseline = baseline.perFamily.engine;
+  const engineCurrent = state.perFamily.engine;
+  const enginePowerRatio = !hasEngine
+    ? 1
+    : engineBaseline > 0
+      ? engineCurrent / engineBaseline
+      : engineCurrent > 0
+        ? 1
+        : 0;
+
   // Radar power ratio → effective aim-assist range (erkul's `or`): interpolated
   // between the radar's min and max by radar power, 0 when the radar is off.
   const radarColumn = columns.find((column) => column.family === "radar");
@@ -622,6 +640,7 @@ export function simulateLoadoutPower(
       acc.otherPorts,
     ),
     shieldPoolRatio,
+    enginePowerRatio,
     aimAssist,
     aimAssistMax,
     coolingPerSec: heat.coolingPerSec,

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -64,6 +64,9 @@ export type LoadoutSimResult = {
   // uses as its baseline. Equals min(1, poolSize/consumption) unless the plant
   // literally can't deliver enough segments to fill the pool.
   weaponMaxRatio: number;
+  // Shield power ratio (allocated shield segments / capacity) — scales shield
+  // HP/regen; 0 when shields are unpowered.
+  shieldPoolRatio: number;
 };
 
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
@@ -288,6 +291,14 @@ export function simulateLoadoutPower(
 
   const columns = buildColumns(ports, acc.portLabels, state);
 
+  // Shield power ratio = allocated shield segments / shield capacity (0 when
+  // shields are unpowered, 1 when there are no shields). Drives shield HP/regen.
+  const shieldColumn = columns.find((column) => column.family === "shield");
+  const shieldPoolRatio =
+    shieldColumn && shieldColumn.capacity > 0
+      ? Math.min(1, shieldColumn.allocated / shieldColumn.capacity)
+      : 1;
+
   return {
     totalSegments: segments,
     remaining: state.remaining,
@@ -301,6 +312,7 @@ export function simulateLoadoutPower(
       segments,
       acc.otherPorts,
     ),
+    shieldPoolRatio,
   };
 }
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -59,6 +59,10 @@ const EXTRA_HEAT_FAMILIES = new Set<PowerFamily>([
   "qdrive",
 ]);
 
+// Families whose active segments generate no heat load (matching erkul, where
+// powering the tractor/towing beams doesn't change the cooling ratio).
+const NON_HEAT_FAMILIES = new Set<PowerFamily>(["tractorBeam", "towingbeam"]);
+
 // A component's power-range modifier curve — `{start, modifier}` breakpoints
 // sorted ascending by `start`. The modifier for a given active-segment count is
 // the entry with the greatest `start` ≤ segments (erkul's `L`), default 1.
@@ -375,6 +379,7 @@ function computeHeat(
   let coolingPerSec = 0;
   let coolingMaxPerSec = 0;
   let extraHeat = 0;
+  let nonHeatSegments = 0;
 
   for (const component of components) {
     const active = perPort[component.portPath] ?? 0;
@@ -390,10 +395,14 @@ function computeHeat(
     if (active > 0 && EXTRA_HEAT_FAMILIES.has(component.family)) {
       extraHeat += active * rangeModifier(component.ranges, active);
     }
+    if (NON_HEAT_FAMILIES.has(component.family)) {
+      nonHeatSegments += active;
+    }
   }
 
-  // Heat generated = every active power segment, plus the extra component heat.
-  const heatGeneration = usedSegments + extraHeat;
+  // Heat generated = every active power segment (minus the families that emit
+  // none, e.g. tractor beams), plus the extra component heat.
+  const heatGeneration = usedSegments - nonHeatSegments + extraHeat;
   // Cooling load: heat ÷ coolant provided (uncapped, so > 1 when under-cooled);
   // 0 when no cooler is powered.
   const coolingRatio = coolingPerSec > 0 ? heatGeneration / coolingPerSec : 0;

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -154,6 +154,9 @@ export type LoadoutSimResult = {
   // that scales boosted handling. 0 at the mandatory floor (base handling only),
   // 1 with every engine pip filled.
   enginePowerRatio: number;
+  // Whether the engine has any power (can the ship fly at all). False only when
+  // every engine pip is pulled; true when there's no engine family to gate on.
+  engineActive: boolean;
   // Effective aim-assist range (m) at the current radar power, and the radar's
   // max (for the bar's full scale). 0 when there's no radar / it's unpowered.
   aimAssist: number;
@@ -604,6 +607,12 @@ export function simulateLoadoutPower(
         )
       : 0;
 
+  // Whether the engine has any power at all. With every engine pip pulled the
+  // ship is dead in the water — the flight card reads 0 — while any power keeps
+  // it flying at its rated speeds/handling. True when the ship has no engine
+  // power family (nothing to gate on).
+  const engineActive = !engineColumn || engineColumn.allocated > 0;
+
   // Radar power ratio → effective aim-assist range (erkul's `or`): interpolated
   // between the radar's min and max by radar power, 0 when the radar is off.
   const radarColumn = columns.find((column) => column.family === "radar");
@@ -649,6 +658,7 @@ export function simulateLoadoutPower(
     ),
     shieldPoolRatio,
     enginePowerRatio,
+    engineActive,
     aimAssist,
     aimAssistMax,
     coolingPerSec: heat.coolingPerSec,

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -78,8 +78,15 @@ function collectPorts(
         if (family === "weapon") {
           acc.weaponUnits += draw;
         } else if (family && draw > 0) {
+          const minimumFraction =
+            typeData.powerMinimumFraction == null
+              ? undefined
+              : numeric(typeData.powerMinimumFraction);
           acc.otherPorts.push(
-            ...componentBlocks(hardpoint.id, family, { units: draw }),
+            ...componentBlocks(hardpoint.id, family, {
+              units: draw,
+              minimumFraction,
+            }),
           );
         }
       }

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -18,13 +18,16 @@ import {
 export { WEAPON_POOL_PORT, type PortOverrides } from "./powerSim";
 
 // A single power column in the pip UI — one component, or the shared weapon
-// pool. `label` is the component name (undefined for the weapon pool).
+// pool. `label` is the component name (undefined for the weapon pool). `locked`
+// means every segment is mandatory (all-critical, e.g. a quantum drive) so the
+// level can't be changed.
 export type PowerColumn = {
   portPath: string;
   family: PowerFamily;
   label?: string;
   allocated: number;
   capacity: number;
+  locked: boolean;
 };
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
@@ -66,6 +69,10 @@ export type LoadoutSimResult = {
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
 // pool `maxItemCount`); the rest are unpowered backups. 2 is the game default.
 export const DEFAULT_SHIELD_MAX_ITEM_COUNT = 2;
+
+// The active shields share a pool (like weapons), so they aggregate into one
+// column / override key rather than one per generator.
+export const SHIELD_POOL_PORT = "shieldPool";
 
 type Collected = {
   plants: { units: number; size: number; poweredOn: boolean }[];
@@ -114,17 +121,21 @@ function collectPorts(
           const isBackupShield =
             family === "shield" && ++acc.shieldsSeen > shieldMaxItemCount;
           if (!isBackupShield) {
+            // Shields share a pool → one aggregate column; every other family
+            // is one column per component.
+            const portPath =
+              family === "shield" ? SHIELD_POOL_PORT : hardpoint.id;
             const minimumFraction =
               typeData.powerMinimumFraction == null
                 ? undefined
                 : numeric(typeData.powerMinimumFraction);
             acc.otherPorts.push(
-              ...componentBlocks(hardpoint.id, family, {
+              ...componentBlocks(portPath, family, {
                 units: draw,
                 minimumFraction,
               }),
             );
-            if (hardpoint.component?.name) {
+            if (family !== "shield" && hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
             }
           }
@@ -173,16 +184,22 @@ function buildColumns(
   portLabels: Record<string, string>,
   state: AllocationState,
 ): PowerColumn[] {
-  const byPort = new Map<string, { family: PowerFamily; capacity: number }>();
+  const byPort = new Map<
+    string,
+    { family: PowerFamily; capacity: number; critical: number }
+  >();
   const order: string[] = [];
   for (const port of ports) {
     let entry = byPort.get(port.portPath);
     if (!entry) {
-      entry = { family: port.family, capacity: 0 };
+      entry = { family: port.family, capacity: 0, critical: 0 };
       byPort.set(port.portPath, entry);
       order.push(port.portPath);
     }
-    if (!port.disabled) entry.capacity += port.size;
+    if (!port.disabled) {
+      entry.capacity += port.size;
+      if (port.critical) entry.critical += port.size;
+    }
   }
 
   const columns = order
@@ -190,6 +207,7 @@ function buildColumns(
       const entry = byPort.get(portPath) as {
         family: PowerFamily;
         capacity: number;
+        critical: number;
       };
       return {
         portPath,
@@ -197,6 +215,8 @@ function buildColumns(
         label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
         allocated: state.perPort[portPath] ?? 0,
         capacity: entry.capacity,
+        // All-critical components (e.g. quantum drives) can't be turned down.
+        locked: entry.critical >= entry.capacity,
       };
     })
     .filter((column) => column.capacity > 0);

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -1,0 +1,134 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { HardpointCategoryEnum, type Hardpoint } from "@/services/fyApi";
+import {
+  allocatePower,
+  componentBlocks,
+  totalSegments,
+  weaponPoolBlocks,
+  weaponPoolRatio,
+  type FlightMode,
+  type PowerFamily,
+  type PowerPort,
+} from "./powerSim";
+
+// FleetYards hardpoint category → erkul power family. Only the families erkul
+// feeds power segments to are mapped; every other category (thrusters, fuel,
+// cargo, seats, …) draws no segments. A mapped component still contributes
+// ports only when it actually declares a Power draw (`powerConsumption`).
+export const POWER_FAMILY_BY_CATEGORY: Partial<
+  Record<HardpointCategoryEnum, PowerFamily>
+> = {
+  [HardpointCategoryEnum.WEAPONS]: "weapon",
+  [HardpointCategoryEnum.WEAPON_MOUNTS]: "weapon",
+  [HardpointCategoryEnum.TURRET]: "weapon",
+  [HardpointCategoryEnum.SHIELDGENERATOR]: "shield",
+  [HardpointCategoryEnum.COOLER]: "coolers",
+  [HardpointCategoryEnum.RADAR]: "radar",
+  [HardpointCategoryEnum.QUANTUMDRIVE]: "qdrive",
+  [HardpointCategoryEnum.QUANTUMENFORCEMENTDEVICE]: "qed",
+  [HardpointCategoryEnum.EMP]: "emp",
+  [HardpointCategoryEnum.LIFESUPPORT]: "lifeSupport",
+  [HardpointCategoryEnum.CONTROLLER]: "engine",
+  [HardpointCategoryEnum.SALVAGEMUNCHING]: "salvage",
+};
+
+export type LoadoutSimResult = {
+  totalSegments: number;
+  remaining: number;
+  perFamily: Record<PowerFamily, number>;
+  weaponPoolRatio: number;
+};
+
+type Collected = {
+  plants: { units: number; size: number; poweredOn: boolean }[];
+  weaponUnits: number;
+  otherPorts: PowerPort[];
+};
+
+function numeric(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Walk the hardpoint tree, gathering the powered plants (segment sources), the
+// summed weapon Power draw (the shared pool), and the per-component blocks for
+// every other power-drawing family.
+function collectPorts(
+  hardpoints: Hardpoint[] | undefined,
+  acc: Collected,
+): Collected {
+  for (const hardpoint of hardpoints ?? []) {
+    const typeData = hardpoint.component?.typeData as
+      Record<string, unknown> | undefined;
+    const category = hardpoint.category;
+
+    if (typeData && category) {
+      if (category === HardpointCategoryEnum.POWERPLANT) {
+        const units = numeric(typeData.powerBase);
+        if (units > 0) {
+          acc.plants.push({
+            units,
+            size: numeric(hardpoint.component?.size),
+            poweredOn: true,
+          });
+        }
+      } else {
+        const family = POWER_FAMILY_BY_CATEGORY[category];
+        const draw = numeric(typeData.powerConsumption);
+        if (family === "weapon") {
+          acc.weaponUnits += draw;
+        } else if (family && draw > 0) {
+          acc.otherPorts.push(
+            ...componentBlocks(hardpoint.id, family, { units: draw }),
+          );
+        }
+      }
+    }
+
+    if (hardpoint.hardpoints?.length) {
+      collectPorts(hardpoint.hardpoints, acc);
+    }
+  }
+
+  return acc;
+}
+
+// The default power auto-distribution for a loadout: build the family ports from
+// the installed components, run erkul's allocation over the plants' segments,
+// and expose the per-family segments + the weapon sustained-DPS `poolRatio`.
+// This is the read-only default; the pip UI will later override the targets.
+export function useLoadoutSim(
+  hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
+  weaponPoolSize: MaybeRefOrGetter<number | undefined>,
+  mode: MaybeRefOrGetter<FlightMode> = () => "SCM",
+) {
+  return computed<LoadoutSimResult>(() => {
+    const acc = collectPorts(toValue(hardpoints), {
+      plants: [],
+      weaponUnits: 0,
+      otherPorts: [],
+    });
+    const pool = toValue(weaponPoolSize) ?? 0;
+    const segments = totalSegments(acc.plants);
+    const consumption = Math.ceil(acc.weaponUnits);
+
+    const ports: PowerPort[] = [
+      ...weaponPoolBlocks("weaponPool", acc.weaponUnits, pool),
+      ...acc.otherPorts,
+    ];
+
+    const state = allocatePower(ports, segments, {
+      mode: toValue(mode),
+      weaponConsumption: consumption,
+      weaponPoolSize: pool,
+    });
+
+    return {
+      totalSegments: segments,
+      remaining: state.remaining,
+      perFamily: state.perFamily,
+      // No fixed weapon pool → the ship's guns are power-unlimited (ratio 1).
+      weaponPoolRatio: pool <= 0 ? 1 : weaponPoolRatio(state, consumption),
+    };
+  });
+}

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -49,6 +49,49 @@ const GROUPED_FAMILIES = new Set<PowerFamily>([
   "towingbeam",
 ]);
 
+// Families that emit extra component heat on top of their active segments
+// (erkul's `l` term in the heat-generation sum): shields, life support, radar
+// and the quantum drive.
+const EXTRA_HEAT_FAMILIES = new Set<PowerFamily>([
+  "shield",
+  "lifeSupport",
+  "radar",
+  "qdrive",
+]);
+
+// A component's power-range modifier curve — `{start, modifier}` breakpoints
+// sorted ascending by `start`. The modifier for a given active-segment count is
+// the entry with the greatest `start` ≤ segments (erkul's `L`), default 1.
+type PowerRange = { start: number; modifier: number };
+
+function toRanges(raw: unknown): PowerRange[] {
+  if (!raw || typeof raw !== "object") return [];
+  return Object.values(raw as Record<string, unknown>)
+    .filter((r): r is Record<string, unknown> => !!r && typeof r === "object")
+    .map((r) => ({ start: numeric(r.start), modifier: numeric(r.modifier) }))
+    .sort((a, b) => a.start - b.start);
+}
+
+function rangeModifier(ranges: PowerRange[], segments: number): number {
+  let modifier = 1;
+  for (const range of ranges) {
+    if (range.start <= segments) modifier = range.modifier;
+    else break;
+  }
+  return modifier;
+}
+
+// A power-drawing component captured for the heat pass: its allocated segments
+// come from the allocation state (by portPath). Coolers additionally carry the
+// coolant they produce at full power (`coolingRate`).
+type HeatComponent = {
+  portPath: string;
+  family: PowerFamily;
+  units: number;
+  ranges: PowerRange[];
+  coolingRate: number;
+};
+
 // FleetYards hardpoint category → erkul power family. Only the families erkul
 // feeds power segments to are mapped; every other category (thrusters, fuel,
 // cargo, seats, …) draws no segments. A mapped component still contributes
@@ -90,6 +133,14 @@ export type LoadoutSimResult = {
   // max (for the bar's full scale). 0 when there's no radar / it's unpowered.
   aimAssist: number;
   aimAssistMax: number;
+  // Heat: coolant produced per second at the current allocation, the maximum
+  // coolers could produce, the heat generated, and the cooling load — heat ÷
+  // coolant (erkul's `coolingRatio`, uncapped so > 1 when under-cooled; 0 with
+  // no active cooler). It also drives the IR signature.
+  coolingPerSec: number;
+  coolingMaxPerSec: number;
+  heatGeneration: number;
+  coolingRatio: number;
 };
 
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
@@ -103,6 +154,7 @@ type Collected = {
   portLabels: Record<string, string>;
   shieldsSeen: number;
   radarAim?: { min: number; max: number };
+  components: HeatComponent[];
 };
 
 function numeric(value: unknown): number {
@@ -162,6 +214,14 @@ function collectPorts(
                 minimumFraction,
               }),
             );
+            acc.components.push({
+              portPath: hardpoint.id,
+              family,
+              units: draw,
+              ranges: toRanges(typeData.powerRanges),
+              coolingRate:
+                family === "coolers" ? numeric(typeData.coolingRate) : 0,
+            });
             if (hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
             }
@@ -297,6 +357,50 @@ function buildColumns(
   );
 }
 
+// Heat pass (erkul's `Ze`/`G`): coolers turn active power segments into coolant;
+// every powered component generates heat. `coolingRatio` is the cooling *load* —
+// heat generated ÷ coolant provided — so it rises above 1 when the active
+// coolers can't keep up, and is 0 when no cooler is powered (there is no active
+// cooling system to load). It also drives the IR signature.
+function computeHeat(
+  components: HeatComponent[],
+  usedSegments: number,
+  perPort: Record<string, number>,
+): {
+  coolingPerSec: number;
+  coolingMaxPerSec: number;
+  heatGeneration: number;
+  coolingRatio: number;
+} {
+  let coolingPerSec = 0;
+  let coolingMaxPerSec = 0;
+  let extraHeat = 0;
+
+  for (const component of components) {
+    const active = perPort[component.portPath] ?? 0;
+    if (component.family === "coolers" && component.units > 0) {
+      coolingPerSec +=
+        component.coolingRate *
+        (active / component.units) *
+        rangeModifier(component.ranges, active);
+      coolingMaxPerSec +=
+        component.coolingRate *
+        rangeModifier(component.ranges, component.units);
+    }
+    if (active > 0 && EXTRA_HEAT_FAMILIES.has(component.family)) {
+      extraHeat += active * rangeModifier(component.ranges, active);
+    }
+  }
+
+  // Heat generated = every active power segment, plus the extra component heat.
+  const heatGeneration = usedSegments + extraHeat;
+  // Cooling load: heat ÷ coolant provided (uncapped, so > 1 when under-cooled);
+  // 0 when no cooler is powered.
+  const coolingRatio = coolingPerSec > 0 ? heatGeneration / coolingPerSec : 0;
+
+  return { coolingPerSec, coolingMaxPerSec, heatGeneration, coolingRatio };
+}
+
 // Pure core: build the family ports from a loadout, run erkul's allocation over
 // the plants' segments, and expose the per-component columns and the weapon
 // sustained-DPS ratios (current allocation + max-weapon).
@@ -315,6 +419,7 @@ export function simulateLoadoutPower(
       otherPorts: [],
       portLabels: {},
       shieldsSeen: 0,
+      components: [],
     },
     shieldMaxItemCount,
   );
@@ -385,6 +490,12 @@ export function simulateLoadoutPower(
         )
       : 0;
 
+  const heat = computeHeat(
+    acc.components,
+    segments - state.remaining,
+    state.perPort,
+  );
+
   return {
     totalSegments: segments,
     remaining: state.remaining,
@@ -401,6 +512,10 @@ export function simulateLoadoutPower(
     shieldPoolRatio,
     aimAssist,
     aimAssistMax,
+    coolingPerSec: heat.coolingPerSec,
+    coolingMaxPerSec: heat.coolingMaxPerSec,
+    heatGeneration: heat.heatGeneration,
+    coolingRatio: heat.coolingRatio,
   };
 }
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -18,16 +18,16 @@ import {
 export { WEAPON_POOL_PORT, type PortOverrides } from "./powerSim";
 
 // A single power column in the pip UI — one component, or the shared weapon
-// pool. `label` is the component name (undefined for the weapon pool). `locked`
-// means every segment is mandatory (all-critical, e.g. a quantum drive) so the
-// level can't be changed.
+// pool. `label` is the component name (undefined for the weapon pool). `min` is
+// the mandatory floor: the component is either off (0) or on at ≥ `min`
+// segments (min === capacity for all-critical systems like the quantum drive).
 export type PowerColumn = {
   portPath: string;
   family: PowerFamily;
   label?: string;
   allocated: number;
   capacity: number;
-  locked: boolean;
+  min: number;
 };
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
@@ -215,8 +215,9 @@ function buildColumns(
         label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
         allocated: state.perPort[portPath] ?? 0,
         capacity: entry.capacity,
-        // All-critical components (e.g. quantum drives) can't be turned down.
-        locked: entry.critical >= entry.capacity,
+        // Mandatory floor: a component is either off or on at ≥ this many
+        // segments (equals capacity for all-critical systems like the QD).
+        min: entry.critical,
       };
     })
     .filter((column) => column.capacity > 0);

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -51,10 +51,15 @@ export type LoadoutSimResult = {
   weaponMaxRatio: number;
 };
 
+// Ships run only the first N shields at once (the vehicle's Dynamic Shield power
+// pool `maxItemCount`); the rest are unpowered backups. 2 is the game default.
+export const DEFAULT_SHIELD_MAX_ITEM_COUNT = 2;
+
 type Collected = {
   plants: { units: number; size: number; poweredOn: boolean }[];
   weaponUnits: number;
   otherPorts: PowerPort[];
+  shieldsSeen: number;
 };
 
 function numeric(value: unknown): number {
@@ -64,10 +69,12 @@ function numeric(value: unknown): number {
 
 // Walk the hardpoint tree, gathering the powered plants (segment sources), the
 // summed weapon Power draw (the shared pool), and the per-component blocks for
-// every other power-drawing family.
+// every other power-drawing family. Shields beyond `shieldMaxItemCount` are
+// backups and draw no power.
 function collectPorts(
   hardpoints: Hardpoint[] | undefined,
   acc: Collected,
+  shieldMaxItemCount: number,
 ): Collected {
   for (const hardpoint of hardpoints ?? []) {
     const typeData = hardpoint.component?.typeData as
@@ -90,22 +97,27 @@ function collectPorts(
         if (family === "weapon") {
           acc.weaponUnits += draw;
         } else if (family && draw > 0) {
-          const minimumFraction =
-            typeData.powerMinimumFraction == null
-              ? undefined
-              : numeric(typeData.powerMinimumFraction);
-          acc.otherPorts.push(
-            ...componentBlocks(hardpoint.id, family, {
-              units: draw,
-              minimumFraction,
-            }),
-          );
+          // Shields past the active cap are unpowered backups.
+          const isBackupShield =
+            family === "shield" && ++acc.shieldsSeen > shieldMaxItemCount;
+          if (!isBackupShield) {
+            const minimumFraction =
+              typeData.powerMinimumFraction == null
+                ? undefined
+                : numeric(typeData.powerMinimumFraction);
+            acc.otherPorts.push(
+              ...componentBlocks(hardpoint.id, family, {
+                units: draw,
+                minimumFraction,
+              }),
+            );
+          }
         }
       }
     }
 
     if (hardpoint.hardpoints?.length) {
-      collectPorts(hardpoint.hardpoints, acc);
+      collectPorts(hardpoint.hardpoints, acc, shieldMaxItemCount);
     }
   }
 
@@ -146,12 +158,18 @@ export function simulateLoadoutPower(
   weaponPoolSize: number | undefined,
   mode: FlightMode = "SCM",
   overrides?: FamilyOverrides,
+  shieldMaxItemCount: number = DEFAULT_SHIELD_MAX_ITEM_COUNT,
 ): LoadoutSimResult {
-  const acc = collectPorts(hardpoints, {
-    plants: [],
-    weaponUnits: 0,
-    otherPorts: [],
-  });
+  const acc = collectPorts(
+    hardpoints,
+    {
+      plants: [],
+      weaponUnits: 0,
+      otherPorts: [],
+      shieldsSeen: 0,
+    },
+    shieldMaxItemCount,
+  );
   const pool = weaponPoolSize ?? 0;
   const segments = totalSegments(acc.plants);
   const consumption = Math.ceil(acc.weaponUnits);
@@ -197,6 +215,7 @@ export function useLoadoutSim(
   weaponPoolSize: MaybeRefOrGetter<number | undefined>,
   mode: MaybeRefOrGetter<FlightMode> = () => "SCM",
   overrides: MaybeRefOrGetter<FamilyOverrides | undefined> = () => undefined,
+  shieldMaxItemCount: MaybeRefOrGetter<number | undefined> = () => undefined,
 ) {
   return computed<LoadoutSimResult>(() =>
     simulateLoadoutPower(
@@ -204,6 +223,7 @@ export function useLoadoutSim(
       toValue(weaponPoolSize),
       toValue(mode),
       toValue(overrides),
+      toValue(shieldMaxItemCount) ?? DEFAULT_SHIELD_MAX_ITEM_COUNT,
     ),
   );
 }

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -87,13 +87,15 @@ function rangeModifier(ranges: PowerRange[], segments: number): number {
 
 // A power-drawing component captured for the heat pass: its allocated segments
 // come from the allocation state (by portPath). Coolers additionally carry the
-// coolant they produce at full power (`coolingRate`).
+// coolant they produce at full power (`coolingRate`); `irNominal` is the
+// component's infrared signature emission at full power.
 type HeatComponent = {
   portPath: string;
   family: PowerFamily;
   units: number;
   ranges: PowerRange[];
   coolingRate: number;
+  irNominal: number;
 };
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
@@ -145,6 +147,8 @@ export type LoadoutSimResult = {
   coolingMaxPerSec: number;
   heatGeneration: number;
   coolingRatio: number;
+  // Emitted infrared signature at the current allocation (scaled by cooling).
+  emittedIr: number;
 };
 
 // Ships run only the first N shields at once (the vehicle's Dynamic Shield power
@@ -225,6 +229,7 @@ function collectPorts(
               ranges: toRanges(typeData.powerRanges),
               coolingRate:
                 family === "coolers" ? numeric(typeData.coolingRate) : 0,
+              irNominal: numeric(typeData.signatureIr),
             });
             if (hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
@@ -375,22 +380,27 @@ function computeHeat(
   coolingMaxPerSec: number;
   heatGeneration: number;
   coolingRatio: number;
+  emittedIr: number;
 } {
   let coolingPerSec = 0;
   let coolingMaxPerSec = 0;
   let extraHeat = 0;
   let nonHeatSegments = 0;
+  let irRaw = 0;
 
   for (const component of components) {
     const active = perPort[component.portPath] ?? 0;
     if (component.family === "coolers" && component.units > 0) {
+      const modifier = rangeModifier(component.ranges, active);
       coolingPerSec +=
-        component.coolingRate *
-        (active / component.units) *
-        rangeModifier(component.ranges, active);
+        component.coolingRate * (active / component.units) * modifier;
       coolingMaxPerSec +=
         component.coolingRate *
         rangeModifier(component.ranges, component.units);
+      // IR is emitted by the active coolers (erkul's `gr` over heat sources).
+      if (active > 0) {
+        irRaw += component.irNominal * (active / component.units) * modifier;
+      }
     }
     if (active > 0 && EXTRA_HEAT_FAMILIES.has(component.family)) {
       extraHeat += active * rangeModifier(component.ranges, active);
@@ -406,8 +416,16 @@ function computeHeat(
   // Cooling load: heat ÷ coolant provided (uncapped, so > 1 when under-cooled);
   // 0 when no cooler is powered.
   const coolingRatio = coolingPerSec > 0 ? heatGeneration / coolingPerSec : 0;
+  // Emitted IR signature scales with the active cooling (0 when cooling is off).
+  const emittedIr = irRaw * coolingRatio;
 
-  return { coolingPerSec, coolingMaxPerSec, heatGeneration, coolingRatio };
+  return {
+    coolingPerSec,
+    coolingMaxPerSec,
+    heatGeneration,
+    coolingRatio,
+    emittedIr,
+  };
 }
 
 // Pure core: build the family ports from a loadout, run erkul's allocation over
@@ -525,6 +543,7 @@ export function simulateLoadoutPower(
     coolingMaxPerSec: heat.coolingMaxPerSec,
     heatGeneration: heat.heatGeneration,
     coolingRatio: heat.coolingRatio,
+    emittedIr: heat.emittedIr,
   };
 }
 

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -149,8 +149,10 @@ export type LoadoutSimResult = {
   // Shield power ratio (allocated shield segments / capacity) — scales shield
   // HP/regen; 0 when shields are unpowered.
   shieldPoolRatio: number;
-  // Engine power relative to the default distribution — scales flight speed and
-  // handling; 1 at the default, 0 when the engine is fully unpowered.
+  // Engine power above its floor as a fraction of its span
+  // ((allocated − min) / (capacity − min)) — the game's IFCS afterburner ratio
+  // that scales boosted handling. 0 at the mandatory floor (base handling only),
+  // 1 with every engine pip filled.
   enginePowerRatio: number;
   // Effective aim-assist range (m) at the current radar power, and the radar's
   // max (for the bar's full scale). 0 when there's no radar / it's unpowered.
@@ -581,20 +583,26 @@ export function simulateLoadoutPower(
   const shieldPoolRatio =
     shieldCapacity > 0 ? Math.min(1, shieldAllocated / shieldCapacity) : 1;
 
-  // Engine (thruster) power relative to the default distribution — scales the
-  // flight stats. 1 at the default allocation (the ship's rated figures already
-  // reflect it), lower as the user pulls engine pips, higher as they add them.
+  // Engine (thruster) power → boosted-handling scale. The game's IFCS afterburner
+  // interpolates the angular velocity from its base (`maxAngularVelocity`) up to
+  // the boosted rate (× `afterburnAngVelocityMultiplier`) by the engine's power
+  // ratio: `(activeSegments − min) / (capacity − min)`, where `min` is the
+  // mandatory power floor. 0 at the floor (no afterburner, base handling only)
+  // and 1 with every pip filled — so the default part-filled distribution shows
+  // a partial boost, exactly like erkul, which reads the same game fields.
   // 1 when the ship has no engine power family (nothing to scale against).
-  const hasEngine = columns.some((column) => column.family === "engine");
-  const engineBaseline = baseline.perFamily.engine;
-  const engineCurrent = state.perFamily.engine;
-  const enginePowerRatio = !hasEngine
+  const engineColumn = columns.find((column) => column.family === "engine");
+  const engineSpan = engineColumn
+    ? engineColumn.capacity - engineColumn.min
+    : 0;
+  const enginePowerRatio = !engineColumn
     ? 1
-    : engineBaseline > 0
-      ? engineCurrent / engineBaseline
-      : engineCurrent > 0
-        ? 1
-        : 0;
+    : engineSpan > 0
+      ? Math.min(
+          1,
+          Math.max(0, (engineColumn.allocated - engineColumn.min) / engineSpan),
+        )
+      : 0;
 
   // Radar power ratio → effective aim-assist range (erkul's `or`): interpolated
   // between the radar's min and max by radar power, 0 when the radar is off.

--- a/app/frontend/frontend/composables/useLoadoutSim.ts
+++ b/app/frontend/frontend/composables/useLoadoutSim.ts
@@ -17,18 +17,33 @@ import {
 
 export { WEAPON_POOL_PORT, type PortOverrides } from "./powerSim";
 
-// A single power column in the pip UI — one component, or the shared weapon
-// pool. `label` is the component name (undefined for the weapon pool). `min` is
-// the mandatory floor: the component is either off (0) or on at ≥ `min`
-// segments (min === capacity for all-critical systems like the quantum drive).
-export type PowerColumn = {
+// One controllable unit inside a column: a single component (or the shared
+// weapon pool). `min` is the mandatory floor — the unit is either off (0) or on
+// at ≥ `min` segments (min === capacity for all-critical systems like the QD).
+export type PowerColumnMember = {
   portPath: string;
-  family: PowerFamily;
   label?: string;
   allocated: number;
   capacity: number;
   min: number;
 };
+
+// A single column in the pip UI. Most families render one column per component;
+// grouped families (shields, tractor/towing beams) stack every component into
+// one column with a `members` entry per generator/beam so each can be toggled
+// individually. Column-level `allocated`/`capacity`/`min` sum the members.
+export type PowerColumn = PowerColumnMember & {
+  family: PowerFamily;
+  members: PowerColumnMember[];
+};
+
+// Families whose components stack into a single column (each still individually
+// toggleable). Everything else — notably coolers — is one column per component.
+const GROUPED_FAMILIES = new Set<PowerFamily>([
+  "shield",
+  "tractorBeam",
+  "towingbeam",
+]);
 
 // FleetYards hardpoint category → erkul power family. Only the families erkul
 // feeds power segments to are mapped; every other category (thrusters, fuel,
@@ -77,10 +92,6 @@ export type LoadoutSimResult = {
 // pool `maxItemCount`); the rest are unpowered backups. 2 is the game default.
 export const DEFAULT_SHIELD_MAX_ITEM_COUNT = 2;
 
-// The active shields share a pool (like weapons), so they aggregate into one
-// column / override key rather than one per generator.
-export const SHIELD_POOL_PORT = "shieldPool";
-
 type Collected = {
   plants: { units: number; size: number; poweredOn: boolean }[];
   weaponUnits: number;
@@ -120,7 +131,13 @@ function collectPorts(
           });
         }
       } else {
-        const family = POWER_FAMILY_BY_CATEGORY[category];
+        // Tractor/towing beams are miscategorised (weapons/turret/unknown), so
+        // their component type is the reliable signal — it also keeps them out
+        // of the shared weapon pool.
+        const componentType = hardpoint.component?.type;
+        let family = POWER_FAMILY_BY_CATEGORY[category];
+        if (componentType === "TractorBeam") family = "tractorBeam";
+        else if (componentType === "TowingBeam") family = "towingbeam";
         const draw = numeric(typeData.powerConsumption);
         if (family === "weapon") {
           acc.weaponUnits += draw;
@@ -129,21 +146,19 @@ function collectPorts(
           const isBackupShield =
             family === "shield" && ++acc.shieldsSeen > shieldMaxItemCount;
           if (!isBackupShield) {
-            // Shields share a pool → one aggregate column; every other family
-            // is one column per component.
-            const portPath =
-              family === "shield" ? SHIELD_POOL_PORT : hardpoint.id;
+            // One column per component (each shield generator included) so any
+            // single generator can be toggled independently.
             const minimumFraction =
               typeData.powerMinimumFraction == null
                 ? undefined
                 : numeric(typeData.powerMinimumFraction);
             acc.otherPorts.push(
-              ...componentBlocks(portPath, family, {
+              ...componentBlocks(hardpoint.id, family, {
                 units: draw,
                 minimumFraction,
               }),
             );
-            if (family !== "shield" && hardpoint.component?.name) {
+            if (hardpoint.component?.name) {
               acc.portLabels[hardpoint.id] = hardpoint.component.name;
             }
             // Capture the radar's aim-assist range for the power-pane readout.
@@ -196,8 +211,9 @@ function computeWeaponMaxRatio(
   return Math.min(uncapped, weaponMax / consumption);
 }
 
-// Group the allocation into display columns: one per component (+ the shared
-// weapon pool), ordered by family, dropping ports with no capacity.
+// Group the allocation into display columns: one member per component (+ the
+// shared weapon pool), with grouped families stacking their members into a
+// single column. Ordered by family, dropping ports with no capacity.
 function buildColumns(
   ports: PowerPort[],
   portLabels: Record<string, string>,
@@ -221,25 +237,44 @@ function buildColumns(
     }
   }
 
-  const columns = order
-    .map((portPath) => {
-      const entry = byPort.get(portPath) as {
-        family: PowerFamily;
-        capacity: number;
-        critical: number;
-      };
-      return {
-        portPath,
-        family: entry.family,
-        label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
-        allocated: state.perPort[portPath] ?? 0,
-        capacity: entry.capacity,
-        // Mandatory floor: a component is either off or on at ≥ this many
-        // segments (equals capacity for all-critical systems like the QD).
-        min: entry.critical,
-      };
-    })
-    .filter((column) => column.capacity > 0);
+  const columns: PowerColumn[] = [];
+  const grouped = new Map<PowerFamily, PowerColumn>();
+  for (const portPath of order) {
+    const entry = byPort.get(portPath)!;
+    if (entry.capacity <= 0) continue;
+    const member: PowerColumnMember = {
+      portPath,
+      label: portPath === WEAPON_POOL_PORT ? undefined : portLabels[portPath],
+      allocated: state.perPort[portPath] ?? 0,
+      capacity: entry.capacity,
+      // Mandatory floor: a component is either off or on at ≥ this many
+      // segments (equals capacity for all-critical systems like the QD).
+      min: entry.critical,
+    };
+
+    if (GROUPED_FAMILIES.has(entry.family)) {
+      let column = grouped.get(entry.family);
+      if (!column) {
+        column = {
+          ...member,
+          allocated: 0,
+          capacity: 0,
+          min: 0,
+          label: undefined,
+          family: entry.family,
+          members: [],
+        };
+        grouped.set(entry.family, column);
+        columns.push(column);
+      }
+      column.members.push(member);
+      column.allocated += member.allocated;
+      column.capacity += member.capacity;
+      column.min += member.min;
+    } else {
+      columns.push({ ...member, family: entry.family, members: [member] });
+    }
+  }
 
   return columns.sort(
     (a, b) =>
@@ -307,13 +342,17 @@ export function simulateLoadoutPower(
 
   const columns = buildColumns(ports, acc.portLabels, state);
 
-  // Shield power ratio = allocated shield segments / shield capacity (0 when
-  // shields are unpowered, 1 when there are no shields). Drives shield HP/regen.
-  const shieldColumn = columns.find((column) => column.family === "shield");
+  // Shield power ratio = allocated shield segments / total shield capacity
+  // across every active generator (0 when shields are unpowered, 1 when there
+  // are no shields). Drives shield HP/regen and scales with a disabled generator.
+  const shieldColumns = columns.filter((column) => column.family === "shield");
+  const shieldCapacity = shieldColumns.reduce((sum, c) => sum + c.capacity, 0);
+  const shieldAllocated = shieldColumns.reduce(
+    (sum, c) => sum + c.allocated,
+    0,
+  );
   const shieldPoolRatio =
-    shieldColumn && shieldColumn.capacity > 0
-      ? Math.min(1, shieldColumn.allocated / shieldColumn.capacity)
-      : 1;
+    shieldCapacity > 0 ? Math.min(1, shieldAllocated / shieldCapacity) : 1;
 
   // Radar power ratio → effective aim-assist range (erkul's `or`): interpolated
   // between the radar's min and max by radar power, 0 when the radar is off.

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -27,6 +27,24 @@ function weaponHardpoint(
   } as Hardpoint;
 }
 
+// A power plant so the loadout has segments to allocate (the weapon power ratio
+// follows the real allocation whenever segments exist).
+function plant(powerBase = 40): Hardpoint {
+  return {
+    id: Math.random().toString(),
+    name: "plant",
+    category: HardpointCategoryEnum.POWERPLANT,
+    component: {
+      name: "Power Plant",
+      size: "2",
+      typeData: { powerBase },
+    } as Hardpoint["component"],
+    hardpoints: [],
+    createdAt: "",
+    updatedAt: "",
+  } as Hardpoint;
+}
+
 describe("computeLoadoutStats", () => {
   it("returns empty stats when there are no weapons", () => {
     const stats = computeLoadoutStats([]);
@@ -186,9 +204,13 @@ describe("computeLoadoutStats", () => {
       regen: { maxAmmoLoad: 10, maxRegenPerSecond: 5, regenerationCooldown: 0 },
     });
 
-    expect(computeLoadoutStats([weapon], 4).dps.total).toBeGreaterThan(0);
+    expect(computeLoadoutStats([plant(), weapon], 4).dps.total).toBeGreaterThan(
+      0,
+    );
 
-    const off = computeLoadoutStats([weapon], 4, { [WEAPON_POOL_PORT]: 0 });
+    const off = computeLoadoutStats([plant(), weapon], 4, {
+      [WEAPON_POOL_PORT]: 0,
+    });
     expect(off.dps.total).toBe(0);
     expect(off.sustainedDps.total).toBe(0);
     expect(off.alpha.total).toBe(0);
@@ -208,12 +230,14 @@ describe("computeLoadoutStats", () => {
     });
 
     // 0 pips → off.
-    const off = computeLoadoutStats([weapon], 4, { [WEAPON_POOL_PORT]: 0 });
+    const off = computeLoadoutStats([plant(), weapon], 4, {
+      [WEAPON_POOL_PORT]: 0,
+    });
     expect(off.dps.total).toBe(0);
     expect(off.alpha.total).toBe(0);
 
     // Powered → full burst and heat-limited sustained (0.5), not power-scaled.
-    const on = computeLoadoutStats([weapon], 4);
+    const on = computeLoadoutStats([plant(), weapon], 4);
     expect(on.dps.total).toBeCloseTo(100);
     expect(on.alpha.total).toBeCloseTo(100);
     expect(on.sustainedDps.total).toBeCloseTo(50);

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -177,12 +177,13 @@ describe("computeLoadoutStats", () => {
     expect(stats.weapons[0].type).toBe("energy");
   });
 
-  it("zeroes all weapon damage when weapons are unpowered (0 pips)", () => {
+  it("zeroes all weapon damage when energy weapons are unpowered (0 pips)", () => {
     const weapon = weaponHardpoint({
       fireRate: 60,
       pelletsPerShot: 1,
       damagePerShot: { energy: 100 },
       powerConsumption: 2,
+      regen: { maxAmmoLoad: 10, maxRegenPerSecond: 5, regenerationCooldown: 0 },
     });
 
     expect(computeLoadoutStats([weapon], 4).dps.total).toBeGreaterThan(0);
@@ -191,5 +192,30 @@ describe("computeLoadoutStats", () => {
     expect(off.dps.total).toBe(0);
     expect(off.sustainedDps.total).toBe(0);
     expect(off.alpha.total).toBe(0);
+  });
+
+  it("needs a weapon pip for ballistics, then fires them unthrottled", () => {
+    // Heat-limited (no energy pool). Like erkul, ballistics still need the
+    // weapon system powered (≥1 pip) to fire, but once on they aren't
+    // throttled by the weapon pool — only their overheat duty cycle applies.
+    const weapon = weaponHardpoint({
+      fireRate: 60,
+      pelletsPerShot: 1,
+      damagePerShot: { physical: 100 },
+      powerConsumption: 0.1,
+      heat: { overheatTemperature: 100, overheatFixTime: 10 },
+      heatPerShot: 10,
+    });
+
+    // 0 pips → off.
+    const off = computeLoadoutStats([weapon], 4, { [WEAPON_POOL_PORT]: 0 });
+    expect(off.dps.total).toBe(0);
+    expect(off.alpha.total).toBe(0);
+
+    // Powered → full burst and heat-limited sustained (0.5), not power-scaled.
+    const on = computeLoadoutStats([weapon], 4);
+    expect(on.dps.total).toBeCloseTo(100);
+    expect(on.alpha.total).toBeCloseTo(100);
+    expect(on.sustainedDps.total).toBeCloseTo(50);
   });
 });

--- a/app/frontend/frontend/composables/useLoadoutStats.spec.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.spec.ts
@@ -5,6 +5,7 @@ import {
   type ComponentWeapon,
 } from "@/services/fyApi";
 import { computeLoadoutStats } from "./useLoadoutStats";
+import { WEAPON_POOL_PORT } from "./useLoadoutSim";
 
 function weaponHardpoint(
   typeData: ComponentWeapon,
@@ -174,5 +175,21 @@ describe("computeLoadoutStats", () => {
     expect(stats.weapons[0].dps).toBeCloseTo(900);
     expect(stats.weapons[0].size).toBe("4");
     expect(stats.weapons[0].type).toBe("energy");
+  });
+
+  it("zeroes all weapon damage when weapons are unpowered (0 pips)", () => {
+    const weapon = weaponHardpoint({
+      fireRate: 60,
+      pelletsPerShot: 1,
+      damagePerShot: { energy: 100 },
+      powerConsumption: 2,
+    });
+
+    expect(computeLoadoutStats([weapon], 4).dps.total).toBeGreaterThan(0);
+
+    const off = computeLoadoutStats([weapon], 4, { [WEAPON_POOL_PORT]: 0 });
+    expect(off.dps.total).toBe(0);
+    expect(off.sustainedDps.total).toBe(0);
+    expect(off.alpha.total).toBe(0);
   });
 });

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -134,11 +134,12 @@ export function computeLoadoutStats(
     "SCM",
     overrides,
   );
-  // Baseline sustained uses the max-power ratio; once the user engages the pip
-  // UI (any family override — even a shield bump squeezes weapons), it follows
-  // the actual weapon allocation.
-  const hasOverrides = overrides && Object.keys(overrides).length > 0;
-  const powerRatio = hasOverrides ? sim.weaponPoolRatio : sim.weaponMaxRatio;
+  // Weapon power follows the actual pip allocation shown in the power UI — the
+  // default distribution until the user assigns pips, their choices afterwards.
+  // Only when the ship has no parsed plant segments do we fall back to the
+  // segment-independent max-power ratio, so those ships never regress to 0 DPS.
+  const powerRatio =
+    sim.totalSegments > 0 ? sim.weaponPoolRatio : sim.weaponMaxRatio;
   // Every weapon needs the weapon system powered (≥1 pip) to fire at all — zero
   // burst/alpha too when unpowered, not just sustained. The sustained *throttle*
   // from partial power is energy-only and handled by sustainedRatio's branch

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -139,8 +139,10 @@ export function computeLoadoutStats(
   // the actual weapon allocation.
   const hasOverrides = overrides && Object.keys(overrides).length > 0;
   const powerRatio = hasOverrides ? sim.weaponPoolRatio : sim.weaponMaxRatio;
-  // Unpowered weapons (0 pips) can't fire at all — zero burst/alpha too, not
-  // just sustained.
+  // Every weapon needs the weapon system powered (≥1 pip) to fire at all — zero
+  // burst/alpha too when unpowered, not just sustained. The sustained *throttle*
+  // from partial power is energy-only and handled by sustainedRatio's branch
+  // (ballistics use the heat model and ignore powerRatio).
   const powered = powerRatio > 0 ? 1 : 0;
 
   const dps = emptyBreakdown();

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -4,7 +4,7 @@ import {
   type Hardpoint,
   type ComponentWeapon,
 } from "@/services/fyApi";
-import { simulateLoadoutPower } from "./useLoadoutSim";
+import { simulateLoadoutPower, type FamilyOverrides } from "./useLoadoutSim";
 
 export type DamageBreakdown = {
   total: number;
@@ -125,12 +125,19 @@ export function sustainedRatio(
 export function computeLoadoutStats(
   hardpoints: Hardpoint[] | undefined,
   weaponPoolSize?: number,
+  overrides?: FamilyOverrides,
 ): LoadoutStats {
   const weaponHardpoints = collectWeaponHardpoints(hardpoints);
-  const powerRatio = simulateLoadoutPower(
+  const sim = simulateLoadoutPower(
     hardpoints,
     weaponPoolSize,
-  ).weaponMaxRatio;
+    "SCM",
+    overrides,
+  );
+  // Baseline sustained uses the max-power ratio; once the user throttles weapons
+  // via the pip UI, it follows their actual weapon allocation.
+  const powerRatio =
+    overrides?.weapon === undefined ? sim.weaponMaxRatio : sim.weaponPoolRatio;
 
   const dps = emptyBreakdown();
   const sustainedDps = emptyBreakdown();
@@ -197,8 +204,13 @@ export function computeLoadoutStats(
 export function useLoadoutStats(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
   weaponPoolSize?: MaybeRefOrGetter<number | undefined>,
+  overrides?: MaybeRefOrGetter<FamilyOverrides | undefined>,
 ) {
   return computed(() =>
-    computeLoadoutStats(toValue(hardpoints), toValue(weaponPoolSize)),
+    computeLoadoutStats(
+      toValue(hardpoints),
+      toValue(weaponPoolSize),
+      toValue(overrides),
+    ),
   );
 }

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -4,6 +4,7 @@ import {
   type Hardpoint,
   type ComponentWeapon,
 } from "@/services/fyApi";
+import { simulateLoadoutPower } from "./useLoadoutSim";
 
 export type DamageBreakdown = {
   total: number;
@@ -121,33 +122,15 @@ export function sustainedRatio(
   return 1;
 }
 
-// erkul's weapon-power-pool throttle: the mounted energy weapons draw Power to
-// regen; when their combined draw exceeds the ship's fixed weapon pool, every
-// energy weapon's sustained regen is scaled down by this ratio. Ships without a
-// fixed weapon pool (`weaponPoolSize` absent) are unlimited → 1.
-export function weaponPowerRatio(
-  hardpoints: Hardpoint[] | undefined,
-  weaponPoolSize: number | undefined,
-): number {
-  if (!weaponPoolSize || weaponPoolSize <= 0) return 1;
-
-  const draw = collectWeaponHardpoints(hardpoints).reduce((sum, hardpoint) => {
-    const weapon = hardpoint.component!.typeData as ComponentWeapon;
-    return sum + (weapon.powerConsumption ?? 0);
-  }, 0);
-
-  const consumption = Math.ceil(draw);
-  if (consumption <= 0) return 1;
-
-  return Math.min(1, weaponPoolSize / consumption);
-}
-
 export function computeLoadoutStats(
   hardpoints: Hardpoint[] | undefined,
   weaponPoolSize?: number,
 ): LoadoutStats {
   const weaponHardpoints = collectWeaponHardpoints(hardpoints);
-  const powerRatio = weaponPowerRatio(hardpoints, weaponPoolSize);
+  const powerRatio = simulateLoadoutPower(
+    hardpoints,
+    weaponPoolSize,
+  ).weaponMaxRatio;
 
   const dps = emptyBreakdown();
   const sustainedDps = emptyBreakdown();

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -4,7 +4,7 @@ import {
   type Hardpoint,
   type ComponentWeapon,
 } from "@/services/fyApi";
-import { simulateLoadoutPower, type FamilyOverrides } from "./useLoadoutSim";
+import { simulateLoadoutPower, type PortOverrides } from "./useLoadoutSim";
 
 export type DamageBreakdown = {
   total: number;
@@ -125,7 +125,7 @@ export function sustainedRatio(
 export function computeLoadoutStats(
   hardpoints: Hardpoint[] | undefined,
   weaponPoolSize?: number,
-  overrides?: FamilyOverrides,
+  overrides?: PortOverrides,
 ): LoadoutStats {
   const weaponHardpoints = collectWeaponHardpoints(hardpoints);
   const sim = simulateLoadoutPower(
@@ -205,7 +205,7 @@ export function computeLoadoutStats(
 export function useLoadoutStats(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
   weaponPoolSize?: MaybeRefOrGetter<number | undefined>,
-  overrides?: MaybeRefOrGetter<FamilyOverrides | undefined>,
+  overrides?: MaybeRefOrGetter<PortOverrides | undefined>,
 ) {
   return computed(() =>
     computeLoadoutStats(

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -139,6 +139,9 @@ export function computeLoadoutStats(
   // the actual weapon allocation.
   const hasOverrides = overrides && Object.keys(overrides).length > 0;
   const powerRatio = hasOverrides ? sim.weaponPoolRatio : sim.weaponMaxRatio;
+  // Unpowered weapons (0 pips) can't fire at all — zero burst/alpha too, not
+  // just sustained.
+  const powered = powerRatio > 0 ? 1 : 0;
 
   const dps = emptyBreakdown();
   const sustainedDps = emptyBreakdown();
@@ -150,19 +153,19 @@ export function computeLoadoutStats(
     const component = hardpoint.component!;
     const weapon = component.typeData as ComponentWeapon;
     const weaponDps = emptyBreakdown();
-    const ratio = sustainedRatio(weapon, powerRatio);
+    const ratio = sustainedRatio(weapon, powerRatio) * powered;
 
     if (weapon.beam && weapon.damagePerSecond) {
-      addBreakdown(dps, weapon.damagePerSecond, 1);
+      addBreakdown(dps, weapon.damagePerSecond, powered);
       addBreakdown(sustainedDps, weapon.damagePerSecond, ratio);
-      addBreakdown(weaponDps, weapon.damagePerSecond, 1);
+      addBreakdown(weaponDps, weapon.damagePerSecond, powered);
     } else if (!isMissile(weapon) && weapon.fireRate && weapon.damagePerShot) {
       const pellets = weapon.pelletsPerShot || 1;
       const shotsPerSecond = (pellets * weapon.fireRate) / 60;
-      addBreakdown(alpha, weapon.damagePerShot, pellets);
-      addBreakdown(dps, weapon.damagePerShot, shotsPerSecond);
+      addBreakdown(alpha, weapon.damagePerShot, pellets * powered);
+      addBreakdown(dps, weapon.damagePerShot, shotsPerSecond * powered);
       addBreakdown(sustainedDps, weapon.damagePerShot, shotsPerSecond * ratio);
-      addBreakdown(weaponDps, weapon.damagePerShot, shotsPerSecond);
+      addBreakdown(weaponDps, weapon.damagePerShot, shotsPerSecond * powered);
     } else {
       // Missiles (and other non-DPS munitions) don't contribute to DPS/alpha,
       // but their total payload damage is surfaced separately.

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -134,10 +134,11 @@ export function computeLoadoutStats(
     "SCM",
     overrides,
   );
-  // Baseline sustained uses the max-power ratio; once the user throttles weapons
-  // via the pip UI, it follows their actual weapon allocation.
-  const powerRatio =
-    overrides?.weapon === undefined ? sim.weaponMaxRatio : sim.weaponPoolRatio;
+  // Baseline sustained uses the max-power ratio; once the user engages the pip
+  // UI (any family override — even a shield bump squeezes weapons), it follows
+  // the actual weapon allocation.
+  const hasOverrides = overrides && Object.keys(overrides).length > 0;
+  const powerRatio = hasOverrides ? sim.weaponPoolRatio : sim.weaponMaxRatio;
 
   const dps = emptyBreakdown();
   const sustainedDps = emptyBreakdown();

--- a/app/frontend/frontend/composables/useMetricsMasonry.ts
+++ b/app/frontend/frontend/composables/useMetricsMasonry.ts
@@ -1,0 +1,74 @@
+import { onBeforeUnmount, onMounted, watch, type Ref } from "vue";
+
+// Masonry packing for the metrics cards: each card spans as many rows of a
+// fine-grained grid as it is tall, which lets `grid-auto-flow: dense` backfill a
+// short column with a later card. Multi-column flow cannot do this — it fills
+// columns in document order, so a card can never move up into an earlier column
+// and every short column keeps its gap.
+const ROW_HEIGHT = 4;
+// Counted into the span so the trailing rows of a card's area form the gap to
+// the next one; the cards themselves carry no margin in the grid.
+const CARD_SPACING = 20;
+
+export function useMetricsMasonry(
+  container: Ref<HTMLElement | null | undefined>,
+) {
+  let resizeObserver: ResizeObserver | undefined;
+  let mutationObserver: MutationObserver | undefined;
+
+  const applySpan = (element: Element) => {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+
+    const span = Math.ceil((element.offsetHeight + CARD_SPACING) / ROW_HEIGHT);
+
+    element.style.setProperty("--metrics-card-span", `${span}`);
+  };
+
+  const observeChildren = () => {
+    if (!resizeObserver) {
+      return;
+    }
+
+    resizeObserver.disconnect();
+
+    for (const child of container.value?.children || []) {
+      resizeObserver.observe(child);
+      applySpan(child);
+    }
+  };
+
+  const attach = () => {
+    mutationObserver?.disconnect();
+
+    if (container.value) {
+      mutationObserver?.observe(container.value, { childList: true });
+    }
+
+    observeChildren();
+  };
+
+  onMounted(() => {
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    // eslint-disable-next-line compat/compat
+    resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        applySpan(entry.target);
+      }
+    });
+    mutationObserver = new MutationObserver(attach);
+
+    attach();
+  });
+
+  watch(container, attach);
+
+  onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+    mutationObserver?.disconnect();
+  });
+}

--- a/app/frontend/frontend/composables/useShieldStats.spec.ts
+++ b/app/frontend/frontend/composables/useShieldStats.spec.ts
@@ -39,6 +39,19 @@ describe("computeShieldStats", () => {
     expect(stats.hasData).toBe(true);
   });
 
+  it("scales regen with the shield power ratio and zeroes when unpowered", () => {
+    const shields = [shieldHardpoint({ maxHealth: 10000, maxRegen: 1500 })];
+
+    const half = computeShieldStats(shields, 0.5);
+    expect(half.totalRegen).toBe(750);
+    expect(half.totalHp).toBe(10000); // powered → full HP
+
+    const off = computeShieldStats(shields, 0);
+    expect(off.totalRegen).toBe(0);
+    expect(off.totalHp).toBe(0); // unpowered → no protection
+    expect(off.hasData).toBe(true); // still shown (as 0), not hidden
+  });
+
   it("HP-weights resistances across shields", () => {
     const stats = computeShieldStats([
       shieldHardpoint({

--- a/app/frontend/frontend/composables/useShieldStats.ts
+++ b/app/frontend/frontend/composables/useShieldStats.ts
@@ -90,18 +90,28 @@ function weightedByHp(
 
 export function computeShieldStats(
   hardpoints: Hardpoint[] | undefined,
+  shieldPoolRatio = 1,
 ): ShieldStats {
   const shields = collectShieldHardpoints(hardpoints).map(
     (hardpoint) => hardpoint.component!.typeData as ComponentShield,
   );
 
-  let totalHp = 0;
-  let totalRegen = 0;
+  // Regen scales with the shield power allocation; an unpowered shield (0 pips)
+  // offers no protection, so its HP drops to 0 as well.
+  const powered = shieldPoolRatio > 0 ? 1 : 0;
+
+  let rawHp = 0;
+  let rawRegen = 0;
 
   for (const shield of shields) {
-    totalHp += shield.maxHealth || 0;
-    totalRegen += shield.maxRegen || 0;
+    rawHp += shield.maxHealth || 0;
+    rawRegen += shield.maxRegen || 0;
   }
+
+  // Displayed values reflect the current power; hasData stays true whenever the
+  // ship structurally has shields, so an unpowered shield shows 0 (not hidden).
+  const totalHp = rawHp * powered;
+  const totalRegen = rawRegen * shieldPoolRatio;
 
   const resistanceByType: Record<string, number> = {};
   const resistanceMinByType: Record<string, number> = {};
@@ -157,12 +167,15 @@ export function computeShieldStats(
     resistanceMinByType,
     absorptionByType,
     absorptionMinByType,
-    hasData: shields.length > 0 && totalHp > 0,
+    hasData: shields.length > 0 && rawHp > 0,
   };
 }
 
 export function useShieldStats(
   hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
+  shieldPoolRatio?: MaybeRefOrGetter<number | undefined>,
 ) {
-  return computed(() => computeShieldStats(toValue(hardpoints)));
+  return computed(() =>
+    computeShieldStats(toValue(hardpoints), toValue(shieldPoolRatio) ?? 1),
+  );
 }

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -23,7 +23,6 @@ import {
 import FleetchartImages from "@/frontend/components/Models/FleetchartImages/index.vue";
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
-import ModelSpeedMetrics from "@/frontend/components/Models/SpeedMetrics/index.vue";
 import ModelCargoMetrics from "@/frontend/components/Models/CargoMetrics/index.vue";
 import ModelExternalFuelTanks from "@/frontend/components/Models/ExternalFuelTanks/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
@@ -367,9 +366,6 @@ const adiMap = computed(() => {
           </Panel>
           <Panel slim>
             <ModelCrewMetrics :model="model" />
-          </Panel>
-          <Panel slim>
-            <ModelSpeedMetrics :model="model" />
           </Panel>
           <div class="page-actions page-actions-block">
             <Btn

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -23,7 +23,6 @@ import {
 import FleetchartImages from "@/frontend/components/Models/FleetchartImages/index.vue";
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
-import ModelCargoMetrics from "@/frontend/components/Models/CargoMetrics/index.vue";
 import ModelExternalFuelTanks from "@/frontend/components/Models/ExternalFuelTanks/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import HoloViewer from "@/shared/components/HoloViewer/index.vue";
@@ -462,14 +461,9 @@ const adiMap = computed(() => {
         </div>
       </div>
       <FleetchartImages v-model:extended="extendedState" :model="model" />
-      <ModelCargoMetrics
-        v-if="combinedCargoHolds.length"
-        :model="model"
-        :cargo-holds="combinedCargoHolds"
-      />
       <ModelExternalFuelTanks :model="model" />
       <hr />
-      <Hardpoints :model="model" />
+      <Hardpoints :model="model" :cargo-holds="combinedCargoHolds" />
       <CrewPositions :model="model" />
     </div>
   </div>

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -23,7 +23,6 @@ import {
 import FleetchartImages from "@/frontend/components/Models/FleetchartImages/index.vue";
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
-import ModelExternalFuelTanks from "@/frontend/components/Models/ExternalFuelTanks/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import HoloViewer from "@/shared/components/HoloViewer/index.vue";
 import ShareBtn from "@/frontend/components/ShareBtn/index.vue";
@@ -461,7 +460,6 @@ const adiMap = computed(() => {
         </div>
       </div>
       <FleetchartImages v-model:extended="extendedState" :model="model" />
-      <ModelExternalFuelTanks :model="model" />
       <hr />
       <Hardpoints :model="model" :cargo-holds="combinedCargoHolds" />
       <CrewPositions :model="model" />

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -30,7 +30,6 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useHangarItems } from "@/frontend/composables/useHangarItems";
 import { useWishlistItems } from "@/frontend/composables/useWishlistItems";
 import { useMetaInfo } from "@/shared/composables/useMetaInfo";
-import Panel from "@/shared/components/base/Panel/index.vue";
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { useMobile } from "@/shared/composables/useMobile";
 import { useModelsStore } from "@/frontend/stores/models";
@@ -359,12 +358,8 @@ const adiMap = computed(() => {
               inline
             />
           </template>
-          <Panel slim>
-            <ModelBaseMetrics :model="model" :extended="extendedState" />
-          </Panel>
-          <Panel slim>
-            <ModelCrewMetrics :model="model" />
-          </Panel>
+          <ModelBaseMetrics :model="model" :extended="extendedState" />
+          <ModelCrewMetrics :model="model" />
           <div class="page-actions page-actions-block">
             <Btn
               v-if="model.onSale && price"

--- a/app/frontend/shared/plugins/Tooltip.ts
+++ b/app/frontend/shared/plugins/Tooltip.ts
@@ -4,6 +4,7 @@ interface TooltipOptions {
   content: string | false;
   placement: string;
   popperClass?: string;
+  html?: boolean;
 }
 
 function parseBinding(binding: DirectiveBinding): TooltipOptions {
@@ -15,6 +16,7 @@ function parseBinding(binding: DirectiveBinding): TooltipOptions {
       content: binding.value.content,
       placement: binding.value.placement || placement,
       popperClass: binding.value.popperClass,
+      html: binding.value.html,
     };
   }
 
@@ -22,6 +24,18 @@ function parseBinding(binding: DirectiveBinding): TooltipOptions {
     content: binding.value || false,
     placement,
   };
+}
+
+// Callers pass formatted i18n strings that carry markup — `toUEC` wraps its unit
+// in a muted span — so without this the tags render as literal text.
+function setContent(el: HTMLElement, options: TooltipOptions) {
+  if (options.html) {
+    el.innerHTML = String(options.content);
+
+    return;
+  }
+
+  el.textContent = String(options.content);
 }
 
 const ARROW_SIZE = 6;
@@ -43,7 +57,7 @@ function createTooltipEl(options: TooltipOptions): HTMLElement {
     "opacity:0",
     "transition:opacity .15s ease",
   ].join(";");
-  el.textContent = String(options.content);
+  setContent(el, options);
 
   const arrow = document.createElement("div");
   arrow.setAttribute("data-tooltip-arrow", "");
@@ -187,7 +201,7 @@ function show(el: HTMLElement) {
 
   // Update text (keep arrow element)
   const arrow = tip.querySelector("[data-tooltip-arrow]");
-  tip.textContent = String(state.options.content);
+  setContent(tip, state.options);
   if (arrow) tip.appendChild(arrow);
 
   // Measure at 0 opacity

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -579,11 +579,12 @@
       "flight": {
         "title": "Flight",
         "scm": "combat cruise",
+        "nav": "cruise",
         "boost": "Boost",
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "Scales with the thrusters' power pips. Base → boosted handling."
+        "hint": "Boosted handling scales with the thrusters' power pips; speeds don't."
       },
       "combat": {
         "title": "Combat",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -586,6 +586,15 @@
         "maneuverability": "Maneuverability",
         "hint": "Boosted handling scales with the engine pips; all zero when the engine is unpowered."
       },
+      "base": {
+        "price": "Price",
+        "priceInGame": "In-game",
+        "pricePledge": "Pledge",
+        "fuel": "Fuel",
+        "fuelHydrogen": "Hydrogen",
+        "fuelQuantum": "Quantum",
+        "availability": "Availability"
+      },
       "cargo": {
         "title": "Cargo",
         "holdsSub": "across %{count} holds",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -600,6 +600,7 @@
         "reset": "Reset",
         "auto": "Auto",
         "aimAssist": "Aim Assist",
+        "cooling": "Cooling",
         "segmentsUsed": "%{used} / %{total} segments",
         "hint": "Move power between systems. Weapons' sustained DPS scales with the power they get; the rest is auto-balanced.",
         "families": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -584,6 +584,9 @@
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
+        "fuel": "Fuel",
+        "fuelHydrogen": "Hydrogen",
+        "fuelQuantum": "Quantum",
         "hint": "Boosted handling scales with the engine pips; all zero when the engine is unpowered."
       },
       "base": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -622,7 +622,6 @@
         "shieldHp": "Shield HP",
         "shieldHpSub": "%{count} generators",
         "shieldRegen": "Regeneration",
-        "shieldRegenSub": "at full power",
         "shieldResistances": "Resistance",
         "shieldAbsorption": "Absorption",
         "armor": "Armor",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -593,6 +593,30 @@
         "damageThermal": "Thermal",
         "hint": "DPS from the default loadout. Sustained factors in each weapon's energy-pool regen and overheat cycle. Missiles excluded."
       },
+      "power": {
+        "title": "Power Distribution",
+        "scm": "SCM",
+        "nav": "NAV",
+        "reset": "Reset",
+        "auto": "Auto",
+        "segmentsUsed": "%{used} / %{total} segments",
+        "hint": "Move power between systems. Weapons' sustained DPS scales with the power they get; the rest is auto-balanced.",
+        "families": {
+          "weapon": "Weapons",
+          "shield": "Shields",
+          "engine": "Engine",
+          "radar": "Radar",
+          "coolers": "Coolers",
+          "qdrive": "Quantum Drive",
+          "qed": "QED",
+          "emp": "EMP",
+          "lifeSupport": "Life Support",
+          "miningLaser": "Mining Laser",
+          "salvage": "Salvage",
+          "tractorBeam": "Tractor Beam",
+          "towingbeam": "Towing Beam"
+        }
+      },
       "defense": {
         "title": "Defense",
         "shieldHp": "Shield HP",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -891,7 +891,6 @@
           "maxForce": "Max Force",
           "minForce": "Min Force",
           "range": "Range",
-          "fullStrength": "Full Strength",
           "cone": "Cone",
           "tetherBreak": "Tether Break",
           "cargoForce": "Cargo Force",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -593,10 +593,19 @@
         "price": "Price",
         "priceInGame": "In-game",
         "pricePledge": "Pledge",
-        "fuel": "Fuel",
-        "fuelHydrogen": "Hydrogen",
-        "fuelQuantum": "Quantum",
         "availability": "Availability"
+      },
+      "availability": {
+        "title": "Availability",
+        "buy": "Buy",
+        "rent": "Rent",
+        "empty": "No known buy or rental locations.",
+        "timeRange": {
+          "1-day": "1 day",
+          "3-days": "3 days",
+          "7-days": "7 days",
+          "30-days": "30 days"
+        }
       },
       "cargo": {
         "title": "Cargo",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -584,7 +584,7 @@
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "Boosted handling scales with the thruster pips; all zero when the engine is unpowered."
+        "hint": "Boosted handling scales with the engine pips; speeds and base handling are fixed."
       },
       "cargo": {
         "title": "Cargo",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -593,6 +593,20 @@
         "containers": "Container Capacity",
         "hint": "Maximum number of containers of each size that fit the cargo grids; the bar shows how much of the total capacity that fills."
       },
+      "fuelTanks": {
+        "capacitySub": "across %{count} pods",
+        "podsSub": "external mounts",
+        "components": "Pod Types",
+        "perPod": "per pod",
+        "hint": "Fuel carried in pods mounted on external hardpoints; the bar shows each type's share of the total capacity."
+      },
+      "refuelBoom": {
+        "fuelFlowSub": "hydrogen transfer",
+        "quantumFlowSub": "quantum transfer",
+        "captureRadiusSub": "docking tolerance",
+        "equipment": "Equipment",
+        "hint": "Transfer rates of the refueling arm and the docking tolerance of its nozzle."
+      },
       "combat": {
         "title": "Combat",
         "dps": "Burst DPS",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -601,6 +601,8 @@
         "auto": "Auto",
         "aimAssist": "Aim Assist",
         "cooling": "Cooling",
+        "ir": "IR",
+        "cs": "CS",
         "segmentsUsed": "%{used} / %{total} segments",
         "hint": "Move power between systems. Weapons' sustained DPS scales with the power they get; the rest is auto-balanced.",
         "families": {
@@ -884,6 +886,21 @@
           "lockRange": "Lock Range",
           "lockTime": "Lock Time",
           "trackingSignal": "Tracking"
+        },
+        "tractorBeams": {
+          "maxForce": "Max Force",
+          "minForce": "Min Force",
+          "range": "Range",
+          "fullStrength": "Full Strength",
+          "cone": "Cone",
+          "tetherBreak": "Tether Break",
+          "cargoForce": "Cargo Force",
+          "cargoRange": "Cargo Range",
+          "towForce": "Tow Force",
+          "towDistance": "Tow Range",
+          "quantumTowMass": "QT Mass Limit",
+          "rotationSpeed": "Rotation",
+          "moveSpeed": "Move Speed"
         },
         "shields": {
           "hp": "HP",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -584,7 +584,7 @@
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "Rated figures; all drop to zero when the engine is unpowered."
+        "hint": "Boosted handling scales with the thruster pips; all zero when the engine is unpowered."
       },
       "combat": {
         "title": "Combat",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -576,6 +576,13 @@
         "hardpoints": "Hardpoints",
         "missileOptions": "Missle Options (if available)"
       },
+      "flight": {
+        "title": "Flight",
+        "scm": "combat cruise",
+        "nav": "max / boost",
+        "maneuverability": "Maneuverability",
+        "hint": "SCM and maximum speeds with the ship's handling rates."
+      },
       "combat": {
         "title": "Combat",
         "dps": "Burst DPS",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -579,9 +579,11 @@
       "flight": {
         "title": "Flight",
         "scm": "combat cruise",
-        "nav": "max / boost",
+        "boost": "Boost",
+        "boostSub": "afterburner",
+        "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "SCM and maximum speeds with the ship's handling rates."
+        "hint": "Scales with the thrusters' power pips. Base → boosted handling."
       },
       "combat": {
         "title": "Combat",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -584,7 +584,7 @@
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "Boosted handling scales with the engine pips; speeds and base handling are fixed."
+        "hint": "Boosted handling scales with the engine pips; all zero when the engine is unpowered."
       },
       "cargo": {
         "title": "Cargo",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -599,6 +599,14 @@
         "title": "Availability",
         "buy": "Buy",
         "rent": "Rent",
+        "cheapest": {
+          "buy": "Cheapest buy",
+          "rent": "Cheapest rent"
+        },
+        "locations": {
+          "one": "%{count} location",
+          "other": "%{count} locations"
+        },
         "empty": "No known buy or rental locations.",
         "timeRange": {
           "1-day": "1 day",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -602,7 +602,9 @@
         "aimAssist": "Aim Assist",
         "cooling": "Cooling",
         "ir": "IR",
+        "em": "EM",
         "cs": "CS",
+        "csAxisHint": "Click to switch axis (x / y / z)",
         "segmentsUsed": "%{used} / %{total} segments",
         "hint": "Move power between systems. Weapons' sustained DPS scales with the power they get; the rest is auto-balanced.",
         "families": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -599,6 +599,7 @@
         "nav": "NAV",
         "reset": "Reset",
         "auto": "Auto",
+        "aimAssist": "Aim Assist",
         "segmentsUsed": "%{used} / %{total} segments",
         "hint": "Move power between systems. Weapons' sustained DPS scales with the power they get; the rest is auto-balanced.",
         "families": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -584,7 +584,7 @@
         "boostSub": "afterburner",
         "reverse": "Reverse",
         "maneuverability": "Maneuverability",
-        "hint": "Boosted handling scales with the thrusters' power pips; speeds don't."
+        "hint": "Rated figures; all drop to zero when the engine is unpowered."
       },
       "combat": {
         "title": "Combat",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -586,6 +586,13 @@
         "maneuverability": "Maneuverability",
         "hint": "Boosted handling scales with the thruster pips; all zero when the engine is unpowered."
       },
+      "cargo": {
+        "title": "Cargo",
+        "holdsSub": "across %{count} holds",
+        "maxContainerSub": "largest box that fits",
+        "containers": "Container Capacity",
+        "hint": "Maximum number of containers of each size that fit the cargo grids; the bar shows how much of the total capacity that fills."
+      },
       "combat": {
         "title": "Combat",
         "dps": "Burst DPS",

--- a/app/frontend/translations/en/number.json
+++ b/app/frontend/translations/en/number.json
@@ -33,6 +33,7 @@
       "seconds": "%{count} s",
       "rateOfFire": "%{count} shots/min",
       "rotation": "%{count} deg/s",
+      "degrees": "%{count}°",
       "cargo": "%{count} SCU",
       "integer": "%{count}",
       "dps": "%{count} DPS",

--- a/app/jobs/loaders/uex_prices_job.rb
+++ b/app/jobs/loaders/uex_prices_job.rb
@@ -23,6 +23,7 @@ module Loaders
           updated: result.updated,
           removed: result.removed,
           skipped_removals: result.skipped_removals,
+          repriced: result.repriced,
           unmatched: result.unmatched.map { |vehicle| vehicle["slug"] }
         }
       )

--- a/app/lib/uex/price_syncer.rb
+++ b/app/lib/uex/price_syncer.rb
@@ -117,7 +117,7 @@ module Uex
           price_type:,
           location:,
           time_range:,
-          location_url: terminal["contact_url"].presence,
+          location_url: web_url(terminal["contact_url"]),
           price:
         }
 
@@ -129,6 +129,15 @@ module Uex
         existing = result[key]
         result[key] = attributes if existing.blank? || price < existing[:price]
       end
+    end
+
+    # `contact_url` is whatever a UEX contributor typed. Anything that is not a
+    # web link is dropped rather than stored: `ItemPrice` rejects it, and one odd
+    # row must not fail a validation and take the whole snapshot down with it.
+    private def web_url(value)
+      url = value.to_s.strip
+
+      url if url.match?(%r{\Ahttps?://}i)
     end
 
     # None of the four feeds is ever legitimately empty. An empty one still

--- a/app/lib/uex/price_syncer.rb
+++ b/app/lib/uex/price_syncer.rb
@@ -15,10 +15,14 @@ module Uex
     # not plausible churn; a feed that came back short looks exactly like that.
     MIN_TERMINAL_RETENTION = 0.5
 
-    Result = Struct.new(:created, :updated, :removed, :skipped_removals, :unmatched) do
+    # Stamped on the paper-trail version so a repriced model reads apart from an
+    # admin having typed the figure in by hand.
+    REPRICE_REASON = "uex_price_sync"
+
+    Result = Struct.new(:created, :updated, :removed, :skipped_removals, :repriced, :unmatched) do
       def to_s
         "created=#{created} updated=#{updated} removed=#{removed} " \
-          "skipped_removals=#{skipped_removals} unmatched=#{unmatched.size}"
+          "skipped_removals=#{skipped_removals} repriced=#{repriced} unmatched=#{unmatched.size}"
       end
     end
 
@@ -57,11 +61,39 @@ module Uex
         )
       )
 
-      persist(
+      result = persist(
         desired,
         live: terminals.values.map { |terminal| terminal["name"].to_s.strip }.to_set,
         unmatched: matcher.misses
       )
+
+      result.repriced = reprice_models
+      result
+    end
+
+    # `models.price` is the figure the ship list sorts and filters on and the one
+    # fleet value totals add up, and nothing kept it in step with the shops — it
+    # was hand-entered per model. The cheapest sell price is what a player
+    # actually pays, so that is what it now tracks.
+    #
+    # Models UEX prices nothing for keep whatever they hold: no feed row is not
+    # the same as not for sale, and a stale figure still beats none for sorting.
+    private def reprice_models
+      cheapest = ItemPrice.where(item_type: ITEM_TYPE, price_type: "sell")
+        .group(:item_id)
+        .minimum(:price)
+
+      repriced = 0
+
+      Model.where(id: cheapest.keys).find_each do |model|
+        price = cheapest[model.id]
+        next if model.price == price
+
+        model.update!(price:, update_reason: REPRICE_REASON)
+        repriced += 1
+      end
+
+      repriced
     end
 
     private def collect(rows, vehicles:, terminals:, matcher:, price_key:, price_type:, time_range:)

--- a/app/models/item_price.rb
+++ b/app/models/item_price.rb
@@ -31,6 +31,10 @@ class ItemPrice < ApplicationRecord
   validates :time_range, presence: true, if: -> { rental? }
   validates :price, presence: true
   validates :location, presence: true
+  # Rendered as an `href`, and admin-writable, so a `javascript:` value here
+  # would run on click. The views check the scheme too, for rows that predate
+  # this.
+  validates :location_url, format: {with: %r{\Ahttps?://}i}, allow_blank: true
 
   def self.ransackable_attributes(auth_object = nil)
     [

--- a/docs/exec-plans/flight-power-heat-sim.md
+++ b/docs/exec-plans/flight-power-heat-sim.md
@@ -213,6 +213,53 @@ simplified cooler allocation (all coolers on) and Phase 2 refines it. **Revised
 approach:** treat "power + heat" as one combined phase; ship flight (IFCS)
 separately as it's the only truly independent piece.
 
+## Decode log — Phase 2 (heat + signature)
+
+Findings from `chunk-HVTWRICT.js` (erkul's current calc chunk; 2026-08-11).
+
+**Power-range modifier `L(powerRanges, seg)`** — `powerRanges` is an array of
+`{start, modifier}` sorted by `start`; `L` returns the entry whose
+`start ≤ seg < nextStart` (last = ∞), `.modifier` (default 1). Our parsed
+`power_ranges {low,medium,high:{start,modifier}}` is the same 3 entries —
+reshape to a start-sorted array for the lookup.
+
+**Cooling + coolingRatio (`Ze`/`G`)** — coolers only (`item.category==="Cooler"`).
+Per cooler: `units` = power draw, `ratedCooling` = `convert produces[Coolant].units`
+(our `cooling_rate`), `floor = round(units × (minimumFraction || 1/units))`.
+- `activeSeg = poweredOn && seg≥floor && floor>0 ? clamp(seg,0,units) : 0`.
+- `effectiveCoolingPerSec = ratedCooling × (activeSeg/units) × L(powerRanges,activeSeg)`.
+- `coolingPerSec` = Σ effective; `coolingMaxPerSec` = Σ `ratedCooling × L(powerRanges,units)`.
+- heat gen `u` = (Σ active segments across all families incl. shields + weapon
+  `min(selected,consumption)`) + (Σ over shield/lifeSupport/radar/qdrive of
+  `activeSeg × L(powerRanges,activeSeg)`).
+- **`coolingRatio = coolingPerSec>0 ? min(u/coolingPerSec, 1) : (u>0 ? 1 : 0)`.**
+
+**EM (`yr`)** = `armor.signalElectromagnetic × Σ terms`, 4 term categories:
+shields (`emNominal × L(pr,f)` × shieldRatio, `f=round(totalSeg×shieldRatio)/nShields`),
+weapons (`emNominal × L(pr,weaponSelected)` × selected/enabled), `fr` sources
+(shields/coolers/radar: `emNominal × L(pr,activeSeg) × activeSeg/units`), and
+remaining powered ports (`emNominal × L(pr,seg) × seg/powerSegmentUnits`).
+
+**IR (`gr`)** = `coolingRatio × armor.signalInfrared × Σ_{heat.sources}
+irNominal × (activeSeg/units) × L(powerRanges,activeSeg)`. Gated by coolingRatio
+(and 0 with no power).
+
+**CS (`ko`)** = `vehicle.crossSection.{x,y,z} × (armor.signalCrossSection ?? 1)`;
+displayed value = the max axis. Independent of power — trivial, ship first.
+
+**Inputs & parser gaps:** `emNominal`=`states[Online].signature.em.nominal` (❌
+new), `irNominal`=`…signature.ir.nominal` (❌ new), `powerSegmentUnits`=our
+`power_consumption` (✅), `powerRanges`=our `power_ranges` (✅ reshape),
+`ratedCooling`=our `cooling_rate` (⚠️ confirm = coolant produced),
+armor `signalElectromagnetic/Infrared/CrossSection` (❌ new, armor item),
+vehicle `crossSection.{x,y,z}` (❌ new Model metric). Armor mults default 1.
+
+**Delivery order (by cost):** CS (trivial, no power dep) → cooling %/coolingRatio
+(uses existing active-segments + cooler rates) → IR (needs `irNominal` parse) →
+EM (heaviest: 4 categories + `emNominal`). ⚠️ COOLING-bar display transform not
+in the calc chunk — verify `coolingRatio×100` vs `coolingPerSec/coolingMaxPerSec`
+against the live Ironclad (idle showed 90%) before committing.
+
 ## Risks
 
 - **Faithfulness:** erkul's engine is intricate (power-range curves, per-mode

--- a/docs/exec-plans/pledge-prices.md
+++ b/docs/exec-plans/pledge-prices.md
@@ -1,0 +1,195 @@
+# Pledge prices — a table for store prices, fed from UEX
+
+Source: `GET https://api.uexcorp.uk/2.0/vehicles_prices/` (verified 2026-08-12).
+
+## Goal
+
+Give RSI pledge-store prices a relational home instead of a single scalar on
+`models`, so that the figures we hold **none** of today — warbond, concierge and
+in-package prices — have somewhere to live, and so a store price carries a
+history rather than only its current value.
+
+The pattern mirrors what in-game prices already do after `feat/power-distribution-ui`:
+`item_prices` is the record and `models.price` the derived cache. Here
+`pledge_prices` becomes the record and `models.pledge_price` stays the cache.
+
+Non-goals, each for its own reason:
+
+- **CCU prices.** A CCU price is keyed on a *pair* of models (from → to), so it
+  fits neither this table nor `item_prices` without a second model reference. It
+  also has no data source: UEX exposes no CCU endpoint (`vehicles_pledges`,
+  `vehicles_pledge_prices`, `vehicles_prices_pledges` all 404, and the API docs
+  list nothing pledge-related beyond `vehicles_prices`), and RSI's
+  `TySkuUpgradeFragment` returns id, title, subtitle, slug, isWarbond and stock
+  — no price. Scraping RSI's upgrade store is a separate project.
+- **Package entities.** A package is a bundle with contents — a ship, a game
+  package, insurance. UEX's `price_package` is not that; it is "what this ship costs
+  when bought inside a package", which is a per-model figure and therefore a
+  `kind` in this table.
+- **`item_prices` and in-game pricing.** Untouched.
+- **`model_upgrades.pledge_price`.** The two hand-entered kit prices stay where
+  they are; folding them in is a follow-up at best.
+
+## Where we are
+
+| Holder | Meaning | Written by |
+| --- | --- | --- |
+| `models.pledge_price` `decimal(15,2)` | current standalone MSRP, excl. VAT | `Rsi::PledgeStoreLoader` from GraphQL `msrp / 100.0`, falling back to the held value when RSI omits `msrp` |
+| `models.rsi_pledge_value` `integer` | the same figure in cents | same loader — a duplicate |
+| `models.on_sale` `boolean` | RSI `purchasable` | same loader |
+| `model_upgrades.pledge_price` | upgrade kits (2 rows locally) | admin form only |
+
+Nothing holds warbond, concierge or package prices, and nothing holds a previous
+price.
+
+## What the feed gives us
+
+786 rows over 260 vehicles. One row per `(vehicle, game_version)` — **it is a
+history, not a snapshot**: 3 rows per vehicle on average, up to 6, spanning
+versions up to `4.8.2`.
+
+```json
+{
+  "id": 1, "id_vehicle": 107, "price": 210, "price_warbond": 0,
+  "price_package": 0, "price_concierge": 0, "on_sale": 0, "on_sale_warbond": 0,
+  "on_sale_package": 0, "on_sale_concierge": 0, "currency": "USD",
+  "game_version": "4.0.2", "date_added": 1703566807,
+  "date_modified": 1741107787, "vehicle_name": "Hurricane"
+}
+```
+
+Fill rates, so the sparseness is on the record before anyone reaches for columns:
+
+| Field | Rows non-zero | Distinct vehicles |
+| --- | ---: | ---: |
+| `price` | 779 (99%) | 255 |
+| `price_warbond` | 147 (19%) | 95 |
+| `price_package` | 76 (10%) | 30 |
+| `price_concierge` | 37 (5%) | 29 |
+
+`on_sale = 1` on 476 rows, `on_sale_warbond = 1` on 24.
+
+## Three decisions before coding
+
+### 1. UEX is not the source for the standalone price
+
+Taking the newest UEX row per vehicle against our 240 `pledge_price` values, over
+231 matched models:
+
+| Relationship | Models | Reading |
+| --- | ---: | --- |
+| identical | 76 | agree |
+| UEX ≈ ×1.071 | ~55 | UEX figure is tax-inclusive (Javelin ours $3000 vs $3213) |
+| UEX = ×0.9 | 34 | UEX row is a sale or warbond price (Ironclad $600 vs $540) |
+
+Ours comes from RSI's `msrp`, excl. VAT, which is what the ship page labels it as
+("On Sale: $155 excl. VAT"). So **`models.pledge_price` stays RSI-fed and remains
+what the card renders.** UEX's contribution is the kinds we have no other source
+for, plus the history.
+
+UEX standalone rows are still stored — a warbond price means nothing without the
+standalone figure from the same row to discount against — but they carry
+`source: :uex` and **must not be rendered beside the RSI figure**. Two
+contradictory prices on one card is exactly the bug this branch just fixed for
+the in-game price.
+
+Do not normalise the ~7.1% uplift away. Whether it is VAT, a regional rate, or
+UEX storing gross for some entries is unresolved, and dividing by a guessed
+constant would launder the uncertainty into a number that looks exact.
+
+### 2. A table, not four more columns on `models`
+
+`pledge_prices`:
+
+| Column | Type | Note |
+| --- | --- | --- |
+| `model_id` | uuid, not null | |
+| `kind` | integer, not null | enum `standalone: 0, warbond: 1, concierge: 2, package: 3` |
+| `price` | decimal(15,2), not null | |
+| `currency` | string, default `"USD"` | the feed states it per row |
+| `game_version` | string | null for a row that is not version-tagged |
+| `on_sale` | boolean, default false | the per-kind flag, not the model-level one |
+| `source` | integer, not null | enum `uex: 0, rsi: 1, manual: 2` |
+| `external_id` | integer | UEX row `id`, for re-identification |
+| `source_updated_at` | datetime | from `date_modified` |
+
+Unique index on `(model_id, kind, game_version, source)`; index on `model_id`.
+
+Three reasons over columns: the kinds are sparse (a package price exists for 30
+of 246 models, so three mostly-null columns), history is the point and columns
+cannot hold it, and a fifth kind later is a row rather than a migration.
+
+### 3. Matching reuses `Uex::VehicleMatcher`
+
+It already resolves every priced vehicle in the in-game sync with 8 `MAPPINGS`
+entries. This feed covers 260 vehicles against that sync's 179, so expect fresh
+misses — reuse the `GithubIssueCreator` path so they surface as an issue rather
+than silence.
+
+## Steps
+
+### Step 1 — migration + `PledgePrice`
+
+Model with the two enums (`validate: true`, as `ItemPrice` does), `belongs_to
+:model`, `validates :price, presence: true`. On `Model`: `has_many
+:pledge_prices, dependent: :destroy` plus a `current_pledge_prices` scope that
+picks the newest `game_version` row per kind.
+
+### Step 2 — `Uex::Client#vehicle_pledge_prices`
+
+One more method over `get("vehicles_prices")`. The existing 403-without-User-Agent
+and `status != "ok"` guards apply unchanged.
+
+### Step 3 — `Uex::PledgePriceSyncer`
+
+Per vehicle row, resolve the model through the matcher, then emit up to four
+desired rows — one per non-zero `price*` field, carrying that kind's `on_sale*`
+flag. Upsert on the unique key; count `created` / `updated`.
+
+**History is append-only: never delete a row because the feed stopped mentioning
+it.** That inverts `Uex::PriceSyncer`'s reconciliation deliberately — there, a
+vanished row means a shop stopped stocking the ship; here it means an old patch
+scrolled out of the window, and the price was still true when it was true. Which
+also means none of the retention/truncation guarding needs porting: an empty feed
+can create nothing, and creates no deletions to guard against. Keep the
+`require_rows` guard anyway so a 200-with-no-data still raises rather than
+reporting a clean no-op run.
+
+### Step 4 — job, import type, schedule
+
+`Loaders::UexPledgePricesJob` mirroring `Loaders::UexPricesJob`:
+`Imports::UexPledgePricesImport` STI class, added to
+`Shared::V1::Schemas::Enums::ImportTypeEnum`, then `./bin/generate-schema`, plus
+a jbuilder partial under `app/views/api/v1/imports/uex_pledge_prices_imports/` —
+without both, `ImportTest`'s "every broadcasting import type renders its jbuilder
+partial" fails.
+
+Schedule **weekly**, not daily: store prices move at patch and sale cadence, and
+the feed is version-tagged rather than live. `'0 6 * * 0'` in
+`config/sidekiq_schedule.yml`, queue `loaders`.
+
+### Step 5 — API and UI (defer until someone wants the numbers)
+
+Serialise a `pledgePrices` block on the model via `api_components` (never
+`schema.yaml` directly), omitting the field when empty rather than nulling it.
+The natural surface is a Pledge modal as a sibling to the Availability modal
+reached from the same Base card — standalone / warbond / concierge / package as
+rows, previous versions behind them — reusing the classes the availability modal
+now establishes. Not worth building before the table has data.
+
+### Step 6 — Verify
+
+Live run in development; assert idempotency on a second run (`created=0
+updated=0`); expect roughly 255 standalone / 95 warbond / 30 package / 29
+concierge rows across matched models, and check the unmatched list is either
+empty or lands in `MAPPINGS`.
+
+## Open questions
+
+- **`rsi_pledge_value`** duplicates `pledge_price` in cents. Drop it in a
+  follow-up; it is unrelated to this table but adjacent enough to name here.
+- **Sale flags.** `models.on_sale` (RSI `purchasable`) and a row's `on_sale` mean
+  different things — "buyable right now" vs "this price was a sale price". Do not
+  let the second overwrite the first.
+- **CCUs remain unsolved and unblocked by this plan.** If a CCU tool is the real
+  goal, the first question is where the prices come from, not where they go.

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -47,11 +47,34 @@ See `flight-power-heat-sim.md` for the full decode of erkul's engine.
 Each phase lands as its own PR, validated against erkul on the **Asgard**.
 
 ### Phase 1 — Port construction + `useLoadoutSim` (default allocation)
-- Parse the coverage-gap families (engine/lifeSupport power draw) or confirm
-  absent; pin the non-weapon block sizing from the decode.
-- Build `useLoadoutSim` (loadout → ports → `allocatePower` → result).
-- **Validate the default allocation vs erkul** (per-family segments on the
-  Asgard). No UI yet.
+- **Decode complete.** The whole port model is decoded: `z` (a component's
+  Power draw = units + `minimumConsumptionFraction`), `K` (critical block size),
+  `le` (a component's blocks: one `critical` block of size `K`, then
+  `round(units − K)` size-1 blocks), `ue` (weapon pool = `poolSize` size-1
+  blocks, first `ceil(Σ units)` enabled), `Wt` (shields, capped at
+  `shieldMaxItemCount`), `Et` (total segments = `Σ round(units/n) + (n−1)·Σ size`
+  over powered plants), and the family map `Kn` (Weapon→weapon, Shield→shield,
+  Cooler→coolers, Radar→radar, LifeSupport→lifeSupport, QuantumDrive→qdrive,
+  QED→qed, EMP→emp, MiningLaser/SalvageHead→…, Controller+FlightController→
+  engine). Nothing left to reverse-engineer.
+- **Built + unit-tested** (`powerSim.ts` + `useLoadoutSim.ts`):
+  - `componentBlocks`/`weaponPoolBlocks`/`totalSegments` (the `le`/`ue`/`Et`
+    port primitives).
+  - `useLoadoutSim(hardpoints, weaponPoolSize, mode)` — walks the hardpoint
+    tree, maps each category to its family (`POWER_FAMILY_BY_CATEGORY`), gathers
+    plants + shared weapon pool + per-component blocks, runs `allocatePower`,
+    and returns per-family segments + weapon `poolRatio`.
+- **Coverage-gap resolution:** a component contributes ports only when it
+  declares a Power draw, so there is no separate "gap" — engine (`Controller`)
+  and lifeSupport (`LifeSupport`) are mapped and will populate once their
+  `power_consumption` is in the DB. `minimumConsumptionFraction` is not parsed
+  yet; `componentBlocks` defaults the critical block to 1 segment (exact when
+  the fraction is 0, which is today's norm — a fidelity refinement otherwise).
+- **Remaining gate (needs the app + fresh data):** the on-disk parsed data + DB
+  are **stale** — only weapons carry `power_consumption`. Re-parse/reload so the
+  generic per-component power draw (shields/coolers/radar/qdrive/emp/
+  lifeSupport/controller) lands in the DB, then **validate the default
+  per-family segments vs erkul on the Asgard**. No UI yet.
 
 ### Phase 2 — Wire default sustained (no regression)
 - Replace the standalone `weaponPowerRatio` in `useLoadoutStats` with the sim's
@@ -79,9 +102,9 @@ Each phase adds regression coverage in a spec.
 
 ## Risks / open questions
 
-- **Non-weapon block sizing** — the exact segment sizing per non-weapon family
-  isn't fully decoded; Phase 1 must pin it (decode `An`/`kn`/the family block
-  construction) or reverse-fit against the Asgard.
+- ~~**Non-weapon block sizing**~~ — **decoded** (`le`/`K`, see Phase 1): each
+  component becomes one `critical` block of size `round(units × minFraction)`
+  (default 1) plus `round(units − critical)` size-1 blocks.
 - **Power ↔ heat coupling** — the default allocation's cooler pass (`ft`) needs
   the heat model; Phase 1 may use a simplified cooler allocation, refined in
   Phase 4.

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -1,0 +1,91 @@
+# Interactive power-distribution (pip) UI
+
+Date: 2026-08-09. Branch: `feat/power-distribution-ui` (off `feat/sim-power-heat`).
+
+## Goal
+
+An erkul-style **power-distribution control** on the ship loadout page: the user
+allocates power segments across component families (weapons / shields / engines
+/ …) and sees **DPS, sustained DPS, and signatures recompute live**. This is the
+headline interactive feature that makes FleetYards a *calculator*, not just a
+stats display.
+
+## Dependencies
+
+- **`powerSim.ts`** — the allocation core (`co()` port: primitives + Zn/Jn
+  passes + `weaponPoolRatio`), already built + unit-tested on
+  `feat/sim-power-heat` (PR #4266).
+- **Per-component power parsing** — `power_consumption` + `power_ranges` on all
+  power-drawing components (also #4266).
+- **Still needed** (built in this feature): engine/lifeSupport power draw
+  (coverage gap), the exact non-weapon block sizing, and — for signatures — the
+  heat model (`coolingRatio`).
+
+See `flight-power-heat-sim.md` for the full decode of erkul's engine.
+
+## Architecture
+
+- **`useLoadoutSim(hardpoints, model, overrides?)`** — the integration layer:
+  1. Build `PowerPort[]` from the loadout — per family (`item_type` → family:
+     WeaponGun→weapon, Shield→shield, Cooler→coolers, Radar→radar,
+     QuantumDrive→qdrive, EMP→emp, + engine/lifeSupport once parsed), with the
+     weapon pool as `poolSize` size-1 blocks (`consumption` enabled).
+  2. `totalSegments = Σ power_base` over powered plants.
+  3. Run `allocatePower(ports, totalSegments, {…, overrides})` → per-family
+     segments + per-family power ratios.
+  4. Return `{ perFamily, weaponPoolRatio, remaining, byPort }`, reactive to
+     `overrides` (the user's pip choices).
+- **`PowerDistribution.vue`** — the control: a segment/pip allocator per family
+  (allocated vs available, +/- controls, SCM/NAV mode toggle). Emits per-family
+  target segments → feeds `overrides`.
+- **Wiring** — `useLoadoutStats` sustained DPS consumes the sim's weapon
+  `poolRatio` (instead of the standalone `weaponPowerRatio`); Combat card +
+  per-weapon rows react to the distribution; the signature card (later) too.
+
+## Phases
+
+Each phase lands as its own PR, validated against erkul on the **Asgard**.
+
+### Phase 1 — Port construction + `useLoadoutSim` (default allocation)
+- Parse the coverage-gap families (engine/lifeSupport power draw) or confirm
+  absent; pin the non-weapon block sizing from the decode.
+- Build `useLoadoutSim` (loadout → ports → `allocatePower` → result).
+- **Validate the default allocation vs erkul** (per-family segments on the
+  Asgard). No UI yet.
+
+### Phase 2 — Wire default sustained (no regression)
+- Replace the standalone `weaponPowerRatio` in `useLoadoutStats` with the sim's
+  weapon `poolRatio`. Validate a sample of ships (ample-power ships unchanged;
+  segment-starved ships now more accurate).
+
+### Phase 3 — The pip UI
+- `PowerDistribution.vue` control (per-family segments, +/- pips, SCM/NAV mode).
+- User overrides flow into `useLoadoutSim` (erkul's `te`/`Q` override path);
+  DPS/sustained recompute live. Optional: persist the user's setting.
+
+### Phase 4 — Signatures (§6) react to the distribution
+- Build the heat model (`coolingRatio`) + parse per-component EM/IR nominal.
+- Emitted EM/IR (erkul's `dr`/`pr`) computed from the allocation → update as the
+  user moves pips. Cross-section (`§6-CS`) is static (ship geometry × armor).
+
+### Phase 5 — Follow-ons
+- Overheat state (§3) from the heat model; flight boost (§8) via the IFCS sim.
+
+## Validation
+
+erkul parity on the **Asgard**: per-family default segments, sustained DPS at
+default and at a couple of manual pip settings, and emitted EM/IR (Phase 4).
+Each phase adds regression coverage in a spec.
+
+## Risks / open questions
+
+- **Non-weapon block sizing** — the exact segment sizing per non-weapon family
+  isn't fully decoded; Phase 1 must pin it (decode `An`/`kn`/the family block
+  construction) or reverse-fit against the Asgard.
+- **Power ↔ heat coupling** — the default allocation's cooler pass (`ft`) needs
+  the heat model; Phase 1 may use a simplified cooler allocation, refined in
+  Phase 4.
+- **UX** — how to present the power triangle (per-family bars vs erkul's pip
+  segments); SCM vs NAV mode; whether pip settings persist per loadout.
+- **Reactivity/perf** — recompute the sim on every pip change; keep it cheap
+  (the allocation is O(segments), fine).

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -92,10 +92,17 @@ Each phase lands as its own PR, validated against erkul on the **Asgard**.
   data-pipeline task**, not part of this feature branch; the local worktree DB
   was reloaded so development/validation can proceed.
 
-### Phase 2 — Wire default sustained (no regression)
-- Replace the standalone `weaponPowerRatio` in `useLoadoutStats` with the sim's
-  weapon `poolRatio`. Validate a sample of ships (ample-power ships unchanged;
-  segment-starved ships now more accurate).
+### Phase 2 — Wire sustained from the sim ✅
+- **Done.** `useLoadoutStats` now drives sustained DPS from the sim's
+  `weaponMaxRatio` (single source of truth), *not* the default-SCM split — that
+  preserves the chosen **max-power** model. `weaponMaxRatio` = weapons filled to
+  pool after every family's mandatory criticals, capped by the plant's segments:
+  it equals the old `min(1, poolSize/consumption)` for every ship whose plant
+  can fill the pool and only drops lower for genuinely segment-starved ships.
+  Guards on missing plant data (`segments <= 0` → uncapped) so ships whose plant
+  power isn't parsed (e.g. prod before the data regen) never regress. The
+  standalone `weaponPowerRatio` was removed. 32 unit tests green;
+  `useLoadoutStats.spec` unchanged (no regression).
 
 ### Phase 3 — The pip UI
 - `PowerDistribution.vue` control (per-family segments, +/- pips, SCM/NAV mode).

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -70,11 +70,27 @@ Each phase lands as its own PR, validated against erkul on the **Asgard**.
   `power_consumption` is in the DB. `minimumConsumptionFraction` is not parsed
   yet; `componentBlocks` defaults the critical block to 1 segment (exact when
   the fraction is 0, which is today's norm — a fidelity refinement otherwise).
-- **Remaining gate (needs the app + fresh data):** the on-disk parsed data + DB
-  are **stale** — only weapons carry `power_consumption`. Re-parse/reload so the
-  generic per-component power draw (shields/coolers/radar/qdrive/emp/
-  lifeSupport/controller) lands in the DB, then **validate the default
-  per-family segments vs erkul on the Asgard**. No UI yet.
+- **Parser gap found + fixed.** The generic Power extractor only read
+  `ItemResourceDeltaConsumption` + `SStandardResourceUnit`, so it caught weapons
+  + quantum drives but missed every segment-based converter (shields, coolers,
+  radars, controllers, QEDs declare their draw as `ItemResourceDeltaConversion`
+  with `SPowerSegmentResourceUnit`). Extended to traverse both delta kinds and
+  both unit representations, and to capture `minimumConsumptionFraction`
+  (`power_minimum_fraction`, erkul's `minimumFraction`). After re-parse: 763
+  components now carry a Power draw (controller 238, weapons 233, cooler 81,
+  shield 73, radar 67, qdrive 63, qed 5).
+- **Validated vs erkul on the Asgard** ✅ (real DB data → `useLoadoutSim`):
+  weapons Σ 7.8 → consumption 8, pool 4 → **weapon `poolRatio` = 0.5**, matching
+  erkul exactly. Full SCM split (24 segments): weapon 4, shield 16, radar 3,
+  engine 1 — coherent (shields prioritized, weapon at pool, fully consumed). The
+  precise non-weapon segment split will be visually re-checked against erkul in
+  Phase 3 (when the pip UI actually displays it).
+- **Data note:** the fix lives in the parser; the committed parsed JSON under
+  `data/sc_data/parsed/` is **stale** relative to it (and to `main`'s parser —
+  re-parsing also surfaces unrelated `cooling_rate`/`zero_damage_range`/
+  `max_ammo` drift). Regenerating the committed parsed data is a **separate
+  data-pipeline task**, not part of this feature branch; the local worktree DB
+  was reloaded so development/validation can proceed.
 
 ### Phase 2 — Wire default sustained (no regression)
 - Replace the standalone `weaponPowerRatio` in `useLoadoutStats` with the sim's

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -120,6 +120,54 @@ Each phase lands as its own PR, validated against erkul on the **Asgard**.
 - **Still to validate:** a visual pass in-app against erkul (the worktree DB has
   the fresh power data; committed parsed JSON is still the separate data-regen).
 
+### Phase 3b — Tractor/towing beams + family icons ✅
+- **Parser.** Tractor and towing beams are `WeaponGun`-shaped items, so they fell
+  into the projectile branch and got a type_data of zeros (damage 0, speed 0,
+  `max_ammo` 0) — their real stats sit on `SWeaponActionFireTractorBeamParams`.
+  New `extract_tractor_beam_data` reads erkul's set: force (`min`/`max`), reach
+  (`min`/`max`/`fullStrengthDistance`), `maxAngle`, `maxVolume` +
+  `volumeForceCoefficient`, `tetherBreakTime`, the `rotationParams` /
+  `movementParams` handling, the much stronger `cargoModeOverrideParams`, and —
+  towing beams only — `towingBeamParams` (tow force/distance, QT mass limit).
+  Flagged `tractor_beam: true`, which is the discriminator the frontend uses:
+  the game files categorise these under weapons and even type some military
+  tractor beams as `SalvageHead`. Salvage heads carry a tractor action too, so
+  they gain the same data (replacing their equally meaningless projectile
+  numbers); their scraping stats are still unparsed.
+- **API.** `ComponentTractorBeam` schema + `Component.typeData` anyOf entry.
+- **UI.** `useHardpointStats` renders the beam rows (tow force leads for towing
+  beams — their own `maxForce` is a 5e9 "unlimited" sentinel). Force figures sum
+  across a collapsed stack (beams pull together, like weapon DPS sums); reach,
+  cone, tether and handling stay per-beam. Reach reads as the falloff span erkul
+  shows on its cards — `HANDLING 75 → 150 m` is full-strength → max, *not*
+  min → max. `min_distance` is 0.5 m on every beam (cargo mode included) so it
+  isn't displayed, and `maxVolume` isn't either (unclear unit, identical
+  everywhere).
+- **Verified against erkul's Ironclad card**: `3× S2 SureGrip S2 Tractor Beam`,
+  `handling 75 → 150 m`, `cargo mode ×7 / 100 → 225 m`, `tether 1.5 s`,
+  `rot 2 °/s`, `60° sweep cone` — all match the parsed values. Force figures on
+  erkul's card are power-scaled (they read 0 kN at 0 pips), so only the ratio
+  (`cargoForce / maxForce` = ×7) was checkable there.
+- **Cosmetic child ports.** Turret shells and weapon shrouds mount as nameless
+  `Misc`/`AttachedPart` items that end up uncategorised, and rendered as bare
+  "TBD" rows under their parent (e.g. the Ironclad's manned turrets). `BaseItem`
+  now drops uncategorised nameless children; a genuinely empty slot keeps its
+  category, so it still shows.
+- **Parser hardening.** `blacklisted_item_key?` matched the whole key part
+  "interior", which drops the Ironclad's two interior remote turrets (a
+  tractor-beam arm and a gun turret) on a clean re-parse. The committed parsed
+  data happens to still contain them — the parser only writes, never prunes — so
+  nothing was visibly broken, but the term is gone now. The interior props it was
+  aimed at don't live under the scanned `scitem/{ships,vehicles}` folders.
+- **Icons.** erkul's glyphs have FA Pro equivalents, so life support moved from
+  `fa-star-of-life` (a bare asterisk) to `fa-heart-pulse`, and the beams from the
+  generic utility-items SVG to `fa-arrows-to-circle`. FA glyphs fill ~0.875em, so
+  `power-col__fa` needs 17px to match the 15px SVG icons.
+- **Also.** Power-column tooltips now name the family ("Shields", "Coolers"),
+  not the mounted component; the redundant `overflow-x` on `.power-bars` is gone
+  (it also forced `overflow-y: auto`, so extra columns put scrollbars on the
+  pane).
+
 ### Phase 4 — Signatures (§6) react to the distribution
 - Build the heat model (`coolingRatio`) + parse per-component EM/IR nominal.
 - Emitted EM/IR (erkul's `dr`/`pr`) computed from the allocation → update as the

--- a/docs/exec-plans/power-distribution-ui.md
+++ b/docs/exec-plans/power-distribution-ui.md
@@ -104,10 +104,21 @@ Each phase lands as its own PR, validated against erkul on the **Asgard**.
   standalone `weaponPowerRatio` was removed. 32 unit tests green;
   `useLoadoutStats.spec` unchanged (no regression).
 
-### Phase 3 — The pip UI
-- `PowerDistribution.vue` control (per-family segments, +/- pips, SCM/NAV mode).
-- User overrides flow into `useLoadoutSim` (erkul's `te`/`Q` override path);
-  DPS/sustained recompute live. Optional: persist the user's setting.
+### Phase 3 — The pip UI ✅
+- **Done.** `PowerDistribution.vue` on the loadout page: per-family power
+  segments with +/- steppers, an SCM/NAV toggle, a segment budget, and reset.
+- `allocatePower` gained per-family override targets; `simulateLoadoutPower`
+  threads them through and exposes `familyCapacity` (slider bounds) + the
+  current-allocation `weaponPoolRatio`.
+- Overrides flow into `useLoadoutStats`: engaging **any** override switches
+  sustained DPS from the max-power baseline to the actual weapon allocation (a
+  shield bump squeezes weapons too). Overrides reset on ship / source change.
+- Component typing extended (radar + controller schemas added; power fields on
+  shield/cooler/qdrive) so consumers use generated types.
+- **Not yet:** persistence of the user's pip setting; NAV mode currently
+  re-prioritises the *display* only (DPS stays an SCM stat).
+- **Still to validate:** a visual pass in-app against erkul (the worktree DB has
+  the fresh power data; committed parsed JSON is still the separate data-regen).
 
 ### Phase 4 — Signatures (§6) react to the distribution
 - Build the heat model (`coolingRatio`) + parse per-component EM/IR nominal.

--- a/test/jobs/loaders/uex_prices_job_test.rb
+++ b/test/jobs/loaders/uex_prices_job_test.rb
@@ -15,7 +15,7 @@ module Loaders
 
       assert_equal "finished", import.aasm_state
       assert_equal(
-        {"created" => 4, "updated" => 1, "removed" => 2, "skipped_removals" => 0, "unmatched" => []},
+        {"created" => 4, "updated" => 1, "removed" => 2, "skipped_removals" => 0, "repriced" => 3, "unmatched" => []},
         import.output
       )
     end
@@ -80,7 +80,7 @@ module Loaders
     end
 
     private def stub_syncer(unmatched: [{"slug" => "nova-tank", "name" => "Nova Tank", "name_full" => "Tumbril Nova Tank"}])
-      result = ::Uex::PriceSyncer::Result.new(created: 4, updated: 1, removed: 2, skipped_removals: 0, unmatched:)
+      result = ::Uex::PriceSyncer::Result.new(created: 4, updated: 1, removed: 2, skipped_removals: 0, repriced: 3, unmatched:)
 
       syncer = mock("Uex::PriceSyncer")
       syncer.expects(:run).returns(result)

--- a/test/lib/uex/price_syncer_test.rb
+++ b/test/lib/uex/price_syncer_test.rb
@@ -48,6 +48,17 @@ module Uex
       assert_nil @models[:slug_match].reload.sold_at.first.location_url
     end
 
+    test "#run drops a contact url that is not a web link rather than storing it" do
+      terminals = uex_fixture("terminals").map do |terminal|
+        (terminal["id"] == 101) ? terminal.merge("contact_url" => "javascript:alert(1)") : terminal
+      end
+
+      result = sync(terminals:)
+
+      assert_equal 7, result.created, "one odd url must not fail the whole snapshot"
+      assert_nil @models[:name_match].reload.rental_at.first.location_url
+    end
+
     test "#run resolves a vehicle that only the explicit mapping covers" do
       sync
 

--- a/test/lib/uex/price_syncer_test.rb
+++ b/test/lib/uex/price_syncer_test.rb
@@ -118,6 +118,52 @@ module Uex
       assert_equal 1, @models[:name_match].reload.rental_at.size
     end
 
+    test "#run repoints models.price at the cheapest shop that sells the ship" do
+      titan = @models[:name_match]
+      titan.update!(price: 999)
+
+      result = sync
+
+      assert_equal 4, result.repriced
+      assert_equal 1_290_370, titan.reload.price.to_i
+    end
+
+    test "#run reprices from the cheapest of several shops" do
+      purchases = uex_fixture("vehicles_purchases_prices_all") +
+        [{"id" => 98, "id_vehicle" => 2, "id_terminal" => 103, "price_buy" => 1_100_000}]
+
+      sync(vehicle_purchase_prices: purchases)
+
+      assert_equal 1_100_000, @models[:name_match].reload.price.to_i
+    end
+
+    test "#run leaves the price of a model UEX sells nowhere alone" do
+      rental_only = @models[:name_match]
+      rental_only.update!(price: 999)
+
+      purchases = uex_fixture("vehicles_purchases_prices_all").reject { |row| row["id_vehicle"] == 2 }
+
+      sync(vehicle_purchase_prices: purchases)
+
+      assert_equal 999, rental_only.reload.price.to_i
+    end
+
+    test "#run reprices nothing on a second run that changed no price" do
+      sync
+      result = sync
+
+      assert_equal 0, result.repriced
+    end
+
+    test "#run records the repricing as a version so a hand-entered figure is told apart" do
+      titan = @models[:name_match]
+      titan.update!(price: 999)
+
+      sync
+
+      assert_equal "uex_price_sync", titan.versions.last.reason
+    end
+
     test "#run leaves prices for other item types alone" do
       component = create(:component)
       hand_entered = create(:item_price, item: component, price_type: :sell, time_range: nil)

--- a/test/models/item_price_test.rb
+++ b/test/models/item_price_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ItemPriceTest < ActiveSupport::TestCase
+  test "accepts a web location url" do
+    assert build(:item_price, location_url: "https://example.test/shop").valid?
+    assert build(:item_price, location_url: "http://example.test/shop").valid?
+  end
+
+  test "accepts no location url at all" do
+    assert build(:item_price, location_url: nil).valid?
+    assert build(:item_price, location_url: "").valid?
+  end
+
+  # The url is rendered as an href, so a scheme that executes rather than
+  # navigates must not reach the database.
+  test "rejects a location url that is not a web link" do
+    ["javascript:alert(1)", "JaVaScript:alert(1)", "data:text/html,<script>", "example.test"].each do |url|
+      item_price = build(:item_price, location_url: url)
+
+      assert_not item_price.valid?, "#{url} should be rejected"
+      assert_includes item_price.errors.attribute_names, :location_url
+    end
+  end
+end


### PR DESCRIPTION
The frontend of the power-distribution / loadout work: an erkul-style interactive pip power-distribution control, a power-reactive loadout calculator (combat, defense/shield, hull, flight), and the ship-detail metrics reworked into a self-balancing masonry grid of cards.

Highlights:
- Interactive pip control (per-generator shield toggles, grouped tractor/towing beams, weapon-pool headroom, cooling/EM/IR/CS signature readouts).
- Combat/Defense cards recompute from the pip allocation; shield HP/regen and weapon DPS react to power.
- Flight card: SCM/boost/max speeds + boosted handling from the IFCS afterburner ratio, zeroing when the engine is unpowered.
- Metrics cards (Base, Crew, Combat, Power, Defense, Hull, Flight, Cargo, Fuel, Refuel) packed into a masonry grid.

Stack (4 of 4): **base `feat/api-component-signatures`** (needs the generated schema types + the new Defense hardpoint group). Rebase onto `main` once the parse/load/api PRs (#4311 / #4312 / #4313) land.

🤖