### PR TITLE
feat(visual-tests): add metrics, lists, forms, typography and states pages

### DIFF
--- a/app/frontend/frontend/components/Models/MetricsCard/index.vue
+++ b/app/frontend/frontend/components/Models/MetricsCard/index.vue
@@ -117,9 +117,6 @@ withDefaults(defineProps<Props>(), {
 }
 
 .metrics-card--slim .metrics-card__head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
   padding: 14px 16px;
   border-bottom: 1px solid rgba($gray-light, 0.28);
   background: rgba(#000, 0.12);

--- a/app/frontend/frontend/components/Navigation/VisualTestsNav/index.vue
+++ b/app/frontend/frontend/components/Navigation/VisualTestsNav/index.vue
@@ -31,28 +31,58 @@ const { t } = useI18n();
       prefix="02"
     />
     <NavItem
+      :to="{ name: 'visual-tests-typography' }"
+      :label="t('nav.visualTests.typography')"
+      icon="fadt fa-text-size"
+      prefix="03"
+    />
+    <NavItem
+      :to="{ name: 'visual-tests-forms' }"
+      :label="t('nav.visualTests.forms')"
+      icon="fadt fa-input-text"
+      prefix="04"
+    />
+    <NavItem
       :to="{ name: 'visual-tests-tables' }"
       :label="t('nav.visualTests.tables')"
       icon="fadt fa-table"
-      prefix="02"
+      prefix="05"
+    />
+    <NavItem
+      :to="{ name: 'visual-tests-lists' }"
+      :label="t('nav.visualTests.lists')"
+      icon="fadt fa-list-ul"
+      prefix="06"
+    />
+    <NavItem
+      :to="{ name: 'visual-tests-metrics' }"
+      :label="t('nav.visualTests.metrics')"
+      icon="fadt fa-gauge-high"
+      prefix="07"
+    />
+    <NavItem
+      :to="{ name: 'visual-tests-states' }"
+      :label="t('nav.visualTests.states')"
+      icon="fadt fa-spinner"
+      prefix="08"
     />
     <NavItem
       :to="{ name: 'visual-tests-notifications' }"
       :label="t('nav.visualTests.notifications')"
       icon="fadt fa-bell"
-      prefix="02"
+      prefix="09"
     />
     <NavItem
       :to="{ name: 'visual-tests-sync-modal' }"
       :label="t('nav.visualTests.syncModal')"
       icon="fadt fa-arrows-rotate"
-      prefix="02"
+      prefix="10"
     />
     <NavItem
       :to="{ name: 'visual-tests-support-hint' }"
       :label="t('nav.visualTests.supportHint')"
       icon="fadt fa-heart"
-      prefix="02"
+      prefix="11"
     />
   </div>
 </template>

--- a/app/frontend/frontend/pages/visual-tests/forms.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms.vue
@@ -1,0 +1,523 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsFormsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
+import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
+import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormInputGroup from "@/shared/components/base/FormInputGroup/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import FormToggle from "@/shared/components/base/FormToggle/index.vue";
+import RadioList from "@/shared/components/base/RadioList/index.vue";
+import Slider from "@/shared/components/base/Slider/index.vue";
+import Toggle from "@/shared/components/base/Toggle/index.vue";
+import ErrorStates from "@/frontend/pages/visual-tests/forms/ErrorStates.vue";
+import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import {
+  InputAlignmentsEnum,
+  InputSizesEnum,
+  InputTypesEnum,
+  InputVariantsEnum,
+} from "@/shared/components/base/FormInput/types";
+import { type FilterOption } from "@/services/fyApi";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+
+const { displaySuccess } = useAppNotifications();
+
+const text = ref("Aegis Dynamics");
+const number = ref(42);
+const password = ref("hunter2");
+const email = ref("pilot@fleetyards.net");
+const url = ref("https://fleetyards.net");
+const color = ref("#ffcc00");
+const clearable = ref("Clear me");
+const prefixed = ref(1250);
+const empty = ref<string | null>(null);
+const large = ref("Large size");
+const clean = ref("Clean variant");
+const rightAligned = ref(998);
+
+const textarea = ref(
+  "The Galaxy is a modular multi-role ship. Swap the module to change what the ship does.",
+);
+
+const checkbox = ref(true);
+const checkboxUnchecked = ref(false);
+const checkboxGroup = ref<string[]>(["cargo"]);
+const toggleField = ref(true);
+
+const date = ref("2026-08-12");
+
+const file = ref<string | null>(null);
+
+const radio = ref("medium");
+
+const sliderValue = ref(40);
+const sliderStepped = ref(4);
+
+const toggleActive = ref(true);
+const toggleLoading = ref(false);
+
+const filterSingle = ref<string | null>("medium");
+const filterMultiple = ref<string[]>(["small", "large"]);
+
+const sizes = [
+  { label: "Small", value: "small" },
+  { label: "Medium", value: "medium" },
+  { label: "Large", value: "large" },
+  { label: "Capital", value: "capital" },
+];
+
+// RadioList and FilterGroup type their options differently — RadioList requires
+// a non-null string value, FilterGroup allows null.
+const radioOptions = sizes;
+const sizeOptions: FilterOption[] = sizes;
+
+const submitting = ref(false);
+
+const onSubmit = () => {
+  submitting.value = true;
+
+  setTimeout(() => {
+    submitting.value = false;
+    displaySuccess({ text: "Form submitted." });
+  }, 1500);
+};
+
+const onCancel = () => {
+  displaySuccess({ text: "Form cancelled." });
+};
+
+const toggleTheToggle = () => {
+  toggleActive.value = !toggleActive.value;
+};
+
+const fireToggleLoading = () => {
+  toggleLoading.value = true;
+
+  setTimeout(() => {
+    toggleLoading.value = false;
+  }, 2000);
+};
+
+const sliderMarks = (value: number) =>
+  value % 25 === 0 ? { label: `${value}%` } : false;
+
+const sliderTooltip = (value: number) => `${value}%`;
+
+const powerMarks = (value: number) => ({ label: String(value) });
+</script>
+
+<template>
+  <Heading :level="HeadingLevelEnum.H2">FormInput | Types</Heading>
+  <p>Every input type the component supports, each bound to live state.</p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput v-model="text" name="text" label="Text" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="number"
+        name="number"
+        label="Number"
+        :type="InputTypesEnum.NUMBER"
+        :step="1"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="password"
+        name="password"
+        label="Password"
+        :type="InputTypesEnum.PASSWORD"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="email"
+        name="email"
+        label="Email"
+        :type="InputTypesEnum.EMAIL"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="url"
+        name="url"
+        label="URL"
+        :type="InputTypesEnum.URL"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="color"
+        name="color"
+        label="Color"
+        :type="InputTypesEnum.COLOR"
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormInput | Variations</Heading>
+  <p>
+    Sizes, variants, alignment, affixes, icon labels and the clearable,
+    placeholder-only and disabled states.
+  </p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="large"
+        name="large"
+        label="Large"
+        :size="InputSizesEnum.LARGE"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="clean"
+        name="clean"
+        label="Clean"
+        :variant="InputVariantsEnum.CLEAN"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="rightAligned"
+        name="right-aligned"
+        label="Right aligned"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="clearable"
+        name="clearable"
+        label="Clearable"
+        clearable
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="prefixed"
+        name="prefixed"
+        label="With affixes"
+        :type="InputTypesEnum.NUMBER"
+        prefix="UEC"
+        suffix="/ SCU"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="text"
+        name="with-icon"
+        label="With icon"
+        icon="fa-duotone fa-rocket"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput
+        v-model="empty"
+        name="placeholder-only"
+        label="Hidden until filled"
+        placeholder="Search ships…"
+        hide-label-on-empty
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput v-model="text" name="disabled" label="Disabled" disabled />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormInputGroup</Heading>
+  <p>An input with a button glued to its trailing edge, baseline aligned.</p>
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <FormInputGroup>
+        <FormInput v-model="text" name="grouped" label="RSI Handle" />
+        <Btn :size="BtnSizesEnum.SMALL" inline>Verify</Btn>
+      </FormInputGroup>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormTextarea</Heading>
+  <p>Default and disabled.</p>
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <FormTextarea v-model="textarea" name="textarea" label="Description" />
+    </div>
+    <div class="col-12 col-md-6">
+      <FormTextarea
+        v-model="textarea"
+        name="textarea-disabled"
+        label="Description (disabled)"
+        disabled
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormCheckbox & FormToggle</Heading>
+  <p>
+    Checked, unchecked, partial (the select-all tri-state), disabled, inline,
+    and a multi-value group sharing one array.
+  </p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormCheckbox v-model="checkbox" name="checked" label="Checked" />
+      <FormCheckbox
+        v-model="checkboxUnchecked"
+        name="unchecked"
+        label="Unchecked"
+      />
+      <FormCheckbox name="partial" label="Partial" partial />
+      <FormCheckbox
+        v-model="checkbox"
+        name="checkbox-disabled"
+        label="Disabled"
+        disabled
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormCheckbox
+        v-model="checkboxGroup"
+        name="focus"
+        label="Cargo"
+        checkbox-value="cargo"
+      />
+      <FormCheckbox
+        v-model="checkboxGroup"
+        name="focus"
+        label="Combat"
+        checkbox-value="combat"
+      />
+      <FormCheckbox
+        v-model="checkboxGroup"
+        name="focus"
+        label="Exploration"
+        checkbox-value="exploration"
+      />
+      <p class="text-muted">Selected: {{ checkboxGroup.join(", ") || "—" }}</p>
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormCheckbox name="inline-a" label="Inline A" inline />
+      <FormCheckbox name="inline-b" label="Inline B" inline />
+      <FormCheckbox name="no-label" no-label inline />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormToggle v-model="toggleField" name="toggle-field" label="Public" />
+      <FormToggle
+        v-model="toggleField"
+        name="toggle-field-disabled"
+        label="Public (disabled)"
+        disabled
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormDatePicker</Heading>
+  <p>Bound to an ISO date string.</p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormDatePicker v-model="date" name="date" label="Bought at" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <p class="text-muted">Value: {{ date || "—" }}</p>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FormFileInput</Heading>
+  <p>The drop target, plus the avatar and transparent variants.</p>
+  <div class="row">
+    <div class="col-12 col-md-4">
+      <FormFileInput
+        v-model="file"
+        name="image"
+        label="Image"
+        :allowed-types="AllowedFileTypes.IMAGE"
+        :allowed-size-mb="5"
+        clearable
+      />
+    </div>
+    <div class="col-12 col-md-4">
+      <FormFileInput
+        v-model="file"
+        name="avatar"
+        label="Avatar"
+        :allowed-types="AllowedFileTypes.IMAGE"
+        clearable
+        avatar
+      />
+    </div>
+    <div class="col-12 col-md-4">
+      <FormFileInput
+        v-model="file"
+        name="transparent"
+        label="Transparent"
+        :allowed-types="AllowedFileTypes.IMAGE"
+        transparent
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">RadioList</Heading>
+  <p>Inline and stacked, with and without a reset option.</p>
+  <div class="row">
+    <div class="col-12 col-md-4">
+      <RadioList
+        v-model="radio"
+        name="size-inline"
+        label="Ship Size"
+        :options="radioOptions"
+      />
+    </div>
+    <div class="col-12 col-md-4">
+      <RadioList
+        v-model="radio"
+        name="size-reset"
+        label="Ship Size (resettable)"
+        reset-label="Any"
+        :options="radioOptions"
+      />
+    </div>
+    <div class="col-12 col-md-4">
+      <RadioList
+        v-model="radio"
+        name="size-stacked"
+        label="Ship Size (stacked, disabled)"
+        :options="radioOptions"
+        :inline="false"
+        disabled
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FilterGroup</Heading>
+  <p>
+    Single select, multi select with the selected-options rail, searchable, and
+    disabled. Options are static here — in the app they usually come from a
+    paginated query.
+  </p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FilterGroup
+        v-model="filterSingle"
+        name="filter-single"
+        label="Ship Size"
+        :options="sizeOptions"
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FilterGroup
+        v-model="filterMultiple"
+        name="filter-multiple"
+        label="Ship Sizes"
+        :options="sizeOptions"
+        multiple
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FilterGroup
+        v-model="filterSingle"
+        name="filter-searchable"
+        label="Ship Size (searchable)"
+        search-label="Find a size…"
+        :options="sizeOptions"
+        searchable
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FilterGroup
+        v-model="filterSingle"
+        name="filter-disabled"
+        label="Ship Size (disabled)"
+        :options="sizeOptions"
+        disabled
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Slider</Heading>
+  <p>
+    With a percentage tooltip and quarter marks, and a stepped variant with a
+    mark per stop.
+  </p>
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <Slider
+        v-model="sliderValue"
+        :marks="sliderMarks"
+        :tooltip-formatter="sliderTooltip"
+        process
+      />
+      <p class="text-muted">Value: {{ sliderValue }}</p>
+    </div>
+    <div class="col-12 col-md-6">
+      <Slider
+        v-model="sliderStepped"
+        :min="0"
+        :max="8"
+        :interval="1"
+        :marks="powerMarks"
+        :dot-size="14"
+      />
+      <p class="text-muted">Pips: {{ sliderStepped }}</p>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Toggle</Heading>
+  <p>
+    The standalone switch — not a form field, it just emits
+    <code>toggle</code>.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Toggle :active="toggleActive" label="Active" @toggle="toggleTheToggle" />
+      <Toggle :active="false" label="Inactive" @toggle="toggleTheToggle" />
+      <Toggle
+        :active="toggleActive"
+        :loading="toggleLoading"
+        label="Loading"
+        @toggle="fireToggleLoading"
+      />
+      <Toggle :active="toggleActive" label="Disabled" disabled />
+      <Toggle :active="toggleActive" label="Inline" inline />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Error States</Heading>
+  <p>
+    Fields validated on mount, so the invalid styling shows without interaction.
+    The message itself lives in each field's tooltip.
+  </p>
+  <ErrorStates />
+
+  <Heading :level="HeadingLevelEnum.H2">FormActions</Heading>
+  <p>
+    The submit/cancel footer. Submitting spins the save button; when
+    <code>dirty</code> is set, cancel asks for confirmation first.
+  </p>
+  <form id="visual-tests-form" @submit.prevent="onSubmit">
+    <FormActions
+      form-id="visual-tests-form"
+      :submitting="submitting"
+      dirty
+      @cancel="onCancel"
+    />
+  </form>
+  <form id="visual-tests-form-no-cancel" @submit.prevent="onSubmit">
+    <FormActions
+      form-id="visual-tests-form-no-cancel"
+      :submitting="submitting"
+      hide-cancel
+    />
+  </form>
+</template>

--- a/app/frontend/frontend/pages/visual-tests/forms.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms.vue
@@ -84,10 +84,22 @@ const sizeOptions: FilterOption[] = sizes;
 
 const submitting = ref(false);
 
+// Tracked so a pending fake round-trip cannot resolve after the page is gone and
+// push its notification onto whatever route the user landed on.
+const timers: ReturnType<typeof setTimeout>[] = [];
+
+const later = (callback: () => void, delay: number) => {
+  timers.push(setTimeout(callback, delay));
+};
+
+onBeforeUnmount(() => {
+  timers.forEach(clearTimeout);
+});
+
 const onSubmit = () => {
   submitting.value = true;
 
-  setTimeout(() => {
+  later(() => {
     submitting.value = false;
     displaySuccess({ text: "Form submitted." });
   }, 1500);
@@ -104,7 +116,7 @@ const toggleTheToggle = () => {
 const fireToggleLoading = () => {
   toggleLoading.value = true;
 
-  setTimeout(() => {
+  later(() => {
     toggleLoading.value = false;
   }, 2000);
 };

--- a/app/frontend/frontend/pages/visual-tests/forms/ErrorStates.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms/ErrorStates.vue
@@ -1,0 +1,58 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsFormsErrorStates",
+};
+</script>
+
+<script lang="ts" setup>
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import { useForm } from "vee-validate";
+
+// Only FormInput takes a `rules` prop, so the schema lives on the form — that
+// covers the components that call `useField` without one. Validated up front so
+// the invalid styling is visible without interaction; the message itself only
+// shows in the field's tooltip.
+const { validate } = useForm({
+  validationSchema: {
+    handle: "required",
+    contact: "required|email",
+    quantity: "required|min_value:1",
+    notes: "required",
+  },
+  initialValues: {
+    handle: "",
+    contact: "not-an-email",
+    quantity: 0,
+    notes: "",
+    terms: false,
+  },
+});
+
+onMounted(async () => {
+  await validate();
+});
+</script>
+
+<template>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput name="handle" label="Handle (required)" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput name="contact" label="Contact (email)" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormInput name="quantity" label="Quantity (min 1)" type="number" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <FormCheckbox name="terms" label="Accept terms" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <FormTextarea name="notes" label="Notes (required)" />
+    </div>
+  </div>
+</template>

--- a/app/frontend/frontend/pages/visual-tests/lists.vue
+++ b/app/frontend/frontend/pages/visual-tests/lists.vue
@@ -19,7 +19,7 @@ import { type FilterOption } from "@/services/fyApi";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { v4 as uuidv4 } from "uuid";
 
-const { displaySuccess } = useAppNotifications();
+const { displaySuccess, dismissConfirm } = useAppNotifications();
 
 type Dock = {
   id: string;
@@ -168,7 +168,11 @@ const bulkCopy = (selected: string[]) => {
   displaySuccess({ text: `Copied ${selected.length} docks.` });
 };
 
+// A pending destroy confirmation captured the item it was opened for, and
+// `buildDocks` hands back the same ids, so confirming after a reset would delete
+// a record from the freshly restored list.
 const resetDocks = () => {
+  dismissConfirm();
   docks.value = buildDocks();
   editableList.value?.finishEdit();
   editableList.value?.finishCreate();

--- a/app/frontend/frontend/pages/visual-tests/lists.vue
+++ b/app/frontend/frontend/pages/visual-tests/lists.vue
@@ -141,8 +141,27 @@ const onSaveCreate = () => {
   editableList.value?.finishCreate();
 };
 
+const expandedId = ref<string | null>(null);
+
+const toggleExpanded = (id: string) => {
+  expandedId.value = expandedId.value === id ? null : id;
+};
+
+// Selection deliberately survives `items` changing, so that select-all can span
+// pages — which means removing a record does not deselect it. The owner of the
+// records has to prune the id, or bulk actions keep counting a row nobody sees.
 const onDestroy = (item: Dock) => {
   docks.value = docks.value.filter((entry) => entry.id !== item.id);
+
+  if (editableList.value) {
+    editableList.value.selected = editableList.value.selected.filter(
+      (id) => id !== item.id,
+    );
+  }
+
+  if (expandedId.value === item.id) {
+    expandedId.value = null;
+  }
 };
 
 const bulkCopy = (selected: string[]) => {
@@ -151,13 +170,10 @@ const bulkCopy = (selected: string[]) => {
 
 const resetDocks = () => {
   docks.value = buildDocks();
+  editableList.value?.finishEdit();
+  editableList.value?.finishCreate();
   editableList.value?.resetSelected();
-};
-
-const expandedId = ref<string | null>(null);
-
-const toggleExpanded = (id: string) => {
-  expandedId.value = expandedId.value === id ? null : id;
+  expandedId.value = null;
 };
 
 // ── InlineEditableList | actions-only ────────────────────────────────

--- a/app/frontend/frontend/pages/visual-tests/lists.vue
+++ b/app/frontend/frontend/pages/visual-tests/lists.vue
@@ -1,0 +1,479 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsListsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import ListGroup from "@/shared/components/ListGroup/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import { type AsyncStatus } from "@/shared/components/AsyncData.types";
+import { type FilterOption } from "@/services/fyApi";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { v4 as uuidv4 } from "uuid";
+
+const { displaySuccess } = useAppNotifications();
+
+type Dock = {
+  id: string;
+  name: string;
+  dockType: string;
+  shipSize: string;
+};
+
+const dockTypeOptions: FilterOption[] = [
+  { label: "Vehicle Pad", value: "vehiclepad" },
+  { label: "Garage", value: "garage" },
+  { label: "Landing Pad", value: "landingpad" },
+  { label: "Docking Port", value: "dockingport" },
+  { label: "Hangar", value: "hangar" },
+];
+
+const shipSizeOptions: FilterOption[] = [
+  { label: "Small", value: "small" },
+  { label: "Medium", value: "medium" },
+  { label: "Large", value: "large" },
+  { label: "Capital", value: "capital" },
+];
+
+const optionLabel = (options: FilterOption[], value: string) =>
+  options.find((option) => option.value === value)?.label || value;
+
+const buildDocks = (): Dock[] => [
+  {
+    id: "dock-1",
+    name: "Forward Bay",
+    dockType: "hangar",
+    shipSize: "large",
+  },
+  {
+    id: "dock-2",
+    name: "Port Pad",
+    dockType: "landingpad",
+    shipSize: "medium",
+  },
+  {
+    id: "dock-3",
+    name: "Starboard Pad",
+    dockType: "landingpad",
+    shipSize: "medium",
+  },
+  {
+    id: "dock-4",
+    name: "Rover Garage",
+    dockType: "garage",
+    shipSize: "small",
+  },
+];
+
+// ── ListGroup ────────────────────────────────────────────────────────
+
+const listGroupItems = ref(buildDocks());
+
+// ── InlineEditableList | full ────────────────────────────────────────
+
+type EditableListRef = {
+  editingId: string | null;
+  creating: boolean;
+  selected: string[];
+  startCreate: () => void;
+  finishEdit: () => void;
+  finishCreate: () => void;
+  resetSelected: () => void;
+} | null;
+
+const editableList = ref<EditableListRef>(null);
+
+const docks = ref(buildDocks());
+
+const editForm = ref<Partial<Dock>>({});
+
+const onStartEdit = (item: Dock) => {
+  editForm.value = {
+    name: item.name,
+    dockType: item.dockType,
+    shipSize: item.shipSize,
+  };
+};
+
+const onSaveEdit = () => {
+  const id = editableList.value?.editingId;
+
+  if (!id) {
+    return;
+  }
+
+  docks.value = docks.value.map((item) =>
+    item.id === id ? { ...item, ...editForm.value } : item,
+  );
+
+  editableList.value?.finishEdit();
+};
+
+const createForm = ref<Partial<Dock>>({});
+
+const onStartCreate = () => {
+  createForm.value = {
+    name: "",
+    dockType: "landingpad",
+    shipSize: "medium",
+  };
+};
+
+const onSaveCreate = () => {
+  docks.value = [
+    ...docks.value,
+    {
+      id: uuidv4(),
+      name: createForm.value.name || "Unnamed Dock",
+      dockType: createForm.value.dockType || "landingpad",
+      shipSize: createForm.value.shipSize || "medium",
+    },
+  ];
+
+  editableList.value?.finishCreate();
+};
+
+const onDestroy = (item: Dock) => {
+  docks.value = docks.value.filter((entry) => entry.id !== item.id);
+};
+
+const bulkCopy = (selected: string[]) => {
+  displaySuccess({ text: `Copied ${selected.length} docks.` });
+};
+
+const resetDocks = () => {
+  docks.value = buildDocks();
+  editableList.value?.resetSelected();
+};
+
+const expandedId = ref<string | null>(null);
+
+const toggleExpanded = (id: string) => {
+  expandedId.value = expandedId.value === id ? null : id;
+};
+
+// ── InlineEditableList | actions-only ────────────────────────────────
+
+const readOnlyDocks = ref(buildDocks());
+
+// ── FilteredList ─────────────────────────────────────────────────────
+
+const filteredListLoading = ref(false);
+const filteredListRefetching = ref(false);
+const filteredListError = ref(false);
+const filteredListRecords = ref(buildDocks());
+const filteredListSize = ref<string | null>(null);
+
+const asyncStatus: AsyncStatus = {
+  fetchStatus: computed(() =>
+    filteredListLoading.value ? "fetching" : "idle",
+  ),
+  isError: computed(() => filteredListError.value),
+  isPending: computed(() => filteredListLoading.value),
+  isLoading: computed(() => filteredListLoading.value),
+  isFetching: computed(
+    () => filteredListLoading.value || filteredListRefetching.value,
+  ),
+  isRefetching: computed(() => filteredListRefetching.value),
+  error: computed(() =>
+    filteredListError.value ? new Error("Simulated request failure") : null,
+  ),
+};
+
+const toggleFilteredListLoading = () => {
+  filteredListLoading.value = !filteredListLoading.value;
+};
+
+const toggleFilteredListRefetching = () => {
+  filteredListRefetching.value = !filteredListRefetching.value;
+};
+
+const toggleFilteredListError = () => {
+  filteredListError.value = !filteredListError.value;
+};
+
+const toggleFilteredListEmpty = () => {
+  filteredListRecords.value = filteredListRecords.value.length
+    ? []
+    : buildDocks();
+};
+</script>
+
+<template>
+  <Heading :level="HeadingLevelEnum.H2">ListGroup</Heading>
+  <p>
+    The plain list container behind the editable list — rows with a display and
+    an actions area, plus its own loading and empty states.
+  </p>
+  <div class="row">
+    <div class="col-12 col-xl-6">
+      <ListGroup :items="listGroupItems" empty-name="Docks">
+        <template #display="{ item }">
+          <BasePill uppercase margin-right>
+            {{ optionLabel(dockTypeOptions, item.dockType) }}
+          </BasePill>
+          <span>{{ item.name }}</span>
+        </template>
+        <template #actions="{ item }">
+          <Btn
+            :size="BtnSizesEnum.SMALL"
+            inline
+            @click="displaySuccess({ text: `Picked ${item.name}` })"
+          >
+            <i class="fa-duotone fa-arrow-right" />
+          </Btn>
+        </template>
+      </ListGroup>
+    </div>
+    <div class="col-12 col-xl-6">
+      <ListGroup :items="[]" empty-name="Docks" loading />
+      <ListGroup :items="[]" empty-name="Docks" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">InlineEditableList</Heading>
+  <p>
+    Fully wired against local state — create, edit and destroy all mutate the
+    list in place. Rows are selectable, and the expand toggle opens the
+    <code>expanded</code> slot.
+  </p>
+  <div class="flex items-center justify-between">
+    <div>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :disabled="editableList?.creating"
+        data-test="start-create"
+        @click="editableList?.startCreate()"
+      >
+        <i class="fa-duotone fa-plus" />
+        Add
+      </Btn>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        data-test="reset-docks"
+        @click="resetDocks"
+      >
+        <i class="fa-duotone fa-rotate-left" />
+        Reset
+      </Btn>
+    </div>
+  </div>
+
+  <InlineEditableList
+    ref="editableList"
+    empty-name="Docks"
+    selectable
+    :items="docks"
+    confirm-destroy-text="Really destroy this dock?"
+    @start-edit="onStartEdit"
+    @save-edit="onSaveEdit"
+    @start-create="onStartCreate"
+    @save-create="onSaveCreate"
+    @destroy="onDestroy"
+  >
+    <template #selected-actions="{ selected }">
+      <Btn :size="BtnSizesEnum.SMALL" @click="bulkCopy(selected)">
+        <i class="fa-duotone fa-copy" />
+        Copy
+      </Btn>
+    </template>
+
+    <template #display="{ item }">
+      <BasePill uppercase margin-right>
+        {{ optionLabel(dockTypeOptions, item.dockType) }}
+      </BasePill>
+      <BasePill margin-right>
+        {{ optionLabel(shipSizeOptions, item.shipSize) }}
+      </BasePill>
+      <span>{{ item.name }}</span>
+    </template>
+
+    <template #edit>
+      <FilterGroup
+        v-model="editForm.dockType"
+        name="edit-dock-type"
+        :options="dockTypeOptions"
+        :nullable="false"
+        label="Dock Type"
+      />
+      <FilterGroup
+        v-model="editForm.shipSize"
+        name="edit-ship-size"
+        :options="shipSizeOptions"
+        :nullable="false"
+        label="Ship Size"
+      />
+      <FormInput v-model="editForm.name" name="edit-name" label="Name" />
+    </template>
+
+    <template #create>
+      <FilterGroup
+        v-model="createForm.dockType"
+        name="create-dock-type"
+        :options="dockTypeOptions"
+        :nullable="false"
+        label="Dock Type"
+      />
+      <FilterGroup
+        v-model="createForm.shipSize"
+        name="create-ship-size"
+        :options="shipSizeOptions"
+        :nullable="false"
+        label="Ship Size"
+      />
+      <FormInput v-model="createForm.name" name="create-name" label="Name" />
+    </template>
+
+    <template #actions="{ item, mobile }">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :class="expandedId === item.id ? 'text-primary' : ''"
+        data-test="toggle-expanded"
+        @click="toggleExpanded(item.id)"
+      >
+        <i class="fa-duotone fa-chevron-down" />
+        <span v-if="mobile">Details</span>
+      </Btn>
+    </template>
+
+    <template #expanded="{ item }">
+      <div v-if="expandedId === item.id" class="visual-tests-lists__expanded">
+        The <code>expanded</code> slot for <strong>{{ item.name }}</strong> —
+        rendered below the row, full width.
+      </div>
+    </template>
+  </InlineEditableList>
+
+  <Heading :level="HeadingLevelEnum.H2">
+    InlineEditableList | Custom Actions Only
+  </Heading>
+  <p>
+    With <code>hide-edit</code> and <code>hide-destroy</code> the built-in
+    buttons drop out and the <code>actions</code> slot renders bare — no button
+    group, no mobile dropdown.
+  </p>
+  <InlineEditableList
+    empty-name="Docks"
+    hide-edit
+    hide-destroy
+    :items="readOnlyDocks"
+  >
+    <template #display="{ item }">
+      <span>{{ item.name }}</span>
+    </template>
+    <template #actions="{ item }">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        inline
+        @click="displaySuccess({ text: `Pinned ${item.name}` })"
+      >
+        <i class="fa-duotone fa-thumbtack" />
+      </Btn>
+    </template>
+  </InlineEditableList>
+
+  <Heading :level="HeadingLevelEnum.H2">
+    InlineEditableList | Loading & Empty
+  </Heading>
+  <p>Both states are delegated to the underlying ListGroup.</p>
+  <div class="row">
+    <div class="col-12 col-xl-6">
+      <InlineEditableList :items="[]" empty-name="Docks" loading />
+    </div>
+    <div class="col-12 col-xl-6">
+      <InlineEditableList :items="[]" empty-name="Docks" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">FilteredList</Heading>
+  <p>
+    The list shell used by the ships, hangar and fleet pages — filter drawer,
+    action bars and the loading / empty / error states it derives from the query
+    status.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :active="filteredListLoading"
+        data-test="toggle-filtered-list-loading"
+        @click="toggleFilteredListLoading"
+      >
+        Loading
+      </Btn>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :active="filteredListRefetching"
+        data-test="toggle-filtered-list-refetching"
+        @click="toggleFilteredListRefetching"
+      >
+        Refetching
+      </Btn>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :active="!filteredListRecords.length"
+        data-test="toggle-filtered-list-empty"
+        @click="toggleFilteredListEmpty"
+      >
+        Empty
+      </Btn>
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :active="filteredListError"
+        data-test="toggle-filtered-list-error"
+        @click="toggleFilteredListError"
+      >
+        Error
+      </Btn>
+    </div>
+  </div>
+
+  <FilteredList
+    name="visual-tests-docks"
+    :records="filteredListRecords"
+    :async-status="asyncStatus"
+    :is-filter-selected="!!filteredListSize"
+  >
+    <template #actions-left>
+      <Btn :size="BtnSizesEnum.SMALL">
+        <i class="fa-duotone fa-plus" />
+      </Btn>
+    </template>
+    <template #actions-right="{ records }">
+      <span class="text-muted">{{ records.length }} docks</span>
+    </template>
+    <template #filter>
+      <FilterGroup
+        v-model="filteredListSize"
+        name="filtered-list-ship-size"
+        :options="shipSizeOptions"
+        label="Ship Size"
+      />
+    </template>
+    <template #default="{ records }">
+      <ListGroup :items="records" empty-name="Docks">
+        <template #display="{ item }">
+          <BasePill uppercase margin-right>
+            {{ optionLabel(shipSizeOptions, item.shipSize) }}
+          </BasePill>
+          <span>{{ item.name }}</span>
+        </template>
+      </ListGroup>
+    </template>
+  </FilteredList>
+</template>
+
+<style lang="scss" scoped>
+.visual-tests-lists__expanded {
+  padding: 12px 16px;
+  color: $gray-light;
+}
+</style>

--- a/app/frontend/frontend/pages/visual-tests/metrics.vue
+++ b/app/frontend/frontend/pages/visual-tests/metrics.vue
@@ -1,0 +1,326 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsMetricsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import BaseText from "@/shared/components/base/Text/index.vue";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
+import MetricsList from "@/shared/components/MetricsList/index.vue";
+import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
+import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
+import ModelSpeedMetrics from "@/frontend/components/Models/SpeedMetrics/index.vue";
+import ModelCargoMetrics from "@/frontend/components/Models/CargoMetrics/index.vue";
+import ModelPanelMetrics from "@/frontend/components/Models/PanelMetrics/index.vue";
+import ModelCombatMetrics from "@/frontend/components/Models/CombatMetrics/index.vue";
+import ModelDefenseMetrics from "@/frontend/components/Models/DefenseMetrics/index.vue";
+import ModelHullMetrics from "@/frontend/components/Models/HullMetrics/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import {
+  HardpointSourceEnum,
+  useModel as useModelQuery,
+  useModelHardpoints as useModelHardpointsQuery,
+  type Hardpoint,
+} from "@/services/fyApi";
+
+// An in-game combat ship, so the combat, survivability and hull cards all have
+// something to render — a concept ship has no game-file hardpoints and they all
+// self-hide.
+const SLUG = "rsi-constellation-andromeda";
+
+const { data: model } = useModelQuery(SLUG);
+
+const hardpointsParams = computed(() => ({
+  source: model.value?.inGame
+    ? HardpointSourceEnum.GAME_FILES
+    : HardpointSourceEnum.SHIP_MATRIX,
+}));
+
+const { data: hardpointsData, isLoading: hardpointsLoading } =
+  useModelHardpointsQuery(SLUG, hardpointsParams);
+
+const hardpoints = computed(
+  () => (hardpointsData.value as Hardpoint[] | undefined) || [],
+);
+
+provide(
+  "modelSlug",
+  computed(() => SLUG),
+);
+
+provide(
+  "weaponPoolSize",
+  computed(() => model.value?.metrics?.weaponPoolSize),
+);
+
+provide(
+  "quantumFuelTankSize",
+  computed(() => model.value?.metrics?.quantumFuelTankSize),
+);
+
+const extended = ref(false);
+
+const toggleExtended = () => {
+  extended.value = !extended.value;
+};
+
+const sampleMetrics = [
+  { id: "length", label: "Length", value: "128.0 m" },
+  { id: "beam", label: "Beam", value: "70.0 m" },
+  { id: "height", label: "Height", value: "26.5 m" },
+  { id: "mass", label: "Mass", value: "3,568,000 kg" },
+];
+</script>
+
+<template>
+  <Heading :level="HeadingLevelEnum.H2">MetricsCard | Frame</Heading>
+  <p>
+    The bare card frame — title with status dot, optional <code>head</code> slot
+    and a body slot. The default variant carries the end caps; the
+    <code>slim</code> variant drops them for repeated cards (hardpoint groups).
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="Default Variant">
+        Body content goes here. The frame makes no assumptions about what it
+        wraps.
+      </MetricsCard>
+    </div>
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="With Head Slot">
+        <template #head>
+          <Btn :size="BtnSizesEnum.SMALL" inline>
+            <i class="fa-duotone fa-arrow-up-right-from-square" />
+          </Btn>
+        </template>
+        The <code>head</code> slot sits next to the title — used for card-level
+        actions.
+      </MetricsCard>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="Slim Variant" variant="slim">
+        No end caps, thinner border, header divider.
+      </MetricsCard>
+    </div>
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="Slim | Stacked" variant="slim">
+        Slim cards are meant to repeat, so their bottom margin is tighter.
+      </MetricsCard>
+      <MetricsCard title="Slim | Stacked" variant="slim">
+        A second card, to check the rhythm between them.
+      </MetricsCard>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2"
+    >MetricsCard | Content Primitives</Heading
+  >
+  <p>
+    The tile grid, auxiliary row, divider and footer classes that slotted card
+    content uses. Tiles flex, so a card fills with however many are present.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="Three Tiles">
+        <div class="metrics-card__hero">
+          <div class="metrics-card__tile metrics-card__tile--primary">
+            <div class="metrics-card__tile__label">Burst</div>
+            <div class="metrics-card__tile__value">
+              4,182
+              <span class="metrics-card__tile__unit">DPS</span>
+            </div>
+            <div class="metrics-card__tile__sub">across 8 weapons</div>
+          </div>
+          <div class="metrics-card__tile">
+            <div class="metrics-card__tile__label">Sustained</div>
+            <div class="metrics-card__tile__value">
+              2,904
+              <span class="metrics-card__tile__unit">DPS</span>
+            </div>
+            <div class="metrics-card__tile__sub">with power throttle</div>
+          </div>
+          <div class="metrics-card__tile">
+            <div class="metrics-card__tile__label">Alpha</div>
+            <div class="metrics-card__tile__value">
+              1,140
+              <span class="metrics-card__tile__unit">DMG</span>
+            </div>
+            <div class="metrics-card__tile__sub">single volley</div>
+          </div>
+        </div>
+        <div class="metrics-card__aux">
+          <span class="metrics-card__aux-label">Missile Payload</span>
+          <span class="metrics-card__aux-value">18,240</span>
+        </div>
+        <div class="metrics-card__divider" />
+        <div class="metrics-card__section-label">Breakdown</div>
+        <MetricsList :metrics="sampleMetrics" />
+        <div class="metrics-card__footer">
+          <button type="button" class="metrics-card__toggle">
+            Show details
+          </button>
+          <span class="metrics-card__hint">
+            Values are derived from game files.
+          </span>
+        </div>
+      </MetricsCard>
+    </div>
+    <div class="col-12 col-lg-6">
+      <MetricsCard title="Single Tile">
+        <div class="metrics-card__hero">
+          <div class="metrics-card__tile metrics-card__tile--primary">
+            <div class="metrics-card__tile__label">Hull</div>
+            <div class="metrics-card__tile__value">
+              1,284,000
+              <span class="metrics-card__tile__unit">HP</span>
+            </div>
+            <div class="metrics-card__tile__sub">
+              six figures, to check clamping
+            </div>
+          </div>
+        </div>
+      </MetricsCard>
+      <MetricsCard title="Six Tiles" variant="slim">
+        <div class="metrics-card__hero">
+          <div
+            v-for="index in 6"
+            :key="`tile-${index}`"
+            class="metrics-card__tile"
+          >
+            <div class="metrics-card__tile__label">Stat {{ index }}</div>
+            <div class="metrics-card__tile__value">
+              {{ index * 137 }}
+              <span class="metrics-card__tile__unit">u</span>
+            </div>
+          </div>
+        </div>
+      </MetricsCard>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">MetricsList</Heading>
+  <p>
+    Label/value pairs in two columns. The items are half-width with the value
+    pushed right, so the pairs only read as pairs in a narrow container — the
+    wide row below shows how far apart they drift at full width. It carries no
+    padding of its own, so inside a panel it needs a
+    <code>PanelBody</code> around it.
+  </p>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-4">
+      <BaseText muted no-spacing>standalone, narrow</BaseText>
+      <MetricsList :metrics="sampleMetrics" />
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+      <BaseText muted no-spacing>in a panel body</BaseText>
+      <Panel slim>
+        <PanelBody>
+          <MetricsList :metrics="sampleMetrics" />
+        </PanelBody>
+      </Panel>
+    </div>
+    <div class="col-12 col-lg-4">
+      <BaseText muted no-spacing>empty — renders nothing</BaseText>
+      <MetricsList :metrics="[]" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <BaseText muted no-spacing>standalone, full width</BaseText>
+      <MetricsList :metrics="sampleMetrics" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Model Metrics | Panel Rails</Heading>
+  <p>
+    The rail panels from the ship detail page, fed with live
+    <code>{{ SLUG }}</code> data.
+    <Btn :size="BtnSizesEnum.SMALL" inline @click="toggleExtended">
+      {{ extended ? "Collapse" : "Extend" }} dimensions
+    </Btn>
+  </p>
+  <div v-if="model" class="row">
+    <div class="col-12 col-lg-4">
+      <Panel slim>
+        <ModelBaseMetrics :model="model" :extended="extended" />
+      </Panel>
+    </div>
+    <div class="col-12 col-lg-4">
+      <Panel slim>
+        <ModelCrewMetrics :model="model" />
+      </Panel>
+    </div>
+    <div class="col-12 col-lg-4">
+      <Panel slim>
+        <ModelSpeedMetrics :model="model" />
+      </Panel>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Model Metrics | Panel Summary</Heading>
+  <p>The compact metrics block used inside model panels.</p>
+  <div v-if="model" class="row">
+    <div class="col-12 col-lg-6">
+      <Panel slim>
+        <ModelPanelMetrics :model="model" />
+      </Panel>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Model Metrics | Cargo</Heading>
+  <p>Container capacity per size, derived from the model's cargo holds.</p>
+  <ModelCargoMetrics v-if="model" :model="model" />
+
+  <Heading :level="HeadingLevelEnum.H2"
+    >Model Metrics | Combat & Survivability</Heading
+  >
+  <p>
+    The metrics-card family on the ship detail page, fed with the live game-file
+    hardpoints of <code>{{ SLUG }}</code
+    >.
+    <template v-if="hardpointsLoading"> Loading hardpoints…</template>
+  </p>
+  <div v-if="model" class="row">
+    <div class="col-12 col-lg-4">
+      <ModelCombatMetrics :hardpoints="hardpoints" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <ModelDefenseMetrics :hardpoints="hardpoints" :model-name="model.name" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <ModelHullMetrics
+        :hull-health="model.metrics.hullHealth"
+        :hull-parts="model.metrics.hullParts"
+        :hull-doors="model.metrics.hullDoors"
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Model Metrics | No Data</Heading>
+  <p>
+    Combat, survivability and hull cards all self-hide when there is nothing to
+    show — nothing should render below this line.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-4">
+      <ModelCombatMetrics :hardpoints="[]" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <ModelDefenseMetrics :hardpoints="[]" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <ModelHullMetrics />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/frontend/components/Models/metricsCard";
+</style>

--- a/app/frontend/frontend/pages/visual-tests/routes.ts
+++ b/app/frontend/frontend/pages/visual-tests/routes.ts
@@ -27,6 +27,51 @@ export const routes = [
     },
   },
   {
+    path: "typography/",
+    name: "visual-tests-typography",
+    component: () => import("@/frontend/pages/visual-tests/typography.vue"),
+    meta: {
+      title: "visualTests.typography",
+      backgroundImage: "bg-7",
+    },
+  },
+  {
+    path: "forms/",
+    name: "visual-tests-forms",
+    component: () => import("@/frontend/pages/visual-tests/forms.vue"),
+    meta: {
+      title: "visualTests.forms",
+      backgroundImage: "bg-7",
+    },
+  },
+  {
+    path: "lists/",
+    name: "visual-tests-lists",
+    component: () => import("@/frontend/pages/visual-tests/lists.vue"),
+    meta: {
+      title: "visualTests.lists",
+      backgroundImage: "bg-7",
+    },
+  },
+  {
+    path: "metrics/",
+    name: "visual-tests-metrics",
+    component: () => import("@/frontend/pages/visual-tests/metrics.vue"),
+    meta: {
+      title: "visualTests.metrics",
+      backgroundImage: "bg-7",
+    },
+  },
+  {
+    path: "states/",
+    name: "visual-tests-states",
+    component: () => import("@/frontend/pages/visual-tests/states.vue"),
+    meta: {
+      title: "visualTests.states",
+      backgroundImage: "bg-7",
+    },
+  },
+  {
     path: "notifications/",
     name: "visual-tests-notifications",
     component: () => import("@/frontend/pages/visual-tests/notifications.vue"),

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -36,13 +36,20 @@ const bumpProgress = () => {
 
 const fixedLoaderVisible = ref(false);
 
+let fixedLoaderTimer: ReturnType<typeof setTimeout> | undefined;
+
 const showFixedLoader = () => {
   fixedLoaderVisible.value = true;
 
-  setTimeout(() => {
+  clearTimeout(fixedLoaderTimer);
+  fixedLoaderTimer = setTimeout(() => {
     fixedLoaderVisible.value = false;
   }, 2000);
 };
+
+onBeforeUnmount(() => {
+  clearTimeout(fixedLoaderTimer);
+});
 
 const paginated: BaseList = {
   meta: {

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -1,0 +1,248 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsStatesPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import BaseText from "@/shared/components/base/Text/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
+import NotAuthorized from "@/shared/components/NotAuthorized/index.vue";
+import NotFound from "@/shared/components/NotFound/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import ProgressBar from "@/shared/components/ProgressBar/index.vue";
+import ServerError from "@/shared/components/ServerError/index.vue";
+import SmallLoader from "@/shared/components/SmallLoader/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import {
+  type BaseList,
+  useModelsLatest as useLatestModelsQuery,
+} from "@/services/fyApi";
+
+const { isFetching: latestModelsFetching, refetch: refetchLatestModels } =
+  useLatestModelsQuery();
+
+const progress = ref(35);
+
+const bumpProgress = () => {
+  progress.value = progress.value >= 100 ? 0 : progress.value + 15;
+};
+
+const fixedLoaderVisible = ref(false);
+
+const showFixedLoader = () => {
+  fixedLoaderVisible.value = true;
+
+  setTimeout(() => {
+    fixedLoaderVisible.value = false;
+  }, 2000);
+};
+
+const paginated: BaseList = {
+  meta: {
+    pagination: {
+      totalCount: 248,
+      currentPage: 1,
+      totalPages: 10,
+      perPage: 25,
+      defaultPerPage: 25,
+      maxPerPage: 100,
+      perPageSteps: [25, 50, 100],
+    },
+  },
+};
+
+const singlePage: BaseList = {
+  meta: {
+    pagination: {
+      totalCount: 8,
+      currentPage: 1,
+      totalPages: 1,
+      perPage: 25,
+      defaultPerPage: 25,
+    },
+  },
+};
+
+const perPage = ref<number | string>(25);
+
+const updatePerPage = (value: number | string) => {
+  perPage.value = value;
+};
+</script>
+
+<template>
+  <Heading :level="HeadingLevelEnum.H2">Empty</Heading>
+  <p>
+    The no-records state. The <code>box</code> variant wraps itself in a large
+    panel; the bare variant is for use inside one. Actions only appear when the
+    route carries filters or a page — append <code>?page=2</code> to this URL to
+    see them.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Empty :variant="EmptyVariantsEnum.BOX" name="Ships" />
+    </div>
+    <div class="col-12 col-lg-6">
+      <Panel>
+        <PanelBody>
+          <Empty name="Ships" />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Empty :variant="EmptyVariantsEnum.BOX" hide-actions />
+    </div>
+    <div class="col-12 col-lg-6">
+      <Empty
+        :variant="EmptyVariantsEnum.BOX"
+        name="Docks"
+        inline
+        hide-actions
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Empty :variant="EmptyVariantsEnum.BOX" hide-actions>
+        <template #headline>A custom headline</template>
+        <template #info>
+          <BaseText muted>
+            And custom info copy, replacing the default explanation.
+          </BaseText>
+        </template>
+      </Empty>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Loader</Heading>
+  <p>
+    The cube loader. <code>relative</code> and <code>inline</code> sit in the
+    flow; <code>fixed</code> overlays the viewport, so it is behind a button.
+    <code>progress</code> draws the two edge bars.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-3">
+      <BaseText muted no-spacing>relative</BaseText>
+      <Loader loading relative />
+    </div>
+    <div class="col-12 col-lg-3">
+      <BaseText muted no-spacing>inline</BaseText>
+      <Loader loading inline />
+    </div>
+    <div class="col-12 col-lg-3">
+      <BaseText muted no-spacing>admin</BaseText>
+      <Loader loading relative admin />
+    </div>
+    <div class="col-12 col-lg-3">
+      <BaseText muted no-spacing>with progress ({{ progress }}%)</BaseText>
+      <Loader loading relative :progress="progress" />
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        data-test="bump-progress"
+        @click="bumpProgress"
+      >
+        Advance
+      </Btn>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        data-test="show-fixed-loader"
+        @click="showFixedLoader"
+      >
+        Show fixed loader (2s)
+      </Btn>
+      <Loader :loading="fixedLoaderVisible" fixed />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">SmallLoader</Heading>
+  <p>The inline rhombus spinner, at each alignment.</p>
+  <div class="row">
+    <div class="col-12 col-lg-4">
+      <BaseText muted no-spacing>left</BaseText>
+      <SmallLoader loading alignment="left" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <BaseText muted no-spacing>center</BaseText>
+      <SmallLoader loading alignment="center" />
+    </div>
+    <div class="col-12 col-lg-4">
+      <BaseText muted no-spacing>right</BaseText>
+      <SmallLoader loading alignment="right" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">ProgressBar</Heading>
+  <p>Fill with a percentage label.</p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <ProgressBar :progress="0" />
+      <ProgressBar :progress="progress" />
+      <ProgressBar :progress="100" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Paginator</Heading>
+  <p>
+    Ten pages with a per-page dropdown, and a single-page result. Page links
+    write to the route, so clicking one navigates this page.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Paginator
+        :query-result-ref="paginated"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <Paginator :query-result-ref="paginated" inline />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <Paginator :query-result-ref="singlePage" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Error Pages</Heading>
+  <p>
+    The three full-page error blocks. They are normally rendered as a whole
+    route, so they bring their own heading.
+  </p>
+  <NotFound />
+  <NotAuthorized />
+  <ServerError />
+
+  <Heading :level="HeadingLevelEnum.H2">FetchProgressBar</Heading>
+  <p>
+    The top-of-viewport bar is driven by the global in-flight query count, not
+    by props — it is already mounted app-wide. Refetching a real query runs it.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Btn
+        :size="BtnSizesEnum.SMALL"
+        :disabled="latestModelsFetching"
+        data-test="trigger-fetch"
+        @click="refetchLatestModels"
+      >
+        Refetch latest models
+      </Btn>
+    </div>
+  </div>
+</template>

--- a/app/frontend/frontend/pages/visual-tests/typography.vue
+++ b/app/frontend/frontend/pages/visual-tests/typography.vue
@@ -1,0 +1,318 @@
+<script lang="ts">
+export default {
+  name: "VisualTestsTypographyPage",
+};
+</script>
+
+<script lang="ts" setup>
+import BaseGrid from "@/shared/components/base/Grid/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import BaseText from "@/shared/components/base/Text/index.vue";
+import Box from "@/shared/components/Box/index.vue";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import Spacer from "@/shared/components/base/Spacer/index.vue";
+import {
+  HeadingAlignmentEnum,
+  HeadingLevelEnum,
+  HeadingSizeEnum,
+} from "@/shared/components/base/Heading/types";
+import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
+
+const headingSizes = [
+  HeadingSizeEnum.LG,
+  HeadingSizeEnum.XL,
+  HeadingSizeEnum.XXL,
+  HeadingSizeEnum.HERO_SM,
+  HeadingSizeEnum.HERO,
+];
+
+const headingLevels = [
+  HeadingLevelEnum.H1,
+  HeadingLevelEnum.H2,
+  HeadingLevelEnum.H3,
+  HeadingLevelEnum.H4,
+];
+
+const headingAlignments = [
+  HeadingAlignmentEnum.LEFT,
+  HeadingAlignmentEnum.CENTER,
+  HeadingAlignmentEnum.RIGHT,
+];
+
+const pillVariants = ["default", "success", "warning", "danger"] as const;
+
+const gridRecords = [
+  { id: "1", name: "Galaxy", manufacturer: "RSI" },
+  { id: "2", name: "Carrack", manufacturer: "Anvil" },
+  { id: "3", name: "Corsair", manufacturer: "Drake" },
+  { id: "4", name: "Zeus Mk II", manufacturer: "RSI" },
+  { id: "5", name: "Polaris", manufacturer: "RSI" },
+  { id: "6", name: "Perseus", manufacturer: "RSI" },
+];
+</script>
+
+<template>
+  <Heading :level="HeadingLevelEnum.H2">Heading | Sizes</Heading>
+  <p>
+    Each size in the hero face (Orbitron) and the body face (Open Sans). The
+    <code>hero</code> flag picks the face; <code>size</code> is independent of
+    the semantic <code>level</code>.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Heading
+        v-for="size in headingSizes"
+        :key="`hero-${size}`"
+        :level="HeadingLevelEnum.H3"
+        :size="size"
+        hero
+      >
+        Hero / {{ size }}
+      </Heading>
+    </div>
+    <div class="col-12 col-lg-6">
+      <Heading
+        v-for="size in headingSizes"
+        :key="`sans-${size}`"
+        :level="HeadingLevelEnum.H3"
+        :size="size"
+      >
+        Open Sans / {{ size }}
+      </Heading>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Heading | Levels</Heading>
+  <p>
+    Semantic levels at a fixed size — the tag changes, the rendering does not.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Heading
+        v-for="level in headingLevels"
+        :key="`level-${level}`"
+        :level="level"
+        :size="HeadingSizeEnum.XL"
+      >
+        {{ level }}
+      </Heading>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Heading | Alignment</Heading>
+  <p>Left, center and right, with and without an inline sub heading.</p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Heading
+        v-for="alignment in headingAlignments"
+        :key="`stacked-${alignment}`"
+        :level="HeadingLevelEnum.H3"
+        :size="HeadingSizeEnum.XL"
+        :alignment="alignment"
+      >
+        {{ alignment }}
+        <template #subHeading>stacked sub heading</template>
+      </Heading>
+    </div>
+    <div class="col-12 col-lg-6">
+      <Heading
+        v-for="alignment in headingAlignments"
+        :key="`inline-${alignment}`"
+        :level="HeadingLevelEnum.H3"
+        :size="HeadingSizeEnum.XL"
+        :alignment="alignment"
+        inline-sub-heading
+      >
+        {{ alignment }}
+        <template #subHeading>inline sub heading</template>
+      </Heading>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Heading | Modifiers</Heading>
+  <p>
+    Text shadow, truncation, and the margin helpers. There is also
+    <code>hidden</code>, which renders screen-reader-only — nothing visible
+    should appear for it.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Heading :level="HeadingLevelEnum.H3" :size="HeadingSizeEnum.XL" shadow>
+        With text shadow
+      </Heading>
+      <Heading :level="HeadingLevelEnum.H3" :size="HeadingSizeEnum.XL" mt mb>
+        With top and bottom margin
+      </Heading>
+      <Heading :level="HeadingLevelEnum.H3" :size="HeadingSizeEnum.XL" hidden>
+        Screen reader only
+      </Heading>
+    </div>
+    <div class="col-12 col-lg-3">
+      <Heading :level="HeadingLevelEnum.H3" :size="HeadingSizeEnum.XL" truncate>
+        A heading long enough that it has to be truncated in this column
+      </Heading>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Text</Heading>
+  <p>Body copy, muted, without spacing, and as a span or div.</p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <BaseText>
+        Default paragraph text. FleetYards keeps a public roster of all known
+        Star Citizen ships and their loadouts.
+      </BaseText>
+      <BaseText muted>
+        Muted text, for secondary information that should recede.
+      </BaseText>
+    </div>
+    <div class="col-12 col-lg-6">
+      <BaseText no-spacing>First line, no bottom spacing.</BaseText>
+      <BaseText no-spacing>Second line, sitting directly below it.</BaseText>
+      <BaseText as="span">An inline span, </BaseText>
+      <BaseText as="span" muted>followed by a muted one.</BaseText>
+      <BaseText as="div">And a div.</BaseText>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Pill</Heading>
+  <p>All variants, plus the uppercase and margin-right modifiers.</p>
+  <div class="row">
+    <div class="col-12">
+      <BasePill
+        v-for="variant in pillVariants"
+        :key="`pill-${variant}`"
+        :variant="variant"
+        margin-right
+      >
+        {{ variant }}
+      </BasePill>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <BasePill
+        v-for="variant in pillVariants"
+        :key="`pill-uppercase-${variant}`"
+        :variant="variant"
+        uppercase
+        margin-right
+      >
+        {{ variant }}
+      </BasePill>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <BasePill>No margin</BasePill>
+      <BasePill>right, so these</BasePill>
+      <BasePill>run together</BasePill>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Spacer</Heading>
+  <p>
+    Horizontal rules at each weight. Each one below is labelled with the props
+    it carries.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <BaseText muted no-spacing>default</BaseText>
+      <Spacer />
+      <BaseText muted no-spacing>slim</BaseText>
+      <Spacer slim />
+      <BaseText muted no-spacing>large</BaseText>
+      <Spacer large />
+      <BaseText muted no-spacing>dark</BaseText>
+      <Spacer dark />
+      <BaseText muted no-spacing>mb</BaseText>
+      <Spacer mb />
+      <BaseText muted no-spacing>end</BaseText>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Box</Heading>
+  <p>
+    A slim panel with an optional heading and footer, in each panel variant.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-3">
+      <Box>
+        <template #heading>Default</template>
+        Box content.
+      </Box>
+    </div>
+    <div class="col-12 col-lg-3">
+      <Box :variant="PanelVariantsEnum.PRIMARY">
+        <template #heading>Primary</template>
+        Box content.
+      </Box>
+    </div>
+    <div class="col-12 col-lg-3">
+      <Box :variant="PanelVariantsEnum.SUCCESS">
+        <template #heading>Success</template>
+        Box content.
+      </Box>
+    </div>
+    <div class="col-12 col-lg-3">
+      <Box :variant="PanelVariantsEnum.ERROR">
+        <template #heading>Error</template>
+        Box content.
+      </Box>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <Box large>
+        <template #heading>Large</template>
+        Wider padding, used for empty states.
+      </Box>
+    </div>
+    <div class="col-12 col-lg-6">
+      <Box>
+        <template #heading>With footer</template>
+        The footer slot renders outside the panel.
+        <template #footer>
+          <BaseText muted no-spacing>Footer content</BaseText>
+        </template>
+      </Box>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Grid</Heading>
+  <p>
+    The responsive card grid. <code>grid-base</code> picks the column count at
+    medium widths; <code>filter-visible</code> narrows the tracks to make room
+    for a filter drawer. Resize to check the breakpoints.
+  </p>
+  <BaseGrid :records="gridRecords" primary-key="id">
+    <template #default="{ record, index }">
+      <Panel slim>
+        <PanelBody>
+          <BaseText no-spacing>{{ index + 1 }}. {{ record.name }}</BaseText>
+          <BaseText muted no-spacing>{{ record.manufacturer }}</BaseText>
+        </PanelBody>
+      </Panel>
+    </template>
+  </BaseGrid>
+  <BaseGrid :records="gridRecords" primary-key="id" grid-base="2">
+    <template #default="{ record }">
+      <Panel slim>
+        <PanelBody>
+          <BaseText no-spacing>{{ record.name }} — grid-base 2</BaseText>
+        </PanelBody>
+      </Panel>
+    </template>
+  </BaseGrid>
+  <BaseGrid :records="gridRecords" primary-key="id" filter-visible>
+    <template #default="{ record }">
+      <Panel slim>
+        <PanelBody>
+          <BaseText no-spacing>{{ record.name }} — filter visible</BaseText>
+        </PanelBody>
+      </Panel>
+    </template>
+  </BaseGrid>
+</template>

--- a/app/frontend/shared/components/MetricsList/index.scss
+++ b/app/frontend/shared/components/MetricsList/index.scss
@@ -8,7 +8,7 @@
   &-item {
     display: flex;
     justify-content: space-between;
-    align-items: flex-center;
+    align-items: center;
     width: calc(50% - calc(var(--gap) / 2));
 
     &-label {

--- a/app/frontend/shared/components/base/FormActions/index.spec.ts
+++ b/app/frontend/shared/components/base/FormActions/index.spec.ts
@@ -1,0 +1,84 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type AppConfirmOptions } from "@/shared/components/AppConfirm/types";
+import Component from "./index.vue";
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const displayConfirm = vi.fn();
+const dismissConfirm = vi.fn();
+
+vi.mock("@/shared/composables/useAppNotifications", () => ({
+  useAppNotifications: () => ({ displayConfirm, dismissConfirm }),
+}));
+
+const mountWith = (props: { dirty?: boolean } = {}) =>
+  mount(Component, {
+    props: { formId: "form", ...props },
+    global: { stubs: { Btn: { template: "<button><slot /></button>" } } },
+  });
+
+const clickCancel = (wrapper: ReturnType<typeof mountWith>) =>
+  wrapper.get('[data-test="submit-cancel"]').trigger("click");
+
+const confirmOptions = (): AppConfirmOptions =>
+  displayConfirm.mock.calls[0][0] as AppConfirmOptions;
+
+describe("BaseFormActions", () => {
+  beforeEach(() => {
+    displayConfirm.mockClear();
+    dismissConfirm.mockClear();
+  });
+
+  it("cancels straight away when the form is not dirty", async () => {
+    const wrapper = mountWith();
+
+    await clickCancel(wrapper);
+
+    expect(displayConfirm).not.toHaveBeenCalled();
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+  });
+
+  it("waits for the confirmation before cancelling a dirty form", async () => {
+    const wrapper = mountWith({ dirty: true });
+
+    await clickCancel(wrapper);
+
+    expect(wrapper.emitted("cancel")).toBeUndefined();
+
+    await confirmOptions().onConfirm?.();
+
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+  });
+
+  it("dismisses a confirmation still pending at unmount", async () => {
+    const wrapper = mountWith({ dirty: true });
+
+    await clickCancel(wrapper);
+    wrapper.unmount();
+
+    expect(dismissConfirm).toHaveBeenCalled();
+  });
+
+  it("leaves the dialog alone once the confirmation was accepted", async () => {
+    const wrapper = mountWith({ dirty: true });
+
+    await clickCancel(wrapper);
+    await confirmOptions().onConfirm?.();
+    wrapper.unmount();
+
+    expect(dismissConfirm).not.toHaveBeenCalled();
+  });
+
+  it("leaves the dialog alone once the confirmation was dismissed", async () => {
+    const wrapper = mountWith({ dirty: true });
+
+    await clickCancel(wrapper);
+    await confirmOptions().onClose?.();
+    wrapper.unmount();
+
+    expect(dismissConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/shared/components/base/FormActions/index.vue
+++ b/app/frontend/shared/components/base/FormActions/index.vue
@@ -26,20 +26,37 @@ const { t } = useI18n();
 
 const emit = defineEmits(["cancel"]);
 
-const { displayConfirm } = useAppNotifications();
+const { displayConfirm, dismissConfirm } = useAppNotifications();
+
+// The dialog is app-level and holds on to the callback it was given, so one left
+// open outlives this component: confirming it later emits `cancel` at a parent
+// that is no longer on screen, on whatever route the user moved to.
+const awaitingConfirm = ref(false);
 
 const handleCancel = () => {
   if (props.dirty) {
+    awaitingConfirm.value = true;
+
     displayConfirm({
       text: t("appModal.messages.confirm.dirty"),
       onConfirm: () => {
+        awaitingConfirm.value = false;
         emit("cancel");
+      },
+      onClose: () => {
+        awaitingConfirm.value = false;
       },
     });
   } else {
     emit("cancel");
   }
 };
+
+onBeforeUnmount(() => {
+  if (awaitingConfirm.value) {
+    dismissConfirm();
+  }
+});
 </script>
 
 <template>

--- a/app/frontend/shared/composables/useAppNotifications.ts
+++ b/app/frontend/shared/composables/useAppNotifications.ts
@@ -130,6 +130,10 @@ export const useAppNotifications = () => {
     comlink.emit("show-confirm", options);
   };
 
+  const dismissConfirm = () => {
+    comlink.emit("hide-confirm");
+  };
+
   return {
     displayMessage,
     displayAlert,
@@ -137,6 +141,7 @@ export const useAppNotifications = () => {
     displayInfo,
     displayWarning,
     displayConfirm,
+    dismissConfirm,
     displayNativeNotification,
     requestBrowserPermission,
   };

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -290,7 +290,12 @@
         "overview": "Übersicht",
         "panels": "Bereiche",
         "buttons": "Schaltflächen",
+        "typography": "Typografie",
+        "forms": "Formulare",
         "tables": "Tabellen",
+        "lists": "Listen",
+        "metrics": "Metriken",
+        "states": "Zustände",
         "notifications": "Benachrichtigungen",
         "syncModal": "Sync-Modal",
         "supportHint": "Support-Hinweis"

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -87,7 +87,12 @@
         "index": "Visuelle Tests",
         "panels": "Bereiche",
         "buttons": "Schaltflächen",
+        "typography": "Typografie",
+        "forms": "Formulare",
         "tables": "Tabellen",
+        "lists": "Listen",
+        "metrics": "Metriken",
+        "states": "Zustände",
         "notifications": "Benachrichtigungen",
         "syncModal": "Sync-Modal",
         "supportHint": "Support-Hinweis"

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -98,7 +98,12 @@
         "index": "Visuelle Tests",
         "panels": "Panels - Visuelle Tests",
         "buttons": "Buttons - Visuelle Tests",
+        "typography": "Typografie - Visuelle Tests",
+        "forms": "Formulare - Visuelle Tests",
         "tables": "Tabellen - Visuelle Tests",
+        "lists": "Listen - Visuelle Tests",
+        "metrics": "Metriken - Visuelle Tests",
+        "states": "Zustände - Visuelle Tests",
         "notifications": "Benachrichtigungen - Visuelle Tests",
         "syncModal": "Sync-Modal - Visuelle Tests",
         "supportHint": "Support-Hinweis - Visuelle Tests"

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -288,7 +288,12 @@
         "overview": "Overview",
         "panels": "Panels",
         "buttons": "Buttons",
+        "typography": "Typography",
+        "forms": "Forms",
         "tables": "Tables",
+        "lists": "Lists",
+        "metrics": "Metrics",
+        "states": "States",
         "notifications": "Notifications",
         "syncModal": "Sync Modal",
         "supportHint": "Support Hint"

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -87,7 +87,12 @@
         "index": "Visual Tests",
         "panels": "Panels",
         "buttons": "Buttons",
+        "typography": "Typography",
+        "forms": "Forms",
         "tables": "Tables",
+        "lists": "Lists",
+        "metrics": "Metrics",
+        "states": "States",
         "notifications": "Notifications",
         "syncModal": "Sync Modal",
         "supportHint": "Support Hint"

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -99,7 +99,12 @@
         "index": "Visual Tests",
         "panels": "Panels - Visual Tests",
         "buttons": "Buttons - Visual Tests",
+        "typography": "Typography - Visual Tests",
+        "forms": "Forms - Visual Tests",
         "tables": "Tables - Visual Tests",
+        "lists": "Lists - Visual Tests",
+        "metrics": "Metrics - Visual Tests",
+        "states": "States - Visual Tests",
         "notifications": "Notifications - Visual Tests",
         "syncModal": "Sync Modal - Visual Tests",
         "supportHint": "Support Hint - Visual Tests"

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -276,7 +276,12 @@
         "overview": "Resumen",
         "panels": "Paneles",
         "buttons": "Botones",
+        "typography": "Tipografía",
+        "forms": "Formularios",
         "tables": "Tablas",
+        "lists": "Listas",
+        "metrics": "Métricas",
+        "states": "Estados",
         "notifications": "Notificaciones",
         "syncModal": "Modal de sincronización",
         "supportHint": "Aviso de apoyo"

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -87,7 +87,12 @@
         "index": "Pruebas Visuales",
         "panels": "Paneles",
         "buttons": "Botones",
+        "typography": "Tipografía",
+        "forms": "Formularios",
         "tables": "Tablas",
+        "lists": "Listas",
+        "metrics": "Métricas",
+        "states": "Estados",
         "notifications": "Notificaciones",
         "syncModal": "Modal de sincronización",
         "supportHint": "Aviso de apoyo"

--- a/app/frontend/translations/es/title.json
+++ b/app/frontend/translations/es/title.json
@@ -98,7 +98,12 @@
         "index": "Pruebas Visuales",
         "panels": "Paneles - Pruebas Visuales",
         "buttons": "Botones - Pruebas Visuales",
+        "typography": "Tipografía - Pruebas visuales",
+        "forms": "Formularios - Pruebas visuales",
         "tables": "Tablas - Pruebas Visuales",
+        "lists": "Listas - Pruebas visuales",
+        "metrics": "Métricas - Pruebas visuales",
+        "states": "Estados - Pruebas visuales",
         "notifications": "Notificaciones - Pruebas Visuales",
         "syncModal": "Modal de sincronización - Pruebas Visuales",
         "supportHint": "Aviso de apoyo - Pruebas Visuales"

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -276,7 +276,12 @@
         "overview": "Aperçu",
         "panels": "Panneaux",
         "buttons": "Boutons",
+        "typography": "Typographie",
+        "forms": "Formulaires",
         "tables": "Tables",
+        "lists": "Listes",
+        "metrics": "Métriques",
+        "states": "États",
         "notifications": "Notifications",
         "syncModal": "Modale Sync",
         "supportHint": "Indicateur de soutien"

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -87,7 +87,12 @@
         "index": "Tests Visuels",
         "panels": "Panneaux",
         "buttons": "Boutons",
+        "typography": "Typographie",
+        "forms": "Formulaires",
         "tables": "Tableaux",
+        "lists": "Listes",
+        "metrics": "Métriques",
+        "states": "États",
         "notifications": "Notifications",
         "syncModal": "Modale Sync",
         "supportHint": "Indicateur de soutien"

--- a/app/frontend/translations/fr/title.json
+++ b/app/frontend/translations/fr/title.json
@@ -98,7 +98,12 @@
         "index": "Tests Visuels",
         "panels": "Panneaux - Tests Visuels",
         "buttons": "Boutons - Tests Visuels",
+        "typography": "Typographie - Tests visuels",
+        "forms": "Formulaires - Tests visuels",
         "tables": "Tableaux - Tests Visuels",
+        "lists": "Listes - Tests visuels",
+        "metrics": "Métriques - Tests visuels",
+        "states": "États - Tests visuels",
         "notifications": "Notifications - Tests Visuels",
         "syncModal": "Modale Sync - Tests Visuels",
         "supportHint": "Indicateur de soutien - Tests Visuels"

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -276,7 +276,12 @@
         "overview": "Panoramica",
         "panels": "Pannelli",
         "buttons": "Pulsanti",
+        "typography": "Tipografia",
+        "forms": "Moduli",
         "tables": "Tabelle",
+        "lists": "Elenchi",
+        "metrics": "Metriche",
+        "states": "Stati",
         "notifications": "Notifiche",
         "syncModal": "Modal sincronizzazione",
         "supportHint": "Suggerimento supporto"

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -87,7 +87,12 @@
         "index": "Test Visivi",
         "panels": "Pannelli",
         "buttons": "Pulsanti",
+        "typography": "Tipografia",
+        "forms": "Moduli",
         "tables": "Tabelle",
+        "lists": "Elenchi",
+        "metrics": "Metriche",
+        "states": "Stati",
         "notifications": "Notifiche",
         "syncModal": "Modal sincronizzazione",
         "supportHint": "Suggerimento supporto"

--- a/app/frontend/translations/it/title.json
+++ b/app/frontend/translations/it/title.json
@@ -98,7 +98,12 @@
         "index": "Test Visivi",
         "panels": "Pannelli - Test Visivi",
         "buttons": "Pulsanti - Test Visivi",
+        "typography": "Tipografia - Test visivi",
+        "forms": "Moduli - Test visivi",
         "tables": "Tabelle - Test Visivi",
+        "lists": "Elenchi - Test visivi",
+        "metrics": "Metriche - Test visivi",
+        "states": "Stati - Test visivi",
         "notifications": "Notifiche - Test Visivi",
         "syncModal": "Modal sincronizzazione - Test Visivi",
         "supportHint": "Suggerimento supporto - Test Visivi"

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -276,7 +276,12 @@
         "overview": "概览",
         "panels": "面板",
         "buttons": "按钮",
+        "typography": "排版",
+        "forms": "表单",
         "tables": "表格",
+        "lists": "列表",
+        "metrics": "指标",
+        "states": "状态",
         "notifications": "通知",
         "syncModal": "同步弹窗",
         "supportHint": "支持提示"

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -87,7 +87,12 @@
         "index": "视觉测试",
         "panels": "面板",
         "buttons": "按钮",
+        "typography": "排版",
+        "forms": "表单",
         "tables": "表格",
+        "lists": "列表",
+        "metrics": "指标",
+        "states": "状态",
         "notifications": "通知",
         "syncModal": "同步弹窗",
         "supportHint": "支持提示"

--- a/app/frontend/translations/zh-CN/title.json
+++ b/app/frontend/translations/zh-CN/title.json
@@ -98,7 +98,12 @@
         "index": "视觉测试",
         "panels": "面板 - 视觉测试",
         "buttons": "按钮 - 视觉测试",
+        "typography": "排版 - 视觉测试",
+        "forms": "表单 - 视觉测试",
         "tables": "表格 - 视觉测试",
+        "lists": "列表 - 视觉测试",
+        "metrics": "指标 - 视觉测试",
+        "states": "状态 - 视觉测试",
         "notifications": "通知 - 视觉测试",
         "syncModal": "同步弹窗 - 视觉测试",
         "supportHint": "支持提示 - 视觉测试"

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -276,7 +276,12 @@
         "overview": "概覽",
         "panels": "面板",
         "buttons": "按鈕",
+        "typography": "排版",
+        "forms": "表單",
         "tables": "表格",
+        "lists": "列表",
+        "metrics": "指標",
+        "states": "狀態",
         "notifications": "通知",
         "syncModal": "同步彈窗",
         "supportHint": "支援提示"

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -87,7 +87,12 @@
         "index": "視覺測試",
         "panels": "面板",
         "buttons": "按鈕",
+        "typography": "排版",
+        "forms": "表單",
         "tables": "表格",
+        "lists": "列表",
+        "metrics": "指標",
+        "states": "狀態",
         "notifications": "通知",
         "syncModal": "同步彈窗",
         "supportHint": "支援提示"

--- a/app/frontend/translations/zh-TW/title.json
+++ b/app/frontend/translations/zh-TW/title.json
@@ -98,7 +98,12 @@
         "index": "視覺測試",
         "panels": "面板 - 視覺測試",
         "buttons": "按鈕 - 視覺測試",
+        "typography": "排版 - 視覺測試",
+        "forms": "表單 - 視覺測試",
         "tables": "表格 - 視覺測試",
+        "lists": "列表 - 視覺測試",
+        "metrics": "指標 - 視覺測試",
+        "states": "狀態 - 視覺測試",
         "notifications": "通知 - 視覺測試",
         "syncModal": "同步彈窗 - 視覺測試",
         "supportHint": "支援提示 - 視覺測試"


### PR DESCRIPTION
## What

The visual-test section covered panels, buttons, tables, notifications, the sync modal and the support hint. Everything introduced since — the metrics cards, the inline editable list and the shared form, typography and state primitives — had no page to check it on. This adds five pages to close that gap.

| Page | Covers |
| --- | --- |
| `/visual-tests/metrics/` | `MetricsCard` frame (default + slim, `head` slot, 1/3/6-tile bodies) and its slotted content primitives, `MetricsList`, and the model metrics components (Base/Crew/Speed/Panel/Cargo/Combat/Defense/Hull) fed with live data |
| `/visual-tests/lists/` | `ListGroup`, `InlineEditableList`, `FilteredList` |
| `/visual-tests/forms/` | Every `FormInput` type and variation, `FormInputGroup`, `FormTextarea`, `FormCheckbox`, `FormToggle`, `FormDatePicker`, `FormFileInput`, `RadioList`, `FilterGroup`, `Slider`, `Toggle`, `FormActions` |
| `/visual-tests/typography/` | `Heading` sizes/levels/alignments/modifiers, `Text`, `Pill`, `Spacer`, `Box`, `Grid` |
| `/visual-tests/states/` | `Empty`, `Loader`, `SmallLoader`, `ProgressBar`, `Paginator`, and the three error pages |

A few deliberate choices:

- **The editable list is wired, not mocked.** Create, edit, destroy, selection and the expanded slot all mutate local state, so the states are reachable by clicking rather than by prop-toggling.
- **`FilteredList` gets a synthesised `AsyncStatus`**, with buttons to flip loading / refetching / empty / error.
- **The metrics page uses live API data** for the model components, on `rsi-constellation-andromeda` — an in-game combat ship, so the combat, survivability and hull cards all have something to render. A concept ship has no game-file hardpoints and they all self-hide. There is also a no-data section that asserts exactly that self-hiding.
- **Error states are a child component** (`forms/ErrorStates.vue`) with its own `useForm`, validated on mount, because two `useForm` calls in one setup would clobber each other's field context.

The nav prefixes are renumbered along the way — six entries were all sitting on `"02"`.

## Two bugs the pages caught

Both fixed in [`7bdfceb`](https://github.com/fleetyards/fleetyards/commit/7bdfceb66), separate from the pages themselves:

- **`MetricsCard`'s default variant never set a layout on `__head`** — only `--slim` did — so anything passed to the `head` slot stacked *under* the title instead of beside it. The flex row moves onto the base rule and slim keeps just its padding, border and background. No consumer uses the `head` slot yet, which is why this had never shown up.
- **`MetricsList` used `align-items: flex-center`**, which is not a valid CSS value, so label and value were never vertically centred.

Worth flagging separately: `MetricsList` has no callers anywhere in the app.

## Verification

- `eslint`, `vue-tsc`, `tsc` and `prettier` all clean.
- All five pages driven in a browser: no Vue errors, no missing i18n keys. Remaining console output is pre-existing dev noise (CSP, vite HMR socket, service worker, 401 on `/users/me` while logged out).
- Create / edit / expand / select clicked through end to end on the editable list.
- All 10 metrics cards on the real ship page verified unchanged after the `__head` fix.

Translations added for all 7 locales across `nav`, `headlines` and `title`.

Routes stay dev-only — they are already gated behind `NODE_ENV !== "production"`.

🤖
