### PR TITLE
chore: pin redis to 7.2.15 across CI, dev, and prod

### DIFF
--- a/.github/workflows/api-schema-check.job.yml
+++ b/.github/workflows/api-schema-check.job.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.5-alpine
+        image: redis:7.2.15-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/api-schema-check.job.yml
+++ b/.github/workflows/api-schema-check.job.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.2.5-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/e2e.job.yml
+++ b/.github/workflows/e2e.job.yml
@@ -41,7 +41,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.2.5-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/e2e.job.yml
+++ b/.github/workflows/e2e.job.yml
@@ -41,7 +41,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.5-alpine
+        image: redis:7.2.15-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -37,7 +37,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.5-alpine
+        image: redis:7.2.15-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -37,7 +37,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.2.5-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.5-alpine
+        image: redis:7.2.15-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.2.5-alpine
         ports:
           - 6379:6379
         options: >-

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -78,7 +78,7 @@ accessories:
       memory: 4g
 
   redis:
-    image: redis:7.2
+    image: redis:7.2.15
     port: "6379:6379"
     cmd: redis-server --maxmemory 1536mb --maxmemory-policy allkeys-lru
     directories:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
   redis:
-    image: redis:7.2.5-alpine
+    image: redis:7.2.15-alpine
     ports:
       - 8272:6379
     volumes:


### PR DESCRIPTION
## What

Pins every Redis image to the same patch, `7.2.15`.

| Where | Before | After |
| --- | --- | --- |
| `config/deploy.yml` (prod accessory) | `redis:7.2` (floating) | `redis:7.2.15` |
| `docker-compose.yml` (dev) | `redis:7.2.5-alpine` | `redis:7.2.15-alpine` |
| `.github/workflows/*.job.yml` ×4 (CI) | `redis:6.2.10-alpine` | `redis:7.2.15-alpine` |

## Why

CI was testing against Redis 6.2 while dev and prod both ran 7.2 — a two-major-version gap between the test environment and production. Prod additionally floated on the `7.2` tag, so the running version drifted silently with every re-pull.

`7.2` currently resolves to `7.2.15`, so prod is pinned to what it is already effectively running: no version change, only an explicit pin.

## Notes

- Prod's Redis container **will** be recreated on the next deploy — the image reference changed even though the resolved version did not. Data survives via the `data:/data` volume; expect a brief connection blip.
- Redis 7.2 is supported until 2029-12-01 and still receiving patches (7.2.15 shipped 2026-07-23), so this is not an EOL-driven change.
- A move to Redis 8.2 (supported to 2030-09-01) is worth doing separately; it needs a rollback plan because 8.x writes RDB v12, which 7.2 cannot read.

🤖