### PR TITLE
feat(privacy): make the analytics opt-out real

### DIFF
--- a/app/api_components/v1/schemas/inputs/user_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/user_update_input.rb
@@ -23,6 +23,7 @@ module V1
             publicHangarStats: {type: :boolean},
             publicWishlist: {type: :boolean},
             hideOwner: {type: :boolean},
+            tracking: {type: :boolean},
             location: {type: [:string, :null]},
             currentSystem: {type: [:string, :null]}
           },

--- a/app/api_components/v1/schemas/user.rb
+++ b/app/api_components/v1/schemas/user.rb
@@ -32,6 +32,7 @@ module V1
           publicWishlist: {type: :boolean},
           publicWishlistUrl: {type: :string},
           hideOwner: {type: :boolean},
+          tracking: {type: :boolean},
           twoFactorRequired: {type: :boolean},
           twoFactorQrCodeUrl: {type: :string},
           twoFactorProvisioningUrl: {type: :string},
@@ -46,7 +47,7 @@ module V1
         },
         additionalProperties: false,
         required: %w[
-          username email saleNotify publicHangar publicHangarLoaners publicHangarStats publicWishlist hideOwner
+          username email saleNotify publicHangar publicHangarLoaners publicHangarStats publicWishlist hideOwner tracking
           twoFactorRequired resourceAccess authConnections passwordSetManually oauthOnly placeholderEmail createdAt updatedAt
         ]
       })

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -121,7 +121,7 @@ module Api
             .permit(
               :avatar, :remove_avatar, :sale_notify, :public_hangar, :public_hangar_stats, :public_wishlist, :rsi_handle,
               :discord, :homepage, :youtube, :twitch, :guilded, :public_hangar_loaners, :hide_owner,
-              :location, :current_system
+              :location, :current_system, :tracking
             )
           if permitted.delete(:remove_avatar).present?
             @user.avatar.purge if @user.avatar.attached?

--- a/app/frontend/frontend/composables/useAhoy.ts
+++ b/app/frontend/frontend/composables/useAhoy.ts
@@ -1,10 +1,56 @@
 import ahoy from "ahoy.js";
+import { useCookiesStore } from "@/frontend/stores/cookies";
+import { useSessionStore } from "@/frontend/stores/session";
 
 ahoy.configure({
   cookies: false,
 });
 
+let trackingAllowed = true;
+let guarded = false;
+
+// ahoy.js binds its submit listener permanently and offers no way to detach it,
+// so the objection is enforced on the way out instead of at bind time. That way
+// turning tracking off takes effect immediately rather than on the next reload.
+const guardTrack = () => {
+  if (guarded) {
+    return;
+  }
+  guarded = true;
+
+  const track = ahoy.track.bind(ahoy);
+
+  ahoy.track = (name, properties) => {
+    if (!trackingAllowed) {
+      return false;
+    }
+
+    return track(name, properties);
+  };
+};
+
 export const useAhoy = () => {
+  const sessionStore = useSessionStore();
+  const cookiesStore = useCookiesStore();
+
+  // Signed-in users carry the preference on their account so it follows them
+  // between devices; guests only have the locally stored one.
+  const allowed = computed(() =>
+    sessionStore.authenticated
+      ? sessionStore.currentUser?.tracking !== false
+      : cookiesStore.trackingAccepted,
+  );
+
+  guardTrack();
+
+  watch(
+    allowed,
+    (value) => {
+      trackingAllowed = value;
+    },
+    { immediate: true },
+  );
+
   ahoy.trackView();
   ahoy.trackSubmits("form");
 };

--- a/app/frontend/frontend/pages/privacy-policy.vue
+++ b/app/frontend/frontend/pages/privacy-policy.vue
@@ -7,12 +7,29 @@ export default {
 <script lang="ts" setup>
 import AppContact from "@/frontend/components/core/AppContact/index.vue";
 import Panel from "@/shared/components/base/Panel/index.vue";
+import FormToggle from "@/shared/components/base/FormToggle/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
+import { storeToRefs } from "pinia";
+import { useCookiesStore } from "@/frontend/stores/cookies";
+import { useSessionStore } from "@/frontend/stores/session";
 
 const { t } = useI18n();
 
 const appName = computed(() => {
   return window.APP_NAME;
+});
+
+const sessionStore = useSessionStore();
+const cookiesStore = useCookiesStore();
+
+const { authenticated } = storeToRefs(sessionStore);
+const { trackingAccepted } = storeToRefs(cookiesStore);
+
+// Signed-in users object through their account so the choice follows them
+// between devices; this local toggle is the only route open to guests.
+const guestTracking = computed({
+  get: () => trackingAccepted.value,
+  set: (value: boolean) => cookiesStore.setTracking(value),
 });
 </script>
 
@@ -60,6 +77,28 @@ const appName = computed(() => {
           <router-link :to="{ name: 'signup' }">Signup form</router-link>
           .
         </p>
+        <br />
+
+        <h2>{{ t("texts.privacy.analytics.headline") }}</h2>
+        <p>{{ t("texts.privacy.analytics.basis", { app: appName }) }}</p>
+        <p>{{ t("texts.privacy.analytics.retention") }}</p>
+
+        <h3>{{ t("texts.privacy.analytics.objection.headline") }}</h3>
+        <p>{{ t("texts.privacy.analytics.objection.text") }}</p>
+        <p v-if="authenticated">
+          {{ t("texts.privacy.analytics.objection.user") }}
+          <router-link :to="{ name: 'settings-privacy' }">
+            {{ t("nav.settings.privacy") }}
+          </router-link>
+        </p>
+        <template v-else>
+          <p>{{ t("texts.privacy.analytics.objection.guest") }}</p>
+          <FormToggle
+            v-model="guestTracking"
+            name="guestTracking"
+            :label="t('labels.user.tracking')"
+          />
+        </template>
         <br />
 
         <h2>Why do we need this Information?</h2>

--- a/app/frontend/frontend/pages/settings/privacy.vue
+++ b/app/frontend/frontend/pages/settings/privacy.vue
@@ -77,7 +77,9 @@ const onSubmit = handleSubmit(async (values) => {
     })
     .then(() => {
       // Saved values become the new baseline, so the refresh this triggers is
-      // no longer treated as a pending choice.
+      // no longer treated as a pending choice. Safe to rebaseline from the
+      // submitted values because the toggle is locked while the request is in
+      // flight, so they cannot have drifted.
       resetForm({ values });
 
       comlink.emit("user-update");
@@ -112,6 +114,7 @@ const onSubmit = handleSubmit(async (values) => {
           v-model="tracking"
           v-bind="trackingProps"
           name="tracking"
+          :disabled="submitting"
           :label="t('labels.user.tracking')"
         />
       </div>

--- a/app/frontend/frontend/pages/settings/privacy.vue
+++ b/app/frontend/frontend/pages/settings/privacy.vue
@@ -25,14 +25,23 @@ const sessionStore = useSessionStore();
 
 const submitting = ref(false);
 
-const initialValues = ref<UserUpdateInput>({
-  tracking: sessionStore.currentUser?.tracking,
+const comlink = useComlink();
+
+// Defaults to the column default so the toggle never reads as "off" while the
+// account is still loading, which would misstate whether visits are recorded.
+const currentValues = (): UserUpdateInput => ({
+  tracking: sessionStore.currentUser?.tracking ?? true,
 });
 
+const { defineField, handleSubmit, resetForm } = useForm<UserUpdateInput>({
+  initialValues: currentValues(),
+});
+
+// Re-seed the field itself rather than the initial values, which vee-validate
+// has already copied: App.vue refreshes the account after boot, so the first
+// render can be working from a stale persisted user.
 const setupForm = () => {
-  initialValues.value = {
-    tracking: sessionStore.currentUser?.tracking,
-  };
+  resetForm({ values: currentValues() });
 };
 
 onMounted(() => {
@@ -47,12 +56,6 @@ watch(
     setupForm();
   },
 );
-
-const comlink = useComlink();
-
-const { defineField, handleSubmit } = useForm({
-  initialValues: initialValues.value,
-});
 
 const [tracking, trackingProps] = defineField("tracking");
 

--- a/app/frontend/frontend/pages/settings/privacy.vue
+++ b/app/frontend/frontend/pages/settings/privacy.vue
@@ -33,14 +33,21 @@ const currentValues = (): UserUpdateInput => ({
   tracking: sessionStore.currentUser?.tracking ?? true,
 });
 
-const { defineField, handleSubmit, resetForm } = useForm<UserUpdateInput>({
-  initialValues: currentValues(),
-});
+const { defineField, handleSubmit, resetForm, meta } = useForm<UserUpdateInput>(
+  {
+    initialValues: currentValues(),
+  },
+);
 
 // Re-seed the field itself rather than the initial values, which vee-validate
 // has already copied: App.vue refreshes the account after boot, so the first
-// render can be working from a stale persisted user.
+// render can be working from a stale persisted user. A pending choice wins over
+// the refresh, otherwise a background refetch would silently revert it.
 const setupForm = () => {
+  if (meta.value.dirty) {
+    return;
+  }
+
   resetForm({ values: currentValues() });
 };
 
@@ -69,6 +76,10 @@ const onSubmit = handleSubmit(async (values) => {
       data: values,
     })
     .then(() => {
+      // Saved values become the new baseline, so the refresh this triggers is
+      // no longer treated as a pending choice.
+      resetForm({ values });
+
       comlink.emit("user-update");
 
       displaySuccess({

--- a/app/frontend/frontend/pages/settings/privacy.vue
+++ b/app/frontend/frontend/pages/settings/privacy.vue
@@ -1,0 +1,112 @@
+<script lang="ts">
+export default {
+  name: "SettingsPrivacy",
+};
+</script>
+
+<script lang="ts" setup>
+import { useSessionStore } from "@/frontend/stores/session";
+import { type UserUpdateInput } from "@/services/fyApi";
+import FormToggle from "@/shared/components/base/FormToggle/index.vue";
+import FormActions from "@/shared/components/base/FormActions/index.vue";
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useForm } from "vee-validate";
+import { useUpdateProfile as useUpdateProfileMutation } from "@/services/fyApi";
+
+const { t } = useI18n();
+
+const { displaySuccess } = useAppNotifications();
+
+const sessionStore = useSessionStore();
+
+const submitting = ref(false);
+
+const initialValues = ref<UserUpdateInput>({
+  tracking: sessionStore.currentUser?.tracking,
+});
+
+const setupForm = () => {
+  initialValues.value = {
+    tracking: sessionStore.currentUser?.tracking,
+  };
+};
+
+onMounted(() => {
+  if (sessionStore.currentUser) {
+    setupForm();
+  }
+});
+
+watch(
+  () => sessionStore.currentUser,
+  () => {
+    setupForm();
+  },
+);
+
+const comlink = useComlink();
+
+const { defineField, handleSubmit } = useForm({
+  initialValues: initialValues.value,
+});
+
+const [tracking, trackingProps] = defineField("tracking");
+
+const mutation = useUpdateProfileMutation();
+
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  await mutation
+    .mutateAsync({
+      data: values,
+    })
+    .then(() => {
+      comlink.emit("user-update");
+
+      displaySuccess({
+        text: t("messages.updatePrivacy.success"),
+      });
+    })
+    .catch((error) => {
+      console.error(error);
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+</script>
+
+<template>
+  <BreadCrumbs
+    :crumbs="[{ to: { name: 'settings' }, label: t('nav.settings.index') }]"
+  />
+
+  <Heading hero>{{ t("headlines.settings.privacy") }}</Heading>
+
+  <form id="settings-privacy-form" @submit.prevent="onSubmit">
+    <div class="row">
+      <div class="col-12">
+        <p>{{ t("texts.settings.privacy.tracking") }}</p>
+      </div>
+      <div class="col-12 col-md-6">
+        <FormToggle
+          v-model="tracking"
+          v-bind="trackingProps"
+          name="tracking"
+          :label="t('labels.user.tracking')"
+        />
+      </div>
+    </div>
+
+    <FormActions
+      :submitting="submitting"
+      form-id="settings-privacy-form"
+      hide-cancel
+    />
+  </form>
+</template>

--- a/app/frontend/frontend/pages/settings/routes.ts
+++ b/app/frontend/frontend/pages/settings/routes.ts
@@ -41,6 +41,15 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "privacy/",
+    name: "settings-privacy",
+    component: () => import("@/frontend/pages/settings/privacy.vue"),
+    meta: {
+      title: "settings.privacy",
+      needsAuthentication: true,
+    },
+  },
+  {
     path: "features/",
     name: "settings-features",
     component: () => import("@/frontend/pages/settings/features.vue"),

--- a/app/frontend/frontend/stores/cookies.ts
+++ b/app/frontend/frontend/stores/cookies.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia";
 interface CookiesState {
   cookies: {
     youtube: boolean;
+    tracking: boolean;
   };
 }
 
@@ -10,16 +11,25 @@ export const useCookiesStore = defineStore("cookies", {
   state: (): CookiesState => ({
     cookies: {
       youtube: false,
+      // Analytics run on legitimate interest, so guests start opted in and can
+      // object here. Signed-in users are governed by their account setting.
+      tracking: true,
     },
   }),
   getters: {
     youtubeAccepted(): boolean {
       return this.cookies.youtube;
     },
+    trackingAccepted(): boolean {
+      return this.cookies.tracking;
+    },
   },
   actions: {
     acceptYoutube() {
       this.cookies.youtube = true;
+    },
+    setTracking(value: boolean) {
+      this.cookies.tracking = value;
     },
   },
   persist: {

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -219,6 +219,7 @@
         "account": "Konto",
         "profile": "Profileinstellungen",
         "hangar": "Hangar-Einstellungen",
+        "privacy": "Datenschutz-Einstellungen",
         "features": "Feature-Flags",
         "connections": "Verbindungen",
         "oauthApplications": "OAuth-Anwendungen",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -774,6 +774,7 @@
         "publicHangarStats": "Öffentliche Hangar-Statistiken aktiviert",
         "publicWishlist": "Öffentliche Wunschliste aktiviert",
         "hideOwner": "Besitz für Flotten verbergen",
+        "tracking": "Anonyme Nutzungsstatistik erlauben",
         "lastActiveAt": "Zuletzt aktiv",
         "confirmedAt": "Bestätigt am"
       },

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -56,6 +56,9 @@
       "updateHangar": {
         "success": "Hangar-Einstellungen aktualisiert."
       },
+      "updatePrivacy": {
+        "success": "Datenschutz-Einstellungen aktualisiert."
+      },
       "features": {
         "updated": "Funktion aktualisiert.",
         "error": "Funktion konnte nicht aktualisiert werden.",

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -77,6 +77,7 @@
         "security": "Sicherheit",
         "notifications": "Benachrichtigungen",
         "hangar": "Hangar",
+        "privacy": "Datenschutz",
         "features": "Funktionen",
         "connections": "Verbindungen",
         "oauthApplications": "OAuth-Apps",

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -96,6 +96,22 @@
         "p3": {
           "headline": "Als Gast",
           "text": "Als Gast auf %{app} sammeln wir die folgenden Daten:"
+        },
+        "analytics": {
+          "headline": "Nutzungsstatistik",
+          "basis": "%{app} zählt Seitenaufrufe, um zu verstehen, welche Bereiche der Seite tatsächlich genutzt werden. Grundlage dafür ist unser berechtigtes Interesse am Betrieb und an der Verbesserung der Seite, nicht deine Einwilligung: Die Daten werden ausschließlich von uns selbst erhoben, IP-Adressen werden vor dem Speichern anonymisiert, es werden keine Cookies oder andere Kennungen auf deinem Gerät abgelegt und nichts wird an Werbenetzwerke weitergegeben.",
+          "retention": "Einzelne Besuche und Seitenaufrufe werden nach einem Monat gelöscht. Darüber hinaus bleiben nur aggregierte Zahlen erhalten, die sich keiner Person mehr zuordnen lassen. Mit dem Löschen deines Kontos werden auch die dazu erfassten Besuche gelöscht.",
+          "objection": {
+            "headline": "Wie du widersprichst",
+            "text": "Du kannst der Nutzungsstatistik jederzeit widersprechen. Wir hören dann auf, sie zu erfassen, statt sie nur auszublenden.",
+            "user": "Die Einstellung in deinem Konto gilt auf allen Geräten, auf denen du angemeldet bist.",
+            "guest": "Ohne Konto kannst du hier widersprechen. Wir beachten außerdem das Global-Privacy-Control-Signal, wenn dein Browser es sendet."
+          }
+        }
+      },
+      "settings": {
+        "privacy": {
+          "tracking": "Wenn dies aktiviert ist, zählen wir die von dir besuchten Seiten, um zu sehen, welche Bereiche genutzt werden. IP-Adressen werden anonymisiert, auf deinem Gerät wird nichts gespeichert und einzelne Besuche werden nach einem Monat gelöscht. Beim Ausschalten wird die Erfassung vollständig gestoppt."
         }
       },
       "signup": {

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -71,6 +71,7 @@
         "profile": "Profileinstellungen",
         "account": "Konto",
         "hangar": "Hangar Einstellungen",
+        "privacy": "Datenschutz-Einstellungen",
         "features": "Feature-Flags",
         "connections": "Verbindungen",
         "oauthApplications": "OAuth-Anwendungen",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -234,6 +234,7 @@
         "account": "Account",
         "profile": "Profile Settings",
         "hangar": "Hangar Settings",
+        "privacy": "Privacy Settings",
         "features": "Feature Flags",
         "connections": "Connections",
         "oauthApplications": "OAuth Applications",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1134,6 +1134,7 @@
         "publicHangarStats": "Public Hangar Stats enabled",
         "publicWishlist": "Public Wishlist enabled",
         "hideOwner": "Hide Ownership for Fleets",
+        "tracking": "Allow anonymous usage analytics",
         "lastActiveAt": "Last Active",
         "confirmedAt": "Confirmed at"
       },

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -56,6 +56,9 @@
       "updateHangar": {
         "success": "Hangar Settings updated."
       },
+      "updatePrivacy": {
+        "success": "Privacy Settings updated."
+      },
       "features": {
         "updated": "Feature updated.",
         "error": "Could not update feature.",

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -77,6 +77,7 @@
         "security": "Security",
         "notifications": "Notifications",
         "hangar": "Hangar",
+        "privacy": "Privacy",
         "features": "Features",
         "connections": "Connections",
         "oauthApplications": "OAuth Apps",

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -101,6 +101,22 @@
         "p3": {
           "headline": "As a Guest",
           "text": "As a Guest on %{app} we collect the following data:"
+        },
+        "analytics": {
+          "headline": "Usage analytics",
+          "basis": "%{app} counts page views to understand which parts of the site are actually used. This runs on our legitimate interest in operating and improving the site, not on consent: the data is collected first-party only, IP addresses are anonymised before they are stored, no cookies or other identifiers are placed on your device, and nothing is shared with advertising networks.",
+          "retention": "Individual visits and page views are deleted after one month. Only aggregated counts, which cannot be traced back to a person, are kept beyond that. Deleting your account also deletes the visits recorded for it.",
+          "objection": {
+            "headline": "How to object",
+            "text": "You can object to usage analytics at any time, and we will stop recording it rather than merely hiding it.",
+            "user": "Your account setting under Settings is applied to every device you sign in on.",
+            "guest": "Without an account you can object here. We also honour the Global Privacy Control signal if your browser sends one."
+          }
+        }
+      },
+      "settings": {
+        "privacy": {
+          "tracking": "When this is enabled we count the pages you visit to see which parts of the site are used. IP addresses are anonymised, nothing is stored on your device, and individual visits are deleted after one month. Turning it off stops the recording entirely."
         }
       },
       "signup": {

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -72,6 +72,7 @@
         "profile": "Profile Settings",
         "account": "Account",
         "hangar": "Hangar Settings",
+        "privacy": "Privacy Settings",
         "features": "Feature Flags",
         "connections": "Connections",
         "oauthApplications": "OAuth Applications",

--- a/app/views/api/v1/users/_base.jbuilder
+++ b/app/views/api/v1/users/_base.jbuilder
@@ -32,6 +32,7 @@ json.public_hangar_stats user.public_hangar_stats
 json.public_wishlist user.public_wishlist
 json.public_wishlist_url user.public_wishlist_url
 json.hide_owner user.hide_owner
+json.tracking user.tracking
 
 json.two_factor_required user.otp_required_for_login?
 unless user.otp_required_for_login?

--- a/bin/setup
+++ b/bin/setup
@@ -243,15 +243,18 @@ FileUtils.chdir APP_ROOT do
   run_step_wait(ruby_deps, node_deps, docker)
 
   # Group B: Prepare databases and build Vite assets (need deps + Docker)
-  dev_db = run_step "Preparing database (dev)", "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix} bin/rails db:prepare", async: true
-  test_db = run_step "Preparing database (test)", "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix} RAILS_ENV=test bin/rails db:prepare", async: true
+  # db:prepare rewrites db/schema.rb after migrating, so the dev and test runs
+  # must be sequential: a dump from one truncates the file the other is reading.
+  db_env = "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix}"
+  databases = run_step "Preparing databases (dev + test)",
+    "#{db_env} bin/rails db:prepare && #{db_env} RAILS_ENV=test bin/rails db:prepare", async: true
   vite_build = run_step "Building email assets (test)", "bin/build-email-assets", async: true
   # auto-imports.d.ts and components.d.ts are gitignored and only written by the
   # Vite plugins, so vue-tsc reports every auto-imported symbol as undefined
   # until a build has run at least once. Builds to vite-dev, so it does not race
   # the email assets build over the vite-test manifest.
   frontend_types = run_step "Generating frontend type declarations", "bin/vite build", async: true
-  run_step_wait(dev_db, test_db, vite_build, frontend_types)
+  run_step_wait(databases, vite_build, frontend_types)
 
   # Group C: Clean logs/tmp (need databases)
   clean = run_step "Cleaning logs and temp files", "bin/rails log:clear tmp:clear", async: true

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -14,3 +14,14 @@ Ahoy.cookies = :none
 Ahoy.api = true
 Ahoy.geocode = false
 Ahoy.user_agent_parser = :device_detector
+
+# Analytics run on legitimate interest, so an objection has to stop the data
+# being recorded rather than only hiding it from the admin stats. Signed-in
+# users object through their account setting; anonymous visitors through Global
+# Privacy Control, which is the only signal they can send without an account.
+Ahoy.exclude_method = lambda do |controller, request|
+  next true if request&.headers&.[]("Sec-GPC") == "1"
+  next false if controller.blank?
+
+  Ahoy.user_method.call(controller)&.tracking == false
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -13021,6 +13021,8 @@ components:
           type: string
         hideOwner:
           type: boolean
+        tracking:
+          type: boolean
         twoFactorRequired:
           type: boolean
         twoFactorQrCodeUrl:
@@ -13060,6 +13062,7 @@ components:
       - publicHangarStats
       - publicWishlist
       - hideOwner
+      - tracking
       - twoFactorRequired
       - resourceAccess
       - authConnections
@@ -13208,6 +13211,8 @@ components:
         publicWishlist:
           type: boolean
         hideOwner:
+          type: boolean
+        tracking:
           type: boolean
         location:
           type:

--- a/test/lib/ahoy_exclude_method_test.rb
+++ b/test/lib/ahoy_exclude_method_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AhoyExcludeMethodTest < ActiveSupport::TestCase
+  FakeRequest = Struct.new(:headers)
+
+  class FakeController
+    def initialize(current_user = nil)
+      @current_user = current_user
+    end
+
+    attr_reader :current_user
+  end
+
+  def exclude?(user: nil, headers: {})
+    Ahoy.exclude_method.call(FakeController.new(user), FakeRequest.new(headers))
+  end
+
+  test "tracks a signed-in user who has not objected" do
+    assert_not exclude?(user: build(:user, tracking: true))
+  end
+
+  test "tracks an anonymous visitor by default" do
+    assert_not exclude?
+  end
+
+  test "excludes a signed-in user who has objected" do
+    assert exclude?(user: build(:user, tracking: false))
+  end
+
+  test "excludes any visitor sending Global Privacy Control" do
+    assert exclude?(headers: {"Sec-GPC" => "1"})
+  end
+
+  test "excludes a signed-in user sending Global Privacy Control" do
+    assert exclude?(user: build(:user, tracking: true), headers: {"Sec-GPC" => "1"})
+  end
+
+  test "ignores an unset Global Privacy Control header" do
+    assert_not exclude?(headers: {"Sec-GPC" => "0"})
+  end
+
+  test "tracks when there is no controller" do
+    assert_not Ahoy.exclude_method.call(nil, FakeRequest.new({}))
+  end
+
+  test "tracks when there is no request" do
+    assert_not Ahoy.exclude_method.call(FakeController.new, nil)
+  end
+end


### PR DESCRIPTION
## Why

Analytics run on legitimate interest rather than consent — cookieless Ahoy, masked IPs, first-party only, one-month retention. That basis is defensible, but it carries a right to object, and that right was not actually reachable:

- `users.tracking` has existed since analytics were added but appears in no `permit()` list and no serializer, so nothing could set it.
- Where it *was* read (`Admin::BaseController#online_count`, `visits_per_day`), it only filtered the admin stats. An objecting user's visits were still recorded and merely hidden from display.
- The consent modal that used to gate `ahoy.trackView()` was removed in aee02adb8. Its reasoning was sound for cookies — ahoy.js stores nothing on the device, so no cookie banner is required — but the GDPR side needs disclosure and a working objection, which went with it.

## What changed

**Enforcement at write time** (`config/initializers/ahoy.rb`) — `Ahoy.exclude_method` drops the visit and its events before they are stored, instead of filtering after the fact. Signed-in users object through their account setting; anonymous visitors through `Sec-GPC`, which is the only signal they can send without an account. User resolution goes through `Ahoy.user_method` so it matches what Ahoy does everywhere else.

**The preference is reachable** — `tracking` is now permitted in `user_params`, emitted from `_base.jbuilder`, and declared on both the `User` and `UserUpdateInput` components. `swagger/v1/schema.yaml` regenerated (5 added lines, no unrelated churn).

**UI** — a settings page for signed-in users, whose choice follows them between devices, and a local toggle on the privacy policy for guests. Only one of the two is shown at a time, so there is never a second competing control. The policy gains a section covering what is collected, the basis, retention, and how to object.

The client gate wraps `ahoy.track` rather than skipping the setup calls, because `trackSubmits` binds a delegated listener permanently with no way to detach it — gating at bind time would leave a mid-session opt-out ineffective until reload.

## Notes

- No cookie banner here, deliberately. ahoy.js touches no `localStorage`/`sessionStorage`/`indexedDB` and every cookie write is gated on `config.cookies`, which is `false`, so the device-storage rule a banner exists to satisfy is not triggered. What the legitimate-interest basis needs is disclosure plus a working objection, which is what this adds.
- One deliberate gap: on initial load the session has not resolved yet, so an opted-out user's first `$view` may still be sent. The server discards it via `exclude_method`, so nothing is recorded. Closing it client-side would mean delaying the first view until `/me` returns, costing guests their page view.
- English and German written directly; the other five locales fall back to English until Crowdin catches up.

## Testing

- Full backend suite: 1730 tests, 2 failures, 0 errors. Clean `main` baseline is 1722 / 2 failures / 2 errors — the +8 is the new `ahoy_exclude_method_test.rb`, and both remaining failures (`Short::ModelCompareShareTest`) reproduce on unmodified `main`.
- `standardrb`, `eslint`, `prettier`, `vue-tsc`, `tsc` all clean.

🤖
