### PR TITLE
chore(deps): tell dependabot to skip redis 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     labels:
       - dependencies
       - ruby
+    ignore:
+      # ActionCable's redis pubsub adapter declares `>= 4, < 6`, so redis 6
+      # raises Gem::LoadError on boot. Mirrors the `gem "redis", "< 6"` pin in
+      # the Gemfile — lift both once Rails ships the redis-client-based
+      # adapter (8.2+).
+      - dependency-name: redis
+        versions:
+          - ">= 6"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Dependabot keeps reopening the redis 6 bump (#4343). Its CI comes back green, which is misleading — nothing in the suite boots ActionCable's redis pubsub adapter, and that adapter declares `gem "redis", ">= 4", "< 6"`, so redis 6 raises `Gem::LoadError` at boot in a real process.

The `Gemfile` already pins `gem "redis", "< 6"` with a comment explaining this, but the pin only stops the resolve — it doesn't stop the PR churn. This adds the matching `ignore` rule so dependabot stops proposing it.

Kept as a declarative rule in `.github/dependabot.yml` rather than an `@dependabot ignore this major version` comment, so the constraint is visible in the repo next to the other config and easy to find when it's time to lift it.

Lift this rule and the `Gemfile` pin together once Rails ships the redis-client-based adapter (8.2+).

Supersedes #4343, which should be closed once this lands. 🤖