### PR TITLE
feat(commodities): add Commodity reference table from game files

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -8,6 +8,7 @@ module ScData
         ::ScData::Loader::ItemsLoader.new.all
         ::ScData::Loader::ModelsLoader.new.all
         ::ScData::Loader::ModelModulesLoader.new.all
+        ::ScData::Loader::CommoditiesLoader.new.all
       end
 
       def initialize

--- a/app/lib/sc_data/loader/commodities_loader.rb
+++ b/app/lib/sc_data/loader/commodities_loader.rb
@@ -1,0 +1,35 @@
+module ScData
+  module Loader
+    class CommoditiesLoader < ::ScData::Loader::BaseLoader
+      def all
+        load_items("commodities").each do |commodity_data|
+          one(commodity_data)
+        end
+      end
+
+      def one(commodity_data)
+        return if commodity_data["name"].blank?
+
+        commodity = Commodity.find_by(sc_key: commodity_data["sc_key"])
+        commodity ||= Commodity.find_by(name: commodity_data["name"], sc_key: nil)
+        commodity ||= Commodity.new(sc_key: commodity_data["sc_key"])
+
+        commodity.update!(update_params(commodity_data))
+
+        commodity
+      end
+
+      private def update_params(commodity_data)
+        {
+          sc_key: commodity_data["sc_key"],
+          sc_ref: commodity_data["ref"],
+          name: commodity_data["name"],
+          commodity_type: commodity_data["commodity_type"],
+          description: commodity_data["description"],
+          icon: commodity_data["icon"],
+          version: sc_version
+        }
+      end
+    end
+  end
+end

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -70,6 +70,7 @@ module ScData
         ::ScData::Parser::ItemsParser.new(base_folder:, sc_version:, sc_environment:).all
         ::ScData::Parser::ManufacturersParser.new(base_folder:, sc_version:, sc_environment:).all
         ::ScData::Parser::ModelsParser.new(base_folder:, sc_version:, sc_environment:).all
+        ::ScData::Parser::CommoditiesParser.new(base_folder:, sc_version:, sc_environment:).all
       end
 
       def initialize(base_folder:, sc_version:, sc_environment:)

--- a/app/lib/sc_data/parser/commodities_parser.rb
+++ b/app/lib/sc_data/parser/commodities_parser.rb
@@ -1,0 +1,236 @@
+module ScData
+  module Parser
+    class CommoditiesParser < ScData::Parser::BaseParser
+      NAME_PREFIX = "items_commodities_"
+      TYPE_PREFIX = "items_commodities_type_"
+
+      # Commodities are declared twice: once as a bare ResourceContainer under
+      # entities/commodities, and once per crate size under scitem/carryables.
+      # Together the two trees cover every purchasable commodity in the build.
+      CANONICAL_PATH = "entities/commodities"
+      SOURCE_PATHS = [CANONICAL_PATH, "entities/scitem/carryables"]
+
+      # A handful of commodities are named after their own type key. Most are
+      # real products (RMC, HPMC, the two fuels); this one is the generic label
+      # the game puts on unmarked crates — evidence boxes, generic explosives —
+      # so it would list "Processed Goods" alongside the goods themselves.
+      IGNORED_KEYS = ["items_commodities_type_processedgoods"].freeze
+
+      TYPE_SLUGS = {
+        "agriculturalSupply" => "agricultural_supply",
+        "alloy" => "alloy",
+        "consumerGoods" => "consumer_goods",
+        "drink" => "drink",
+        "food" => "food",
+        "gas" => "gas",
+        "HPMC" => "hpmc",
+        "manmade" => "manmade",
+        "medicalSupply" => "medical_supply",
+        "metal" => "metal",
+        "militarySupply" => "military_supply",
+        "Mineral" => "mineral",
+        "natural" => "natural",
+        "nonmetals" => "nonmetals",
+        "plasmaFuel" => "plasma_fuel",
+        "processedGoods" => "processed_goods",
+        "quantumFuel" => "quantum_fuel",
+        "RMC" => "rmc",
+        "scrap" => "scrap",
+        "vice" => "vice",
+        "waste" => "waste"
+      }.freeze
+
+      CANONICAL_FOLDER_TYPES = {
+        "agriculturalsupplies" => "agricultural_supply",
+        "alloys" => "alloy",
+        "consumergoods" => "consumer_goods",
+        "counterfeit" => "consumer_goods",
+        "food" => "food",
+        "gas" => "gas",
+        "halogens" => "nonmetals",
+        "manmade" => "manmade",
+        "medicalsupplies" => "medical_supply",
+        "metals" => "metal",
+        "minerals" => "mineral",
+        "mixedmining" => "mineral",
+        "natural" => "natural",
+        "non_metals" => "nonmetals",
+        "processedgoods" => "processed_goods",
+        "scrap" => "scrap",
+        "vice" => "vice",
+        "waste" => "waste"
+      }.freeze
+
+      # Roughly a third of the commodities never declare a displayType — mostly
+      # harvestables and tractor-beam-only crates. Their record path always names
+      # the material, so fall back to it. Order is precedence: an ore crate lives
+      # under a "metal_ore" path and must not be read as a mineral.
+      PATH_TYPES = [
+        [/trophy/, "natural"],
+        [/_ore_/, "metal"],
+        [/mineral/, "mineral"],
+        [/_gas_/, "gas"],
+        [/nonmetal/, "nonmetals"],
+        [/special|holiday|lunar/, "consumer_goods"],
+        [/processedgoods/, "processed_goods"],
+        [/organic/, "food"],
+        [/consumergoods/, "consumer_goods"],
+        [/harvestable|_cy_/, "natural"]
+      ].freeze
+
+      def all
+        save_items(commodities, folder: "commodities")
+      end
+
+      def commodities
+        records = Hash.new { |hash, key| hash[key] = new_record }
+
+        load_commodity_data.each do |item|
+          collect_record(records, item)
+        end
+
+        records.filter_map { |sc_key, record| parse_commodity(sc_key, record) }
+      end
+
+      private def new_record
+        {types: Hash.new(0), canonical_type: nil, canonical_ref: nil, canonical_folder: nil, icons: [], paths: []}
+      end
+
+      private def collect_record(records, item)
+        canonical = item[:path].start_with?(CANONICAL_PATH)
+
+        purchasable_params(item[:values]).each do |params|
+          sc_key = commodity_key(params["displayName"])
+
+          next if sc_key.blank?
+          next if IGNORED_KEYS.include?(sc_key)
+
+          record = records[sc_key]
+          record[:paths] << item[:path]
+
+          if canonical
+            record[:canonical_ref] ||= value_or_nil(item[:values].dig("__ref"))
+            record[:canonical_folder] ||= canonical_folder(item[:path])
+          end
+
+          type = type_key(params["displayType"])
+
+          if type.present?
+            record[:types][type] += 1
+            record[:canonical_type] ||= type if canonical
+          end
+
+          icon = value_or_nil(params["displayThumbnail"])
+          record[:icons] << icon.downcase if icon.present?
+        end
+      end
+
+      private def parse_commodity(sc_key, record)
+        name = localize(sc_key)
+
+        return if name.blank?
+
+        type = resolve_type(record)
+
+        {
+          key: sc_key.delete_prefix(NAME_PREFIX),
+          sc_key:,
+          ref: record[:canonical_ref],
+          name:,
+          commodity_type: type,
+          commodity_type_name: type_name(type),
+          description: localize("#{sc_key}_desc"),
+          icon: record[:icons].first
+        }
+      end
+
+      # A record that declares the type under entities/commodities always wins:
+      # crate records disagree with each other (the alloys are tagged both
+      # "alloy" and "metal", contraband variants claim "vice"), and the bare
+      # commodity record is the one the commodity kiosk reads.
+      private def resolve_type(record)
+        declared = record[:canonical_type] || record[:types].max_by { |_, count| count }&.first
+
+        return TYPE_SLUGS[declared] if declared.present?
+
+        CANONICAL_FOLDER_TYPES[record[:canonical_folder]] || type_from_paths(record[:paths])
+      end
+
+      private def canonical_folder(path)
+        path.delete_prefix("#{CANONICAL_PATH}/").split("/").first
+      end
+
+      private def type_from_paths(paths)
+        joined = paths.join(" ").downcase
+
+        PATH_TYPES.find { |pattern, _| pattern.match?(joined) }&.last
+      end
+
+      private def type_name(type)
+        return if type.blank?
+
+        localize("#{TYPE_PREFIX}#{TYPE_SLUGS.key(type)}")
+      end
+
+      # The commodity display name occasionally points at the description key
+      # instead of the name key (wuotan seed). Fall back to the base key so the
+      # commodity doesn't end up named after a paragraph of flavour text.
+      private def commodity_key(display_name)
+        key = display_name.to_s.delete("@").sub(/,P\z/, "").downcase
+
+        return unless key.start_with?(NAME_PREFIX)
+
+        base_key = key.sub(/_desc\z/, "")
+
+        commodity_translations.key?(base_key) ? base_key : key
+      end
+
+      # Localization keys are mixed case and some carry a ",P" plural marker,
+      # while the record references are not consistently cased. Index both down.
+      private def commodity_translations
+        @commodity_translations ||= translations.each_with_object({}) do |(key, value), index|
+          index[key.sub(/,P\z/, "").downcase] = value
+        end
+      end
+
+      private def localize(key)
+        value = commodity_translations[key]
+
+        return if value.blank? || value == "@LOC_EMPTY"
+
+        value.gsub('\\n', "\n").strip
+      end
+
+      private def type_key(display_type)
+        key = display_type.to_s.delete("@").sub(/,P\z/, "")
+
+        return unless key.start_with?(TYPE_PREFIX)
+
+        key.delete_prefix(TYPE_PREFIX)
+      end
+
+      private def purchasable_params(values)
+        params = values.dig("Components", "SCItemPurchasableParams")
+
+        return [] if params.blank?
+
+        params.is_a?(Array) ? params : [params]
+      end
+
+      private def load_commodity_data
+        SOURCE_PATHS.flat_map do |path|
+          Dir.glob("#{import_path}/#{path}/**/*.xml").filter_map do |file|
+            content = File.read(file)
+
+            next unless content.include?(NAME_PREFIX)
+
+            {
+              path: file.sub("#{import_path}/", ""),
+              values: Hash.from_xml(content).values.first
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/sc_data/parser/commodities_parser.rb
+++ b/app/lib/sc_data/parser/commodities_parser.rb
@@ -194,7 +194,10 @@ module ScData
       end
 
       private def localize(key)
-        value = commodity_translations[key]
+        # The index is downcased, so the lookup has to be too. Commodity keys
+        # arrive downcased already, but the type keys are camel case
+        # (@items_commodities_type_consumerGoods) and silently missed.
+        value = commodity_translations[key.downcase]
 
         return if value.blank? || value == "@LOC_EMPTY"
 

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: commodities
+#
+#  id             :uuid             not null, primary key
+#  commodity_type :string
+#  description    :text
+#  icon           :string
+#  name           :string           not null
+#  sc_key         :string
+#  sc_ref         :string
+#  slug           :string           not null
+#  uex_slug       :string
+#  version        :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  uex_id         :integer
+#
+# Indexes
+#
+#  index_commodities_on_commodity_type  (commodity_type)
+#  index_commodities_on_sc_key          (sc_key) UNIQUE
+#  index_commodities_on_slug            (slug) UNIQUE
+#  index_commodities_on_uex_slug        (uex_slug)
+#
+class Commodity < ApplicationRecord
+  paginates_per 60
+
+  has_many :fleet_inventory_items, as: :item, dependent: :nullify
+
+  before_save :update_slugs
+
+  validates :sc_key, uniqueness: true, allow_nil: true
+  validates :name, presence: true
+
+  # Mirrors the displayType keys the game files ship. Stored as a string rather
+  # than an enum so a type added in a future build loads instead of raising.
+  TYPES = %w[
+    agricultural_supply alloy consumer_goods drink food gas hpmc manmade
+    medical_supply metal military_supply mineral natural nonmetals plasma_fuel
+    processed_goods quantum_fuel rmc scrap vice waste
+  ].freeze
+
+  DEFAULT_SORTING_PARAMS = ["name asc"]
+  ALLOWED_SORTING_PARAMS = [
+    "name asc", "name desc",
+    "commodityType asc", "commodityType desc",
+    "createdAt asc", "createdAt desc",
+    "updatedAt asc", "updatedAt desc"
+  ]
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name slug commodity_type sc_key uex_slug created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
+  end
+end

--- a/data/sc_data/parsed/live/commodities/acryliplex.json
+++ b/data/sc_data/parsed/live/commodities/acryliplex.json
@@ -1,0 +1,10 @@
+{
+  "key": "acryliplex",
+  "sc_key": "items_commodities_acryliplex",
+  "ref": "d92c2f26-75e3-45b3-9df6-84c3cec72d8a",
+  "name": "AcryliPlex Composite",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "This composite is a moldable material used in the construction of explosives. In addition to being commonly used in demolition applications for heavy industry and mining, it is also used to create small potent warheads. Care must be taken while transporting larger quantities of the composite as it is impact and heat sensitive.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/acryliplex.json
+++ b/data/sc_data/parsed/live/commodities/acryliplex.json
@@ -4,7 +4,7 @@
   "ref": "d92c2f26-75e3-45b3-9df6-84c3cec72d8a",
   "name": "AcryliPlex Composite",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "This composite is a moldable material used in the construction of explosives. In addition to being commonly used in demolition applications for heavy industry and mining, it is also used to create small potent warheads. Care must be taken while transporting larger quantities of the composite as it is impact and heat sensitive.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/agricium.json
+++ b/data/sc_data/parsed/live/commodities/agricium.json
@@ -1,0 +1,10 @@
+{
+  "key": "agricium",
+  "sc_key": "items_commodities_agricium",
+  "ref": "a3975b75-4566-4849-a46e-e462a99a2c34",
+  "name": "Agricium",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A rare and valuable silvery metal with a blue-green sheen. Malleable, ductile, and largely non-reactive.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/agricium_ore.json
+++ b/data/sc_data/parsed/live/commodities/agricium_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "agricium_ore",
+  "sc_key": "items_commodities_agricium_ore",
+  "ref": "49397ce6-d764-47dc-9f74-bcb1663ee1c1",
+  "name": "Agricium (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A rare and valuable silvery metal with a blue-green sheen. Malleable, ductile, and largely non-reactive.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/agriculturalsupplies.json
+++ b/data/sc_data/parsed/live/commodities/agriculturalsupplies.json
@@ -4,7 +4,7 @@
   "ref": "dcb64476-e7be-4fe2-9a39-89df37f25270",
   "name": "Agricultural Supplies",
   "commodity_type": "agricultural_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Agricultural Supply",
   "description": "Items required for agricultural production. Includes fertilizers, feed, and pesticides.",
   "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
 }

--- a/data/sc_data/parsed/live/commodities/agriculturalsupplies.json
+++ b/data/sc_data/parsed/live/commodities/agriculturalsupplies.json
@@ -1,0 +1,10 @@
+{
+  "key": "agriculturalsupplies",
+  "sc_key": "items_commodities_agriculturalsupplies",
+  "ref": "dcb64476-e7be-4fe2-9a39-89df37f25270",
+  "name": "Agricultural Supplies",
+  "commodity_type": "agricultural_supply",
+  "commodity_type_name": null,
+  "description": "Items required for agricultural production. Includes fertilizers, feed, and pesticides.",
+  "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
+}

--- a/data/sc_data/parsed/live/commodities/altruciatoxin.json
+++ b/data/sc_data/parsed/live/commodities/altruciatoxin.json
@@ -1,0 +1,10 @@
+{
+  "key": "altruciatoxin",
+  "sc_key": "items_commodities_altruciatoxin",
+  "ref": "f9bb228a-d3d3-4756-a0f1-65bfeca71a1d",
+  "name": "Altruciatoxin",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Created by chemically processing the pollen of Revenant Tree (altrucia lacus), common effects of ingesting or smoking altruciatoxin include relaxing of the muscles, sensory enhancement, and lethargy. Heavy usage can cause staining of the tongue.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/altruciatoxin_unprocessed.json
+++ b/data/sc_data/parsed/live/commodities/altruciatoxin_unprocessed.json
@@ -1,0 +1,10 @@
+{
+  "key": "altruciatoxin_unprocessed",
+  "sc_key": "items_commodities_altruciatoxin_unprocessed",
+  "ref": "599a5fca-1d2f-4661-bd97-1fbb17fbc6ac",
+  "name": "Revenant Tree Pollen",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "The pollen of Revenant Tree (altrucia lacus).",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/aluminum.json
+++ b/data/sc_data/parsed/live/commodities/aluminum.json
@@ -1,0 +1,10 @@
+{
+  "key": "aluminum",
+  "sc_key": "items_commodities_aluminum",
+  "ref": "6eaded2d-1f4e-4192-b436-299ecdfac899",
+  "name": "Aluminum",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A chemically reactive, gray metal that is malleable, lightweight, ductile, strong, and resistant to corrosion. Capable of superconductivity.",
+  "icon": "ui/textures/vector/general/items/inv_icon_aluminium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/aluminum_ore.json
+++ b/data/sc_data/parsed/live/commodities/aluminum_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "aluminum_ore",
+  "sc_key": "items_commodities_aluminum_ore",
+  "ref": "308f24a7-e314-4c41-ba58-b0927f28c42c",
+  "name": "Aluminum (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A chemically reactive, gray metal that is malleable, lightweight, ductile, strong, and resistant to corrosion. Capable of superconductivity.",
+  "icon": "ui/textures/vector/general/items/inv_icon_aluminium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/amioshiplague.json
+++ b/data/sc_data/parsed/live/commodities/amioshiplague.json
@@ -1,0 +1,10 @@
+{
+  "key": "amioshiplague",
+  "sc_key": "items_commodities_amioshiplague",
+  "ref": "9b18dc50-eb7f-46ff-b30b-c2753cee1c19",
+  "name": "Amioshi Plague",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Not nearly as ominous as its name, the Amioshi Plague is an invasive lichen that grows in the cracks of rocks. While the core of the lichen burrows out of sight to try and absorb as much moisture as it can find, the part near the surface sprouts hooded scales that eject spores to spread to other rocks. It's relatively short maturation period is the origin of its name.",
+  "icon": "ui/textures/vector/general/items/inv_icon_amioshiplague.svg"
+}

--- a/data/sc_data/parsed/live/commodities/ammocrate.json
+++ b/data/sc_data/parsed/live/commodities/ammocrate.json
@@ -1,0 +1,10 @@
+{
+  "key": "ammocrate",
+  "sc_key": "items_commodities_ammocrate",
+  "ref": null,
+  "name": "Ammo Crate",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/ammocrate.json
+++ b/data/sc_data/parsed/live/commodities/ammocrate.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Ammo Crate",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/ammonia.json
+++ b/data/sc_data/parsed/live/commodities/ammonia.json
@@ -1,0 +1,10 @@
+{
+  "key": "ammonia",
+  "sc_key": "items_commodities_ammonia",
+  "ref": "d1b4dc27-a66c-4b3c-b8b2-0cfb01384521",
+  "name": "Ammonia",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "Ammonia description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/aphorite.json
+++ b/data/sc_data/parsed/live/commodities/aphorite.json
@@ -4,7 +4,7 @@
   "ref": "2026020f-3708-42fb-acf7-5100a5c0f472",
   "name": "Aphorite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Decorative jewel crystal prized for its multi-hued tones.",
   "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/aphorite.json
+++ b/data/sc_data/parsed/live/commodities/aphorite.json
@@ -1,0 +1,10 @@
+{
+  "key": "aphorite",
+  "sc_key": "items_commodities_aphorite",
+  "ref": "2026020f-3708-42fb-acf7-5100a5c0f472",
+  "name": "Aphorite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Decorative jewel crystal prized for its multi-hued tones.",
+  "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/argon.json
+++ b/data/sc_data/parsed/live/commodities/argon.json
@@ -1,0 +1,10 @@
+{
+  "key": "argon",
+  "sc_key": "items_commodities_argon",
+  "ref": "2be53905-e22e-4c75-9b05-7716d65552dc",
+  "name": "Argon",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "Chemically inert under most conditions, argon is an odorless, colorless gas that is as soluble in water as oxygen. Appears lilac in a discharge tube.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/astatine.json
+++ b/data/sc_data/parsed/live/commodities/astatine.json
@@ -1,0 +1,10 @@
+{
+  "key": "astatine",
+  "sc_key": "items_commodities_astatine",
+  "ref": "89dd252f-cb81-48fc-ad8a-3576a6c348cc",
+  "name": "Astatine",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "A dangerously radioactive, highly unstable halogen. Some of its isotopes have half-lives of one second or less.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/atlasium.json
+++ b/data/sc_data/parsed/live/commodities/atlasium.json
@@ -1,0 +1,10 @@
+{
+  "key": "atlasium",
+  "sc_key": "items_commodities_atlasium",
+  "ref": "af5dcf22-7a28-4b1e-88f0-4309d34be11a",
+  "name": "Atlasium",
+  "commodity_type": "alloy",
+  "commodity_type_name": "Alloy",
+  "description": "This very strong metal alloy is often one of the few materials salvageable from severe wreck sites.",
+  "icon": "ui/textures/vector/general/items/inv_icon_atlasium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/audiovisualequipment.json
+++ b/data/sc_data/parsed/live/commodities/audiovisualequipment.json
@@ -1,0 +1,10 @@
+{
+  "key": "audiovisualequipment",
+  "sc_key": "items_commodities_audiovisualequipment",
+  "ref": "7d6416a5-7ec4-4fec-9a07-ae88a5e2ee98",
+  "name": "Audio-Visual Equipment",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Devices, cabling, and rigging used for multimedia presentations and events.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/audiovisualequipment.json
+++ b/data/sc_data/parsed/live/commodities/audiovisualequipment.json
@@ -4,7 +4,7 @@
   "ref": "7d6416a5-7ec4-4fec-9a07-ae88a5e2ee98",
   "name": "Audio-Visual Equipment",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Devices, cabling, and rigging used for multimedia presentations and events.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/beradom.json
+++ b/data/sc_data/parsed/live/commodities/beradom.json
@@ -1,0 +1,10 @@
+{
+  "key": "beradom",
+  "sc_key": "items_commodities_beradom",
+  "ref": null,
+  "name": "Beradom",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Formed when sap from the Beraber Fir is crystalized during forest fires, this transparent deep blue \"gemstone\" is often polished smooth and used in jewelry. While it can be manufactured by growing trees and then doing a controlled burn, the time investment for the trees to reach the proper maturity still make this a rare commodity.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/beradom.json
+++ b/data/sc_data/parsed/live/commodities/beradom.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Beradom",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Formed when sap from the Beraber Fir is crystalized during forest fires, this transparent deep blue \"gemstone\" is often polished smooth and used in jewelry. While it can be manufactured by growing trees and then doing a controlled burn, the time investment for the trees to reach the proper maturity still make this a rare commodity.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/beryl.json
+++ b/data/sc_data/parsed/live/commodities/beryl.json
@@ -1,0 +1,10 @@
+{
+  "key": "beryl",
+  "sc_key": "items_commodities_beryl",
+  "ref": "57e2094c-bc2d-4479-9af6-8918059b604e",
+  "name": "Beryl",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A mineral that creates natural hexagonal crystals. Colorless in its pure form, its impure forms include the gems emerald and aquamarine.",
+  "icon": "ui/textures/vector/general/items/inv_icon_beryl.svg"
+}

--- a/data/sc_data/parsed/live/commodities/beryl.json
+++ b/data/sc_data/parsed/live/commodities/beryl.json
@@ -4,7 +4,7 @@
   "ref": "57e2094c-bc2d-4479-9af6-8918059b604e",
   "name": "Beryl",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A mineral that creates natural hexagonal crystals. Colorless in its pure form, its impure forms include the gems emerald and aquamarine.",
   "icon": "ui/textures/vector/general/items/inv_icon_beryl.svg"
 }

--- a/data/sc_data/parsed/live/commodities/beryl_raw.json
+++ b/data/sc_data/parsed/live/commodities/beryl_raw.json
@@ -4,7 +4,7 @@
   "ref": "be686734-729a-43e1-93ea-d7f7f127ecde",
   "name": "Beryl (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A mineral that creates natural hexagonal crystals. Colorless in its pure form, its impure forms include the gems emerald and aquamarine.",
   "icon": "ui/textures/vector/general/items/inv_icon_beryl.svg"
 }

--- a/data/sc_data/parsed/live/commodities/beryl_raw.json
+++ b/data/sc_data/parsed/live/commodities/beryl_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "beryl_raw",
+  "sc_key": "items_commodities_beryl_raw",
+  "ref": "be686734-729a-43e1-93ea-d7f7f127ecde",
+  "name": "Beryl (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A mineral that creates natural hexagonal crystals. Colorless in its pure form, its impure forms include the gems emerald and aquamarine.",
+  "icon": "ui/textures/vector/general/items/inv_icon_beryl.svg"
+}

--- a/data/sc_data/parsed/live/commodities/bexalite.json
+++ b/data/sc_data/parsed/live/commodities/bexalite.json
@@ -1,0 +1,10 @@
+{
+  "key": "bexalite",
+  "sc_key": "items_commodities_bexalite",
+  "ref": "7a404a18-04f1-48c4-a4bd-c60af6ed1769",
+  "name": "Bexalite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "This mineral harvested from worlds with no natural magnetic core, has found widespread use in electrical systems.",
+  "icon": "ui/textures/vector/general/items/inv_icon_bexalite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/bexalite.json
+++ b/data/sc_data/parsed/live/commodities/bexalite.json
@@ -4,7 +4,7 @@
   "ref": "7a404a18-04f1-48c4-a4bd-c60af6ed1769",
   "name": "Bexalite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "This mineral harvested from worlds with no natural magnetic core, has found widespread use in electrical systems.",
   "icon": "ui/textures/vector/general/items/inv_icon_bexalite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/bexalite_raw.json
+++ b/data/sc_data/parsed/live/commodities/bexalite_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "bexalite_raw",
+  "sc_key": "items_commodities_bexalite_raw",
+  "ref": "05544778-ca64-44fb-85fd-fdd6db81d543",
+  "name": "Bexalite (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "This mineral harvested from worlds with no natural magnetic core, has found widespread use in electrical systems.",
+  "icon": "ui/textures/vector/general/items/inv_icon_bexalite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/bexalite_raw.json
+++ b/data/sc_data/parsed/live/commodities/bexalite_raw.json
@@ -4,7 +4,7 @@
   "ref": "05544778-ca64-44fb-85fd-fdd6db81d543",
   "name": "Bexalite (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "This mineral harvested from worlds with no natural magnetic core, has found widespread use in electrical systems.",
   "icon": "ui/textures/vector/general/items/inv_icon_bexalite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/biologicalsamples.json
+++ b/data/sc_data/parsed/live/commodities/biologicalsamples.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Biological Samples",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/biologicalsamples.json
+++ b/data/sc_data/parsed/live/commodities/biologicalsamples.json
@@ -1,0 +1,10 @@
+{
+  "key": "biologicalsamples",
+  "sc_key": "items_commodities_biologicalsamples",
+  "ref": null,
+  "name": "Biological Samples",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/bioplastic.json
+++ b/data/sc_data/parsed/live/commodities/bioplastic.json
@@ -1,0 +1,10 @@
+{
+  "key": "bioplastic",
+  "sc_key": "items_commodities_bioplastic",
+  "ref": "8bf0e596-235e-40da-aedf-4209f5427b49",
+  "name": "Bioplastic",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A plastic replacement material created when fossil fuels began running low in Sol. It is derived from renewable biomass sources, often from vat grown bacteria but can be derived from industrial byproducts as well.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/bluebilva.json
+++ b/data/sc_data/parsed/live/commodities/bluebilva.json
@@ -1,0 +1,10 @@
+{
+  "key": "bluebilva",
+  "sc_key": "items_commodities_bluebilva",
+  "ref": "c186b9db-f002-423d-8001-4f9a3cc74264",
+  "name": "Blue Bilva",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 23\nHEI: 10\nEffects: Hydrating, Energizing\n\nThe Blue Bilva is known for its distinctive rich flavor; which is highly astringent, aromatic and very high in fructose. The fruit can also be identified by its slightly pointed, ovoid shape, and dark blue to indigo skin. The fibrous flesh of the bilva clings firmly to its large stone which is so hard that it can only be cracked through mechanical means. It takes about 11 months to ripen on the tree. It is commonly eaten dried or turned into brandy.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/borase.json
+++ b/data/sc_data/parsed/live/commodities/borase.json
@@ -1,0 +1,10 @@
+{
+  "key": "borase",
+  "sc_key": "items_commodities_borase",
+  "ref": "001c7bc6-2bb6-4f66-a8ef-a1c63e80ffc5",
+  "name": "Borase",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "This highly thermally conductive material is often formed from cosmic ray spallation and is most typically found in younger star systems.",
+  "icon": "ui/textures/vector/general/items/inv_icon_borase.svg"
+}

--- a/data/sc_data/parsed/live/commodities/borase_ore.json
+++ b/data/sc_data/parsed/live/commodities/borase_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "borase_ore",
+  "sc_key": "items_commodities_borase_ore",
+  "ref": "fbc087d7-f674-4075-a39f-eb500557d39f",
+  "name": "Borase (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "This highly thermally conductive material is often formed from cosmic ray spallation and is most typically found in younger star systems.",
+  "icon": "ui/textures/vector/general/items/inv_icon_borase.svg"
+}

--- a/data/sc_data/parsed/live/commodities/cadmiumallinide.json
+++ b/data/sc_data/parsed/live/commodities/cadmiumallinide.json
@@ -1,0 +1,10 @@
+{
+  "key": "cadmiumallinide",
+  "sc_key": "items_commodities_cadmiumallinide",
+  "ref": "26b69994-6bae-419a-9a0f-1e3db2786596",
+  "name": "Cadmium Allinide",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "This refined form of cadmium has great energy potential and is used frequently in reactors and batteries.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/carbon.json
+++ b/data/sc_data/parsed/live/commodities/carbon.json
@@ -1,0 +1,10 @@
+{
+  "key": "carbon",
+  "sc_key": "items_commodities_carbon",
+  "ref": "1e65e4c1-c7c2-4ed6-9d02-f20deb26d74b",
+  "name": "Carbon",
+  "commodity_type": "nonmetals",
+  "commodity_type_name": "Nonmetals",
+  "description": "Owing to carbon's ability to form a variety of allotropes with vastly different properties and its sheer abundance in the universe, this element is used in a wide variety of applications.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/carbonsilk.json
+++ b/data/sc_data/parsed/live/commodities/carbonsilk.json
@@ -1,0 +1,10 @@
+{
+  "key": "carbonsilk",
+  "sc_key": "items_commodities_carbonsilk",
+  "ref": "c070cba1-88f5-49d1-bdae-6ca89e926f53",
+  "name": "Carbon-Silk",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "This light, flexible and incredibly strong material is woven from carbon strands collected from the secretions of specially bioengineered worms.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/carinite.json
+++ b/data/sc_data/parsed/live/commodities/carinite.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Carinite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A rare mineral because the extreme pressure needed for its formation is very uncommon, it is in high demand thanks to its use in advanced computer processors and other cutting-edge electronics.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/carinite.json
+++ b/data/sc_data/parsed/live/commodities/carinite.json
@@ -1,0 +1,10 @@
+{
+  "key": "carinite",
+  "sc_key": "items_commodities_carinite",
+  "ref": null,
+  "name": "Carinite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A rare mineral because the extreme pressure needed for its formation is very uncommon, it is in high demand thanks to its use in advanced computer processors and other cutting-edge electronics.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/chlorine.json
+++ b/data/sc_data/parsed/live/commodities/chlorine.json
@@ -1,0 +1,10 @@
+{
+  "key": "chlorine",
+  "sc_key": "items_commodities_chlorine",
+  "ref": "decc7745-5003-44b0-9b0d-720e12374308",
+  "name": "Chlorine",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "A light gas with a high electron affinity and a yellow-green tone at room temperature. One of the halogens.",
+  "icon": "ui/textures/vector/general/items/inv_icon_chlorine.svg"
+}

--- a/data/sc_data/parsed/live/commodities/ck13gidseeds.json
+++ b/data/sc_data/parsed/live/commodities/ck13gidseeds.json
@@ -4,7 +4,7 @@
   "ref": "2d70b5eb-0691-4270-b173-f91b7f59ee88",
   "name": "CK13-GID Seed Blend",
   "commodity_type": "agricultural_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Agricultural Supply",
   "description": "These genetically-modified barley seeds were banned because of their aggressive growth and high-levels of cross-pollination that has frequently ravaged any neighboring plant life. However, the plant's high yield and ease of growth have continued to make it a sought-after commodity.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/ck13gidseeds.json
+++ b/data/sc_data/parsed/live/commodities/ck13gidseeds.json
@@ -1,0 +1,10 @@
+{
+  "key": "ck13gidseeds",
+  "sc_key": "items_commodities_ck13gidseeds",
+  "ref": "2d70b5eb-0691-4270-b173-f91b7f59ee88",
+  "name": "CK13-GID Seed Blend",
+  "commodity_type": "agricultural_supply",
+  "commodity_type_name": null,
+  "description": "These genetically-modified barley seeds were banned because of their aggressive growth and high-levels of cross-pollination that has frequently ravaged any neighboring plant life. However, the plant's high yield and ease of growth have continued to make it a sought-after commodity.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/cobalt.json
+++ b/data/sc_data/parsed/live/commodities/cobalt.json
@@ -1,0 +1,10 @@
+{
+  "key": "cobalt",
+  "sc_key": "items_commodities_cobalt",
+  "ref": "1c56dde0-3483-4324-8f5a-25c3b446c233",
+  "name": "Cobalt",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Cobalt description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/compboard.json
+++ b/data/sc_data/parsed/live/commodities/compboard.json
@@ -1,0 +1,10 @@
+{
+  "key": "compboard",
+  "sc_key": "items_commodities_compboard",
+  "ref": "14798b94-9280-475b-8bbe-9ffb6698cf99",
+  "name": "Compboard",
+  "commodity_type": "scrap",
+  "commodity_type_name": "Scrap",
+  "description": "A main processing unit used inside various computers and electronics.",
+  "icon": "ui/textures/vector/general/items/inv_icon_compboard.svg"
+}

--- a/data/sc_data/parsed/live/commodities/constructionmaterials.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterials.json
@@ -4,7 +4,7 @@
   "ref": "383e3a8d-2b9a-4550-81fb-5700b7344ced",
   "name": "Construction Materials",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Various supplies used to build, repair, and maintain buildings and structures.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/constructionmaterials.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterials.json
@@ -1,0 +1,10 @@
+{
+  "key": "constructionmaterials",
+  "sc_key": "items_commodities_constructionmaterials",
+  "ref": "383e3a8d-2b9a-4550-81fb-5700b7344ced",
+  "name": "Construction Materials",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Various supplies used to build, repair, and maintain buildings and structures.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/constructionmaterialschunks.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialschunks.json
@@ -1,0 +1,10 @@
+{
+  "key": "constructionmaterialschunks",
+  "sc_key": "items_commodities_constructionmaterialschunks",
+  "ref": null,
+  "name": "Construction Salvage",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/constructionmaterialschunks.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialschunks.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Construction Salvage",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/constructionmaterialspowder.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialspowder.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Construction Rubble",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/constructionmaterialspowder.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialspowder.json
@@ -1,0 +1,10 @@
+{
+  "key": "constructionmaterialspowder",
+  "sc_key": "items_commodities_constructionmaterialspowder",
+  "ref": null,
+  "name": "Construction Rubble",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/constructionmaterialsscraps.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialsscraps.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Construction Pieces",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/constructionmaterialsscraps.json
+++ b/data/sc_data/parsed/live/commodities/constructionmaterialsscraps.json
@@ -1,0 +1,10 @@
+{
+  "key": "constructionmaterialsscraps",
+  "sc_key": "items_commodities_constructionmaterialsscraps",
+  "ref": null,
+  "name": "Construction Pieces",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/copper.json
+++ b/data/sc_data/parsed/live/commodities/copper.json
@@ -1,0 +1,10 @@
+{
+  "key": "copper",
+  "sc_key": "items_commodities_copper",
+  "ref": "fff8c75a-af63-4e2e-ad1e-1f80380fdb3c",
+  "name": "Copper",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A soft red-orange colored metal with high conductivity. Prone to oxidation unless properly treated.",
+  "icon": "ui/textures/vector/general/items/inv_icon_copper.svg"
+}

--- a/data/sc_data/parsed/live/commodities/copper_ore.json
+++ b/data/sc_data/parsed/live/commodities/copper_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "copper_ore",
+  "sc_key": "items_commodities_copper_ore",
+  "ref": "8772fc77-f003-44c1-97c3-de3726059d21",
+  "name": "Copper (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A soft red-orange colored metal with high conductivity. Prone to oxidation unless properly treated.",
+  "icon": "ui/textures/vector/general/items/inv_icon_copper.svg"
+}

--- a/data/sc_data/parsed/live/commodities/corundum.json
+++ b/data/sc_data/parsed/live/commodities/corundum.json
@@ -4,7 +4,7 @@
   "ref": "4f15da23-7bf1-464a-8a22-b50ba9536200",
   "name": "Corundum",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "The crystalline form of aluminum oxide. Used as a gem. Varieties include ruby, sapphire, and padparadscha.",
   "icon": "ui/textures/vector/general/items/inv_icon_corundum.svg"
 }

--- a/data/sc_data/parsed/live/commodities/corundum.json
+++ b/data/sc_data/parsed/live/commodities/corundum.json
@@ -1,0 +1,10 @@
+{
+  "key": "corundum",
+  "sc_key": "items_commodities_corundum",
+  "ref": "4f15da23-7bf1-464a-8a22-b50ba9536200",
+  "name": "Corundum",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "The crystalline form of aluminum oxide. Used as a gem. Varieties include ruby, sapphire, and padparadscha.",
+  "icon": "ui/textures/vector/general/items/inv_icon_corundum.svg"
+}

--- a/data/sc_data/parsed/live/commodities/corundum_raw.json
+++ b/data/sc_data/parsed/live/commodities/corundum_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "corundum_raw",
+  "sc_key": "items_commodities_corundum_raw",
+  "ref": "29095211-071d-404b-a2fb-1fff7f45f791",
+  "name": "Corundum (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "The crystalline form of aluminum oxide. Used as a gem. Varieties include ruby, sapphire, and padparadscha.",
+  "icon": "ui/textures/vector/general/items/inv_icon_corundum.svg"
+}

--- a/data/sc_data/parsed/live/commodities/corundum_raw.json
+++ b/data/sc_data/parsed/live/commodities/corundum_raw.json
@@ -4,7 +4,7 @@
   "ref": "29095211-071d-404b-a2fb-1fff7f45f791",
   "name": "Corundum (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "The crystalline form of aluminum oxide. Used as a gem. Varieties include ruby, sapphire, and padparadscha.",
   "icon": "ui/textures/vector/general/items/inv_icon_corundum.svg"
 }

--- a/data/sc_data/parsed/live/commodities/dcsr2.json
+++ b/data/sc_data/parsed/live/commodities/dcsr2.json
@@ -4,7 +4,7 @@
   "ref": "61f442d3-ec14-48d1-af2e-bcb50b894d58",
   "name": "DCSR2",
   "commodity_type": "agricultural_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Agricultural Supply",
   "description": "An organically derived terpenoid lipid, dicylasterone (commonly known as DCSR2), has been banned from use in biomedical applications. Currently, it is most typically used in the manufacture of illegal narcotic 'SLAM.'",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/dcsr2.json
+++ b/data/sc_data/parsed/live/commodities/dcsr2.json
@@ -1,0 +1,10 @@
+{
+  "key": "dcsr2",
+  "sc_key": "items_commodities_dcsr2",
+  "ref": "61f442d3-ec14-48d1-af2e-bcb50b894d58",
+  "name": "DCSR2",
+  "commodity_type": "agricultural_supply",
+  "commodity_type_name": null,
+  "description": "An organically derived terpenoid lipid, dicylasterone (commonly known as DCSR2), has been banned from use in biomedical applications. Currently, it is most typically used in the manufacture of illegal narcotic 'SLAM.'",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/decaripod.json
+++ b/data/sc_data/parsed/live/commodities/decaripod.json
@@ -1,0 +1,10 @@
+{
+  "key": "decaripod",
+  "sc_key": "items_commodities_decaripod",
+  "ref": "cdcd7391-29d9-4659-8c02-1911f0a552ff",
+  "name": "Decari Pod",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "A large spore pod harvested from the decari that can be collected and used as a food source. However, the decari pod cannot be consumed directly. It must have its thick out layer and spiny filaments removed, and the fibrous hymenium cooked for a long time before it can be safely digested by Humans.",
+  "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
+}

--- a/data/sc_data/parsed/live/commodities/degnousroot.json
+++ b/data/sc_data/parsed/live/commodities/degnousroot.json
@@ -1,0 +1,10 @@
+{
+  "key": "degnousroot",
+  "sc_key": "items_commodities_degnousroot",
+  "ref": "35e16838-7bfe-4140-84b7-52e93745c957",
+  "name": "Degnous Root",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Degnous root is a macroalgae that was discovered in the shallow coastlines of Prime on Terra. Once harvested, degnous can be utilized as an ingredient in medical and health products thanks to its unique blend of amino acids.",
+  "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
+}

--- a/data/sc_data/parsed/live/commodities/detatrine.json
+++ b/data/sc_data/parsed/live/commodities/detatrine.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Detatrine",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "Refined from the natural toxin found within the rare detatium fruit, this chemical has numerous medical applications.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/detatrine.json
+++ b/data/sc_data/parsed/live/commodities/detatrine.json
@@ -1,0 +1,10 @@
+{
+  "key": "detatrine",
+  "sc_key": "items_commodities_detatrine",
+  "ref": null,
+  "name": "Detatrine",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "Refined from the natural toxin found within the rare detatium fruit, this chemical has numerous medical applications.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/diamond.json
+++ b/data/sc_data/parsed/live/commodities/diamond.json
@@ -1,0 +1,10 @@
+{
+  "key": "diamond",
+  "sc_key": "items_commodities_diamond",
+  "ref": "aee3eac7-a05a-44d4-b6de-47344ec1f707",
+  "name": "Diamond",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "An allotrope of the element carbon, diamonds form over billions of years under high heat and pressure. Extremely hard and thermally conductive.",
+  "icon": "ui/textures/vector/general/items/inv_icon_diamond.svg"
+}

--- a/data/sc_data/parsed/live/commodities/diamond.json
+++ b/data/sc_data/parsed/live/commodities/diamond.json
@@ -4,7 +4,7 @@
   "ref": "aee3eac7-a05a-44d4-b6de-47344ec1f707",
   "name": "Diamond",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "An allotrope of the element carbon, diamonds form over billions of years under high heat and pressure. Extremely hard and thermally conductive.",
   "icon": "ui/textures/vector/general/items/inv_icon_diamond.svg"
 }

--- a/data/sc_data/parsed/live/commodities/diamond_raw.json
+++ b/data/sc_data/parsed/live/commodities/diamond_raw.json
@@ -4,7 +4,7 @@
   "ref": "3888a61f-0d88-4d43-b8c0-3dea23b5d68f",
   "name": "Diamond (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "An allotrope of the element carbon, diamonds form over billions of years under high heat and pressure. Extremely hard and thermally conductive.",
   "icon": "ui/textures/vector/general/items/inv_icon_diamond.svg"
 }

--- a/data/sc_data/parsed/live/commodities/diamond_raw.json
+++ b/data/sc_data/parsed/live/commodities/diamond_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "diamond_raw",
+  "sc_key": "items_commodities_diamond_raw",
+  "ref": "3888a61f-0d88-4d43-b8c0-3dea23b5d68f",
+  "name": "Diamond (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "An allotrope of the element carbon, diamonds form over billions of years under high heat and pressure. Extremely hard and thermally conductive.",
+  "icon": "ui/textures/vector/general/items/inv_icon_diamond.svg"
+}

--- a/data/sc_data/parsed/live/commodities/diamondlaminate.json
+++ b/data/sc_data/parsed/live/commodities/diamondlaminate.json
@@ -1,0 +1,10 @@
+{
+  "key": "diamondlaminate",
+  "sc_key": "items_commodities_diamondlaminate",
+  "ref": "81d50d99-83b2-4caa-81a1-e8d15bcf1b2e",
+  "name": "Diamond Laminate",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "One of the hardest manufactured materials today, this glass-like substance is frequently used in the construction of cockpit windows.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/diluthermex.json
+++ b/data/sc_data/parsed/live/commodities/diluthermex.json
@@ -4,7 +4,7 @@
   "ref": "84b92a6a-8c34-4b4c-b8be-88f6ecf03626",
   "name": "Diluthermex",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "An extremely heat resistant epoxy often used in the mounting and repair of ship thrusters. It is considered very difficult to transport in its uncured state as it becomes explosively unstable when exposed to Chan-Eisen fields during quantum travel. Specialized containers must be used to safely transport the epoxy long distances. Once set and cured, the Diluthermex is no longer reactive.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/diluthermex.json
+++ b/data/sc_data/parsed/live/commodities/diluthermex.json
@@ -1,0 +1,10 @@
+{
+  "key": "diluthermex",
+  "sc_key": "items_commodities_diluthermex",
+  "ref": "84b92a6a-8c34-4b4c-b8be-88f6ecf03626",
+  "name": "Diluthermex",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "An extremely heat resistant epoxy often used in the mounting and repair of ship thrusters. It is considered very difficult to transport in its uncured state as it becomes explosively unstable when exposed to Chan-Eisen fields during quantum travel. Specialized containers must be used to safely transport the epoxy long distances. Once set and cured, the Diluthermex is no longer reactive.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/distilledspirits.json
+++ b/data/sc_data/parsed/live/commodities/distilledspirits.json
@@ -1,0 +1,10 @@
+{
+  "key": "distilledspirits",
+  "sc_key": "items_commodities_distilledspirits",
+  "ref": "f4ddbdca-2266-456f-afbc-e46586f9b4a4",
+  "name": "Distilled Spirits",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "A purified beverage produced through the distillation of fermented substances. Possesses at least 20 percent of alcohol by volume.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/dolivine.json
+++ b/data/sc_data/parsed/live/commodities/dolivine.json
@@ -1,0 +1,10 @@
+{
+  "key": "dolivine",
+  "sc_key": "items_commodities_dolivine",
+  "ref": "f5246e60-4877-4c0a-8bad-e6b9b26e8887",
+  "name": "Dolivine",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A dull green gemstone that is used decoratively but also can be used for industrial purposes thanks to its resistance to weathering and high density.",
+  "icon": "ui/textures/vector/general/items/inv_icon_dolivine.svg"
+}

--- a/data/sc_data/parsed/live/commodities/dolivine.json
+++ b/data/sc_data/parsed/live/commodities/dolivine.json
@@ -4,7 +4,7 @@
   "ref": "f5246e60-4877-4c0a-8bad-e6b9b26e8887",
   "name": "Dolivine",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A dull green gemstone that is used decoratively but also can be used for industrial purposes thanks to its resistance to weathering and high density.",
   "icon": "ui/textures/vector/general/items/inv_icon_dolivine.svg"
 }

--- a/data/sc_data/parsed/live/commodities/dopple.json
+++ b/data/sc_data/parsed/live/commodities/dopple.json
@@ -1,0 +1,10 @@
+{
+  "key": "dopple",
+  "sc_key": "items_commodities_dopple",
+  "ref": "d09bd9d5-0d62-4732-b7d1-5c33662e03f9",
+  "name": "Dopple",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "A dissociative drug that creates a strong feeling of separation. People, places, and objects familiar to the user take on a distorted and unreal quality. Some users report a detachment from emotions. Doplencyethorphine is used in small dosages medically to help with extreme emotion issues and rage management problems. Recreational users take it for the effect of resetting the mundane and everyday into something new and different. Side effects include memory loss, panic attacks, paranoia, and psychotic episodes.",
+  "icon": "ui/textures/vector/general/items/inv_icon_hpmc.svg"
+}

--- a/data/sc_data/parsed/live/commodities/dymantium.json
+++ b/data/sc_data/parsed/live/commodities/dymantium.json
@@ -1,0 +1,10 @@
+{
+  "key": "dymantium",
+  "sc_key": "items_commodities_dymantium",
+  "ref": "bd56ff6d-3ab7-4f66-8346-f620e7f77391",
+  "name": "Dymantium",
+  "commodity_type": "alloy",
+  "commodity_type_name": "Alloy",
+  "description": "One of the toughest known metal alloys that can be forged. It is extremely difficult to manufacture and must be used with care in order to avoid accidentally weakening the material during application.",
+  "icon": "ui/textures/vector/general/items/inv_icon_dymantium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/dynaflex.json
+++ b/data/sc_data/parsed/live/commodities/dynaflex.json
@@ -1,0 +1,10 @@
+{
+  "key": "dynaflex",
+  "sc_key": "items_commodities_dynaflex",
+  "ref": "6bd57fda-6ead-4b39-98dd-108833abe918",
+  "name": "DynaFlex",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "Developed for use by the military, this absorptive material can withstand severe stress owing to its flexibility.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/elespo.json
+++ b/data/sc_data/parsed/live/commodities/elespo.json
@@ -1,0 +1,10 @@
+{
+  "key": "elespo",
+  "sc_key": "items_commodities_elespo",
+  "ref": "f0add17d-33bb-499e-bd68-47959cea9bb8",
+  "name": "Elespo",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A brand name of a light sponge-like material that has exceptional electrical absorption properties.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/etam.json
+++ b/data/sc_data/parsed/live/commodities/etam.json
@@ -1,0 +1,10 @@
+{
+  "key": "etam",
+  "sc_key": "items_commodities_etam",
+  "ref": "ab0b493c-9faf-401e-a27b-a81998bf07a5",
+  "name": "E'tam",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Created from the leaves of indigenous plants, E'tam is an organic hallucinogenic drug used by the Xi'an to slow body function and focus in order to achieve a deeper meditative state. For Humans, the effects are much more severe. E'tam causes hyper awareness, cognitive enhancement and improved focus. Users can be so engrossed in tasks that they neglect to eat, sleep or take care of other body functions.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/feynmaline.json
+++ b/data/sc_data/parsed/live/commodities/feynmaline.json
@@ -1,0 +1,10 @@
+{
+  "key": "feynmaline",
+  "sc_key": "items_commodities_feynmaline",
+  "ref": null,
+  "name": "Feynmaline",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "The paramorphic crystalline structure of this mineral is extremely volatile. When extra energy is introduced, as is typical with modern mining, the ore will often explosively degrade into the more stably structured Janalite. This instability makes Feynamline very dangerous to acquire but also extremely valuable as an industrial anti-matter precursor if it can be properly harvested.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/feynmaline.json
+++ b/data/sc_data/parsed/live/commodities/feynmaline.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Feynmaline",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "The paramorphic crystalline structure of this mineral is extremely volatile. When extra energy is introduced, as is typical with modern mining, the ore will often explosively degrade into the more stably structured Janalite. This instability makes Feynamline very dangerous to acquire but also extremely valuable as an industrial anti-matter precursor if it can be properly harvested.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/fireworks.json
+++ b/data/sc_data/parsed/live/commodities/fireworks.json
@@ -4,7 +4,7 @@
   "ref": "ccd2081c-25e8-46ba-9013-853ee1284554",
   "name": "Fireworks",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Colorful pyrotechnic devices used at celebrations and special events.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/fireworks.json
+++ b/data/sc_data/parsed/live/commodities/fireworks.json
@@ -1,0 +1,10 @@
+{
+  "key": "fireworks",
+  "sc_key": "items_commodities_fireworks",
+  "ref": "ccd2081c-25e8-46ba-9013-853ee1284554",
+  "name": "Fireworks",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Colorful pyrotechnic devices used at celebrations and special events.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/fluorine.json
+++ b/data/sc_data/parsed/live/commodities/fluorine.json
@@ -1,0 +1,10 @@
+{
+  "key": "fluorine",
+  "sc_key": "items_commodities_fluorine",
+  "ref": "dfa75309-d4d1-48be-be0b-c3bddb413965",
+  "name": "Fluorine",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "A toxic and highly reactive gas that appears pale yellow in its natural state. Very easily forms compounds with almost all other elements.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/fotiascrub.json
+++ b/data/sc_data/parsed/live/commodities/fotiascrub.json
@@ -1,0 +1,10 @@
+{
+  "key": "fotiascrub",
+  "sc_key": "items_commodities_fotiascrub",
+  "ref": "728aecfa-ade1-4ab2-a7ab-44ecd20fec97",
+  "name": "Fotia Seedpod",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "The fotia scrub relies on solar flares for its reproduction. Rather than having traditional stamen and pollen, it allows radiation from flares to mutate its genetics before releasing its seedpod. Some enterprising individuals seek out and collect the seedpods because of their natural radiological properties that can be utilized in various ways.",
+  "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
+}

--- a/data/sc_data/parsed/live/commodities/freeze.json
+++ b/data/sc_data/parsed/live/commodities/freeze.json
@@ -1,0 +1,10 @@
+{
+  "key": "freeze",
+  "sc_key": "items_commodities_freeze",
+  "ref": "674f116f-d1b8-4000-bd8f-e17afbcf95ae",
+  "name": "Freeze",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "A synthetic tranquilizer used for muscle therapy that causes very heavy sedation in the user while also activating the nerve endings in their muscles. Originally created as a way to rebuild damaged/rebuilt muscle tissue, it found another use as a sedative weight-loss supplement, and when in a concentrated form, as a party drug.",
+  "icon": "ui/textures/vector/general/items/inv_icon_distilledspirits.svg"
+}

--- a/data/sc_data/parsed/live/commodities/freshfood.json
+++ b/data/sc_data/parsed/live/commodities/freshfood.json
@@ -1,0 +1,10 @@
+{
+  "key": "freshfood",
+  "sc_key": "items_commodities_freshfood",
+  "ref": null,
+  "name": "Fresh Food",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": "Various meats, grains and produce that have not yet been cooked, dried, salted, frozen, pickled, or otherwise preserved.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/gaspingweevileggs.json
+++ b/data/sc_data/parsed/live/commodities/gaspingweevileggs.json
@@ -1,0 +1,10 @@
+{
+  "key": "gaspingweevileggs",
+  "sc_key": "items_commodities_gaspingweevileggs",
+  "ref": "c9529853-42a5-4924-bfe8-0a016a1f9218",
+  "name": "Gasping Weevil Eggs",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": "The eggs of this small beetle are commonly held to be an aphrodisiac, but when allowed to hatch the weevils themselves will eat through sealants used in space station construction. Transport of the insect or its eggs is banned in the UEE.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/genmodseeds.json
+++ b/data/sc_data/parsed/live/commodities/genmodseeds.json
@@ -1,0 +1,10 @@
+{
+  "key": "genmodseeds",
+  "sc_key": "items_commodities_genmodseeds",
+  "ref": null,
+  "name": "Genmod Seeds",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/glacosite.json
+++ b/data/sc_data/parsed/live/commodities/glacosite.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Glacosite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "As glaciers form, heavier mineral contents sink over time and are then crushed by the weight above as the ice deforms and flows. When the glacier recedes, Glacosite deposits are left behind. White and blue in color, the crystals form in long shiny strands that almost are cotton-like in appearance. Glacosite has found specialized commercial use since it is an extremely light and durable insulator.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/glacosite.json
+++ b/data/sc_data/parsed/live/commodities/glacosite.json
@@ -1,0 +1,10 @@
+{
+  "key": "glacosite",
+  "sc_key": "items_commodities_glacosite",
+  "ref": null,
+  "name": "Glacosite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "As glaciers form, heavier mineral contents sink over time and are then crushed by the weight above as the ice deforms and flows. When the glacier recedes, Glacosite deposits are left behind. White and blue in color, the crystals form in long shiny strands that almost are cotton-like in appearance. Glacosite has found specialized commercial use since it is an extremely light and durable insulator.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/glow.json
+++ b/data/sc_data/parsed/live/commodities/glow.json
@@ -1,0 +1,10 @@
+{
+  "key": "glow",
+  "sc_key": "items_commodities_glow",
+  "ref": "6693f3b7-a913-4e3a-a3ca-b4bf1af1603d",
+  "name": "Glow",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "A variant of the street drug known as \"Neon,\" Glow is formulated to create more euphoric feelings and less hallucinations than are normally associated with other members of its chemical family. The telltale sign of a user is that swallowing the capsule often leaves glowing residue on the tongue. Some people microdose Glow to help them maintain a more positive attitude (being careful to drip the dose directly onto the back of their throat). The main risk is that once the effect wears off people can become suicidally depressed for a short while before their brain chemistry normalizes.",
+  "icon": "ui/textures/vector/general/items/inv_icon_slam.svg"
+}

--- a/data/sc_data/parsed/live/commodities/gold.json
+++ b/data/sc_data/parsed/live/commodities/gold.json
@@ -1,0 +1,10 @@
+{
+  "key": "gold",
+  "sc_key": "items_commodities_gold",
+  "ref": "5e8cc1f5-8f21-4e4b-b534-214008c027dc",
+  "name": "Gold",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A commonly found ductile metal favored for its conductivity. Though it falls in and out of fashion, it is often used for decorative purposes as well.",
+  "icon": "ui/textures/vector/general/items/inv_icon_gold.svg"
+}

--- a/data/sc_data/parsed/live/commodities/gold_ore.json
+++ b/data/sc_data/parsed/live/commodities/gold_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "gold_ore",
+  "sc_key": "items_commodities_gold_ore",
+  "ref": "53664ffa-ca6a-4c44-850d-fb71b62f5ec9",
+  "name": "Gold (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "A commonly found ductile metal favored for its conductivity. Though it falls in and out of fashion, it is often used for decorative purposes as well.",
+  "icon": "ui/textures/vector/general/items/inv_icon_gold.svg"
+}

--- a/data/sc_data/parsed/live/commodities/goldenmedmon.json
+++ b/data/sc_data/parsed/live/commodities/goldenmedmon.json
@@ -1,0 +1,10 @@
+{
+  "key": "goldenmedmon",
+  "sc_key": "items_commodities_goldenmedmon",
+  "ref": "2978969b-f2c8-4255-91b5-20328148ce25",
+  "name": "Golden Medmon",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 39\nHEI: 19\nEffects: Energizing, Hydrating\n\nGrown in temperate climates on the Maru Ebony Tree, Golden Medmons are left to fall off the tree when ripe and collected. The fruit at that stage is extremely firm and astringent. They only become edible after being 'bletted' or softened through ethylene ripening.",
+  "icon": "ui/textures/vector/general/items/inv_icon_goldenmedmons.svg"
+}

--- a/data/sc_data/parsed/live/commodities/hadanite.json
+++ b/data/sc_data/parsed/live/commodities/hadanite.json
@@ -1,0 +1,10 @@
+{
+  "key": "hadanite",
+  "sc_key": "items_commodities_hadanite",
+  "ref": "02f40255-e567-4daa-a784-71d40f495a4b",
+  "name": "Hadanite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A crystal oscillator sought out for its extremely high frequency of vibration which makes it useful in various applications.",
+  "icon": "ui/textures/vector/general/items/inv_icon_hadanite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/hadanite.json
+++ b/data/sc_data/parsed/live/commodities/hadanite.json
@@ -4,7 +4,7 @@
   "ref": "02f40255-e567-4daa-a784-71d40f495a4b",
   "name": "Hadanite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A crystal oscillator sought out for its extremely high frequency of vibration which makes it useful in various applications.",
   "icon": "ui/textures/vector/general/items/inv_icon_hadanite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/heartofthewoods.json
+++ b/data/sc_data/parsed/live/commodities/heartofthewoods.json
@@ -1,0 +1,10 @@
+{
+  "key": "heartofthewoods",
+  "sc_key": "items_commodities_heartofthewoods",
+  "ref": "b4f39fc2-6d8f-4d71-82a1-33be63dbc035",
+  "name": "Heart of the Woods",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 31\nEffects: Toxic\n\nThis fungus produces fleshy deep-red caps that grow in a pattern resembling a internal structure of a heart. Found in cold climates, it typically grows on trees and decaying logs. Not yet successfully cultivated commercially, this deep flavored mushroom is prized by epicureans across the 'verse and can fetch a high price in the right markets. It does contain a mild toxin that is destroyed when cooked, so consuming raw should be avoided.",
+  "icon": "ui/textures/vector/general/items/inv_icon_heartofthewoods.svg"
+}

--- a/data/sc_data/parsed/live/commodities/helium.json
+++ b/data/sc_data/parsed/live/commodities/helium.json
@@ -1,0 +1,10 @@
+{
+  "key": "helium",
+  "sc_key": "items_commodities_helium",
+  "ref": "592a2f03-c37b-454f-be73-014168f5d2ca",
+  "name": "Helium",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "An inert noble gas that is colorless, tasteless, and non-toxic. The second most abundant element in the universe. Produced within stars during the nuclear fusion of hydrogen.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/hephaestanite.json
+++ b/data/sc_data/parsed/live/commodities/hephaestanite.json
@@ -4,7 +4,7 @@
   "ref": "20d1f023-d753-4d1e-938a-51e1770ba0b9",
   "name": "Hephaestanite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Found often near volcanic outcroppings, this mineral is commonly used for a thermal insulator.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/hephaestanite.json
+++ b/data/sc_data/parsed/live/commodities/hephaestanite.json
@@ -1,0 +1,10 @@
+{
+  "key": "hephaestanite",
+  "sc_key": "items_commodities_hephaestanite",
+  "ref": "20d1f023-d753-4d1e-938a-51e1770ba0b9",
+  "name": "Hephaestanite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Found often near volcanic outcroppings, this mineral is commonly used for a thermal insulator.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/hephaestanite_raw.json
+++ b/data/sc_data/parsed/live/commodities/hephaestanite_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "hephaestanite_raw",
+  "sc_key": "items_commodities_hephaestanite_raw",
+  "ref": "aff90cc0-4851-47f2-ab68-82ff8791f857",
+  "name": "Hephaestanite (R)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Found often near volcanic outcroppings, this mineral is commonly used for a thermal insulator.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/hephaestanite_raw.json
+++ b/data/sc_data/parsed/live/commodities/hephaestanite_raw.json
@@ -4,7 +4,7 @@
   "ref": "aff90cc0-4851-47f2-ab68-82ff8791f857",
   "name": "Hephaestanite (R)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Found often near volcanic outcroppings, this mineral is commonly used for a thermal insulator.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/hlx99hyperprocessors.json
+++ b/data/sc_data/parsed/live/commodities/hlx99hyperprocessors.json
@@ -4,7 +4,7 @@
   "ref": "1da71ac6-b728-4a16-81ee-b5cedc465431",
   "name": "HLX99 Hyperprocessors",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Commonly known as \"Helixes\" these Banu manufactured processing chips were designed for fullcore crypto-cracking and are used in the manufacture of computer system infiltration devices.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/hlx99hyperprocessors.json
+++ b/data/sc_data/parsed/live/commodities/hlx99hyperprocessors.json
@@ -1,0 +1,10 @@
+{
+  "key": "hlx99hyperprocessors",
+  "sc_key": "items_commodities_hlx99hyperprocessors",
+  "ref": "1da71ac6-b728-4a16-81ee-b5cedc465431",
+  "name": "HLX99 Hyperprocessors",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Commonly known as \"Helixes\" these Banu manufactured processing chips were designed for fullcore crypto-cracking and are used in the manufacture of computer system infiltration devices.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/humanfoodbars.json
+++ b/data/sc_data/parsed/live/commodities/humanfoodbars.json
@@ -1,0 +1,10 @@
+{
+  "key": "humanfoodbars",
+  "sc_key": "items_commodities_humanfoodbars",
+  "ref": "a468aa6f-f2fa-46a4-b0e9-3e6f60e9e90f",
+  "name": "Human Food Bars",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": "Despite what the label on the packaging declares, the Banu manufactured \"Human Food Bars\" have been shown to contain multiple additives deemed unsafe for Human consumption.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/hydrogen.json
+++ b/data/sc_data/parsed/live/commodities/hydrogen.json
@@ -1,0 +1,10 @@
+{
+  "key": "hydrogen",
+  "sc_key": "items_commodities_hydrogen",
+  "ref": "3a6782c6-8ffa-4df8-9daa-5656be09356e",
+  "name": "Hydrogen",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "The most abundant element in the universe. The building block of stars. Highly flammable in its pure form.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/inert_materials.json
+++ b/data/sc_data/parsed/live/commodities/inert_materials.json
@@ -4,7 +4,7 @@
   "ref": "39e6305c-8d6a-4a1f-a0b0-70eaf2c1e43a",
   "name": "Inert Materials",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Non-valuable materials collected during the mining process.",
   "icon": "ui/textures/vector/general/items/inv_icon_inertmaterials.svg"
 }

--- a/data/sc_data/parsed/live/commodities/inert_materials.json
+++ b/data/sc_data/parsed/live/commodities/inert_materials.json
@@ -1,0 +1,10 @@
+{
+  "key": "inert_materials",
+  "sc_key": "items_commodities_inert_materials",
+  "ref": "39e6305c-8d6a-4a1f-a0b0-70eaf2c1e43a",
+  "name": "Inert Materials",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Non-valuable materials collected during the mining process.",
+  "icon": "ui/textures/vector/general/items/inv_icon_inertmaterials.svg"
+}

--- a/data/sc_data/parsed/live/commodities/iodine.json
+++ b/data/sc_data/parsed/live/commodities/iodine.json
@@ -1,0 +1,10 @@
+{
+  "key": "iodine",
+  "sc_key": "items_commodities_iodine",
+  "ref": "a542c867-6f1b-497e-860e-c8353dac6169",
+  "name": "Iodine",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "The heaviest stable halogen. Sublimes from a purple-black metallic solid into a violet gas.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/iron_ore.json
+++ b/data/sc_data/parsed/live/commodities/iron_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "iron_ore",
+  "sc_key": "items_commodities_iron_ore",
+  "ref": null,
+  "name": "Iron (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Element Fe, strong, malleable, highly susceptible to rust and found in large volume across most star systems.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/jaclium_ore.json
+++ b/data/sc_data/parsed/live/commodities/jaclium_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "jaclium_ore",
+  "sc_key": "items_commodities_jaclium_ore",
+  "ref": null,
+  "name": "Jaclium (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/janalite.json
+++ b/data/sc_data/parsed/live/commodities/janalite.json
@@ -1,0 +1,10 @@
+{
+  "key": "janalite",
+  "sc_key": "items_commodities_janalite",
+  "ref": null,
+  "name": "Janalite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "This rare mineral is valued as an industrial anti-matter precursor. While more stable than other precursors like Feynmaline, it's tougher structure and energy resistance makes it much more difficult to utilize as well as collect.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/janalite.json
+++ b/data/sc_data/parsed/live/commodities/janalite.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Janalite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "This rare mineral is valued as an industrial anti-matter precursor. While more stable than other precursors like Feynmaline, it's tougher structure and energy resistance makes it much more difficult to utilize as well as collect.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/jumpinglimes.json
+++ b/data/sc_data/parsed/live/commodities/jumpinglimes.json
@@ -1,0 +1,10 @@
+{
+  "key": "jumpinglimes",
+  "sc_key": "items_commodities_jumpinglimes",
+  "ref": "7f9f8570-5f3b-4437-808c-a666441b06aa",
+  "name": "Jumping Limes",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 09\nHEI: 06\nEffects: Dehydrating\n\nGrows on a cactus in the deserts of Yar (Centauri II). A local variant that developed naturally after terraformation was complete, the spiny fruit start off purple and turn green when they are ripe.\n\nThey acquired their name because of the ease in which they fall off the cactus and attach themselves to clothing and skin, as if they \"jumped\" there.\n\nThe leathery, barbed skin must be peeled back to reveal the juicy flesh of the interior. The taste is sweet, extremely tart and astringent.\n\nLocals warn that if you become lost in the dessert you should be careful using jumping limes for hydration as they can make you feel even more thirsty.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/kopionhorn.json
+++ b/data/sc_data/parsed/live/commodities/kopionhorn.json
@@ -1,0 +1,10 @@
+{
+  "key": "kopionhorn",
+  "sc_key": "items_commodities_kopionhorn",
+  "ref": null,
+  "name": "Kopion Horn",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "The horn of the kopion is made of a unique combination of bone and naturally-occurring carbon nanomaterials. When properly processed, it can be used to aid in bone regeneration with a far greater rate of success than lab-grown materials. This application has made it a valuable commodity.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/laranite.json
+++ b/data/sc_data/parsed/live/commodities/laranite.json
@@ -1,0 +1,10 @@
+{
+  "key": "laranite",
+  "sc_key": "items_commodities_laranite",
+  "ref": "585bff8d-43a9-49ca-8d92-aabb252dfde6",
+  "name": "Laranite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A somewhat radioactive, crystalline gemstone. Black with streaks of dark red, it can only be used as jewelry if shielded.",
+  "icon": "ui/textures/vector/general/items/inv_icon_laranite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/laranite.json
+++ b/data/sc_data/parsed/live/commodities/laranite.json
@@ -4,7 +4,7 @@
   "ref": "585bff8d-43a9-49ca-8d92-aabb252dfde6",
   "name": "Laranite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A somewhat radioactive, crystalline gemstone. Black with streaks of dark red, it can only be used as jewelry if shielded.",
   "icon": "ui/textures/vector/general/items/inv_icon_laranite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/laranite_raw.json
+++ b/data/sc_data/parsed/live/commodities/laranite_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "laranite_raw",
+  "sc_key": "items_commodities_laranite_raw",
+  "ref": "8bbbdeac-788c-43fc-9a84-0b3a0ed2e714",
+  "name": "Laranite (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A somewhat radioactive, crystalline gemstone. Black with streaks of dark red, it can only be used as jewelry if shielded.",
+  "icon": "ui/textures/vector/general/items/inv_icon_laranite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/laranite_raw.json
+++ b/data/sc_data/parsed/live/commodities/laranite_raw.json
@@ -4,7 +4,7 @@
   "ref": "8bbbdeac-788c-43fc-9a84-0b3a0ed2e714",
   "name": "Laranite (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A somewhat radioactive, crystalline gemstone. Black with streaks of dark red, it can only be used as jewelry if shielded.",
   "icon": "ui/textures/vector/general/items/inv_icon_laranite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/lastaprene.json
+++ b/data/sc_data/parsed/live/commodities/lastaprene.json
@@ -1,0 +1,10 @@
+{
+  "key": "lastaprene",
+  "sc_key": "items_commodities_lastaprene",
+  "ref": "15b7e9bd-cf1a-497a-9dd4-e59e2dc7fb7a",
+  "name": "Lastaprene",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "An advanced synthetic polymer designed with optimal properties for several commercial applications. It has greater viscoelasticity than most commonly produced rubbers.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/lifecuremedsticks.json
+++ b/data/sc_data/parsed/live/commodities/lifecuremedsticks.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "LifeCure Medsticks",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "The use of these imitation CureLife Medpens has resulted in numerous deaths.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/lifecuremedsticks.json
+++ b/data/sc_data/parsed/live/commodities/lifecuremedsticks.json
@@ -1,0 +1,10 @@
+{
+  "key": "lifecuremedsticks",
+  "sc_key": "items_commodities_lifecuremedsticks",
+  "ref": null,
+  "name": "LifeCure Medsticks",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "The use of these imitation CureLife Medpens has resulted in numerous deaths.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/lycara.json
+++ b/data/sc_data/parsed/live/commodities/lycara.json
@@ -1,0 +1,10 @@
+{
+  "key": "lycara",
+  "sc_key": "items_commodities_lycara",
+  "ref": "86e41701-8c75-4690-b124-f429cc9b8b60",
+  "name": "Lycara",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A extremely light and strong carbon composite material first developed for racing ship rudders.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/mala.json
+++ b/data/sc_data/parsed/live/commodities/mala.json
@@ -1,0 +1,10 @@
+{
+  "key": "mala",
+  "sc_key": "items_commodities_mala",
+  "ref": "7e672aee-b473-4989-a497-c31ec1faffa0",
+  "name": "Mala",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Digestion of the unique toxins found in the Mala fly causes confusion of the congnitive pathways of the brain and results in synesthesia where different sensory experiences cross and mix. Effects described by users range widely; from being able to see music to tasting colors. Since pain does not register the same way while under the influence of the toxin, many people of have been severely injured while \"sense swapping.\" For example, one user lost their arm after perceiving the heat from a thruster engine as pleasurable.",
+  "icon": "ui/textures/vector/general/items/inv_icon_etam.svg"
+}

--- a/data/sc_data/parsed/live/commodities/marokgem.json
+++ b/data/sc_data/parsed/live/commodities/marokgem.json
@@ -1,0 +1,10 @@
+{
+  "key": "marokgem",
+  "sc_key": "items_commodities_marokgem",
+  "ref": null,
+  "name": "Marok Gem",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "The marok has a gizzard, which takes food that has been previously swallowed from the stomach and \"chews\" it before passing it back into the stomach to be digested. To help this process, the marok's body secretes a substance that hardens into a large crystalline stone that stays in the gizzard and helps food get pulverized more efficiently. The stone has unique conductive properties that make it sought-after for use in computer chips.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/maze.json
+++ b/data/sc_data/parsed/live/commodities/maze.json
@@ -1,0 +1,10 @@
+{
+  "key": "maze",
+  "sc_key": "items_commodities_maze",
+  "ref": "20155793-a24c-48fc-a986-26b442145858",
+  "name": "Maze",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Street name for a tranquilizer and knock-out hallucinogen that's Tevarin in origin. Dosing up is like taking a massive journey into your own mind. To the outside world, you’re nearly comatose, but to you, it’s a wild trip. A handful of religions have been started after a user took a trip into the maze. Aside from the toxic element, there’s a chance you won’t come down from the high. They call this ‘getting disconnected.’ Users stay locked in their own head until their brain decays. Maze was originally used as a near religious experience for Tevarin warriors to find their path in life. Since the fall of the Tevarin empire, it's become corrupted into a purely recreational drug. The Tevarin who once treated this drug with reverence and ritual, now make boatloads of credits selling it to anyone who wants to risk a potentially dangerous trip.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/medicalsupplies.json
+++ b/data/sc_data/parsed/live/commodities/medicalsupplies.json
@@ -4,7 +4,7 @@
   "ref": "5dc139aa-39b1-4c50-8c1e-c17d012c7b92",
   "name": "Medical Supplies",
   "commodity_type": "medical_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Medical Supply",
   "description": "A variety of items produced primarily to treat injury or illness.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/medicalsupplies.json
+++ b/data/sc_data/parsed/live/commodities/medicalsupplies.json
@@ -1,0 +1,10 @@
+{
+  "key": "medicalsupplies",
+  "sc_key": "items_commodities_medicalsupplies",
+  "ref": "5dc139aa-39b1-4c50-8c1e-c17d012c7b92",
+  "name": "Medical Supplies",
+  "commodity_type": "medical_supply",
+  "commodity_type_name": null,
+  "description": "A variety of items produced primarily to treat injury or illness.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/medpens.json
+++ b/data/sc_data/parsed/live/commodities/medpens.json
@@ -4,7 +4,7 @@
   "ref": "41224404-8b20-45ee-8719-4a60e2b026c8",
   "name": "MedPens",
   "commodity_type": "medical_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Medical Supply",
   "description": "The MedPen from CureLife is a complete multi-function individual first-aid system designed and constructed for the rigors of field use.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/medpens.json
+++ b/data/sc_data/parsed/live/commodities/medpens.json
@@ -1,0 +1,10 @@
+{
+  "key": "medpens",
+  "sc_key": "items_commodities_medpens",
+  "ref": "41224404-8b20-45ee-8719-4a60e2b026c8",
+  "name": "MedPens",
+  "commodity_type": "medical_supply",
+  "commodity_type_name": null,
+  "description": "The MedPen from CureLife is a complete multi-function individual first-aid system designed and constructed for the rigors of field use.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/mercury.json
+++ b/data/sc_data/parsed/live/commodities/mercury.json
@@ -1,0 +1,10 @@
+{
+  "key": "mercury",
+  "sc_key": "items_commodities_mercury",
+  "ref": "8ec29949-159d-4980-b36b-c6f9b8215333",
+  "name": "Mercury",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Mercury description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/methane.json
+++ b/data/sc_data/parsed/live/commodities/methane.json
@@ -1,0 +1,10 @@
+{
+  "key": "methane",
+  "sc_key": "items_commodities_methane",
+  "ref": null,
+  "name": "Methane",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "A highly flammable gas composed of carbon and hydrogen. It is colorless and odorless in its natural state.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/mixedmining.json
+++ b/data/sc_data/parsed/live/commodities/mixedmining.json
@@ -4,7 +4,7 @@
   "ref": "891080af-43fb-4afa-890c-8d7acdf5eb76",
   "name": "Mixed Mining",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A mixed collection of commodities obtained by mining",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/mixedmining.json
+++ b/data/sc_data/parsed/live/commodities/mixedmining.json
@@ -1,0 +1,10 @@
+{
+  "key": "mixedmining",
+  "sc_key": "items_commodities_mixedmining",
+  "ref": "891080af-43fb-4afa-890c-8d7acdf5eb76",
+  "name": "Mixed Mining",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A mixed collection of commodities obtained by mining",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/mobyglass.json
+++ b/data/sc_data/parsed/live/commodities/mobyglass.json
@@ -4,7 +4,7 @@
   "ref": "b294c88b-b988-4413-94bc-70f71f9401f6",
   "name": "mobyGlass Personal Computers",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "These knock-off mobiGlas use pirated software and are often infected with spyware and malicious programming.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/mobyglass.json
+++ b/data/sc_data/parsed/live/commodities/mobyglass.json
@@ -1,0 +1,10 @@
+{
+  "key": "mobyglass",
+  "sc_key": "items_commodities_mobyglass",
+  "ref": "b294c88b-b988-4413-94bc-70f71f9401f6",
+  "name": "mobyGlass Personal Computers",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "These knock-off mobiGlas use pirated software and are often infected with spyware and malicious programming.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/neograph.json
+++ b/data/sc_data/parsed/live/commodities/neograph.json
@@ -1,0 +1,10 @@
+{
+  "key": "neograph",
+  "sc_key": "items_commodities_neograph",
+  "ref": "60849815-6ad6-4cb6-853c-a3b333442168",
+  "name": "Neograph",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A recently discovered form of graphene, this complicated lattice structure of carbon molecules produces an extremely light and strong material.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/neon.json
+++ b/data/sc_data/parsed/live/commodities/neon.json
@@ -1,0 +1,10 @@
+{
+  "key": "neon",
+  "sc_key": "items_commodities_neon",
+  "ref": "c106984b-73fe-4e6b-aa72-65c14443e171",
+  "name": "Neon",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "A psychoactive designer drug known for increased energy, euphoria, and mild hallucinations (particularly how the body processes light). Due to its chemical complexity, it's much more expensive than other street drugs, but is very popular in club culture.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/nitrogen.json
+++ b/data/sc_data/parsed/live/commodities/nitrogen.json
@@ -1,0 +1,10 @@
+{
+  "key": "nitrogen",
+  "sc_key": "items_commodities_nitrogen",
+  "ref": "f00b7cd0-5f10-494c-9fef-e49a6585520d",
+  "name": "Nitrogen",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "A low-density, diatomic gas with no color or odor in its natural state. A necessary element in human respiration.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/omnapoxy.json
+++ b/data/sc_data/parsed/live/commodities/omnapoxy.json
@@ -1,0 +1,10 @@
+{
+  "key": "omnapoxy",
+  "sc_key": "items_commodities_omnapoxy",
+  "ref": "5f9763a6-48b6-42aa-a6ba-83c1b5c6331c",
+  "name": "Omnapoxy",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "Durable and resistant, this resin quickly sets when applied to form a hardened polymer.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/organs.json
+++ b/data/sc_data/parsed/live/commodities/organs.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Organs",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/organs.json
+++ b/data/sc_data/parsed/live/commodities/organs.json
@@ -1,0 +1,10 @@
+{
+  "key": "organs",
+  "sc_key": "items_commodities_organs",
+  "ref": null,
+  "name": "Organs",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/osoianhides.json
+++ b/data/sc_data/parsed/live/commodities/osoianhides.json
@@ -4,7 +4,7 @@
   "ref": "d1120c0f-2060-429a-b120-34825a16e3e0",
   "name": "Osoian Hides",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/osoianhides.json
+++ b/data/sc_data/parsed/live/commodities/osoianhides.json
@@ -1,0 +1,10 @@
+{
+  "key": "osoianhides",
+  "sc_key": "items_commodities_osoianhides",
+  "ref": "d1120c0f-2060-429a-b120-34825a16e3e0",
+  "name": "Osoian Hides",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/oxypens.json
+++ b/data/sc_data/parsed/live/commodities/oxypens.json
@@ -4,7 +4,7 @@
   "ref": "40453bc6-e2e6-4643-ae75-064f3fe4f036",
   "name": "OxyPens",
   "commodity_type": "medical_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Medical Supply",
   "description": "The OxyPen is an easy-to-carry disposable first-aid system designed by CureLife to refill pressure suit oxygen reserves in emergency situations.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/oxypens.json
+++ b/data/sc_data/parsed/live/commodities/oxypens.json
@@ -1,0 +1,10 @@
+{
+  "key": "oxypens",
+  "sc_key": "items_commodities_oxypens",
+  "ref": "40453bc6-e2e6-4643-ae75-064f3fe4f036",
+  "name": "OxyPens",
+  "commodity_type": "medical_supply",
+  "commodity_type_name": null,
+  "description": "The OxyPen is an easy-to-carry disposable first-aid system designed by CureLife to refill pressure suit oxygen reserves in emergency situations.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/oza.json
+++ b/data/sc_data/parsed/live/commodities/oza.json
@@ -1,0 +1,10 @@
+{
+  "key": "oza",
+  "sc_key": "items_commodities_oza",
+  "ref": "c64fb1be-5153-4ba1-8952-2b7943a43244",
+  "name": "Oza",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 09\nHEI: 07\nEffects: Hydrating\n\nA hybrid citrus first grown in Croshaw, it's hardiness, ease of transport, and juice yield has seen it rapidly spread across the Empire. It features thick, bumpy dark green skin, bright orange flesh ribbed with heavy pithing, and no seeds. \n\nTart, sweet and bitter, the taste of Oza often described as being a combination of all the other citrus types rolled into one fruit. Difficult to peel and fibrous, its pulp is not often eaten. Typically it is split open and sucked on, its flesh being discarded. It is also popularly used in many cocktail recipes.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/partillium.json
+++ b/data/sc_data/parsed/live/commodities/partillium.json
@@ -1,0 +1,10 @@
+{
+  "key": "partillium",
+  "sc_key": "items_commodities_partillium",
+  "ref": "65d3a21c-b265-4a25-91e8-55b25c56afee",
+  "name": "Partillium",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "Partillium description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/partyfavors.json
+++ b/data/sc_data/parsed/live/commodities/partyfavors.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Party Favors",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "Small items used to help encourage a festive mood. Typically given or sold to celebrants in attendance at an event or party.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/partyfavors.json
+++ b/data/sc_data/parsed/live/commodities/partyfavors.json
@@ -1,0 +1,10 @@
+{
+  "key": "partyfavors",
+  "sc_key": "items_commodities_partyfavors",
+  "ref": null,
+  "name": "Party Favors",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "Small items used to help encourage a festive mood. Typically given or sold to celebrants in attendance at an event or party.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/pingala.json
+++ b/data/sc_data/parsed/live/commodities/pingala.json
@@ -1,0 +1,10 @@
+{
+  "key": "pingala",
+  "sc_key": "items_commodities_pingala",
+  "ref": "9b262b7a-e251-44cb-bd62-4cb2fb4733d9",
+  "name": "Pingala Seeds",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Every aspect of the pingala follows the golden ratio resulting a visually arresting plant. This include its seeds which are highly sought after by plant collectors. Especially since attempts to cultivate the pingala in greenhouse environments has proven extremely difficult.",
+  "icon": "ui/textures/vector/general/items/inv_icon_agriculturalsupplies.svg"
+}

--- a/data/sc_data/parsed/live/commodities/pitambu.json
+++ b/data/sc_data/parsed/live/commodities/pitambu.json
@@ -1,0 +1,10 @@
+{
+  "key": "pitambu",
+  "sc_key": "items_commodities_pitambu",
+  "ref": "6a428cbb-21a4-434d-a477-a04a1f946629",
+  "name": "Pitambu",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 25\nHEI: 10\nEffects: Hydrating, Hypo-Metabolic, Immune Boosting\n\nThe skin of the pitambu is thin and waxy and easily peeled away using its green leaf-like growths. Inside is a is crisp and watery, bright red flesh which is filled with tiny white seeds that have a mild, nutty taste. The flesh and seeds are traditionally consumed together.",
+  "icon": "ui/textures/vector/general/items/inv_icon_pitambu.svg"
+}

--- a/data/sc_data/parsed/live/commodities/potassium.json
+++ b/data/sc_data/parsed/live/commodities/potassium.json
@@ -1,0 +1,10 @@
+{
+  "key": "potassium",
+  "sc_key": "items_commodities_potassium",
+  "ref": "fb2ff434-6c54-471a-9f64-48f866498cd2",
+  "name": "Potassium",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Potassium description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/pressurized_ice.json
+++ b/data/sc_data/parsed/live/commodities/pressurized_ice.json
@@ -1,0 +1,10 @@
+{
+  "key": "pressurized_ice",
+  "sc_key": "items_commodities_pressurized_ice",
+  "ref": null,
+  "name": "Pressurized Ice",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Ice that has been purified and compressed to transparent by restricting natural expansion. This allows for more efficient transport in bulk.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/pressurized_ice.json
+++ b/data/sc_data/parsed/live/commodities/pressurized_ice.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Pressurized Ice",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Ice that has been purified and compressed to transparent by restricting natural expansion. This allows for more efficient transport in bulk.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/processedfood.json
+++ b/data/sc_data/parsed/live/commodities/processedfood.json
@@ -1,0 +1,10 @@
+{
+  "key": "processedfood",
+  "sc_key": "items_commodities_processedfood",
+  "ref": "6f93f3be-2d21-4dc8-acfb-aa6eb4386c51",
+  "name": "Processed Food",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": "A nutritional substance that has been transformed trough physical or chemical means into food.",
+  "icon": "ui/textures/vector/general/items/inv_icon_processedfood.svg"
+}

--- a/data/sc_data/parsed/live/commodities/prota.json
+++ b/data/sc_data/parsed/live/commodities/prota.json
@@ -1,0 +1,10 @@
+{
+  "key": "prota",
+  "sc_key": "items_commodities_prota",
+  "ref": "648a7bb9-3e5d-4fb7-8014-a9900ae3bdfa",
+  "name": "Prota",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "A resilient slime mold that can form in extremely corrosive environments and pressure, Prota secretes a strong adhesive that can be distilled into a commercial-grade glue.",
+  "icon": "ui/textures/vector/general/items/inv_icon_prota.svg"
+}

--- a/data/sc_data/parsed/live/commodities/quantainium.json
+++ b/data/sc_data/parsed/live/commodities/quantainium.json
@@ -4,7 +4,7 @@
   "ref": "ef684d49-1b24-4a5b-9ff6-0c7e61228553",
   "name": "Quantainium",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A highly unstable mineral used in the production of quantum fuel.",
   "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/quantainium.json
+++ b/data/sc_data/parsed/live/commodities/quantainium.json
@@ -1,0 +1,10 @@
+{
+  "key": "quantainium",
+  "sc_key": "items_commodities_quantainium",
+  "ref": "ef684d49-1b24-4a5b-9ff6-0c7e61228553",
+  "name": "Quantainium",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A highly unstable mineral used in the production of quantum fuel.",
+  "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/quantainium_raw.json
+++ b/data/sc_data/parsed/live/commodities/quantainium_raw.json
@@ -4,7 +4,7 @@
   "ref": "f4e2b50a-e19a-4bb2-8253-90a8f03b0f4c",
   "name": "Quantainium (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A highly unstable mineral used in the production of quantum fuel.",
   "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/quantainium_raw.json
+++ b/data/sc_data/parsed/live/commodities/quantainium_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "quantainium_raw",
+  "sc_key": "items_commodities_quantainium_raw",
+  "ref": "f4e2b50a-e19a-4bb2-8253-90a8f03b0f4c",
+  "name": "Quantainium (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A highly unstable mineral used in the production of quantum fuel.",
+  "icon": "ui/textures/vector/general/items/inv_icon_aphorite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/quartz.json
+++ b/data/sc_data/parsed/live/commodities/quartz.json
@@ -4,7 +4,7 @@
   "ref": "9f6d7b98-31ad-447b-8061-702f39a22ac2",
   "name": "Quartz",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A chiral crystal composed of silicon and oxygen that can be found in a wide variety of forms and colors.",
   "icon": "ui/textures/vector/general/items/inv_icon_quartz.svg"
 }

--- a/data/sc_data/parsed/live/commodities/quartz.json
+++ b/data/sc_data/parsed/live/commodities/quartz.json
@@ -1,0 +1,10 @@
+{
+  "key": "quartz",
+  "sc_key": "items_commodities_quartz",
+  "ref": "9f6d7b98-31ad-447b-8061-702f39a22ac2",
+  "name": "Quartz",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A chiral crystal composed of silicon and oxygen that can be found in a wide variety of forms and colors.",
+  "icon": "ui/textures/vector/general/items/inv_icon_quartz.svg"
+}

--- a/data/sc_data/parsed/live/commodities/quartz_raw.json
+++ b/data/sc_data/parsed/live/commodities/quartz_raw.json
@@ -4,7 +4,7 @@
   "ref": "14992573-022e-41eb-b1b1-b9a2a2836169",
   "name": "Quartz (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A chiral crystal composed of silicon and oxygen that can be found in a wide variety of forms and colors.",
   "icon": "ui/textures/vector/general/items/inv_icon_quartz.svg"
 }

--- a/data/sc_data/parsed/live/commodities/quartz_raw.json
+++ b/data/sc_data/parsed/live/commodities/quartz_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "quartz_raw",
+  "sc_key": "items_commodities_quartz_raw",
+  "ref": "14992573-022e-41eb-b1b1-b9a2a2836169",
+  "name": "Quartz (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A chiral crystal composed of silicon and oxygen that can be found in a wide variety of forms and colors.",
+  "icon": "ui/textures/vector/general/items/inv_icon_quartz.svg"
+}

--- a/data/sc_data/parsed/live/commodities/rantadung.json
+++ b/data/sc_data/parsed/live/commodities/rantadung.json
@@ -1,0 +1,10 @@
+{
+  "key": "rantadung",
+  "sc_key": "items_commodities_rantadung",
+  "ref": "86c1fde0-1e2b-40d9-a3c7-1d39ef742c68",
+  "name": "Ranta Dung",
+  "commodity_type": "agricultural_supply",
+  "commodity_type_name": null,
+  "description": "A dry cube-shaped dung that comes from a large isopod-like crustacean known as a Ranta. It has recently been discovered that the dung contains a unique bacterial biome that helps the Ranta process and digest minerals and some researches are hopeful will lead to industrial or medical innovations.",
+  "icon": "ui/textures/vector/general/items/inv_icon_rantadung.svg"
+}

--- a/data/sc_data/parsed/live/commodities/rantadung.json
+++ b/data/sc_data/parsed/live/commodities/rantadung.json
@@ -4,7 +4,7 @@
   "ref": "86c1fde0-1e2b-40d9-a3c7-1d39ef742c68",
   "name": "Ranta Dung",
   "commodity_type": "agricultural_supply",
-  "commodity_type_name": null,
+  "commodity_type_name": "Agricultural Supply",
   "description": "A dry cube-shaped dung that comes from a large isopod-like crustacean known as a Ranta. It has recently been discovered that the dung contains a unique bacterial biome that helps the Ranta process and digest minerals and some researches are hopeful will lead to industrial or medical innovations.",
   "icon": "ui/textures/vector/general/items/inv_icon_rantadung.svg"
 }

--- a/data/sc_data/parsed/live/commodities/raw_silicon.json
+++ b/data/sc_data/parsed/live/commodities/raw_silicon.json
@@ -1,0 +1,10 @@
+{
+  "key": "raw_silicon",
+  "sc_key": "items_commodities_raw_silicon",
+  "ref": null,
+  "name": "Raw Silicon",
+  "commodity_type": "nonmetals",
+  "commodity_type_name": "Nonmetals",
+  "description": "A strong and brittle element with good thermal conductivity. Crystalizes in a diamond form.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/redfinenergymodulator.json
+++ b/data/sc_data/parsed/live/commodities/redfinenergymodulator.json
@@ -1,0 +1,10 @@
+{
+  "key": "redfinenergymodulator",
+  "sc_key": "items_commodities_redfinenergymodulator",
+  "ref": "1d33767e-d9af-449c-a717-7e4de02f00b3",
+  "name": "Redfin Energy Modulators",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Made by various Banu manufacturers, this energy modulator is distinct for its red-hued heatsinks. Though it can be installed into most Human component subsystems to reduce power draw, its extremely dangerous fail rate has caused it to be banned for import into the UEE.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/redfinenergymodulator.json
+++ b/data/sc_data/parsed/live/commodities/redfinenergymodulator.json
@@ -4,7 +4,7 @@
   "ref": "1d33767e-d9af-449c-a717-7e4de02f00b3",
   "name": "Redfin Energy Modulators",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Made by various Banu manufacturers, this energy modulator is distinct for its red-hued heatsinks. Though it can be installed into most Human component subsystems to reduce power draw, its extremely dangerous fail rate has caused it to be banned for import into the UEE.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/revenantpod.json
+++ b/data/sc_data/parsed/live/commodities/revenantpod.json
@@ -1,0 +1,10 @@
+{
+  "key": "revenantpod",
+  "sc_key": "items_commodities_revenantpod",
+  "ref": "603f4b9c-4ab0-403c-ba0d-fe4bdffb6a57",
+  "name": "Revenant Pod",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Contrary to its ominous name, the Revenant is actually a variety of the Altrucia Tree, an indigenous plant of Terra known for its thick and colorful leaves. Geoengineers introduced fields of Altrucias to Hyperion in an effort to break up the dust storms. Although the project failed, the Altrucia trees adapted to the perpetual wind patterns, shedding its leaves and thickening the wood in the trunk. Botanists initially believed that the Altrucias had died, but on closer inspection, discovered that they were quite alive and thus, the name was born.The pods are collected because the pollen is processed and turned into Altruciatoxin.",
+  "icon": "ui/textures/vector/general/items/inv_icon_revenantpods.svg"
+}

--- a/data/sc_data/parsed/live/commodities/riccite.json
+++ b/data/sc_data/parsed/live/commodities/riccite.json
@@ -1,0 +1,10 @@
+{
+  "key": "riccite",
+  "sc_key": "items_commodities_riccite",
+  "ref": null,
+  "name": "Riccite",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/rs1odyseyspacesuits.json
+++ b/data/sc_data/parsed/live/commodities/rs1odyseyspacesuits.json
@@ -4,7 +4,7 @@
   "ref": "6007e444-0a50-483b-b787-59047e6b0121",
   "name": "RS1 Odysey Spacesuits",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "These imitation RSI Odyssey undersuits are cheaply made counterfeits that are hazardous to use.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/rs1odyseyspacesuits.json
+++ b/data/sc_data/parsed/live/commodities/rs1odyseyspacesuits.json
@@ -1,0 +1,10 @@
+{
+  "key": "rs1odyseyspacesuits",
+  "sc_key": "items_commodities_rs1odyseyspacesuits",
+  "ref": "6007e444-0a50-483b-b787-59047e6b0121",
+  "name": "RS1 Odysey Spacesuits",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "These imitation RSI Odyssey undersuits are cheaply made counterfeits that are hazardous to use.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/sadaryx.json
+++ b/data/sc_data/parsed/live/commodities/sadaryx.json
@@ -1,0 +1,10 @@
+{
+  "key": "sadaryx",
+  "sc_key": "items_commodities_sadaryx",
+  "ref": null,
+  "name": "Sadaryx",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "A durable crystal, sadaryx is commonly used in the production of industrial focal lenses in laser applications.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/sadaryx.json
+++ b/data/sc_data/parsed/live/commodities/sadaryx.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Sadaryx",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "A durable crystal, sadaryx is commonly used in the production of industrial focal lenses in laser applications.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/saldynium_ore.json
+++ b/data/sc_data/parsed/live/commodities/saldynium_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "saldynium_ore",
+  "sc_key": "items_commodities_saldynium_ore",
+  "ref": null,
+  "name": "Saldynium (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/sarilus.json
+++ b/data/sc_data/parsed/live/commodities/sarilus.json
@@ -1,0 +1,10 @@
+{
+  "key": "sarilus",
+  "sc_key": "items_commodities_sarilus",
+  "ref": "c56f26eb-0189-4d42-9a82-19e85099fa9e",
+  "name": "Sarilus",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A material first introduced into Human manufacturing after trade with the Banu. It is extremely distortion resistant. Though Human made Sarilus does a good job, many hold that the Banu manufactured product is superior.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/scrap.json
+++ b/data/sc_data/parsed/live/commodities/scrap.json
@@ -1,0 +1,10 @@
+{
+  "key": "scrap",
+  "sc_key": "items_commodities_scrap",
+  "ref": "00cbfce5-8215-4619-9399-cafe96a5c5a9",
+  "name": "Scrap",
+  "commodity_type": "scrap",
+  "commodity_type_name": "Scrap",
+  "description": "Waste that is ready to be converted into new materials for reuse.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/silicon.json
+++ b/data/sc_data/parsed/live/commodities/silicon.json
@@ -1,0 +1,10 @@
+{
+  "key": "silicon",
+  "sc_key": "items_commodities_silicon",
+  "ref": "e2bfa87a-cd18-4d93-b7fc-8103dbef2ba0",
+  "name": "Silicon",
+  "commodity_type": "nonmetals",
+  "commodity_type_name": "Nonmetals",
+  "description": "A strong and brittle element with good thermal conductivity. Crystalizes in a diamond form.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/silnex.json
+++ b/data/sc_data/parsed/live/commodities/silnex.json
@@ -1,0 +1,10 @@
+{
+  "key": "silnex",
+  "sc_key": "items_commodities_silnex",
+  "ref": "cf86cfe4-28fe-4530-a1a7-f2e6d3d2117e",
+  "name": "Silnex",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "An advanced silica ceramic developed by early RSI researchers to allow ships to better withstand atmospheric reentry.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/slam.json
+++ b/data/sc_data/parsed/live/commodities/slam.json
@@ -1,0 +1,10 @@
+{
+  "key": "slam",
+  "sc_key": "items_commodities_slam",
+  "ref": "77fc71bd-e2c2-42d2-8924-b5fae46caf58",
+  "name": "SLAM",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Most commonly ingested as a gas. Vials of SLAM are cracked and inhaled. Initially developed as a performance enhancer for athletes, SLAM targets the user's nervous system acting as a fear-inhibitor and painkiller. Once the severe physical side effects were discovered, the drug went underground and found popularity among mercs and outlaws who relied on it to provide that slight edge in combat. Unfortunately, SLAM is also heavily addictive, so many of these mercs ended up getting burned out on the drug. Heavy-duty SLAM junkies are easily identifiable in public; they have ‘the shakes’ -- involuntary muscle twitches. Important to note that this is not a sign of withdrawal, simply a side effect.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/souvenirs.json
+++ b/data/sc_data/parsed/live/commodities/souvenirs.json
@@ -1,0 +1,10 @@
+{
+  "key": "souvenirs",
+  "sc_key": "items_commodities_souvenirs",
+  "ref": "1bf49100-2d23-4e72-8afe-764f9610828b",
+  "name": "Souvenirs",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "Mementos purchased to commemorate visiting a location or attending an special event.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/souvenirs.json
+++ b/data/sc_data/parsed/live/commodities/souvenirs.json
@@ -4,7 +4,7 @@
   "ref": "1bf49100-2d23-4e72-8afe-764f9610828b",
   "name": "Souvenirs",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "Mementos purchased to commemorate visiting a location or attending an special event.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/special_holidaybox.json
+++ b/data/sc_data/parsed/live/commodities/special_holidaybox.json
@@ -1,0 +1,10 @@
+{
+  "key": "special_holidaybox",
+  "sc_key": "items_commodities_special_holidaybox",
+  "ref": "de5b17b7-a9f8-4495-bd74-8cb1785c95d8",
+  "name": "Luminalia Gift",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "A small, wrapped package meant to get you in the Luminalia spirit. Banu merchants celebrating the holiday used to hide small gifts aboard their ship to encourage revelers to explore all their wares. As the holiday grew in popularity within the UEE, Human merchants modified this tradition by hiding empty gift-wrapped packages around a space station or landing zone that could be exchanged for credits if returned unopened. The increased foot traffic into their stores spurned holiday sales and became a tradition in its own right. \n\nStow this gift for sentimental value, or sell it at a commodities terminal and spend the credits on a holiday gift for yourself.",
+  "icon": "ui/textures/vector/general/items/inv_icon_holiday_box.svg"
+}

--- a/data/sc_data/parsed/live/commodities/special_holidaybox.json
+++ b/data/sc_data/parsed/live/commodities/special_holidaybox.json
@@ -4,7 +4,7 @@
   "ref": "de5b17b7-a9f8-4495-bd74-8cb1785c95d8",
   "name": "Luminalia Gift",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "A small, wrapped package meant to get you in the Luminalia spirit. Banu merchants celebrating the holiday used to hide small gifts aboard their ship to encourage revelers to explore all their wares. As the holiday grew in popularity within the UEE, Human merchants modified this tradition by hiding empty gift-wrapped packages around a space station or landing zone that could be exchanged for credits if returned unopened. The increased foot traffic into their stores spurned holiday sales and became a tradition in its own right. \n\nStow this gift for sentimental value, or sell it at a commodities terminal and spend the credits on a holiday gift for yourself.",
   "icon": "ui/textures/vector/general/items/inv_icon_holiday_box.svg"
 }

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_dog_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_dog_a.json
@@ -1,0 +1,10 @@
+{
+  "key": "special_lunar_envelope_1_dog_a",
+  "sc_key": "items_commodities_special_lunar_envelope_1_dog_a",
+  "ref": "1b64845a-42f1-48e8-960d-9a5099519b44",
+  "name": "Year of the Dog Envelope",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "A gilded red envelope celebrating the Year of the Dog. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need.",
+  "icon": "ui/textures/vector/general/items/inv_icon_holiday_box.svg"
+}

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_dog_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_dog_a.json
@@ -4,7 +4,7 @@
   "ref": "1b64845a-42f1-48e8-960d-9a5099519b44",
   "name": "Year of the Dog Envelope",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "A gilded red envelope celebrating the Year of the Dog. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need.",
   "icon": "ui/textures/vector/general/items/inv_icon_holiday_box.svg"
 }

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_pig_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_pig_a.json
@@ -1,0 +1,10 @@
+{
+  "key": "special_lunar_envelope_1_pig_a",
+  "sc_key": "items_commodities_special_lunar_envelope_1_pig_a",
+  "ref": null,
+  "name": "Year of the Pig Envelope",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "A gilded red envelope celebrating the Year of the Pig. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_pig_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_pig_a.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Year of the Pig Envelope",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "A gilded red envelope celebrating the Year of the Pig. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_rooster_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_rooster_a.json
@@ -1,0 +1,10 @@
+{
+  "key": "special_lunar_envelope_1_rooster_a",
+  "sc_key": "items_commodities_special_lunar_envelope_1_rooster_a",
+  "ref": null,
+  "name": "Year of the Rooster Envelope",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "A gilded red envelope celebrating the Year of the Rooster. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need. \n\nStow the envelope as a token of luck, share it with a friend or loved one to spread good fortune, or exchange it at a commodities terminal and use the credits for a prosperous beginning to a new cycle.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_rooster_a.json
+++ b/data/sc_data/parsed/live/commodities/special_lunar_envelope_1_rooster_a.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Year of the Rooster Envelope",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "A gilded red envelope celebrating the Year of the Rooster. Exchanging these envelopes is one of the most popular ways of celebrating Red Festival. Often the envelope may include a small amount of credits inside to help those you care about have a strong start in the upcoming cycle. Growing in popularity is the newer tradition of hiding the envelopes as a way of spreading good fortune and prosperity to those that fate has deemed in need. \n\nStow the envelope as a token of luck, share it with a friend or loved one to spread good fortune, or exchange it at a commodities terminal and use the credits for a prosperous beginning to a new cycle.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/spiral.json
+++ b/data/sc_data/parsed/live/commodities/spiral.json
@@ -1,0 +1,10 @@
+{
+  "key": "spiral",
+  "sc_key": "items_commodities_spiral",
+  "ref": "16e0129e-6ee8-4707-94cb-1dec7e77645a",
+  "name": "Lunes (Spiral Fruit)",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 23\nHEI: 10\nEffects: Hydrating\n\nThe Lunes is a deciduous tree native to the warmer areas of Osha in Kilian system. It bears an edible fruit known as a Lunes fruit or a Spiral Fruit based on the circular ridges that can form once the fruit begins to ripen. The fruit’s skin is covered with a short fuzz that is generally removed before consumption. When ripe, the Lunes is a very sweet and juicy flavor and have become a very popular summer delicacy, commonly found in ice cream and other desserts.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/steel.json
+++ b/data/sc_data/parsed/live/commodities/steel.json
@@ -1,0 +1,10 @@
+{
+  "key": "steel",
+  "sc_key": "items_commodities_steel",
+  "ref": "08e30ea3-0b36-4945-a57e-91bf3608f1b4",
+  "name": "Steel",
+  "commodity_type": "alloy",
+  "commodity_type_name": "Alloy",
+  "description": "An alloy of iron and carbon, this ancient material is still in uses thanks to its affordable price and high tensile strength.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/stileron.json
+++ b/data/sc_data/parsed/live/commodities/stileron.json
@@ -1,0 +1,10 @@
+{
+  "key": "stileron",
+  "sc_key": "items_commodities_stileron",
+  "ref": null,
+  "name": "Stileron",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/stims.json
+++ b/data/sc_data/parsed/live/commodities/stims.json
@@ -1,0 +1,10 @@
+{
+  "key": "stims",
+  "sc_key": "items_commodities_stims",
+  "ref": "31855cfd-a9b5-42f6-b7d8-11739205bd7c",
+  "name": "Stims",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Composed of various combinations of tobacco, caffeine, and mood-enhancer, stims are smoked as a cigarette.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/stonebugshell.json
+++ b/data/sc_data/parsed/live/commodities/stonebugshell.json
@@ -1,0 +1,10 @@
+{
+  "key": "stonebugshell",
+  "sc_key": "items_commodities_stonebugshell",
+  "ref": null,
+  "name": "Stone Bug Shell",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Known to curl into a tight ball when threatened, the stone bug is sought after for its tough shell, which can be removed and used as a durable material that has even been utilized in certain armor composites.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/sunsetberry.json
+++ b/data/sc_data/parsed/live/commodities/sunsetberry.json
@@ -1,0 +1,10 @@
+{
+  "key": "sunsetberry",
+  "sc_key": "items_commodities_sunsetberry",
+  "ref": "6ac72f3c-d071-4a0b-b8ef-18959dcf5303",
+  "name": "Sunset Berries",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "NDR: 08\nHEI: 06\nEffect: Toxic\n\nThese sunset-hued berries grow best in cold climates. They are toxic and not suitable for Human consumption. Eating them can result in symptoms such as vomiting and extreme cramping. Higher dosages have been known to be fatal. While the raw unprocessed berries are very bitter and tannic, once fermented, the resulting poisonous brew has a very sweet taste and is more commonly known as \"Death Wine.\" Recently, medical researchers are investigating if the toxin in sunset berries could be used to help treat nerve damage or neurological diseases.",
+  "icon": "ui/textures/vector/general/items/inv_icon_sunsetberry.svg"
+}

--- a/data/sc_data/parsed/live/commodities/taranite.json
+++ b/data/sc_data/parsed/live/commodities/taranite.json
@@ -4,7 +4,7 @@
   "ref": "2726bff4-2370-4a3b-a1e1-85af0791ee11",
   "name": "Taranite",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Extremely conductive, this mineral was first discovered when a researcher noticed a breed of electrosensitive hermit crab using pieces of it to form its shell.",
   "icon": "ui/textures/vector/general/items/inv_icon_taranite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/taranite.json
+++ b/data/sc_data/parsed/live/commodities/taranite.json
@@ -1,0 +1,10 @@
+{
+  "key": "taranite",
+  "sc_key": "items_commodities_taranite",
+  "ref": "2726bff4-2370-4a3b-a1e1-85af0791ee11",
+  "name": "Taranite",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Extremely conductive, this mineral was first discovered when a researcher noticed a breed of electrosensitive hermit crab using pieces of it to form its shell.",
+  "icon": "ui/textures/vector/general/items/inv_icon_taranite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/taranite_raw.json
+++ b/data/sc_data/parsed/live/commodities/taranite_raw.json
@@ -1,0 +1,10 @@
+{
+  "key": "taranite_raw",
+  "sc_key": "items_commodities_taranite_raw",
+  "ref": "522803b2-6cb5-4a2a-9d17-6d80b5578cc2",
+  "name": "Taranite (Raw)",
+  "commodity_type": "mineral",
+  "commodity_type_name": null,
+  "description": "Extremely conductive, this mineral was first discovered when a researcher noticed a breed of electrosensitive hermit crab using pieces of it to form its shell.",
+  "icon": "ui/textures/vector/general/items/inv_icon_taranite.svg"
+}

--- a/data/sc_data/parsed/live/commodities/taranite_raw.json
+++ b/data/sc_data/parsed/live/commodities/taranite_raw.json
@@ -4,7 +4,7 @@
   "ref": "522803b2-6cb5-4a2a-9d17-6d80b5578cc2",
   "name": "Taranite (Raw)",
   "commodity_type": "mineral",
-  "commodity_type_name": null,
+  "commodity_type_name": "Mineral",
   "description": "Extremely conductive, this mineral was first discovered when a researcher noticed a breed of electrosensitive hermit crab using pieces of it to form its shell.",
   "icon": "ui/textures/vector/general/items/inv_icon_taranite.svg"
 }

--- a/data/sc_data/parsed/live/commodities/thermalfoam.json
+++ b/data/sc_data/parsed/live/commodities/thermalfoam.json
@@ -1,0 +1,10 @@
+{
+  "key": "thermalfoam",
+  "sc_key": "items_commodities_thermalfoam",
+  "ref": "95880b9b-a5ec-40c6-a6ba-2322ceccb70d",
+  "name": "ThermalFoam",
+  "commodity_type": "manmade",
+  "commodity_type_name": "Man-made",
+  "description": "A light and flexible heat insulating foam. Must be stored under very high pressure to avoid it setting before application.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/thrust.json
+++ b/data/sc_data/parsed/live/commodities/thrust.json
@@ -1,0 +1,10 @@
+{
+  "key": "thrust",
+  "sc_key": "items_commodities_thrust",
+  "ref": "385e46f7-9768-45af-aa9f-4049c2021386",
+  "name": "Thrust",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "This cocktail of chemicals provides the user with a massive boost of energy, increased sociability, euphoria, and heightened tactile sensitivity. Rumored to have been developed as an energy drink base, this drug has proven popular among those wishing for extra energy or to \"party longer.\" However, owing to the risk of heart attack, deadly dehydration, and seizures, the mix has been banned in most areas. Users can be identified by their stuttering, rambling speech, flushed skin, and sweating.",
+  "icon": "ui/textures/vector/general/items/inv_icon_altruciatoxin.svg"
+}

--- a/data/sc_data/parsed/live/commodities/tin.json
+++ b/data/sc_data/parsed/live/commodities/tin.json
@@ -1,0 +1,10 @@
+{
+  "key": "tin",
+  "sc_key": "items_commodities_tin",
+  "ref": null,
+  "name": "Tin",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Tin is a pliable, soft metal, with a silvery white-blue tint. It is conductive and resistance to corrosion.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/titanium.json
+++ b/data/sc_data/parsed/live/commodities/titanium.json
@@ -1,0 +1,10 @@
+{
+  "key": "titanium",
+  "sc_key": "items_commodities_titanium",
+  "ref": "893b2031-a1a0-4f6a-9940-e909f8cf4a05",
+  "name": "Titanium",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "This silver-colored chemical element is excellent at producing strong, lightweight alloys.",
+  "icon": "ui/textures/vector/general/items/inv_icon_titanium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/titanium_ore.json
+++ b/data/sc_data/parsed/live/commodities/titanium_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "titanium_ore",
+  "sc_key": "items_commodities_titanium_ore",
+  "ref": "8b1b0ceb-971c-42d2-9b83-069237c0c7fe",
+  "name": "Titanium (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "This silver-colored chemical element is excellent at producing strong, lightweight alloys.",
+  "icon": "ui/textures/vector/general/items/inv_icon_titanium.svg"
+}

--- a/data/sc_data/parsed/live/commodities/tritium.json
+++ b/data/sc_data/parsed/live/commodities/tritium.json
@@ -1,0 +1,10 @@
+{
+  "key": "tritium",
+  "sc_key": "items_commodities_tritium",
+  "ref": "75f85461-74a3-47e0-843e-d4059dfb22af",
+  "name": "Tritium",
+  "commodity_type": "gas",
+  "commodity_type_name": "Gas",
+  "description": "Tritium description.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/tungsten.json
+++ b/data/sc_data/parsed/live/commodities/tungsten.json
@@ -1,0 +1,10 @@
+{
+  "key": "tungsten",
+  "sc_key": "items_commodities_tungsten",
+  "ref": "28ec789c-a7ea-4f6c-a43f-77fe4480123a",
+  "name": "Tungsten",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Used in many different alloys, tungsten in its pure form becomes malleable while maintaining its hardness.",
+  "icon": "ui/textures/vector/general/items/inv_icon_tungsten.svg"
+}

--- a/data/sc_data/parsed/live/commodities/tungsten_ore.json
+++ b/data/sc_data/parsed/live/commodities/tungsten_ore.json
@@ -1,0 +1,10 @@
+{
+  "key": "tungsten_ore",
+  "sc_key": "items_commodities_tungsten_ore",
+  "ref": "03c95e4d-0f7a-4efc-89ad-b8e61da5e30c",
+  "name": "Tungsten (Ore)",
+  "commodity_type": "metal",
+  "commodity_type_name": "Metal",
+  "description": "Used in many different alloys, tungsten in its pure form becomes malleable while maintaining its hardness.",
+  "icon": "ui/textures/vector/general/items/inv_icon_tungsten.svg"
+}

--- a/data/sc_data/parsed/live/commodities/type_hpmc.json
+++ b/data/sc_data/parsed/live/commodities/type_hpmc.json
@@ -4,7 +4,7 @@
   "ref": "e39c7a65-a67e-4086-a71c-7635bdff7759",
   "name": "HexaPolyMesh Coating",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "This liquid hexagonal lattice bonds readily to surfaces when electrically charged, solidifying almost instantaneously to create an incredibly strong and durable polymer mesh that maintains integrity at a range of temperatures and pressures.",
   "icon": "ui/textures/vector/general/items/inv_icon_hpmc.svg"
 }

--- a/data/sc_data/parsed/live/commodities/type_hpmc.json
+++ b/data/sc_data/parsed/live/commodities/type_hpmc.json
@@ -1,0 +1,10 @@
+{
+  "key": "type_hpmc",
+  "sc_key": "items_commodities_type_hpmc",
+  "ref": "e39c7a65-a67e-4086-a71c-7635bdff7759",
+  "name": "HexaPolyMesh Coating",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "This liquid hexagonal lattice bonds readily to surfaces when electrically charged, solidifying almost instantaneously to create an incredibly strong and durable polymer mesh that maintains integrity at a range of temperatures and pressures.",
+  "icon": "ui/textures/vector/general/items/inv_icon_hpmc.svg"
+}

--- a/data/sc_data/parsed/live/commodities/type_plasmafuel.json
+++ b/data/sc_data/parsed/live/commodities/type_plasmafuel.json
@@ -1,0 +1,10 @@
+{
+  "key": "type_plasmafuel",
+  "sc_key": "items_commodities_type_plasmafuel",
+  "ref": "6d14787a-8e7d-4595-b80c-ae6f85450b79",
+  "name": "Hydrogen Fuel",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "Hydrogen that is energized and then used by thrusters to propel vehicles.",
+  "icon": "ui/textures/vector/general/items/inv_icon_plasmafuel.svg"
+}

--- a/data/sc_data/parsed/live/commodities/type_plasmafuel.json
+++ b/data/sc_data/parsed/live/commodities/type_plasmafuel.json
@@ -4,7 +4,7 @@
   "ref": "6d14787a-8e7d-4595-b80c-ae6f85450b79",
   "name": "Hydrogen Fuel",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "Hydrogen that is energized and then used by thrusters to propel vehicles.",
   "icon": "ui/textures/vector/general/items/inv_icon_plasmafuel.svg"
 }

--- a/data/sc_data/parsed/live/commodities/type_quantumfuel.json
+++ b/data/sc_data/parsed/live/commodities/type_quantumfuel.json
@@ -4,7 +4,7 @@
   "ref": "d86099d1-e57e-4e73-b966-534c9410f04e",
   "name": "Quantum Fuel",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "Fuel used by quantum drives to propel ships at high speeds or, if equipped with a jump module, through jump tunnels to other systems.",
   "icon": "ui/textures/vector/general/items/inv_icon_quantumfuel.svg"
 }

--- a/data/sc_data/parsed/live/commodities/type_quantumfuel.json
+++ b/data/sc_data/parsed/live/commodities/type_quantumfuel.json
@@ -1,0 +1,10 @@
+{
+  "key": "type_quantumfuel",
+  "sc_key": "items_commodities_type_quantumfuel",
+  "ref": "d86099d1-e57e-4e73-b966-534c9410f04e",
+  "name": "Quantum Fuel",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "Fuel used by quantum drives to propel ships at high speeds or, if equipped with a jump module, through jump tunnels to other systems.",
+  "icon": "ui/textures/vector/general/items/inv_icon_quantumfuel.svg"
+}

--- a/data/sc_data/parsed/live/commodities/type_rmc.json
+++ b/data/sc_data/parsed/live/commodities/type_rmc.json
@@ -4,7 +4,7 @@
   "ref": "59a0ff6e-6c48-48c5-8e75-00bbebd3fbf2",
   "name": "Recycled Material Composite",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": "Recycled Material Composite, commonly referred to as RMC, is the end result of low-tier salvaging where a myriad of alloys and polymers are mixed together during the collection process.",
   "icon": "ui/textures/vector/general/items/inv_icon_hpmc.svg"
 }

--- a/data/sc_data/parsed/live/commodities/type_rmc.json
+++ b/data/sc_data/parsed/live/commodities/type_rmc.json
@@ -1,0 +1,10 @@
+{
+  "key": "type_rmc",
+  "sc_key": "items_commodities_type_rmc",
+  "ref": "59a0ff6e-6c48-48c5-8e75-00bbebd3fbf2",
+  "name": "Recycled Material Composite",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": "Recycled Material Composite, commonly referred to as RMC, is the end result of low-tier salvaging where a myriad of alloys and polymers are mixed together during the collection process.",
+  "icon": "ui/textures/vector/general/items/inv_icon_hpmc.svg"
+}

--- a/data/sc_data/parsed/live/commodities/uncutslam.json
+++ b/data/sc_data/parsed/live/commodities/uncutslam.json
@@ -1,0 +1,10 @@
+{
+  "key": "uncutslam",
+  "sc_key": "items_commodities_uncutslam",
+  "ref": null,
+  "name": "Uncut SLAM",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Initially developed for athletes before being outlawed, SLAM acts as a combat performance enhancer, targeting the user's nervous system as a fear-inhibitor and painkiller. Uncut SLAM is the concentrated form of the drug, and must be diluted to non-lethal dosages before it can be packaged into dispersal vials and consumed.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/ventslug.json
+++ b/data/sc_data/parsed/live/commodities/ventslug.json
@@ -1,0 +1,10 @@
+{
+  "key": "ventslug",
+  "sc_key": "items_commodities_ventslug",
+  "ref": null,
+  "name": "Vent Slug",
+  "commodity_type": "food",
+  "commodity_type_name": "Food",
+  "description": "NDR: 19\nHEI: 05\nEffects: Toxic, Cognitive Impairing\n\nThese slugs live in moist environments and eat mold that grows there. They can frequently be found inside and near life support vents where condensation can accumulate and are often brought aboard stations to help keep systems clean. Can be consumed, but they often can be mildly toxic to Humans owing to their diet.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/viruscultures.json
+++ b/data/sc_data/parsed/live/commodities/viruscultures.json
@@ -4,7 +4,7 @@
   "ref": null,
   "name": "Virus Cultures",
   "commodity_type": "processed_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Processed Goods",
   "description": null,
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/viruscultures.json
+++ b/data/sc_data/parsed/live/commodities/viruscultures.json
@@ -1,0 +1,10 @@
+{
+  "key": "viruscultures",
+  "sc_key": "items_commodities_viruscultures",
+  "ref": null,
+  "name": "Virus Cultures",
+  "commodity_type": "processed_goods",
+  "commodity_type_name": null,
+  "description": null,
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/waste.json
+++ b/data/sc_data/parsed/live/commodities/waste.json
@@ -1,0 +1,10 @@
+{
+  "key": "waste",
+  "sc_key": "items_commodities_waste",
+  "ref": "eff51505-e247-4516-8988-51a996b58fc6",
+  "name": "Waste",
+  "commodity_type": "waste",
+  "commodity_type_name": "Waste",
+  "description": "Unwanted and unusable materials that are designated to be discarded.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/widow.json
+++ b/data/sc_data/parsed/live/commodities/widow.json
@@ -1,0 +1,10 @@
+{
+  "key": "widow",
+  "sc_key": "items_commodities_widow",
+  "ref": "f73f3601-8edd-4b3b-a5f3-f3bb67f24771",
+  "name": "WiDoW",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Thick, ink-black synthetic opioid commonly used as a recreational drug. WiDoW has spread like wildfire throughout the Empire thanks to the fact that it's relatively easy to produce. This also creates a wide variety of quality between batches of the drug. Designed to be injected as a liquid directly into the bloodstream, the name derived from one of the main side effects from extensive use, the drug stains the veins black, creating web-like subcutaneous patterns through the body. Illegal inside the UEE.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/wuotanseed.json
+++ b/data/sc_data/parsed/live/commodities/wuotanseed.json
@@ -1,0 +1,10 @@
+{
+  "key": "wuotanseed",
+  "sc_key": "items_commodities_wuotanseed",
+  "ref": null,
+  "name": "Wuotan Seed",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Harvested from the wuotan plant, these seed pods become bioluminescent when ripe to draw attention and encourage their spread. They are often collected to utilize as a natural light source.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/xapyen.json
+++ b/data/sc_data/parsed/live/commodities/xapyen.json
@@ -1,0 +1,10 @@
+{
+  "key": "xapyen",
+  "sc_key": "items_commodities_xapyen",
+  "ref": "0da39bc8-5174-43ac-afd3-3f4670e1906c",
+  "name": "Xa'Pyen",
+  "commodity_type": "alloy",
+  "commodity_type_name": "Alloy",
+  "description": "Only recently used in Human manufacturing, this complex alloy of Xi'an origin is a jack of all trades that is extremely useful in numerous applications.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/yormandi_eye.json
+++ b/data/sc_data/parsed/live/commodities/yormandi_eye.json
@@ -1,0 +1,10 @@
+{
+  "key": "yormandi_eye",
+  "sc_key": "items_commodities_yormandi_eye",
+  "ref": null,
+  "name": "Yormandi Eye",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "Able to thrive in a wide variety of environments, the yormandi has a robust immune system that responds to unknown pathogens at incredible speed. Its eyes contain antibodies that are much sought-after by medical researchers.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/yormandi_tongue.json
+++ b/data/sc_data/parsed/live/commodities/yormandi_tongue.json
@@ -1,0 +1,10 @@
+{
+  "key": "yormandi_tongue",
+  "sc_key": "items_commodities_yormandi_tongue",
+  "ref": null,
+  "name": "Yormandi Tongue",
+  "commodity_type": "natural",
+  "commodity_type_name": "Natural Materials",
+  "description": "The yormandi uses its sensitive tongue to taste its surroundings and detect prey from great distances. Renowned for its complex, subtle flavor, the tip of this organ is sought after by culinary enthusiasts throughout the Empire.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/zetaprolanide.json
+++ b/data/sc_data/parsed/live/commodities/zetaprolanide.json
@@ -4,7 +4,7 @@
   "ref": "6cff1dcd-b2f7-4e4f-ba48-ffa884184b37",
   "name": "Zeta-Prolanide",
   "commodity_type": "consumer_goods",
-  "commodity_type_name": null,
+  "commodity_type_name": "Consumer Goods",
   "description": "This chemical is an industrial reactant that has found widespread use neutralizing irradiated materials. Because of how volatile it is, it must be kept in an electrically charged state or else a rapid exothermic reaction may occur before desired.",
   "icon": null
 }

--- a/data/sc_data/parsed/live/commodities/zetaprolanide.json
+++ b/data/sc_data/parsed/live/commodities/zetaprolanide.json
@@ -1,0 +1,10 @@
+{
+  "key": "zetaprolanide",
+  "sc_key": "items_commodities_zetaprolanide",
+  "ref": "6cff1dcd-b2f7-4e4f-ba48-ffa884184b37",
+  "name": "Zeta-Prolanide",
+  "commodity_type": "consumer_goods",
+  "commodity_type_name": null,
+  "description": "This chemical is an industrial reactant that has found widespread use neutralizing irradiated materials. Because of how volatile it is, it must be kept in an electrically charged state or else a rapid exothermic reaction may occur before desired.",
+  "icon": null
+}

--- a/data/sc_data/parsed/live/commodities/zip.json
+++ b/data/sc_data/parsed/live/commodities/zip.json
@@ -1,0 +1,10 @@
+{
+  "key": "zip",
+  "sc_key": "items_commodities_zip",
+  "ref": "7c2acbc5-ca35-4dc0-b6c3-be61afa9b060",
+  "name": "Zip",
+  "commodity_type": "vice",
+  "commodity_type_name": "Vice",
+  "description": "Zip is a hyper-accelerant that when added directly to the bloodstream, \"supercharges\" the user's nervous system causing sensory hallucinations such as colors become more vivid and hearing sounds that aren't there. These effects tend to make users seem to be in constant motion and easily distracted.",
+  "icon": "ui/textures/vector/general/items/inv_icon_widow.svg"
+}

--- a/db/migrate/20260815120000_create_commodities.rb
+++ b/db/migrate/20260815120000_create_commodities.rb
@@ -1,0 +1,24 @@
+class CreateCommodities < ActiveRecord::Migration[8.1]
+  def change
+    create_table :commodities, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      # Nullable: a commodity can also come from UEX, which lists goods the
+      # game files don't declare.
+      t.string :sc_key
+      t.string :sc_ref
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :commodity_type
+      t.text :description
+      t.string :icon
+      t.string :version
+      t.integer :uex_id
+      t.string :uex_slug
+      t.timestamps
+
+      t.index :sc_key, unique: true
+      t.index :slug, unique: true
+      t.index :commodity_type
+      t.index :uex_slug
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -154,6 +154,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_120000) do
     t.index ["capacity_scu"], name: "index_cargo_holds_on_capacity_scu"
     t.index ["parent_type", "parent_id", "max_container_size_scu"], name: "index_cargo_holds_on_parent_and_max_container_size"
     t.index ["parent_type", "parent_id"], name: "index_cargo_holds_on_parent_type_and_parent_id"
+  end
+
+  create_table "commodities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "commodity_type"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "icon"
+    t.string "name", null: false
+    t.string "sc_key"
+    t.string "sc_ref"
+    t.string "slug", null: false
+    t.integer "uex_id"
+    t.string "uex_slug"
+    t.datetime "updated_at", null: false
+    t.string "version"
+    t.index ["commodity_type"], name: "index_commodities_on_commodity_type"
+    t.index ["sc_key"], name: "index_commodities_on_sc_key", unique: true
+    t.index ["slug"], name: "index_commodities_on_slug", unique: true
+    t.index ["uex_slug"], name: "index_commodities_on_uex_slug"
   end
 
   create_table "compare_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: commodities
+#
+#  id             :uuid             not null, primary key
+#  commodity_type :string
+#  description    :text
+#  icon           :string
+#  name           :string           not null
+#  sc_key         :string
+#  sc_ref         :string
+#  slug           :string           not null
+#  uex_slug       :string
+#  version        :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  uex_id         :integer
+#
+# Indexes
+#
+#  index_commodities_on_commodity_type  (commodity_type)
+#  index_commodities_on_sc_key          (sc_key) UNIQUE
+#  index_commodities_on_slug            (slug) UNIQUE
+#  index_commodities_on_uex_slug        (uex_slug)
+#
+FactoryBot.define do
+  factory :commodity do
+    sequence(:name) { |n| "#{Faker::Commerce.material} #{n}" }
+    sequence(:sc_key) { |n| "items_commodities_test_#{n}" }
+    commodity_type { "metal" }
+    description { Faker::Lorem.sentence }
+
+    trait :mineral do
+      commodity_type { "mineral" }
+    end
+
+    trait :with_uex_mapping do
+      sequence(:uex_id) { |n| n }
+      sequence(:uex_slug) { |n| "uex-commodity-#{n}" }
+    end
+  end
+end

--- a/test/loaders/sc_data/commodities_loader_test.rb
+++ b/test/loaders/sc_data/commodities_loader_test.rb
@@ -22,6 +22,16 @@ module ScData
         assert_equal slugs.uniq.size, slugs.size
       end
 
+      # The localization index is downcased while the game's type keys are camel
+      # case, so a lookup that skips the downcase silently drops the label for
+      # every multi-word type and leaves the single-word ones looking fine.
+      test "every parsed commodity carries the label for its type" do
+        parsed = @loader.load_items("commodities")
+
+        assert_empty parsed.select { |commodity| commodity[:commodity_type_name].blank? }
+          .map { |commodity| commodity[:sc_key] }
+      end
+
       test "#all assigns a type to every commodity" do
         @loader.all
 

--- a/test/loaders/sc_data/commodities_loader_test.rb
+++ b/test/loaders/sc_data/commodities_loader_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ScData
+  module Loader
+    class CommoditiesLoaderTest < ActiveSupport::TestCase
+      setup do
+        Commodity.delete_all
+        @loader = ::ScData::Loader::CommoditiesLoader.new
+      end
+
+      test "#all loads commodities from game files" do
+        @loader.all
+
+        assert_operator Commodity.count, :>=, 160
+
+        sc_keys = Commodity.pluck(:sc_key)
+        assert_equal sc_keys.uniq.size, sc_keys.size
+
+        slugs = Commodity.pluck(:slug)
+        assert_equal slugs.uniq.size, slugs.size
+      end
+
+      test "#all assigns a type to every commodity" do
+        @loader.all
+
+        assert_empty Commodity.where(commodity_type: nil).pluck(:name)
+        assert_empty Commodity.where.not(commodity_type: Commodity::TYPES).pluck(:commodity_type)
+      end
+
+      test "#all resolves refined metals, ores and harvestables" do
+        @loader.all
+
+        assert_equal "metal", Commodity.find_by(sc_key: "items_commodities_gold")&.commodity_type
+        assert_equal "metal", Commodity.find_by(sc_key: "items_commodities_iron_ore")&.commodity_type
+        assert_equal "mineral", Commodity.find_by(sc_key: "items_commodities_janalite")&.commodity_type
+        assert_equal "natural", Commodity.find_by(sc_key: "items_commodities_kopionhorn")&.commodity_type
+
+        # The alloys are tagged both "alloy" and "metal" across crate records;
+        # the bare commodity record settles it.
+        assert_equal "alloy", Commodity.find_by(sc_key: "items_commodities_steel")&.commodity_type
+      end
+
+      test "#all is idempotent" do
+        @loader.all
+        count = Commodity.count
+
+        assert_no_difference -> { Commodity.count } do
+          @loader.all
+        end
+
+        assert_equal count, Commodity.count
+      end
+
+      test "#all keeps a commodity that already exists without an sc_key" do
+        existing = create(:commodity, name: "Gold", sc_key: nil, commodity_type: nil)
+
+        @loader.all
+
+        existing.reload
+
+        assert_equal "items_commodities_gold", existing.sc_key
+        assert_equal "metal", existing.commodity_type
+      end
+    end
+  end
+end

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommodityTest < ActiveSupport::TestCase
+  test "generates a slug from the name" do
+    commodity = create(:commodity, name: "Agricium (Ore)")
+
+    assert_equal "agricium-ore", commodity.slug
+  end
+
+  test "requires a name" do
+    commodity = build(:commodity, name: nil)
+
+    assert_not commodity.valid?
+    assert_includes commodity.errors.attribute_names, :name
+  end
+
+  test "rejects a duplicate sc_key" do
+    create(:commodity, sc_key: "items_commodities_gold")
+    duplicate = build(:commodity, sc_key: "items_commodities_gold")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :sc_key
+  end
+
+  test "allows commodities without an sc_key" do
+    commodity = build(:commodity, sc_key: nil)
+
+    assert_predicate commodity, :valid?
+  end
+
+  test "can be referenced by a fleet inventory item" do
+    commodity = create(:commodity, name: "Gold")
+    item = create(:fleet_inventory_item, item: commodity, name: nil)
+
+    assert_equal "Gold", item.name
+    assert_equal commodity, item.item
+    assert_includes commodity.fleet_inventory_items, item
+  end
+end


### PR DESCRIPTION
Adds a `Commodity` reference table sourced from the Star Citizen game files, as the first of several reference tables backing the fleet inventory feature.

## Why

`FleetInventoryItem` stores a free-text `name` and has an unused polymorphic `item` association. This gives that association something to point at for `category: commodity`, so members can pick a real commodity instead of typing one.

## What's here

- **`ScData::Parser::CommoditiesParser`** → `data/sc_data/parsed/live/commodities/*.json` (168 commodities)
- **`ScData::Loader::CommoditiesLoader`** → upserts into the new `commodities` table
- **`Commodity` model + migration**, registered in `BaseParser.all` / `BaseLoader.all` so the existing `Loaders::ScData::AllJob` picks both up

## Notes on the parse

Commodities are declared across **two** record trees, not one. `entities/commodities/` looks like the list but holds only 131 — the per-crate-size records under `entities/scitem/carryables/` cover 165, including every ore and harvestable. The union is the complete set.

Type resolution needed a precedence rule because the game data disagrees with itself:

- The alloys (Steel, Atlasium, Dymantium) are tagged both `alloy` and `metal` across crate records
- Contraband variants of legal goods claim `vice`
- ~38 commodities declare no `displayType` at all — mostly harvestables and tractor-beam-only crates

So: the `displayType` on the `entities/commodities/` record wins (it's what the commodity kiosk reads), then most-common declared type, then canonical folder, then record-path tokens. Result is **0 untyped and 0 unresolved conflicts**, verified in the loader test.

Two game-data bugs are handled: Wuotan Seed's display name points at its description key, and `items_commodities_type_processedGoods` is the generic label on unmarked crates rather than a commodity (dropped — hence 168, not 169).

## Loaded data

168 rows — mineral 30, metal 23, natural 22, vice 16, consumer_goods 16, processed_goods 14, manmade 12, gas 12, food 6, agricultural_supply 4, alloy 4, nonmetals 3, medical_supply 3, scrap 2, waste 1. 155 have descriptions, 131 have a canonical game ref.

## Design decisions

- **Keyed on the game localization key** (`sc_key`), nullable so a UEX-only commodity can exist without a game record.
- **`uex_id` / `uex_slug` are nullable and unpopulated.** Prices, supply/demand and terminal inventories are datacore-only and not in the extracted XML — those come from UEX, and this is the join column for when they do.

## Not in this PR

- The API endpoint, the picker in `InventoryItemModal`, and an `item_type` allowlist — all in progress on this branch next.
- Storing the localized type label (agreed, coming next).
- Icons. `Commodity#icon` holds a path that currently resolves to nothing: the game-data exporter only extracts `*.xml` and `*.ini`, so the referenced SVGs were never pulled. Filed as fleetyards/sc-tools#1.
- Translated commodity names. All 11 locales are available in the dump, but no sc_data is translated anywhere in the app today, so this stays English-only.

## Testing

`bin/rails test test/models test/loaders` → 182 tests, 0 failures. 10 of those are new (model + loader), covering type resolution for refined metals, ores, harvestables and the alloy conflict, plus loader idempotency.

🤖
