### PR TITLE
fix(frontend): collapse the mobile list header into two rows

### DIFF
--- a/app/frontend/frontend/pages/ships/index.vue
+++ b/app/frontend/frontend/pages/ships/index.vue
@@ -92,6 +92,7 @@ const openDisplayOptionsModal = () => {
         name: 'compare',
       }"
       :aria-label="t('actions.compare.ships')"
+      :size="BtnSizesEnum.SMALL"
       mobile-icon-only
     >
       <i class="fa-duotone fa-code-compare" />
@@ -100,6 +101,7 @@ const openDisplayOptionsModal = () => {
     <Btn
       data-test="fleetchart-link"
       :aria-label="t('labels.fleetchart')"
+      :size="BtnSizesEnum.SMALL"
       mobile-icon-only
       @click="toggleFleetchart"
     >

--- a/app/frontend/shared/components/AppNavigation/Header/index.scss
+++ b/app/frontend/shared/components/AppNavigation/Header/index.scss
@@ -42,21 +42,28 @@
 
 @media (max-width: $desktop-breakpoint) {
   .navigation-header {
-    gap: 20px;
+    gap: 10px;
     right: 0;
     left: auto;
-    flex-direction: column;
+    flex-wrap: wrap;
+    padding: 15px;
     transition: right ease $transition-base-speed;
 
     &__left {
-      width: 100%;
+      flex: 1 1 auto;
+      min-width: 0;
       max-width: 100%;
     }
 
     &__right {
-      width: 100%;
-      max-width: 100%;
+      flex: 0 0 auto;
       justify-content: flex-end;
+
+      // an empty teleport target would still claim the flex gap and pull the
+      // quicksearch away from the right edge the rows below align to
+      &:not(:has(*)) {
+        display: none;
+      }
     }
   }
 

--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -18,25 +18,38 @@
 @media (max-width: $desktop-breakpoint) {
   .filtered-list {
     &__actions {
+      gap: 0 10px;
+
       &-left,
       &-right {
-        flex: 1 1 auto;
         display: flex;
       }
 
       &-left {
+        flex: 0 0 auto;
         justify-content: flex-start;
       }
 
       &-right {
+        flex: 1 1 auto;
+        min-width: 0;
         justify-content: flex-end;
+        gap: 10px;
+
+        :deep(.panel-btn),
+        :deep(.panel-btn-group),
+        :deep(.panel-btn-dropdown) {
+          margin-right: 0;
+        }
       }
     }
 
     &__pagination-top {
+      order: -1;
+      flex: 1 1 auto;
+      min-width: 0;
       display: flex;
       justify-content: center;
-      width: 100%;
     }
   }
 }

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -182,11 +182,10 @@ const toggleFilter = () => {
           </div>
           <div class="filtered-list__actions-right">
             <slot name="actions-right" :records="records" />
-            <slot v-if="!mobile" name="pagination-top" />
+            <div class="filtered-list__pagination-top">
+              <slot name="pagination-top" />
+            </div>
           </div>
-        </div>
-        <div v-if="mobile" class="col-12 filtered-list__pagination-top">
-          <slot name="pagination-top" />
         </div>
       </div>
       <div class="row">

--- a/app/frontend/shared/components/Paginator/index.scss
+++ b/app/frontend/shared/components/Paginator/index.scss
@@ -24,5 +24,10 @@ $innerBorderWidth: 2px;
 @media (max-width: $desktop-breakpoint) {
   .pagination {
     justify-content: center;
+
+    &__pages {
+      min-width: 0;
+      padding: 5px;
+    }
   }
 }

--- a/app/frontend/shared/components/Paginator/index.vue
+++ b/app/frontend/shared/components/Paginator/index.vue
@@ -12,6 +12,7 @@ import { type BaseList } from "@/services/fyApi";
 import { useRoute } from "vue-router";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useMobile } from "@/shared/composables/useMobile";
 import type { MaybeRef } from "vue";
 
 type Props = {
@@ -47,6 +48,8 @@ const internalPerPage = computed(
 
 const { t } = useI18n();
 
+const mobile = useMobile();
+
 const route = useRoute();
 
 const pageRoute = (page: number) => ({
@@ -75,6 +78,7 @@ const currentPage = computed(() => {
       />
       <template v-if="pagination.totalCount > 0 && pagination.totalPages > 1">
         <Btn
+          v-if="!mobile"
           :size="size"
           :to="pageRoute(1)"
           :disabled="currentPage <= 1"
@@ -113,6 +117,7 @@ const currentPage = computed(() => {
           <i class="fa fa-chevron-right" />
         </Btn>
         <Btn
+          v-if="!mobile"
           :size="size"
           :to="pageRoute(pagination.totalPages)"
           :disabled="currentPage >= pagination.totalPages"

--- a/app/frontend/shared/composables/useMobile.ts
+++ b/app/frontend/shared/composables/useMobile.ts
@@ -1,4 +1,4 @@
-import { useMobileStore } from "@/shared/stores/mobile";
+import { isMobileWidth, useMobileStore } from "@/shared/stores/mobile";
 import { storeToRefs } from "pinia";
 
 export const useMobile = () => {
@@ -17,7 +17,7 @@ export const useMobile = () => {
   });
 
   const checkMobile = () => {
-    mobileStore.mobile = document.documentElement.clientWidth < 992;
+    mobileStore.mobile = isMobileWidth();
   };
 
   return mobile;

--- a/app/frontend/shared/stores/mobile.ts
+++ b/app/frontend/shared/stores/mobile.ts
@@ -1,11 +1,17 @@
 import { defineStore } from "pinia";
 
+const mobileBreakpoint = 992;
+
+export const isMobileWidth = () =>
+  typeof document !== "undefined" &&
+  document.documentElement.clientWidth < mobileBreakpoint;
+
 type MobileState = {
   mobile: boolean;
 };
 
 export const useMobileStore = defineStore("mobile", {
   state: (): MobileState => ({
-    mobile: false,
+    mobile: isMobileWidth(),
   }),
 });


### PR DESCRIPTION
## What

Mobile list headers (ships, hangar, fleet ships, admin lists, …) spent four stacked rows before the first record: quicksearch, page actions, filter/action buttons, and the paginator on its own centered row. This collapses that into two.

| | |
|---|---|
| **Before** | search / page actions / filter + actions / paginator |
| **After** | search + page actions / filter + paginator + actions |

## How

Four focused commits, all in shared components except the last:

- **`AppNavigation/Header`** — mobile no longer stacks the two teleport targets. The quicksearch flexes and the page actions sit inline to its right. The actions target is collapsed when nothing is teleported into it, so its flex gap does not pull the quicksearch off the right edge the rows below align to (`:has` rather than `:empty`, since Teleport can leave a zero-length text node behind).
- **`FilteredList`** — the `pagination-top` slot was rendered twice behind `v-if="mobile"` / `v-if="!mobile"`. It is now rendered once inside the actions row and ordered between the two button groups on mobile. Desktop layout is unchanged.
- **`Paginator`** — on mobile the first/last-page buttons are hidden and the page label loses its 100px minimum width, taking the control from ~290px to ~180px so it fits alongside the list actions instead of wrapping.
- **`pages/ships`** — compare and fleetchart rendered at the default 48px while every button in the row below uses the small 38px size, as the admin list pages already do for their header actions.

## Notes

- Hiding first/last-page on mobile is the single biggest width saving here. Happy to put them back and let the row wrap instead if that trade is wrong.
- The ships header buttons shrink on desktop too, since `size` is not breakpoint-scoped. That brings them in line with the admin list pages.
- At ≤360px the hangar row will wrap, since it carries three action buttons plus the dropdown — still no worse than the four rows it replaces.

Verified with prettier, eslint and vue-tsc; the layout itself was reviewed against screenshots from a running app rather than automated tests.

🤖
