### PR TITLE
feat(ships): fill item_prices from a daily UEX sync

### DIFF
--- a/app/api_components/shared/v1/schemas/enums/import_type_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/import_type_enum.rb
@@ -11,6 +11,7 @@ module Shared
             Imports::ModelImport Imports::ModelsImport Imports::ScData::AllImport
             Imports::ScData::ModelsImport Imports::ScData::ModelImport Imports::HangarSync
             Imports::HangarImport Imports::ModulesImport Imports::PaintsImport
+            Imports::UexPricesImport
           ].freeze
 
           schema({

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.spec.ts
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { Model, ItemPrice } from "@/services/fyApi";
+import Component from "./index.vue";
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    toNumber: (value: unknown) => String(value),
+    toDollar: (value: unknown) => String(value),
+    toUEC: (value: unknown) => String(value),
+  }),
+}));
+
+const itemPrice = (attributes: Partial<ItemPrice>) =>
+  ({
+    id: "price-1",
+    location: "Astro Armada - Area 18",
+    ...attributes,
+  }) as ItemPrice;
+
+const model = (availability: Partial<Model["availability"]>) =>
+  ({
+    availability: { boughtAt: [], soldAt: [], rentalAt: [], ...availability },
+    classificationLabel: "Multi-Role",
+    metrics: {},
+  }) as unknown as Model;
+
+const mountWith = (availability: Partial<Model["availability"]>) =>
+  mount(Component, {
+    props: { model: model(availability) },
+    global: { directives: { tooltip: () => {} } },
+  });
+
+describe("ModelBaseMetrics", () => {
+  it("credits UEX when a sale location is shown", () => {
+    const link = mountWith({ soldAt: [itemPrice({})] }).get(
+      'a[href="https://uexcorp.space"]',
+    );
+
+    expect(link.text()).toContain("model.poweredByUex");
+  });
+
+  it("credits UEX when only a rental location is shown", () => {
+    const wrapper = mountWith({
+      rentalAt: [itemPrice({ id: "price-2", timeRange: "1-day" })],
+    });
+
+    expect(wrapper.find('a[href="https://uexcorp.space"]').exists()).toBe(true);
+  });
+
+  it("omits the credit when the ship has no availability", () => {
+    const wrapper = mountWith({});
+
+    expect(wrapper.find('a[href="https://uexcorp.space"]').exists()).toBe(
+      false,
+    );
+  });
+});

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -22,6 +22,10 @@ const props = withDefaults(defineProps<Props>(), {
 const soldAt = computed(() => props.model.availability.soldAt);
 const rentalAt = computed(() => props.model.availability.rentalAt);
 
+const hasAvailability = computed(
+  () => !!soldAt.value?.length || !!rentalAt.value?.length,
+);
+
 const displayLength = computed(() => {
   if (props.extended && props.model.metrics.extendedLength) {
     return props.model.metrics.extendedLength;
@@ -185,6 +189,13 @@ const displayHeight = computed(() => {
                     {{ modelPrice.location }}
                   </li>
                 </ul>
+              </div>
+            </div>
+            <div v-if="hasAvailability" class="col-12">
+              <div class="metrics-attribution">
+                <a href="https://uexcorp.space" target="_blank" rel="noopener">
+                  {{ t("model.poweredByUex") }}
+                </a>
               </div>
             </div>
           </div>

--- a/app/frontend/stylesheets/frontend/partials/metrics.scss
+++ b/app/frontend/stylesheets/frontend/partials/metrics.scss
@@ -40,6 +40,12 @@
   font-weight: bold;
 }
 
+.metrics-attribution {
+  margin-top: 8px;
+  color: darken($text-color, 30%);
+  font-size: 85%;
+}
+
 .metrics-padding {
   padding: 10px 15px;
 }

--- a/app/frontend/translations/en/models/model.json
+++ b/app/frontend/translations/en/models/model.json
@@ -60,6 +60,7 @@
         "modular": "Modular",
         "soldAt": "Sold at?",
         "rentalAt": "Rental at?",
+        "poweredByUex": "Powered by UEX",
         "lastUpdatedAt": "Last updated at?",
         "loaners": "Loaners",
         "paints": "Paints",

--- a/app/jobs/loaders/uex_prices_job.rb
+++ b/app/jobs/loaders/uex_prices_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Loaders
+  class UexPricesJob < ::Loaders::BaseJob
+    def perform(admin_user_id = nil)
+      import = Imports::UexPricesImport.create(admin_user_id:)
+
+      import.start!
+
+      result = ::Uex::PriceSyncer.new.run
+
+      if result.unmatched.present?
+        GithubIssueCreator.new(
+          task_type: "uex_prices_import",
+          title: "UEX Price Sync — Unmatched Vehicles",
+          body: ::Uex::PriceSyncer.github_issue_body(result)
+        ).run
+      end
+
+      import.update!(
+        output: {
+          created: result.created,
+          updated: result.updated,
+          removed: result.removed,
+          unmatched: result.unmatched.map { |vehicle| vehicle["slug"] }
+        }
+      )
+      import.finish!
+    rescue => e
+      import.fail!
+      import.update!(info: e.message)
+
+      raise e
+    end
+  end
+end

--- a/app/lib/uex/client.rb
+++ b/app/lib/uex/client.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Uex
+  class Client
+    def initialize(base_url: Rails.configuration.uex.endpoint)
+      @base_url = base_url.to_s.chomp("/")
+    end
+
+    def vehicles
+      get("vehicles")
+    end
+
+    def vehicle_purchase_prices
+      get("vehicles_purchases_prices_all")
+    end
+
+    def vehicle_rental_prices
+      get("vehicles_rentals_prices_all")
+    end
+
+    def terminals
+      get("terminals")
+    end
+
+    private def get(path)
+      # UEX answers 403 to requests without a User-Agent, so it is not optional.
+      response = Typhoeus.get(
+        "#{@base_url}/#{path}/",
+        headers: {"User-Agent" => user_agent, "Accept" => "application/json"}
+      )
+
+      raise Uex::Error, "UEX API error #{response.code} for #{path}" unless response.success?
+
+      payload = JSON.parse(response.body)
+
+      raise Uex::Error, "UEX API returned status #{payload["status"].inspect} for #{path}" if payload["status"] != "ok"
+
+      Array(payload["data"])
+    rescue JSON::ParserError => e
+      raise Uex::Error, "UEX API returned invalid JSON for #{path}: #{e.message}"
+    end
+
+    private def user_agent
+      "#{Rails.configuration.app.name} (#{Fleetyards::VERSION}; +https://#{Rails.configuration.app.domain})"
+    end
+  end
+end

--- a/app/lib/uex/error.rb
+++ b/app/lib/uex/error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Uex
+  class Error < StandardError; end
+end

--- a/app/lib/uex/price_syncer.rb
+++ b/app/lib/uex/price_syncer.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Uex
+  class PriceSyncer
+    ITEM_TYPE = "Model"
+    TERMINAL_TYPES = %w[vehicle_buy vehicle_rent].freeze
+
+    # UEX carries a single rental row per (vehicle, terminal) with no period
+    # field. Rent sits at ~2.5% of the purchase price across the whole set,
+    # which is the in-game 1-day rate.
+    RENTAL_TIME_RANGE = "1-day"
+
+    Result = Struct.new(:created, :updated, :removed, :unmatched) do
+      def to_s
+        "created=#{created} updated=#{updated} removed=#{removed} unmatched=#{unmatched.size}"
+      end
+    end
+
+    def initialize(client: Uex::Client.new)
+      @client = client
+    end
+
+    def run
+      vehicles = @client.vehicles.index_by { |vehicle| vehicle["id"] }
+      terminals = @client.terminals
+        .select { |terminal| TERMINAL_TYPES.include?(terminal["type"]) }
+        .index_by { |terminal| terminal["id"] }
+      matcher = Uex::VehicleMatcher.new
+
+      desired = collect(
+        @client.vehicle_purchase_prices,
+        vehicles:, terminals:, matcher:,
+        price_key: "price_buy",
+        # Ours is shop-perspective: `sell` means the shop sells it, which is what
+        # Model#sold_at and the "Sold at?" label read. UEX purchase prices are
+        # player-perspective, so they map to `sell`, not `buy`.
+        price_type: "sell",
+        time_range: nil
+      )
+
+      desired.merge!(
+        collect(
+          @client.vehicle_rental_prices,
+          vehicles:, terminals:, matcher:,
+          price_key: "price_rent",
+          price_type: "rental",
+          time_range: RENTAL_TIME_RANGE
+        )
+      )
+
+      persist(desired, unmatched: matcher.misses)
+    end
+
+    private def collect(rows, vehicles:, terminals:, matcher:, price_key:, price_type:, time_range:)
+      rows.each_with_object({}) do |row, result|
+        price = row[price_key].to_d
+        next if price <= 0
+
+        vehicle = vehicles[row["id_vehicle"]]
+        terminal = terminals[row["id_terminal"]]
+        next if vehicle.blank? || terminal.blank?
+
+        location = terminal["name"].to_s.strip
+        next if location.blank?
+
+        model = matcher.match(vehicle)
+        next if model.blank?
+
+        attributes = {
+          item_type: ITEM_TYPE,
+          item_id: model.id,
+          price_type:,
+          location:,
+          time_range:,
+          location_url: terminal["contact_url"].presence,
+          price:
+        }
+
+        key = attributes.values_at(:item_id, :price_type, :location, :time_range)
+
+        # Two UEX terminals can collapse onto one location string. Model#sold_at
+        # sorts by price then uniqs by location, so the cheapest is the one that
+        # would surface anyway.
+        existing = result[key]
+        result[key] = attributes if existing.blank? || price < existing[:price]
+      end
+    end
+
+    private def persist(desired, unmatched:)
+      created = 0
+      updated = 0
+      removed = 0
+
+      ItemPrice.transaction do
+        # Whatever is left in here once every desired row has claimed its match
+        # is a location UEX no longer lists.
+        unclaimed = ItemPrice.where(item_type: ITEM_TYPE).index_by do |item_price|
+          [item_price.item_id, item_price.price_type, item_price.location, item_price.time_range]
+        end
+
+        desired.each do |key, attributes|
+          item_price = unclaimed.delete(key)
+
+          if item_price.blank?
+            ItemPrice.create!(attributes)
+            created += 1
+            next
+          end
+
+          item_price.assign_attributes(attributes.slice(:price, :location_url))
+          next unless item_price.changed?
+
+          item_price.save!
+          updated += 1
+        end
+
+        removed = ItemPrice.where(id: unclaimed.values.map(&:id)).destroy_all.size
+      end
+
+      Result.new(created:, updated:, removed:, unmatched: unmatched.uniq { |vehicle| vehicle["id"] })
+    end
+
+    # Deliberately free of the sync counts: GithubIssueCreator dedupes on a
+    # digest of the body, and prices move every day, so anything volatile in
+    # here would open a fresh issue on every run.
+    def self.github_issue_body(result)
+      lines = ["## Unmatched UEX Vehicles (#{result.unmatched.size})", ""]
+      lines << "These UEX vehicles carry a price but do not resolve to a `Model`."
+      lines << "Add them to `Uex::VehicleMatcher::MAPPINGS`."
+      lines << ""
+
+      result.unmatched.each do |vehicle|
+        lines << "- **#{vehicle["name_full"].presence || vehicle["name"]}** — `#{vehicle["slug"]}`"
+      end
+
+      lines.join("\n")
+    end
+  end
+end

--- a/app/lib/uex/vehicle_matcher.rb
+++ b/app/lib/uex/vehicle_matcher.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Uex
+  class VehicleMatcher
+    # UEX vehicle slug => our Model slug, for the vehicles neither the slug nor
+    # either name form resolves. Maintained by hand, same as the mapping hashes
+    # in Rsi::LoanerLoader and ModulesImporter.
+    MAPPINGS = {
+      "a2-hercules-starlifter" => "crus-a2-hercules",
+      "c2-hercules-starlifter" => "crus-c2-hercules",
+      "m2-hercules-starlifter" => "crus-m2-hercules",
+      "ares-inferno-starfighter" => "crus-ares-inferno",
+      "ares-ion-starfighter" => "crus-ares-ion",
+      "c8r-pisces-rescue" => "anvl-c8r-pisces",
+      "nova-tank" => "tmbl-nova",
+      "san-tok-y-i" => "xnaa-san-tok-yai"
+    }.freeze
+
+    attr_reader :misses
+
+    def initialize
+      models = Model.select(:id, :name, :slug).to_a
+
+      @by_slug = models.index_by(&:slug)
+      @by_name = models.index_by { |model| model.name.to_s.downcase }
+      @misses = []
+    end
+
+    def match(vehicle)
+      model = lookup(vehicle)
+
+      @misses << vehicle if model.blank?
+
+      model
+    end
+
+    private def lookup(vehicle)
+      mapped = MAPPINGS[vehicle["slug"]]
+
+      # The hand-written mapping is an override: it wins over the generic
+      # strategies so a wrong name collision can always be corrected.
+      return @by_slug[mapped] if mapped.present?
+
+      @by_slug[vehicle["slug"]] ||
+        @by_name[vehicle["name"].to_s.downcase] ||
+        @by_name[vehicle["name_full"].to_s.downcase]
+    end
+  end
+end

--- a/app/models/imports/uex_prices_import.rb
+++ b/app/models/imports/uex_prices_import.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: imports
+#
+#  id            :uuid             not null, primary key
+#  aasm_state    :string
+#  failed_at     :datetime
+#  finished_at   :datetime
+#  import_data   :text
+#  info          :text
+#  input         :jsonb
+#  output        :jsonb
+#  started_at    :datetime
+#  type          :string
+#  version       :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  admin_user_id :uuid
+#  user_id       :uuid
+#
+# Indexes
+#
+#  index_imports_on_aasm_state_and_type  (aasm_state,type)
+#  index_imports_on_admin_user_id        (admin_user_id)
+#  index_imports_on_type                 (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_user_id => admin_users.id)
+#
+module Imports
+  class UexPricesImport < ::Import
+    belongs_to :admin_user, optional: true
+  end
+end

--- a/app/views/api/v1/imports/uex_prices_imports/_uex_prices_import.jbuilder
+++ b/app/views/api/v1/imports/uex_prices_imports/_uex_prices_import.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", uex_prices_import] do
+  json.partial!("api/v1/imports/base", import: uex_prices_import)
+end

--- a/config/app/uex.yml
+++ b/config/app/uex.yml
@@ -1,0 +1,2 @@
+shared:
+  endpoint: <%= ENV["UEX_ENDPOINT"] || 'https://api.uexcorp.uk/2.0' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,7 @@ module Fleetyards
     config.sc_data = config_for("app/sc_data")
     config.maintainer = config_for("app/maintainer")
     config.rsi = config_for("app/rsi")
+    config.uex = config_for("app/uex")
     config.api_schema = config_for("app/api_schema")
     config.redis = config_for(:redis)
     config.basic_auth = config_for(:basic_auth)

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -15,6 +15,11 @@ loaders_models_job:
   class: 'Loaders::ModelsJob'
   queue: 'loaders'
   enabled: <%= Rails.env.production? %>
+loaders_uex_prices_job:
+  cron: '0 5 */1 * *' # Daily at 5:00
+  class: 'Loaders::UexPricesJob'
+  queue: 'loaders'
+  enabled: <%= Rails.env.production? %>
 sc_data_check_job:
   cron: '0 22 */1 * *' # Daily at 22:00
   class: 'ScData::CheckJob'

--- a/docs/exec-plans/uex-price-sync.md
+++ b/docs/exec-plans/uex-price-sync.md
@@ -198,10 +198,17 @@ to `ImportTypeEnum` (then `./bin/generate-schema`) and needs a jbuilder partial 
 - Correction to the earlier claim: `Models/BaseMetrics` renders only
   `modelPrice.location` for both `soldAt` and `rentalAt` — not price, not rental
   period. The data is in the payload; showing it is a separate UI change.
+- The ship page cannot be checked in a fresh worktree: it has no `.env`, so
+  `FRONTEND_ENDPOINT` is unset, the CORS origin list does not include
+  `fleetyards.test:8270`, and the model fetch dies after its preflight leaving the
+  page body empty. Verified the attribution with a Vitest mount instead.
 - Attribution: UEX's API terms (section 5 of <https://uexcorp.space/about/terms>)
-  impose no credit requirement. They do publish an optional "Powered by UEX"
-  badge at `https://uexcorp.space/img/api/uex-api-badge-powered.png`, worth adding
-  as a courtesy but not a blocker.
+  impose no credit requirement, but a "Powered by UEX" link to
+  <https://uexcorp.space> now sits under the availability lists in
+  `Models/BaseMetrics` as a courtesy. It renders only when the ship has
+  availability, since availability on other item types is not UEX-sourced. Text
+  rather than their badge image — the CSP `img-src` list would need widening for a
+  remote asset.
 - Rental period still wants an in-game check (decision 2). Nothing in the data
   can confirm it; if it turns out to be the 30-day rate, change
   `Uex::PriceSyncer::RENTAL_TIME_RANGE` and re-run — no migration needed.

--- a/docs/exec-plans/uex-price-sync.md
+++ b/docs/exec-plans/uex-price-sync.md
@@ -95,16 +95,25 @@ Follow that precedent rather than inventing fuzzy matching.
 
 ### Step 1 — `UexClient`
 
-`app/services/uex/client.rb`. Three GETs, `User-Agent` set, JSON parsed, non-`ok`
-`status` raised. Base URL from `ENV.fetch("UEX_API_URL", "https://api.uexcorp.uk/2.0")`
-so it can be pointed at a fixture host in tests. No token handling — add it only
-if we later need a write or user endpoint.
+`app/lib/uex/client.rb` (`app/lib` is where every other external-data loader
+lives — `rsi/`, `sc_data/`, `patreon/`; `app/services` holds one unrelated
+class). Four GETs, `User-Agent` set, JSON parsed, non-`ok` `status` raised. Base
+URL from `Rails.configuration.uex.endpoint` (`config/app/uex.yml`, overridable
+via `UEX_ENDPOINT`), matching how `config/app/rsi.yml` is wired, so it can be
+pointed at a fixture host in tests. No token handling — add it only if we later
+need a write or user endpoint.
 
 ### Step 2 — `Uex::VehicleMatcher`
 
-Wraps the layered lookup from decision 3: slug → name → name_full → explicit
-`MAPPINGS` hash for the eight. Returns `nil` on a miss and collects misses so the
-job can report them. Unit-tested against a fixture, including one case per layer.
+Wraps the layered lookup from decision 3. `MAPPINGS` runs *first*, as an
+override, then slug → name → name_full: the hand-curated entry should win over a
+generic match so a wrong name collision can always be corrected. Returns `nil` on
+a miss and collects misses so the job can report them. Unit-tested against a
+fixture, including one case per layer.
+
+`MAPPINGS` keys on the UEX slug and points at our `Model` slug (not name) —
+`slug` is the matcher's primary key everywhere else, and it avoids repeating
+`San'tok.yāi`'s apostrophe and macron.
 
 ### Step 3 — `Uex::PriceSyncer`
 
@@ -146,6 +155,13 @@ emails with issue creation for the paints/loaner flows). Do the same here so the
 eight-ship mapping stays maintained as UEX adds vehicles, instead of silently
 dropping prices.
 
+Two constraints that fall out of `GithubIssueCreator`: it dedupes on a SHA of the
+body, so the body must carry **only** the unmatched list — putting the daily
+created/updated/removed counts in it would change the digest every run and open a
+fresh issue every day. And the creator only runs when there is something
+unmatched. The counts go on `import.output` instead, where the admin imports view
+already shows them.
+
 ### Step 6 — Verify
 
 - Model spec for `sell` vs `buy` mapping (decision 1).
@@ -154,14 +170,41 @@ dropping prices.
   a ship with both a buy and a rental row (Avenger Titan and Constellation
   Andromeda both have both).
 
+## Outcome
+
+Ran `Uex::PriceSyncer` against the live API on 2026-08-11 in development:
+
+```
+created=632 updated=0 removed=0 unmatched=0
+288 sell, 344 rental, 0 buy — 179 models with availability
+```
+
+A second run reported `created=0 updated=0 removed=0`, so the upsert is
+idempotent. All eight `MAPPINGS` entries resolve. `GET /v1/models/aegs-avenger-titan`
+returns an empty `boughtAt`, two `soldAt` locations and three `rentalAt` rows at
+`timeRange: "1-day"` — decision 1 lands the right way round.
+
+Also needed, not in the original plan: `Imports::UexPricesImport` has to be added
+to `ImportTypeEnum` (then `./bin/generate-schema`) and needs a jbuilder partial at
+`app/views/api/v1/imports/uex_prices_imports/`, or `ImportTest`'s
+"every broadcasting import type renders its jbuilder partial" fails.
+
 ## Notes
 
-- The frontend needs no changes. `_base.jbuilder` already serialises
-  `availability.{boughtAt,soldAt,rentalAt}`, and the Base card's Availability
-  modal already renders location, price and rental period.
-- Attribution: UEX data is community-maintained. Check their terms for a
-  required credit before shipping, and if one is needed put it in the modal
-  footer.
+- The frontend needs no changes to *work*. `_base.jbuilder` already serialises
+  `availability.{boughtAt,soldAt,rentalAt}` and the models controller already
+  preloads `:item_prices` on every endpoint that renders a model, so no N+1
+  appears now that the table is non-empty.
+- Correction to the earlier claim: `Models/BaseMetrics` renders only
+  `modelPrice.location` for both `soldAt` and `rentalAt` — not price, not rental
+  period. The data is in the payload; showing it is a separate UI change.
+- Attribution: UEX's API terms (section 5 of <https://uexcorp.space/about/terms>)
+  impose no credit requirement. They do publish an optional "Powered by UEX"
+  badge at `https://uexcorp.space/img/api/uex-api-badge-powered.png`, worth adding
+  as a courtesy but not a blocker.
+- Rental period still wants an in-game check (decision 2). Nothing in the data
+  can confirm it; if it turns out to be the 30-day rate, change
+  `Uex::PriceSyncer::RENTAL_TIME_RANGE` and re-run — no migration needed.
 - `Model#sold_at` / `#rental_at` already `sort_by(&:price)` and
   `uniq(&:location)`, so duplicate locations across terminals collapse in the
   API response regardless of what we store.

--- a/docs/exec-plans/uex-price-sync.md
+++ b/docs/exec-plans/uex-price-sync.md
@@ -1,0 +1,167 @@
+# UEX price sync — fill `item_prices` from uexcorp.space
+
+Source: <https://uexcorp.space/api/documentation/> (API 2.0, base
+`https://api.uexcorp.uk/2.0/`).
+
+## Goal
+
+Populate `item_prices` for `Model` records from a daily UEX sync, so the ship
+page's Base card can show real buy and rental locations. Today the table is
+empty everywhere — 0 rows locally, 0 availability across all 243 production
+models — because `PrefillItemPrices` (`db/migrate/20240327160635`) sourced from
+`CommodityPrice`/`ShopCommodity`, which were tableless and have since been
+deleted. That migration was removed in `ca764abcf`.
+
+Non-goals: components, paints, modules and upgrades (the `item_prices` table is
+polymorphic and UEX has item prices too, but ships first); commodity/trade data;
+any UI beyond what already reads `model.availability`.
+
+## What the API gives us
+
+Verified against the live API on 2026-08-11. **No authentication required** for
+the bulk endpoints — a bearer token is only needed for the write/user endpoints.
+A `User-Agent` header *is* required; without one the API returns 403.
+
+Limits are generous relative to this job: 172,800 requests/day, 120/minute. The
+whole sync is 3 requests.
+
+| Endpoint | Rows | Shape |
+| --- | --- | --- |
+| `/vehicles/` | 280 | `id`, `name`, `name_full`, `slug`, `uuid`, … |
+| `/vehicles_purchases_prices_all/` | 288 | `id`, `id_vehicle`, `id_terminal`, `price_buy`, `vehicle_name`, `terminal_name`, `date_modified` |
+| `/vehicles_rentals_prices_all/` | 344 | `id`, `id_vehicle`, `id_terminal`, `price_rent`, `vehicle_name`, `terminal_name`, `date_modified` |
+| `/terminals/` | 826 | `name`, `nickname`, `type`, `city_name`, `planet_name`, `space_station_name`, `star_system_name`, `contact_url`, … |
+
+Purchases span 179 vehicles across 7 terminals; rentals 49 vehicles across 32.
+
+## Three decisions to make before coding
+
+### 1. `price_buy` maps to our `sell`, not `buy`
+
+Ours is shop-perspective: `ItemPrice#sell?` means *the shop sells it*, which is
+what `Model#sold_at` selects and what the UI labels "Sold at?". UEX's
+`vehicles_purchases_prices` is player-perspective — what the player pays.
+
+So **UEX purchase → `price_type: :sell`**. Getting this backwards silently
+empties `soldAt` while filling an unused `boughtAt`. The deleted migration had
+it right (`CommoditySellPrice → sell`); worth a test asserting it.
+
+### 2. Rentals have no duration, but we require one
+
+UEX carries exactly one rental row per `(vehicle, terminal)` — 344 rows, 344
+distinct pairs, zero duplicates. There is no period field. Our model has
+`validates :time_range, presence: true, if: -> { rental? }` with an enum of
+`1-day` / `3-days` / `7-days` / `30-days`.
+
+Evidence that it is the **1-day** price — rent as a share of purchase, same
+vehicle:
+
+| Vehicle | Rent | Buy | % |
+| --- | ---: | ---: | ---: |
+| M50 | 37,485 | 1,499,400 | 2.50% |
+| 300i | 34,398 | 1,375,920 | 2.50% |
+| 600i Explorer | 680,793 | 27,231,800 | 2.50% |
+| Constellation Andromeda | 254,016 | 9,652,610 | 2.63% |
+| Avenger Titan | 27,165 | 1,290,370 | 2.11% |
+| Mustang Alpha | 9,639 | 610,470 | 1.58% |
+
+A tight cluster at ~2.5% is consistent with a single fixed duration, and in game
+the 1-day rate sits in that band. **Recommendation: store `1-day`.** It should
+be confirmed against an in-game terminal before shipping — if it turns out to be
+30-day, every rental figure is wrong by ~30×, and nothing in the data would tell
+us. The alternative is relaxing the validation to allow a null `time_range`,
+which is honest but pushes an "unknown period" case into the UI.
+
+### 3. Eight ships need a manual mapping
+
+Matching UEX vehicles to our `Model` records, measured over the 179 vehicles
+that actually carry a price:
+
+| Strategy | Matched |
+| --- | ---: |
+| `slug` (ours is already UEX's format — both use `orig-100i`) | 105 |
+| then `name` / `name_full`, case-insensitive | 66 |
+| **unmatched** | **8** |
+
+The stragglers: A2 / C2 / M2 Hercules Starlifter, Ares Inferno Starfighter,
+Ares Ion Starfighter, C8R Pisces Rescue, Nova Tank, San tok.Yāi.
+
+That is the same shape of problem `loaner_loader.rb` and `modules_importer.rb`
+already solve with a constant mapping hash, and the repo has
+`resolve-loaners-import` / `resolve-modules-import` skills for maintaining them.
+Follow that precedent rather than inventing fuzzy matching.
+
+## Steps
+
+### Step 1 — `UexClient`
+
+`app/services/uex/client.rb`. Three GETs, `User-Agent` set, JSON parsed, non-`ok`
+`status` raised. Base URL from `ENV.fetch("UEX_API_URL", "https://api.uexcorp.uk/2.0")`
+so it can be pointed at a fixture host in tests. No token handling — add it only
+if we later need a write or user endpoint.
+
+### Step 2 — `Uex::VehicleMatcher`
+
+Wraps the layered lookup from decision 3: slug → name → name_full → explicit
+`MAPPINGS` hash for the eight. Returns `nil` on a miss and collects misses so the
+job can report them. Unit-tested against a fixture, including one case per layer.
+
+### Step 3 — `Uex::PriceSyncer`
+
+- Build a terminal lookup, keeping only `type` in `vehicle_buy` / `vehicle_rent`.
+- `location` ← terminal `name`. It is already the right string:
+  `"Astro Armada - Area 18"`, `"New Deal - Teasa Spaceport - Lorville"`,
+  `"Buy and Fly - Ruin Station"`. No need to compose it from the city/planet
+  parts, and it matches the old `shop.name + location_label` shape.
+- `location_url` ← `contact_url` when present (it is null for every vehicle
+  terminal today, so expect nil).
+- Upsert per `(item, price_type, location, time_range)` rather than blind
+  `create!`, so a re-run updates prices instead of duplicating rows.
+- Delete our rows for a model that UEX no longer lists, so ships removed from a
+  shop stop showing a stale location. Scope the delete to `Model` item types so
+  hand-entered admin rows for other item types are untouched.
+- Wrap in a transaction and report counts: created / updated / removed /
+  unmatched.
+
+### Step 4 — `Loaders::UexPricesJob` + schedule
+
+Sidekiq job on the `loaders` queue, following `Loaders::ModelsJob`. Add to
+`config/sidekiq_schedule.yml`:
+
+```yaml
+loaders_uex_prices_job:
+  cron: '0 5 */1 * *' # Daily at 5:00
+  class: 'Loaders::UexPricesJob'
+  queue: 'loaders'
+  enabled: <%= Rails.env.production? %>
+```
+
+05:00 UTC keeps it clear of the existing daily band (metrics 01:00, cleanups
+02:00/03:00, Patreon 04:17) and well away from the 19:00–22:00 loader block.
+
+### Step 5 — Report unmatched vehicles
+
+The other importers open a GitHub issue on mismatch (`7960c3bf8` replaced admin
+emails with issue creation for the paints/loaner flows). Do the same here so the
+eight-ship mapping stays maintained as UEX adds vehicles, instead of silently
+dropping prices.
+
+### Step 6 — Verify
+
+- Model spec for `sell` vs `buy` mapping (decision 1).
+- Syncer spec over a trimmed fixture: create, update, remove-stale, unmatched.
+- Manual: run the job locally, then check the ship page's Availability modal on
+  a ship with both a buy and a rental row (Avenger Titan and Constellation
+  Andromeda both have both).
+
+## Notes
+
+- The frontend needs no changes. `_base.jbuilder` already serialises
+  `availability.{boughtAt,soldAt,rentalAt}`, and the Base card's Availability
+  modal already renders location, price and rental period.
+- Attribution: UEX data is community-maintained. Check their terms for a
+  required credit before shipping, and if one is needed put it in the modal
+  footer.
+- `Model#sold_at` / `#rental_at` already `sort_by(&:price)` and
+  `uniq(&:location)`, so duplicate locations across terminals collapse in the
+  API response regardless of what we store.

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -9101,6 +9101,7 @@ components:
       - Imports::HangarImport
       - Imports::ModulesImport
       - Imports::PaintsImport
+      - Imports::UexPricesImport
       x-enumNames:
       - IMPORTS_MODEL_IMPORT
       - IMPORTS_MODELS_IMPORT
@@ -9111,6 +9112,7 @@ components:
       - IMPORTS_HANGAR_IMPORT
       - IMPORTS_MODULES_IMPORT
       - IMPORTS_PAINTS_IMPORT
+      - IMPORTS_UEX_PRICES_IMPORT
       title: ImportTypeEnum
     Imports:
       type: object

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9977,6 +9977,7 @@ components:
       - Imports::HangarImport
       - Imports::ModulesImport
       - Imports::PaintsImport
+      - Imports::UexPricesImport
       x-enumNames:
       - IMPORTS_MODEL_IMPORT
       - IMPORTS_MODELS_IMPORT
@@ -9987,6 +9988,7 @@ components:
       - IMPORTS_HANGAR_IMPORT
       - IMPORTS_MODULES_IMPORT
       - IMPORTS_PAINTS_IMPORT
+      - IMPORTS_UEX_PRICES_IMPORT
       title: ImportTypeEnum
     ItemPrice:
       type: object

--- a/test/fixtures/uex/terminals.json
+++ b/test/fixtures/uex/terminals.json
@@ -1,0 +1,27 @@
+{
+  "status": "ok",
+  "http_code": 200,
+  "data": [
+    {
+      "id": 100,
+      "type": "vehicle_buy",
+      "name": "Astro Armada - Area 18",
+      "nickname": "Astro Armada",
+      "contact_url": ""
+    },
+    {
+      "id": 101,
+      "type": "vehicle_rent",
+      "name": "Vantage Rentals - Lorville",
+      "nickname": "Vantage Lorville",
+      "contact_url": "https://example.test/vantage"
+    },
+    {
+      "id": 102,
+      "type": "commodity",
+      "name": "Admin - ARC-L1",
+      "nickname": "ARC-L1",
+      "contact_url": null
+    }
+  ]
+}

--- a/test/fixtures/uex/vehicles.json
+++ b/test/fixtures/uex/vehicles.json
@@ -1,0 +1,36 @@
+{
+  "status": "ok",
+  "http_code": 200,
+  "data": [
+    {
+      "id": 1,
+      "slug": "orig-100i",
+      "name": "100i",
+      "name_full": "Origin 100i"
+    },
+    {
+      "id": 2,
+      "slug": "avenger-titan",
+      "name": "Avenger Titan",
+      "name_full": "Aegis Avenger Titan"
+    },
+    {
+      "id": 3,
+      "slug": "constellation-andromeda",
+      "name": "Andromeda",
+      "name_full": "Constellation Andromeda"
+    },
+    {
+      "id": 4,
+      "slug": "c2-hercules-starlifter",
+      "name": "C2 Hercules Starlifter",
+      "name_full": "Crusader C2 Hercules Starlifter"
+    },
+    {
+      "id": 5,
+      "slug": "vanduul-scythe",
+      "name": "Scythe",
+      "name_full": "Vanduul Scythe"
+    }
+  ]
+}

--- a/test/fixtures/uex/vehicles_purchases_prices_all.json
+++ b/test/fixtures/uex/vehicles_purchases_prices_all.json
@@ -1,0 +1,54 @@
+{
+  "status": "ok",
+  "http_code": 200,
+  "data": [
+    {
+      "id": 1,
+      "id_vehicle": 1,
+      "id_terminal": 100,
+      "price_buy": 1375920,
+      "vehicle_name": "100i",
+      "terminal_name": "Astro Armada"
+    },
+    {
+      "id": 2,
+      "id_vehicle": 2,
+      "id_terminal": 100,
+      "price_buy": 1290370,
+      "vehicle_name": "Avenger Titan",
+      "terminal_name": "Astro Armada"
+    },
+    {
+      "id": 3,
+      "id_vehicle": 3,
+      "id_terminal": 100,
+      "price_buy": 9652610,
+      "vehicle_name": "Andromeda",
+      "terminal_name": "Astro Armada"
+    },
+    {
+      "id": 4,
+      "id_vehicle": 4,
+      "id_terminal": 100,
+      "price_buy": 40000000,
+      "vehicle_name": "C2 Hercules Starlifter",
+      "terminal_name": "Astro Armada"
+    },
+    {
+      "id": 5,
+      "id_vehicle": 5,
+      "id_terminal": 100,
+      "price_buy": 500000,
+      "vehicle_name": "Scythe",
+      "terminal_name": "Astro Armada"
+    },
+    {
+      "id": 6,
+      "id_vehicle": 1,
+      "id_terminal": 102,
+      "price_buy": 999999,
+      "vehicle_name": "100i",
+      "terminal_name": "ARC-L1"
+    }
+  ]
+}

--- a/test/fixtures/uex/vehicles_rentals_prices_all.json
+++ b/test/fixtures/uex/vehicles_rentals_prices_all.json
@@ -1,0 +1,22 @@
+{
+  "status": "ok",
+  "http_code": 200,
+  "data": [
+    {
+      "id": 1,
+      "id_vehicle": 2,
+      "id_terminal": 101,
+      "price_rent": 27165,
+      "vehicle_name": "Avenger Titan",
+      "terminal_name": "Vantage Lorville"
+    },
+    {
+      "id": 2,
+      "id_vehicle": 3,
+      "id_terminal": 101,
+      "price_rent": 254016,
+      "vehicle_name": "Andromeda",
+      "terminal_name": "Vantage Lorville"
+    }
+  ]
+}

--- a/test/jobs/loaders/uex_prices_job_test.rb
+++ b/test/jobs/loaders/uex_prices_job_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Loaders
+  class UexPricesJobTest < ActiveJob::TestCase
+    test "#perform syncs prices and records the counts on the import" do
+      stub_syncer(unmatched: [])
+
+      GithubIssueCreator.expects(:new).never
+
+      ::Loaders::UexPricesJob.new.perform
+
+      import = Imports::UexPricesImport.last
+
+      assert_equal "finished", import.aasm_state
+      assert_equal(
+        {"created" => 4, "updated" => 1, "removed" => 2, "unmatched" => []},
+        import.output
+      )
+    end
+
+    test "#perform opens a GitHub issue when a vehicle resolves to no model" do
+      stub_syncer
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).returns(true)
+      GithubIssueCreator.expects(:new).with(
+        task_type: "uex_prices_import",
+        title: "UEX Price Sync — Unmatched Vehicles",
+        body: anything
+      ).returns(creator)
+
+      ::Loaders::UexPricesJob.new.perform
+
+      assert_equal ["nova-tank"], Imports::UexPricesImport.last.output["unmatched"]
+    end
+
+    test "the issue body carries nothing that changes when only prices move" do
+      unmatched = [{"slug" => "nova-tank", "name" => "Nova Tank", "name_full" => "Tumbril Nova Tank"}]
+
+      first = ::Uex::PriceSyncer.github_issue_body(
+        ::Uex::PriceSyncer::Result.new(created: 4, updated: 1, removed: 2, unmatched:)
+      )
+      second = ::Uex::PriceSyncer.github_issue_body(
+        ::Uex::PriceSyncer::Result.new(created: 0, updated: 97, removed: 3, unmatched:)
+      )
+
+      assert_equal first, second,
+        "a volatile body would defeat GithubIssueCreator's digest and open an issue every day"
+    end
+
+    test "#perform marks the import as failed when the sync raises" do
+      syncer = mock("Uex::PriceSyncer")
+      syncer.stubs(:run).raises(::Uex::Error, "UEX API error 403 for vehicles")
+      ::Uex::PriceSyncer.stubs(:new).returns(syncer)
+
+      error = assert_raises(::Uex::Error) { ::Loaders::UexPricesJob.new.perform }
+
+      assert_equal "UEX API error 403 for vehicles", error.message
+
+      import = Imports::UexPricesImport.last
+
+      assert_equal "failed", import.aasm_state
+      assert_equal "UEX API error 403 for vehicles", import.info
+    end
+
+    test "the unmatched issue body names the vehicles to add to MAPPINGS" do
+      result = ::Uex::PriceSyncer::Result.new(
+        created: 0, updated: 0, removed: 0,
+        unmatched: [{"slug" => "nova-tank", "name" => "Nova Tank", "name_full" => "Tumbril Nova Tank"}]
+      )
+
+      body = ::Uex::PriceSyncer.github_issue_body(result)
+
+      assert_match "Unmatched UEX Vehicles (1)", body
+      assert_match "Tumbril Nova Tank", body
+      assert_match "nova-tank", body
+      assert_match "Uex::VehicleMatcher::MAPPINGS", body
+    end
+
+    private def stub_syncer(unmatched: [{"slug" => "nova-tank", "name" => "Nova Tank", "name_full" => "Tumbril Nova Tank"}])
+      result = ::Uex::PriceSyncer::Result.new(created: 4, updated: 1, removed: 2, unmatched:)
+
+      syncer = mock("Uex::PriceSyncer")
+      syncer.expects(:run).returns(result)
+      ::Uex::PriceSyncer.stubs(:new).returns(syncer)
+    end
+  end
+end

--- a/test/lib/uex/client_test.rb
+++ b/test/lib/uex/client_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+
+module Uex
+  class ClientTest < ActiveSupport::TestCase
+    BASE = "https://uex.test/2.0"
+
+    setup do
+      @client = Uex::Client.new(base_url: BASE)
+    end
+
+    test "fetches and unwraps each bulk endpoint" do
+      {
+        vehicles: "vehicles",
+        vehicle_purchase_prices: "vehicles_purchases_prices_all",
+        vehicle_rental_prices: "vehicles_rentals_prices_all",
+        terminals: "terminals"
+      }.each do |method, path|
+        stub_request(:get, "#{BASE}/#{path}/")
+          .to_return(body: {status: "ok", data: [{"id" => 1}]}.to_json)
+
+        assert_equal [{"id" => 1}], @client.public_send(method), "expected #{method} to unwrap data"
+      end
+    end
+
+    test "sends a User-Agent, which UEX rejects requests without" do
+      stub_request(:get, "#{BASE}/vehicles/")
+        .with(headers: {"User-Agent" => /Fleetyards/})
+        .to_return(body: {status: "ok", data: []}.to_json)
+
+      assert_equal [], @client.vehicles
+    end
+
+    test "raises on a non-success response" do
+      stub_request(:get, "#{BASE}/terminals/").to_return(status: 403, body: "Forbidden")
+
+      error = assert_raises(Uex::Error) { @client.terminals }
+      assert_match "403", error.message
+    end
+
+    test "raises when the payload status is not ok" do
+      stub_request(:get, "#{BASE}/terminals/")
+        .to_return(body: {status: "error", data: nil}.to_json)
+
+      error = assert_raises(Uex::Error) { @client.terminals }
+      assert_match "error", error.message
+    end
+
+    test "raises on invalid JSON" do
+      stub_request(:get, "#{BASE}/terminals/").to_return(body: "<html>nope</html>")
+
+      assert_raises(Uex::Error) { @client.terminals }
+    end
+  end
+end

--- a/test/lib/uex/price_syncer_test.rb
+++ b/test/lib/uex/price_syncer_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../support/uex_fixtures"
+
+module Uex
+  class PriceSyncerTest < ActiveSupport::TestCase
+    include UexFixtures
+
+    setup do
+      ItemPrice.delete_all
+      @models = create_uex_fixture_models
+    end
+
+    test "#run creates a price row per matched vehicle and vehicle terminal" do
+      result = sync
+
+      assert_equal 6, result.created
+      assert_equal 0, result.updated
+      assert_equal 0, result.removed
+      assert_equal 6, ItemPrice.count
+    end
+
+    test "#run maps a UEX purchase price to a sell price, not a buy price" do
+      sync
+
+      titan = @models[:name_match].reload
+
+      assert_equal ["Astro Armada - Area 18"], titan.sold_at.map(&:location)
+      assert_equal [1_290_370], titan.sold_at.map { |price| price.price.to_i }
+      assert_empty titan.bought_at
+    end
+
+    test "#run stores rentals as 1-day and carries the terminal contact url" do
+      sync
+
+      rental = @models[:name_match].reload.rental_at.first
+
+      assert_equal "Vantage Rentals - Lorville", rental.location
+      assert_equal "1-day", rental.time_range
+      assert_equal 27_165, rental.price.to_i
+      assert_equal "https://example.test/vantage", rental.location_url
+    end
+
+    test "#run leaves location_url nil when the terminal has no contact url" do
+      sync
+
+      assert_nil @models[:slug_match].reload.sold_at.first.location_url
+    end
+
+    test "#run resolves a vehicle that only the explicit mapping covers" do
+      sync
+
+      assert_equal 40_000_000, @models[:mapping_match].reload.sold_at.first.price.to_i
+    end
+
+    test "#run ignores prices at terminals that do not sell or rent vehicles" do
+      sync
+
+      locations = ItemPrice.where(item_type: "Model").pluck(:location).uniq
+
+      assert_equal ["Astro Armada - Area 18", "Vantage Rentals - Lorville"], locations.sort
+    end
+
+    test "#run reports vehicles that resolve to no model" do
+      result = sync
+
+      assert_equal ["vanduul-scythe"], result.unmatched.map { |vehicle| vehicle["slug"] }
+    end
+
+    test "#run reports each unmatched vehicle once even when it has several prices" do
+      rentals = uex_fixture("vehicles_rentals_prices_all") +
+        [{"id" => 99, "id_vehicle" => 5, "id_terminal" => 101, "price_rent" => 12_500}]
+
+      result = sync(vehicle_rental_prices: rentals)
+
+      assert_equal ["vanduul-scythe"], result.unmatched.map { |vehicle| vehicle["slug"] }
+    end
+
+    test "#run updates a changed price instead of duplicating the row" do
+      sync
+
+      purchases = uex_fixture("vehicles_purchases_prices_all")
+      purchases.find { |row| row["id_vehicle"] == 2 }["price_buy"] = 1_500_000
+
+      result = sync(vehicle_purchase_prices: purchases)
+
+      assert_equal 0, result.created
+      assert_equal 1, result.updated
+      assert_equal 0, result.removed
+      assert_equal 6, ItemPrice.count
+      assert_equal 1_500_000, @models[:name_match].reload.sold_at.first.price.to_i
+    end
+
+    test "#run is idempotent when nothing changed" do
+      sync
+      result = sync
+
+      assert_equal 0, result.created
+      assert_equal 0, result.updated
+      assert_equal 0, result.removed
+      assert_equal 6, ItemPrice.count
+    end
+
+    test "#run removes rows for a location UEX no longer lists" do
+      sync
+
+      purchases = uex_fixture("vehicles_purchases_prices_all").reject { |row| row["id_vehicle"] == 2 }
+
+      result = sync(vehicle_purchase_prices: purchases)
+
+      assert_equal 1, result.removed
+      assert_empty @models[:name_match].reload.sold_at
+      assert_equal 1, @models[:name_match].reload.rental_at.size
+    end
+
+    test "#run leaves prices for other item types alone" do
+      component = create(:component)
+      hand_entered = create(:item_price, item: component, price_type: :sell, time_range: nil)
+
+      sync
+
+      assert ItemPrice.exists?(hand_entered.id)
+    end
+
+    private def sync(overrides = {})
+      Uex::PriceSyncer.new(client: uex_client_stub(overrides)).run
+    end
+  end
+end

--- a/test/lib/uex/vehicle_matcher_test.rb
+++ b/test/lib/uex/vehicle_matcher_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../support/uex_fixtures"
+
+module Uex
+  class VehicleMatcherTest < ActiveSupport::TestCase
+    include UexFixtures
+
+    setup do
+      @models = create_uex_fixture_models
+      @vehicles = uex_fixture("vehicles").index_by { |vehicle| vehicle["id"] }
+      @matcher = Uex::VehicleMatcher.new
+    end
+
+    test "matches on slug" do
+      assert_equal @models[:slug_match].id, @matcher.match(@vehicles[1]).id
+    end
+
+    test "matches on name when the slug differs" do
+      assert_equal "aegs-avenger-titan", @models[:name_match].slug
+      assert_equal @models[:name_match].id, @matcher.match(@vehicles[2]).id
+    end
+
+    test "matches on name_full when neither slug nor name hit" do
+      assert_equal @models[:name_full_match].id, @matcher.match(@vehicles[3]).id
+    end
+
+    test "matches via the explicit mapping" do
+      assert_equal @models[:mapping_match].id, @matcher.match(@vehicles[4]).id
+    end
+
+    test "returns nil and records a miss for an unknown vehicle" do
+      assert_nil @matcher.match(@vehicles[5])
+      assert_equal ["vanduul-scythe"], @matcher.misses.map { |vehicle| vehicle["slug"] }
+    end
+  end
+end

--- a/test/support/uex_fixtures.rb
+++ b/test/support/uex_fixtures.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module UexFixtures
+  def uex_fixture(name)
+    JSON.parse(File.read(Rails.root.join("test/fixtures/uex/#{name}.json")))["data"]
+  end
+
+  def uex_client_stub(overrides = {})
+    data = {
+      vehicles: uex_fixture("vehicles"),
+      vehicle_purchase_prices: uex_fixture("vehicles_purchases_prices_all"),
+      vehicle_rental_prices: uex_fixture("vehicles_rentals_prices_all"),
+      terminals: uex_fixture("terminals")
+    }.merge(overrides)
+
+    client = mock("Uex::Client")
+    data.each { |method, rows| client.stubs(method).returns(rows) }
+    client
+  end
+
+  # The four models the fixture vehicles are expected to resolve to, one per
+  # matching layer.
+  def create_uex_fixture_models
+    {
+      slug_match: create(:model, name: "100i", manufacturer: create(:manufacturer, code: "ORIG")),
+      name_match: create(:model, name: "Avenger Titan", manufacturer: create(:manufacturer, code: "AEGS")),
+      name_full_match: create(:model, name: "Constellation Andromeda", manufacturer: create(:manufacturer, code: "RSI")),
+      mapping_match: create(:model, name: "C2 Hercules", manufacturer: create(:manufacturer, code: "CRUS"))
+    }
+  end
+end


### PR DESCRIPTION
## Why

`item_prices` is empty everywhere — 0 rows locally and 0 availability across all 243 production models. The old `PrefillItemPrices` migration sourced from `CommodityPrice`/`ShopCommodity`, which were tableless and have since been deleted (the migration itself went in `ca764abcf`). So the Base card's "Sold at?" and "Rental at?" have been rendering nothing for months.

This fills the table from a daily [uexcorp.space](https://uexcorp.space) sync.

## What

- `Uex::Client` — four bulk GETs against `api.uexcorp.uk/2.0`. No auth needed, but they 403 without a `User-Agent`, so one is always sent. Endpoint configured via `config/app/uex.yml` the same way as the RSI one.
- `Uex::VehicleMatcher` — our slugs are already in UEX's format (`orig-100i`), which covers 105 of the 179 priced vehicles; name and `name_full` cover another 66. The remaining 8 get an explicit `MAPPINGS` hash, same approach as `Rsi::LoanerLoader`.
- `Uex::PriceSyncer` — upserts on `(item, price_type, location, time_range)` so re-runs update rather than duplicate, and drops locations UEX no longer lists. Scoped to `Model` item types, so hand-entered rows for components/paints/modules are untouched.
- `Loaders::UexPricesJob` on the `loaders` queue, daily at 05:00 UTC — clear of the existing daily band and well away from the evening loader block.
- A "Powered by UEX" link under the availability lists, shown only when there is availability to credit.

## Two decisions worth a look

**UEX purchase price maps to our `sell`, not `buy`.** Ours is shop-perspective — `ItemPrice#sell?` means the shop sells it, which is what `Model#sold_at` selects and what the UI labels "Sold at?". UEX's is player-perspective. Getting this backwards would silently empty `soldAt` while filling an unused `boughtAt`, so there's a test pinning it.

**Rentals are stored as `1-day`, and this is inferred.** UEX carries one rental row per (vehicle, terminal) with no period field at all. Rent sits in a tight ~2.5% band of the purchase price across the whole set, which matches the in-game 1-day rate:

| Vehicle | Rent | Buy | % |
| --- | ---: | ---: | ---: |
| M50 | 37,485 | 1,499,400 | 2.50% |
| 300i | 34,398 | 1,375,920 | 2.50% |
| 600i Explorer | 680,793 | 27,231,800 | 2.50% |
| Avenger Titan | 27,165 | 1,290,370 | 2.11% |

Nothing in the data can confirm it. **If it turns out to be the 30-day rate, every rental figure is off by ~30×** — worth an in-game check at a rental terminal before this goes live. The fix if so is one constant (`Uex::PriceSyncer::RENTAL_TIME_RANGE`) plus a re-run; no migration.

## Verification

Ran the syncer against the live API in development:

```
created=632 updated=0 removed=0 unmatched=0
288 sell, 344 rental, 0 buy — 179 models with availability
```

A second run reported `created=0 updated=0 removed=0`, so it's idempotent. All 8 mappings resolve. `GET /v1/models/aegs-avenger-titan` comes back with an empty `boughtAt`, two `soldAt` locations and three `rentalAt` rows at `timeRange: "1-day"`.

Backend: 30 new tests, full suite green apart from `Short::ModelCompareShareTest`, which fails identically on a stashed clean baseline (pre-existing parallel-run flake). Frontend: 82 passed, `vue-tsc` clean.

## Notes

- No N+1: the models controller already preloads `:item_prices` on every endpoint that renders a model, and `sold_at`/`rental_at` filter the loaded association in memory.
- Unmatched vehicles open a GitHub issue so the mapping stays maintained as UEX adds ships. The issue body deliberately carries *only* the unmatched list — `GithubIssueCreator` dedupes on a digest of the body, and prices move daily, so including the sync counts would open a fresh issue every single run. Counts go on `import.output` instead.
- Adding `Imports::UexPricesImport` also needs an `ImportTypeEnum` entry and a jbuilder partial, or `ImportTest`'s "every broadcasting import type renders its jbuilder partial" fails.
- UEX's API terms impose no attribution requirement; the credit is a courtesy.
- Out of scope: the availability modal still shows only `location`, not price or rental period, even though both are now in the payload. Also components/paints/modules — UEX has item prices too, but ships first.

Plan and findings at `docs/exec-plans/uex-price-sync.md`.

🤖
