### PR TITLE
fix(i18n): add missing model.poweredByUex translation

### DIFF
--- a/app/frontend/translations/de/main.json
+++ b/app/frontend/translations/de/main.json
@@ -60,6 +60,7 @@
       "modular": "Modular",
       "soldAt": "Verkauft bei?",
       "rentalAt": "Vermietung bei?",
+      "poweredByUex": "Bereitgestellt von UEX",
       "lastUpdatedAt": "Zuletzt aktualisiert am?"
     },
     "component": {

--- a/app/frontend/translations/en/main.json
+++ b/app/frontend/translations/en/main.json
@@ -60,6 +60,7 @@
       "modular": "Modular",
       "soldAt": "Sold at?",
       "rentalAt": "Rental at?",
+      "poweredByUex": "Powered by UEX",
       "lastUpdatedAt": "Last updated at?"
     },
     "component": {

--- a/app/frontend/translations/en/models/model.json
+++ b/app/frontend/translations/en/models/model.json
@@ -60,7 +60,6 @@
         "modular": "Modular",
         "soldAt": "Sold at?",
         "rentalAt": "Rental at?",
-        "poweredByUex": "Powered by UEX",
         "lastUpdatedAt": "Last updated at?",
         "loaners": "Loaners",
         "paints": "Paints",

--- a/app/frontend/translations/es/main.json
+++ b/app/frontend/translations/es/main.json
@@ -60,6 +60,7 @@
       "modular": "Modular",
       "soldAt": "¿Vendido en?",
       "rentalAt": "¿Alquilado en?",
+      "poweredByUex": "Con tecnología de UEX",
       "lastUpdatedAt": "¿Última actualización?"
     },
     "component": {

--- a/app/frontend/translations/fr/main.json
+++ b/app/frontend/translations/fr/main.json
@@ -60,6 +60,7 @@
       "modular": "Modulaire",
       "soldAt": "Vendu à?",
       "rentalAt": "Location à ?",
+      "poweredByUex": "Propulsé par UEX",
       "lastUpdatedAt": "Dernière mise à jour le ?"
     },
     "component": {

--- a/app/frontend/translations/it/main.json
+++ b/app/frontend/translations/it/main.json
@@ -60,6 +60,7 @@
       "modular": "Modulare",
       "soldAt": "Venduto a?",
       "rentalAt": "Noleggiato a?",
+      "poweredByUex": "Offerto da UEX",
       "lastUpdatedAt": "Ultimo aggiornamento?"
     },
     "component": {

--- a/app/frontend/translations/zh-CN/main.json
+++ b/app/frontend/translations/zh-CN/main.json
@@ -60,6 +60,7 @@
       "modular": "模块化",
       "soldAt": "出售于？",
       "rentalAt": "租赁于？",
+      "poweredByUex": "数据由 UEX 提供",
       "lastUpdatedAt": "最后更新于？"
     },
     "component": {

--- a/app/frontend/translations/zh-TW/main.json
+++ b/app/frontend/translations/zh-TW/main.json
@@ -60,6 +60,7 @@
       "modular": "模組化",
       "soldAt": "在哪裡出售?",
       "rentalAt": "在哪裡租賃?",
+      "poweredByUex": "資料由 UEX 提供",
       "lastUpdatedAt": "最後更新時間?"
     },
     "component": {


### PR DESCRIPTION
## Problem

The ship base metrics panel rendered a literal `[missing "en.model.poweredByUex" translation]` instead of the UEX attribution link.

#4317 added the string under the `models.model.*` namespace (`translations/en/models/model.json`), but `BaseMetrics` calls `t("model.poweredByUex")`, which resolves against the root `model` namespace in `main.json`.

## Changes

- Add `poweredByUex` to the root `model` namespace in `main.json` for all seven locales
- Drop the unreferenced key from `en/models/model.json`

| locale | value |
| --- | --- |
| en | Powered by UEX |
| de | Bereitgestellt von UEX |
| es | Con tecnología de UEX |
| fr | Propulsé par UEX |
| it | Offerto da UEX |
| zh-CN | 数据由 UEX 提供 |
| zh-TW | 資料由 UEX 提供 |

## Verification

- `prettier --check` clean
- `BaseMetrics/index.spec.ts` passes (3/3)

🤖