### PR TITLE
feat(sc-data): read ground vehicle speeds from the vehicle definition

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -42,6 +42,7 @@ module ScData
         update_params = update_external_fuel_tanks(hardpoints, update_params)
         update_params = update_refuel_boom(hardpoints, update_params)
         update_params = update_speeds(hardpoints, update_params)
+        update_params = update_ground_speeds(model_data, update_params)
 
         model.update!(update_params.merge(update_reason: :sc_data_loader))
       end
@@ -198,6 +199,23 @@ module ScData
         update_params[:yaw_boosted] = ifcs.dig("boosted_angular_velocity", "yaw").to_f if ifcs.dig("boosted_angular_velocity", "yaw").present?
         update_params[:roll] = ifcs.dig("angular_velocity", "roll").to_f if ifcs.dig("angular_velocity", "roll").present?
         update_params[:roll_boosted] = ifcs.dig("boosted_angular_velocity", "roll").to_f if ifcs.dig("boosted_angular_velocity", "roll").present?
+
+        update_params
+      end
+
+      # Ground vehicles have no FlightController to read speeds off, so the
+      # parser takes them straight from the vehicle definition. Only the
+      # vehicles that declare a `Handling/Power` block get reverse speed and
+      # acceleration; the rest have a top speed and nothing else.
+      private def update_ground_speeds(model_data, update_params)
+        speeds = model_data.dig("speeds")
+
+        return update_params if speeds.blank?
+
+        update_params[:ground_max_speed] = speeds.dig("max").to_f if speeds.dig("max").present?
+        update_params[:ground_reverse_speed] = speeds.dig("reverse").to_f if speeds.dig("reverse").present?
+        update_params[:ground_acceleration] = speeds.dig("acceleration").to_f if speeds.dig("acceleration").present?
+        update_params[:ground_decceleration] = speeds.dig("decceleration").to_f if speeds.dig("decceleration").present?
 
         update_params
       end

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -97,6 +97,7 @@ module ScData
             },
             mass: extract_mass(values.dig("Components", "VehicleComponentParams")),
             **extract_hull(values.dig("Components", "VehicleComponentParams")),
+            speeds: extract_ground_speeds(values.dig("Components", "VehicleComponentParams")),
             metrics: {
               x: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "x").to_f,
               y: values.dig("Components", "VehicleComponentParams", "maxBoundingBoxSize", "y").to_f,
@@ -263,6 +264,111 @@ module ScData
           hull_health: parts.sum { |part| part[:health] },
           hull_parts: parts
         }
+      end
+
+      # Ground vehicles carry no flight controller, so their speeds come from the
+      # implementation XML's `MovementParams` rather than an IFCS item. Two
+      # independent limits live there and only around half the vehicles have the
+      # first one: `Handling/Power` is the arcade controller's target speed, while
+      # `wWheelsMax` caps how fast physics may spin the driven wheels. Whichever
+      # is lower is the speed the vehicle actually reaches.
+      private def extract_ground_speeds(component_params)
+        definition_file_path = component_params.dig("vehicleDefinition")
+
+        return {} if definition_file_path.blank?
+
+        definition_data = Hash.from_xml(File.read("#{definition_path}/#{definition_file_path}"))
+
+        movement = extract_movement_params(definition_data, definition_file_path, component_params.dig("modification"))
+
+        return {} if movement.blank?
+
+        power = extract_handling_power(movement)
+        target_speed = power&.dig("topSpeed")&.to_f || movement.dig("TrackWheeled", "maxSpeed")&.to_f
+        wheel_speed = extract_wheel_speed_limit(movement, definition_data)
+
+        return {} if target_speed.blank? && wheel_speed.blank?
+
+        {
+          max: [target_speed, wheel_speed].compact.min,
+          reverse: power&.dig("reverseSpeed")&.to_f,
+          acceleration: power&.dig("acceleration")&.to_f,
+          decceleration: power&.dig("decceleration")&.to_f
+        }
+      end
+
+      # Variants replace the whole `MovementParams` block through their
+      # modification's `patchFile` — the inline `Elems` overrides that
+      # extract_modification_definition applies only carry display names and
+      # masses. The Cyclone tunes every variant this way (RN 55 down to MT 47).
+      private def extract_movement_params(definition_data, definition_file_path, modification_key)
+        base = definition_data.dig("Vehicle", "MovementParams")
+
+        return base if modification_key.blank?
+
+        modifications = definition_data.dig("Vehicle", "Modifications", "Modification")
+        modifications = [modifications] unless modifications.is_a?(Array)
+
+        patch_file = modifications.compact.find { |modification|
+          modification.dig("name") == modification_key
+        }&.dig("patchFile")
+
+        return base if patch_file.blank?
+
+        patch_path = "#{definition_path}/#{File.dirname(definition_file_path)}/#{patch_file}.xml"
+
+        return base unless File.exist?(patch_path)
+
+        Hash.from_xml(File.read(patch_path)).dig("Modifications", "MovementParams") || base
+      end
+
+      # The Lynx carries a second, stray `Handling` block as a sibling of its
+      # movement node; the one nested inside the movement node is the schema
+      # correct source, and document order puts it first.
+      private def extract_handling_power(movement)
+        nested = movement.values.filter_map { |node|
+          node.dig("Handling", "Power") if node.is_a?(Hash)
+        }.first
+
+        nested || movement.dig("Handling", "Power")
+      end
+
+      # `wWheelsMax` is the maximum angular velocity of a wheel in rad/s, so the
+      # speed it allows depends on the wheels the vehicle drives on.
+      private def extract_wheel_speed_limit(movement, definition_data)
+        max_angular_velocity = movement.values.filter_map { |node|
+          node.dig("PhysicsParams", "wWheelsMax") if node.is_a?(Hash)
+        }.first&.to_f
+
+        return if max_angular_velocity.blank?
+
+        radius = extract_driven_wheel_radius(definition_data)
+
+        return if radius.blank?
+
+        (max_angular_velocity * radius).round(2)
+      end
+
+      private def extract_driven_wheel_radius(definition_data)
+        wheels = collect_nodes(definition_data.dig("Vehicle", "Parts"), "SubPartWheel")
+        driven = wheels.select { |wheel| wheel.dig("driving") == "1" }
+
+        (driven.presence || wheels).filter_map { |wheel| wheel.dig("rimRadius")&.to_f }.max
+      end
+
+      private def collect_nodes(node, name)
+        case node
+        when Array
+          node.flat_map { |child| collect_nodes(child, name) }
+        when Hash
+          node.flat_map do |key, value|
+            next Array.wrap(value) if key == name
+
+            collect_nodes(value, name)
+          end
+        else
+          []
+        end
       end
 
       # The ship's shared weapon-power pool size (in power segments). Sustained

--- a/data/sc_data/parsed/live/models/anvl_ballista.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
@@ -317,6 +317,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_centurion.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion.json
@@ -357,6 +357,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.8,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
@@ -357,6 +357,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 20.8,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/anvl_spartan.json
+++ b/data/sc_data/parsed/live/models/anvl_spartan.json
@@ -362,6 +362,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 27.52,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 7.0,
     "y": 17.0,

--- a/data/sc_data/parsed/live/models/argo_csv_cargo.json
+++ b/data/sc_data/parsed/live/models/argo_csv_cargo.json
@@ -242,6 +242,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 13.08,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/drak_mule.json
+++ b/data/sc_data/parsed/live/models/drak_mule.json
@@ -182,6 +182,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 32.0,
+    "reverse": 7.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_mdc.json
+++ b/data/sc_data/parsed/live/models/grin_mdc.json
@@ -277,6 +277,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 19.15,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_mtc.json
+++ b/data/sc_data/parsed/live/models/grin_mtc.json
@@ -277,6 +277,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 19.15,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_ptv.json
+++ b/data/sc_data/parsed/live/models/grin_ptv.json
@@ -217,6 +217,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 15.0,
+    "reverse": 7.0,
+    "acceleration": 8.0,
+    "decceleration": 5.0
+  },
   "metrics": {
     "x": 2.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
+++ b/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
@@ -217,6 +217,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 15.0,
+    "reverse": 7.0,
+    "acceleration": 8.0,
+    "decceleration": 5.0
+  },
   "metrics": {
     "x": 2.5,
     "y": 3.5,

--- a/data/sc_data/parsed/live/models/grin_roc.json
+++ b/data/sc_data/parsed/live/models/grin_roc.json
@@ -137,6 +137,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 32.0,
+    "reverse": 19.0,
+    "acceleration": 10.0,
+    "decceleration": 10.0
+  },
   "metrics": {
     "x": 3.9,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_roc_ds.json
+++ b/data/sc_data/parsed/live/models/grin_roc_ds.json
@@ -182,6 +182,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 28.0,
+    "reverse": 15.0,
+    "acceleration": 7.0,
+    "decceleration": 8.0
+  },
   "metrics": {
     "x": 5.0,
     "y": 6.6,

--- a/data/sc_data/parsed/live/models/grin_stv.json
+++ b/data/sc_data/parsed/live/models/grin_stv.json
@@ -232,6 +232,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 35.49,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/grin_utv.json
+++ b/data/sc_data/parsed/live/models/grin_utv.json
@@ -262,6 +262,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 29.44,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 2.6,
     "y": 4.0,

--- a/data/sc_data/parsed/live/models/rsi_lynx.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx.json
@@ -222,6 +222,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 27.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 5.7,
     "y": 7.75,

--- a/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
@@ -222,6 +222,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 27.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 5.7,
     "y": 7.75,

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
@@ -227,6 +227,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 24.0,
+    "reverse": 12.0,
+    "acceleration": 8.0,
+    "decceleration": 12.0
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 36.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 34.56,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 36.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 33.84,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 38.16,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 39.6,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
@@ -212,6 +212,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 37.44,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 8.75,
     "y": 6.0,

--- a/data/sc_data/parsed/live/models/tmbl_nova.json
+++ b/data/sc_data/parsed/live/models/tmbl_nova.json
@@ -167,6 +167,12 @@
       "category": "cosmetic"
     }
   ],
+  "speeds": {
+    "max": 25.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 12.0,
     "y": 20.0,

--- a/data/sc_data/parsed/live/models/tmbl_storm.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm.json
@@ -362,6 +362,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 30.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 10.25,
     "y": 7.65,

--- a/data/sc_data/parsed/live/models/tmbl_storm_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm_aa.json
@@ -362,6 +362,12 @@
       "category": "subpart"
     }
   ],
+  "speeds": {
+    "max": 30.0,
+    "reverse": null,
+    "acceleration": null,
+    "decceleration": null
+  },
   "metrics": {
     "x": 10.25,
     "y": 7.65,

--- a/data/sc_data/parsed/live/version.json
+++ b/data/sc_data/parsed/live/version.json
@@ -1,5 +1,5 @@
 {
   "version": "4.9.0-live.12344265",
   "environment": "live",
-  "parsed_at": "2026-08-11T13:23:22Z"
+  "parsed_at": "2026-08-15T19:44:18Z"
 }

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -35,6 +35,47 @@ module ScData
 
         assert_equal cross_section, model.reload.signature_cross_section
       end
+
+      test "#load_model persists the parsed ground speeds" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Ground Speed Test", in_game: true)
+
+        loader.stubs(:load_model_data).returns(
+          {
+            "mass" => 1000.0,
+            "loadout" => [],
+            "speeds" => {
+              "max" => 24.0,
+              "reverse" => 12.0,
+              "acceleration" => 8.0,
+              "decceleration" => 12.0
+            }
+          }
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_equal 24.0, model.ground_max_speed.to_f
+        assert_equal 12.0, model.ground_reverse_speed.to_f
+        assert_equal 8.0, model.ground_acceleration.to_f
+        assert_equal 12.0, model.ground_decceleration.to_f
+      end
+
+      test "#load_model keeps the ground speeds a vehicle does not declare" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Wheel Cap Test", in_game: true, ground_reverse_speed: 9.0)
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "speeds" => {"max" => 36.0}}
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_equal 36.0, model.ground_max_speed.to_f
+        assert_equal 9.0, model.ground_reverse_speed.to_f
+      end
     end
   end
 end


### PR DESCRIPTION
Ground vehicles carry no flight controller, so `update_speeds` never found anything for them and `ground_max_speed` and friends stayed empty — `api.fleetyards.net/v1/models/ursa` returns `groundMaxSpeed: 0.0` today. Their speeds live in the vehicle implementation XML's `MovementParams` instead.

## Where the values come from

Two independent limits sit in that block, and only 17 of the 40 ground entities declare the first one:

- `Handling/Power@topSpeed` — the arcade controller's target speed, along with `reverseSpeed`, `acceleration` and `decceleration` (`TrackWheeled@maxSpeed` for the Nova and Storm)
- `PhysicsParams@wWheelsMax` — the cap on how fast physics may spin the driven wheels, in rad/s, so `× rimRadius` gives m/s

Whichever is lower is what the vehicle reaches, so the parser stores `min(...)`. That gives a value for all 40 entities rather than only the 17. The Cyclone family, Ballista, Centurion, Spartan, CSV, MDC, MTC, STV and UTV have no `Power` block at all and get a top speed with no reverse or acceleration figures.

Variant tuning lives in the modification's `patchFile`, which `extract_modification_definition` cannot reach — its inline `Elems` overrides only carry display names and masses. Without following it, every Cyclone variant would report the base 36.0 instead of RN 39.6 through MT 33.84.

## Results

| Vehicle | m/s | km/h | Source |
|---|---|---|---|
| Cyclone RN / RC / TR / base / AA / MT | 39.6 / 38.16 / 37.44 / 36 / 34.56 / 33.84 | 143 / 137 / 135 / 130 / 124 / 122 | wheel cap |
| STV | 35.49 | 128 | wheel cap |
| Mule | 32 | 115 | declared |
| ROC / ROC DS | 32 / 28 | 115 / 101 | declared |
| Storm (+AA) / Nova | 30 / 25 | 108 / 90 | `TrackWheeled` |
| UTV | 29.44 | 106 | wheel cap |
| Spartan | 27.52 | 99 | wheel cap |
| Lynx | 27 | 97 | wheel cap (declared 29) |
| Ursa (all variants) | 24 | 86 | wheel cap (declared 29) |
| Centurion | 20.8 | 75 | wheel cap |
| Ballista (all variants) | 20 | 72 | wheel cap |
| MDC / MTC | 19.15 | 69 | wheel cap |
| PTV | 15 | 54 | declared |
| CSV | 13.08 | 47 | wheel cap |

## Worth a second opinion

- **MDC still needs an in-game check.** It shares `wWheelsMax` and `rimRadius` with the MTC, so if one is wrong both are.
- The `min()` rule means the Ursa and Lynx are stored at their wheel cap rather than the `topSpeed` the file states, which will differ from any site that prints `topSpeed` directly.
- There is no external source to cross-check against: RSI's ship matrix has `scm_speed` for only the two Ballista skins and the G12 concepts, erkul is ships-only, and SPViewer's performance data is IFCS-derived.

## Testing

`bin/rails test test/loaders/sc_data/models_loader_test.rb` — 4 tests, 9 assertions, 0 failures. Two new cases cover a vehicle with all four values and a wheel-cap-only one, asserting the columns it does not declare are left alone.

🤖