### PR TITLE
fix(dev): name the rdbg session after this app

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -56,7 +56,7 @@ if [ -n "$only" ] && { [ -n "$no_web" ] || [ -n "$no_worker" ] || [ -n "$no_vite
 fi
 
 if [ -n "$use_rdbg" ]; then
-  export RUBY_DEBUG_SESSION_NAME="fobizz-rails-web"
+  export RUBY_DEBUG_SESSION_NAME="fleetyards-web"
   export RAILS_SERVER_CMD="bundle exec rdbg -O -n -c -- bin/rails s -b 0.0.0.0"
 fi
 


### PR DESCRIPTION
`bin/dev --rdbg` exported `RUBY_DEBUG_SESSION_NAME="fobizz-rails-web"`, carried over from another project when the rdbg flag was added in 95aea7e1a.

Renames it to `fleetyards-web`. Nothing else in the repo references the name, so the only effect is the socket name `rdbg --attach` looks for when you debug via `bin/dev --rdbg`.

🤖