### PR TITLE
feat(logistics): pick commodities in inventory entries

### DIFF
--- a/app/api_components/v1/schemas/commodities/commodities.rb
+++ b/app/api_components/v1/schemas/commodities/commodities.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Commodities
+      class Commodities < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/Commodity"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/commodity.rb
+++ b/app/api_components/v1/schemas/commodity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class Commodity
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          id: {type: :string, format: :uuid},
+          name: {type: :string},
+          slug: {type: :string},
+          commodityType: {type: [:string, :null]},
+          description: {type: [:string, :null]},
+          createdAt: {type: :string, format: "date-time"},
+          updatedAt: {type: :string, format: "date-time"}
+        },
+        additionalProperties: false,
+        required: %w[id name slug createdAt updatedAt]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/commodity_query.rb
+++ b/app/api_components/v1/schemas/queries/commodity_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Queries
+      class CommodityQuery
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            nameCont: {type: :string},
+            idIn: {type: :array, items: {type: :string, format: :uuid}},
+            nameIn: {type: :array, items: {type: :string}},
+            slugIn: {type: :array, items: {type: :string}},
+            commodityTypeIn: {type: :array, items: {type: :string}}
+          },
+          additionalProperties: false,
+          example: {}
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CommoditiesController < ::Api::PublicBaseController
+      skip_verify_authorized only: %i[index]
+
+      after_action -> { pagination_header(:commodities) }, only: [:index]
+
+      def index
+        commodities_query_params["sorts"] = "name asc"
+
+        @q = Commodity.ransack(commodities_query_params)
+
+        @commodities = @q.result
+          .page(params[:page])
+          .per(per_page(Commodity))
+      end
+
+      private def commodities_query_params
+        @commodities_query_params ||= params.permit(q: [
+          :name_cont,
+          id_in: [], name_in: [], slug_in: [], commodity_type_in: []
+        ]).fetch(:q, {})
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/filters/commodities_controller.rb
+++ b/app/controllers/api/v1/filters/commodities_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Filters
+      class CommoditiesController < ::Api::PublicBaseController
+        skip_verify_authorized
+
+        def types
+          @filters = Commodity.type_filters
+
+          render "api/v1/shared/filters"
+        end
+      end
+    end
+  end
+end

--- a/app/frontend/frontend/components/Fleets/Logistics/InventoryItemModal/index.vue
+++ b/app/frontend/frontend/components/Fleets/Logistics/InventoryItemModal/index.vue
@@ -19,7 +19,10 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useComlink } from "@/shared/composables/useComlink";
 import ComponentPicker from "@/frontend/components/Logistics/ComponentPicker/index.vue";
+import CommodityPicker from "@/frontend/components/Logistics/CommodityPicker/index.vue";
+import { type PickedItem } from "@/frontend/components/Logistics/types";
 import {
+  type Commodity,
   type Component as GameComponent,
   type Fleet,
   type FleetInventory,
@@ -102,6 +105,10 @@ const isComponent = computed(
   () => category.value === FleetInventoryItemCreateInputCategory.component,
 );
 
+const isCommodity = computed(
+  () => category.value === FleetInventoryItemCreateInputCategory.commodity,
+);
+
 const unitOptions = unitOptionsFor(category);
 
 // The category dictates which units make sense, so a category change pulls the
@@ -142,7 +149,9 @@ const existingItemOptions = computed<FilterOption[]>(() =>
 );
 
 const selectedExistingItem = ref<string | undefined>(undefined);
-const pickedComponent = ref<GameComponent | undefined>(undefined);
+// One slot for whichever catalogue the category exposes, so the submit and the
+// name-edit rule stay single rather than growing a branch per item type.
+const pickedItem = ref<PickedItem | undefined>(undefined);
 
 watch(selectedExistingItem, (val) => {
   if (!val) return;
@@ -153,25 +162,47 @@ watch(selectedExistingItem, (val) => {
   setFieldValue("category", itemCategory as any);
   setFieldValue("unit", itemUnit as any);
   /* eslint-enable @typescript-eslint/no-explicit-any */
-  pickedComponent.value = undefined;
+  pickedItem.value = undefined;
 });
 
 const applyPickedComponent = (component: GameComponent) => {
-  pickedComponent.value = component;
+  pickedItem.value = {
+    type: "Component",
+    id: component.id,
+    name: component.name,
+  };
 
   setFieldValue("name", component.name);
 };
 
-// A hand-edited name no longer describes the picked component, so the
-// reference goes with it rather than mislabeling a real component.
+const applyPickedCommodity = (commodity: Commodity) => {
+  pickedItem.value = {
+    type: "Commodity",
+    id: commodity.id,
+    name: commodity.name,
+  };
+
+  setFieldValue("name", commodity.name);
+};
+
+// A hand-edited name no longer describes the picked item, so the reference goes
+// with it rather than mislabeling a real component or commodity. Typing a name
+// that isn't in the catalogue at all stays allowed; it just isn't a reference.
 watch(name, (val) => {
-  if (pickedComponent.value && val !== pickedComponent.value.name) {
-    pickedComponent.value = undefined;
+  if (pickedItem.value && val !== pickedItem.value.name) {
+    pickedItem.value = undefined;
   }
 });
 
-watch(isComponent, (val) => {
-  if (!val) pickedComponent.value = undefined;
+// Switching away from the category that offered the picker leaves the reference
+// pointing at the wrong kind of thing.
+watch([isComponent, isCommodity], ([component, commodity]) => {
+  if (!pickedItem.value) return;
+
+  const stillOffered =
+    pickedItem.value.type === "Component" ? component : commodity;
+
+  if (!stillOffered) pickedItem.value = undefined;
 });
 
 // When switching to withdrawal, load stock
@@ -240,8 +271,8 @@ const onSubmit = handleSubmit(async (values) => {
         memberId: values.memberId || undefined,
         image: values.image || undefined,
         notes: values.notes || undefined,
-        itemType: pickedComponent.value ? "Component" : undefined,
-        itemId: pickedComponent.value?.id,
+        itemType: pickedItem.value?.type,
+        itemId: pickedItem.value?.id,
       },
     })
     .then(() => {
@@ -332,6 +363,7 @@ const onSubmit = handleSubmit(async (values) => {
           :searchable="false"
         />
         <ComponentPicker v-if="isComponent" @select="applyPickedComponent" />
+        <CommodityPicker v-if="isCommodity" @select="applyPickedCommodity" />
       </template>
 
       <div class="row">

--- a/app/frontend/frontend/components/Hangar/Logistics/InventoryItemModal/index.vue
+++ b/app/frontend/frontend/components/Hangar/Logistics/InventoryItemModal/index.vue
@@ -20,7 +20,10 @@ import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useInventoryOptions } from "@/frontend/composables/useInventoryOptions";
 import ComponentPicker from "@/frontend/components/Logistics/ComponentPicker/index.vue";
+import CommodityPicker from "@/frontend/components/Logistics/CommodityPicker/index.vue";
+import { type PickedItem } from "@/frontend/components/Logistics/types";
 import {
+  type Commodity,
   type Component as GameComponent,
   type FilterOption,
   type HangarInventory,
@@ -57,7 +60,9 @@ const entryType = ref<"deposit" | "withdrawal">(
 const selectedStockItem = ref<string | undefined>(undefined);
 const selectedExistingItem = ref<string | undefined>(undefined);
 const stockItems = ref<StockItem[]>([]);
-const pickedComponent = ref<GameComponent | undefined>(undefined);
+// One slot for whichever catalogue the category exposes, so the submit and the
+// name-edit rule stay single rather than growing a branch per item type.
+const pickedItem = ref<PickedItem | undefined>(undefined);
 
 const isDeposit = computed(() => entryType.value === "deposit");
 
@@ -95,6 +100,10 @@ const [notes, notesProps] = defineField("notes");
 
 const isComponent = computed(
   () => category.value === HangarInventoryItemCreateInputCategory.component,
+);
+
+const isCommodity = computed(
+  () => category.value === HangarInventoryItemCreateInputCategory.commodity,
 );
 
 const unitOptions = unitOptionsFor(category);
@@ -143,28 +152,50 @@ const applyPickedItem = (val: string | undefined) => {
   setFieldValue("category", itemCategory as any);
   setFieldValue("unit", itemUnit as any);
   /* eslint-enable @typescript-eslint/no-explicit-any */
-  pickedComponent.value = undefined;
+  pickedItem.value = undefined;
 };
 
 watch(selectedExistingItem, applyPickedItem);
 watch(selectedStockItem, applyPickedItem);
 
 const applyPickedComponent = (component: GameComponent) => {
-  pickedComponent.value = component;
+  pickedItem.value = {
+    type: "Component",
+    id: component.id,
+    name: component.name,
+  };
 
   setFieldValue("name", component.name);
 };
 
-// A hand-edited name no longer describes the picked component, so the
-// reference goes with it rather than mislabeling a real component.
+const applyPickedCommodity = (commodity: Commodity) => {
+  pickedItem.value = {
+    type: "Commodity",
+    id: commodity.id,
+    name: commodity.name,
+  };
+
+  setFieldValue("name", commodity.name);
+};
+
+// A hand-edited name no longer describes the picked item, so the reference goes
+// with it rather than mislabeling a real component or commodity. Typing a name
+// that isn't in the catalogue at all stays allowed; it just isn't a reference.
 watch(name, (val) => {
-  if (pickedComponent.value && val !== pickedComponent.value.name) {
-    pickedComponent.value = undefined;
+  if (pickedItem.value && val !== pickedItem.value.name) {
+    pickedItem.value = undefined;
   }
 });
 
-watch(isComponent, (val) => {
-  if (!val) pickedComponent.value = undefined;
+// Switching away from the category that offered the picker leaves the reference
+// pointing at the wrong kind of thing.
+watch([isComponent, isCommodity], ([component, commodity]) => {
+  if (!pickedItem.value) return;
+
+  const stillOffered =
+    pickedItem.value.type === "Component" ? component : commodity;
+
+  if (!stillOffered) pickedItem.value = undefined;
 });
 
 watch(entryType, (val) => {
@@ -206,8 +237,8 @@ const onSubmit = handleSubmit(async (values) => {
         quality: values.quality != null ? Number(values.quality) : undefined,
         image: values.image || undefined,
         notes: values.notes || undefined,
-        itemType: pickedComponent.value ? "Component" : undefined,
-        itemId: pickedComponent.value?.id,
+        itemType: pickedItem.value?.type,
+        itemId: pickedItem.value?.id,
       },
     })
     .then(() => {
@@ -288,6 +319,7 @@ const onSubmit = handleSubmit(async (values) => {
           :searchable="false"
         />
         <ComponentPicker v-if="isComponent" @select="applyPickedComponent" />
+        <CommodityPicker v-if="isCommodity" @select="applyPickedCommodity" />
       </template>
 
       <div class="row">

--- a/app/frontend/frontend/components/Logistics/CommodityPicker/index.vue
+++ b/app/frontend/frontend/components/Logistics/CommodityPicker/index.vue
@@ -1,0 +1,109 @@
+<script lang="ts">
+export default {
+  name: "LogisticsCommodityPicker",
+};
+</script>
+
+<script lang="ts" setup>
+import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  type Commodity,
+  type Commodities,
+  type FilterOption,
+  commodities as fetchCommodities,
+  commodityTypesFilters,
+} from "@/services/fyApi";
+
+const emit = defineEmits<{
+  select: [commodity: Commodity];
+}>();
+
+const { t } = useI18n();
+
+const typeOptions = ref<FilterOption[]>([]);
+const commodityType = ref<string | undefined>(undefined);
+const selected = ref<string | undefined>(undefined);
+const loaded = ref<Commodity[]>([]);
+
+const loadTypes = async () => {
+  try {
+    typeOptions.value = await commodityTypesFilters();
+  } catch {
+    typeOptions.value = [];
+  }
+};
+
+onMounted(() => {
+  void loadTypes();
+});
+
+const commodityQuery = ({ search, page }: { search?: string; page?: number }) =>
+  fetchCommodities({
+    page: String(page || 1),
+    q: {
+      ...(commodityType.value
+        ? { commodityTypeIn: [commodityType.value] }
+        : {}),
+      ...(search ? { nameCont: search } : {}),
+    },
+  });
+
+const commodityOptions = (response: Commodities): FilterOption[] => {
+  const items = response.items || [];
+
+  loaded.value = [
+    ...loaded.value.filter(
+      (known) => !items.some((item) => item.id === known.id),
+    ),
+    ...items,
+  ];
+
+  return items.map((item) => ({
+    value: item.id,
+    label: item.name,
+  }));
+};
+
+watch(commodityType, () => {
+  selected.value = undefined;
+});
+
+watch(selected, (val) => {
+  if (!val) return;
+
+  const picked = loaded.value.find((item) => item.id === val);
+
+  if (picked) emit("select", picked);
+});
+</script>
+
+<template>
+  <div class="row">
+    <div class="col-12 col-md-5">
+      <FilterGroup
+        v-model="commodityType"
+        name="commodityType"
+        :options="typeOptions"
+        :label="t('labels.logistics.commodityType')"
+        :searchable="true"
+        :nullable="true"
+      />
+    </div>
+    <div class="col-12 col-md-7">
+      <!-- Remounting on type change resets the option list, which is keyed
+           to the FilterGroup instance and would otherwise keep stale entries. -->
+      <FilterGroup
+        :key="commodityType || 'all'"
+        v-model="selected"
+        name="commodity"
+        :query-fn="commodityQuery"
+        :query-response-formatter="commodityOptions"
+        :label="t('labels.logistics.commodity')"
+        :searchable="true"
+        :paginated="true"
+        :nullable="true"
+      />
+    </div>
+  </div>
+</template>

--- a/app/frontend/frontend/components/Logistics/types.ts
+++ b/app/frontend/frontend/components/Logistics/types.ts
@@ -1,0 +1,9 @@
+// The hangar and fleet endpoints each generate their own itemType enum, so the
+// pickers speak in this literal union, which is assignable to both.
+export type PickedItemType = "Component" | "Commodity";
+
+export type PickedItem = {
+  type: PickedItemType;
+  id: string;
+  name: string;
+};

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1221,6 +1221,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1615,6 +1615,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1150,6 +1150,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1154,6 +1154,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1150,6 +1150,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1146,6 +1146,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1146,6 +1146,8 @@
         "category": "Category",
         "component": "Component",
         "componentCategory": "Component Type",
+        "commodity": "Commodity",
+        "commodityType": "Commodity Type",
         "quantity": "Quantity",
         "unit": "Unit",
         "notes": "Notes",

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -53,10 +53,24 @@ class Commodity < ApplicationRecord
   ]
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[name slug commodity_type sc_key uex_code created_at updated_at]
+    %w[id name slug commodity_type sc_key uex_code created_at updated_at]
   end
 
   def self.ransackable_associations(_auth_object = nil)
     []
+  end
+
+  def self.commodity_types
+    where.not(commodity_type: nil).distinct.order(:commodity_type).pluck(:commodity_type)
+  end
+
+  def self.type_filters
+    commodity_types.map do |item|
+      Filter.new(
+        category: "commodity_type",
+        label: I18n.t("filter.commodity.commodity_type.items.#{item}", default: item.titleize),
+        value: item
+      )
+    end
   end
 end

--- a/app/views/api/v1/commodities/_base.jbuilder
+++ b/app/views/api/v1/commodities/_base.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.id commodity.id
+json.name commodity.name
+json.slug commodity.slug
+json.commodity_type commodity.commodity_type
+json.description commodity.description
+
+json.partial! "api/shared/dates", record: commodity

--- a/app/views/api/v1/commodities/_commodity.jbuilder
+++ b/app/views/api/v1/commodities/_commodity.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", commodity] do
+  json.partial!("api/v1/commodities/base", commodity:)
+end

--- a/app/views/api/v1/commodities/index.jbuilder
+++ b/app/views/api/v1/commodities/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @commodities, partial: "api/v1/commodities/commodity", as: :commodity
+end
+json.partial! "api/shared/meta", result: @commodities

--- a/config/routes/api/commodities_routes.rb
+++ b/config/routes/api/commodities_routes.rb
@@ -1,0 +1,7 @@
+resources :commodities, only: [:index]
+
+namespace :filters do
+  resources :commodities, only: [] do
+    get :types, on: :collection
+  end
+end

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -44,6 +44,7 @@ v1_api_routes = lambda do
   draw "api/vehicle_loadouts_routes"
   draw "api/fleets_routes"
   draw "api/components_routes"
+  draw "api/commodities_routes"
   draw "api/notifications_routes"
   draw "api/notification_preferences_routes"
 

--- a/swagger/v1/oasdiff-ignore.txt
+++ b/swagger/v1/oasdiff-ignore.txt
@@ -32,3 +32,11 @@ GET /fleets/{fleetSlug}/inventories/{fleetInventorySlug}/items added the new `Co
 POST /fleets/{fleetSlug}/inventories/{fleetInventorySlug}/items added the new `Commodity` enum value to the `item/type` response property for the response status `201`
 PUT /fleets/{fleetSlug}/inventories/{fleetInventorySlug}/items/{id} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
 GET /fleets/{fleetSlug}/inventory-items added the new `Commodity` enum value to the `items/items/item/type` response property for the response status `200`
+GET /fleets/{fleetSlug}/inventories/{fleetInventorySlug}/stock/{slug} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
+PATCH /fleets/{fleetSlug}/inventories/{fleetInventorySlug}/stock/{slug} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
+GET /hangar/inventories/{hangarInventorySlug}/items added the new `Commodity` enum value to the `items/items/item/type` response property for the response status `200`
+POST /hangar/inventories/{hangarInventorySlug}/items added the new `Commodity` enum value to the `item/type` response property for the response status `201`
+PUT /hangar/inventories/{hangarInventorySlug}/items/{id} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
+GET /hangar/inventories/{hangarInventorySlug}/stock/{slug} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
+PATCH /hangar/inventories/{hangarInventorySlug}/stock/{slug} added the new `Commodity` enum value to the `item/type` response property for the response status `200`
+GET /hangar/inventory-items added the new `Commodity` enum value to the `items/items/item/type` response property for the response status `200`

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10,6 +10,42 @@ info:
     url: https://fleetyards.net/docs/logo.png
     altText: FleetYards.net logo
 paths:
+  "/commodities":
+    get:
+      summary: Commodities list
+      tags:
+      - Commodities
+      operationId: commodities
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: string
+          default: '1'
+        required: false
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 60
+        required: false
+      - name: q
+        in: query
+        schema:
+          type: object
+          "$ref": "#/components/schemas/CommodityQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Commodities"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/compare/share":
     post:
       summary: Create a short share URL for a comparison
@@ -104,6 +140,21 @@ paths:
                 type: array
                 items:
                   type: string
+  "/filters/commodities/types":
+    get:
+      summary: Commodity Types Filters
+      tags:
+      - CommoditiesFilters
+      operationId: commodityTypesFilters
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/FilterOption"
   "/filters/components/categories":
     get:
       summary: Components Categories Filters
@@ -7697,6 +7748,77 @@ components:
       required:
       - value
       title: CheckInput
+    Commodities:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Commodity"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: Commodities
+    Commodity:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        commodityType:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - slug
+      - createdAt
+      - updatedAt
+      title: Commodity
+    CommodityQuery:
+      type: object
+      properties:
+        nameCont:
+          type: string
+        idIn:
+          type: array
+          items:
+            type: string
+            format: uuid
+        nameIn:
+          type: array
+          items:
+            type: string
+        slugIn:
+          type: array
+          items:
+            type: string
+        commodityTypeIn:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      example: {}
+      title: CommodityQuery
     CompareShare:
       type: object
       required:

--- a/test/integration/api/v1/commodities_test.rb
+++ b/test/integration/api/v1/commodities_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/commodities" do
+    get("Commodities list") do
+      operationId "commodities"
+      tags "Commodities"
+      produces "application/json"
+
+      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter name: "perPage", in: :query, schema: {type: :string, default: Commodity.default_per_page}, required: false
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/CommodityQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/Commodities"
+      end
+    end
+  end
+
+  setup do
+    @gold = create(:commodity, name: "Gold", commodity_type: "metal")
+    @laranite = create(:commodity, name: "Laranite", commodity_type: "mineral")
+    @waste = create(:commodity, name: "Waste", commodity_type: "waste")
+  end
+
+  test "GET /commodities lists all commodities sorted by name" do
+    assert_api_response :get, 200 do
+      assert_equal %w[Gold Laranite Waste], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  test "GET /commodities filters by nameCont" do
+    assert_api_response :get, 200, params: {q: {"nameCont" => "aran"}} do
+      assert_equal ["Laranite"], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  test "GET /commodities filters by commodityTypeIn" do
+    assert_api_response :get, 200, params: {q: {"commodityTypeIn" => %w[metal mineral]}} do
+      assert_equal %w[Gold Laranite], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  test "GET /commodities paginates with perPage" do
+    assert_api_response :get, 200, params: {perPage: 2} do
+      assert_equal 2, parsed_body["items"].count
+    end
+  end
+
+  test "GET /commodities exposes the fields the picker needs" do
+    assert_api_response :get, 200 do
+      gold = parsed_body["items"].find { |item| item["name"] == "Gold" }
+
+      assert_equal @gold.id, gold["id"]
+      assert_equal "gold", gold["slug"]
+      assert_equal "metal", gold["commodityType"]
+    end
+  end
+end

--- a/test/integration/api/v1/filters_commodities_types_test.rb
+++ b/test/integration/api/v1/filters_commodities_types_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FiltersCommoditiesTypesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/filters/commodities/types" do
+    get("Commodity Types Filters") do
+      operationId "commodityTypesFilters"
+      tags "CommoditiesFilters"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+      end
+    end
+  end
+
+  setup do
+    create(:commodity, commodity_type: "metal")
+    create(:commodity, commodity_type: "metal")
+    create(:commodity, commodity_type: "consumer_goods")
+  end
+
+  test "GET /filters/commodities/types returns one option per type" do
+    assert_api_response :get, 200 do
+      assert_equal %w[consumer_goods metal], parsed_body.map { |filter| filter["value"] }
+      assert_equal "commodity_type", parsed_body.first["category"]
+    end
+  end
+
+  test "GET /filters/commodities/types falls back to the raw value without a translation" do
+    create(:commodity, commodity_type: "newfangledgoo")
+
+    assert_api_response :get, 200 do
+      option = parsed_body.find { |filter| filter["value"] == "newfangledgoo" }
+
+      assert_equal "Newfangledgoo", option["label"]
+    end
+  end
+
+  test "GET /filters/commodities/types skips commodities without a type" do
+    create(:commodity, commodity_type: nil)
+
+    assert_api_response :get, 200 do
+      assert_equal %w[consumer_goods metal], parsed_body.map { |filter| filter["value"] }
+    end
+  end
+end

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -55,12 +55,20 @@ class CommodityTest < ActiveSupport::TestCase
     assert_predicate commodity, :valid?
   end
 
-  test "can be referenced by a fleet inventory item" do
+  test "can be referenced by an inventory ledger entry" do
     commodity = create(:commodity, name: "Gold")
-    item = create(:fleet_inventory_item, item: commodity, name: nil)
+    item = create(:fleet_inventory_item, item: commodity, name: nil, category: :commodity, unit: :scu)
 
     assert_equal "Gold", item.name
     assert_equal commodity, item.item
-    assert_includes commodity.fleet_inventory_items, item
+  end
+
+  test "lists the types present in the table" do
+    create(:commodity, commodity_type: "metal")
+    create(:commodity, commodity_type: "metal")
+    create(:commodity, commodity_type: "gas")
+    create(:commodity, commodity_type: nil)
+
+    assert_equal %w[gas metal], Commodity.commodity_types
   end
 end

--- a/test/models/fleet_inventory_item_test.rb
+++ b/test/models/fleet_inventory_item_test.rb
@@ -105,6 +105,24 @@ class FleetInventoryItemTest < ActiveSupport::TestCase
     assert_includes item.errors.attribute_names, :item_type
   end
 
+  test "accepts a reference to a commodity" do
+    commodity = create(:commodity, name: "Gold")
+
+    item = build(:fleet_inventory_item, fleet_inventory: @inventory, name: nil,
+      category: :commodity, unit: :scu, item: commodity)
+
+    assert_predicate item, :valid?
+    assert_equal "Gold", item.name
+  end
+
+  test "rejects a reference to a commodity that does not exist" do
+    item = build(:fleet_inventory_item, fleet_inventory: @inventory,
+      item_type: "Commodity", item_id: SecureRandom.uuid)
+
+    assert_not item.valid?
+    assert_includes item.errors.attribute_names, :item_id
+  end
+
   test "rejects a reference to a component that does not exist" do
     item = build(:fleet_inventory_item, fleet_inventory: @inventory,
       item_type: "Component", item_id: SecureRandom.uuid)


### PR DESCRIPTION
Makes the commodity reference table usable from the inventory feature: a picker in the item modal, the API behind it, and `Commodity` added to the item type allowlist.

> **Base:** this targets `feat/hangar-inventories` (#4340), not `main` — everything here builds on the `InventoryLedgerEntry` concern and `ComponentPicker` that PR introduces. It also carries the commodity reference table from #4385. Merge #4340 first, then #4385, and this rebases onto `main` cleanly.

## What's here

**Item type allowlist.** `ITEM_TYPES` gains `Commodity`, so a commodity entry can reference the catalogue the way a component entry references `Component`. Nothing else needed — the existing `referenced_item_exists` check, the `referenced_item?` constantize guard and the OpenAPI item type enums are all derived from that constant and pick it up automatically.

**Commodities API**, mirroring the components endpoints the picker already uses:

- `GET /commodities` — paginated, sorted by name, filterable on `nameCont`, `commodityTypeIn`, `idIn`, `nameIn`, `slugIn`
- `GET /filters/commodities/types` — filter options for the type dropdown, same shape and I18n-with-titleize-fallback as `/filters/components/categories`

**`CommodityPicker`**, mirroring `ComponentPicker`: a type dropdown narrowing a searchable, paginated commodity list, shown when the entry category is `commodity`. Wired into both the hangar and fleet item modals.

## One refactor worth flagging

Both modals held a `pickedComponent` ref, and every rule around it — clear on stock-item pick, clear on hand-edited name, clear on category change, read at submit — was written against that single ref. Adding a second catalogue would have duplicated all four.

So both now hold one `pickedItem` (`{ type, id, name }`) instead, and `itemType`/`itemId` come straight off it. The behaviour is unchanged, including the rule that matters: **hand-editing the name drops the reference**, so an entry can't claim to be a real commodity under a different name. Typing a name that isn't in the catalogue is still perfectly fine — it just isn't a reference. Free text stays the default; the picker is the shortcut.

The shared `PickedItem` type lives in `components/Logistics/types.ts` because the hangar and fleet endpoints each generate their own `itemType` enum, and a literal union is assignable to both.

## Testing

- `bin/rails test` → **1949 tests, 0 new failures.** The 2 failures + 2 errors in the run are pre-existing: the same 4 fail on `feat/hangar-inventories` unchanged (2 are WebMock blocking `vite-test/entrypoints/email.scss`, 2 are order-dependent short-link redirects that pass in isolation).
- `pnpm test` → 190 passed. `pnpm lint:ts`, `pnpm lint:fix`, `standardrb` all clean.
- New coverage: commodities index (sorting, `nameCont`, `commodityTypeIn`, pagination, picker fields), type filters (grouping, translation fallback, skipping untyped rows), and ledger entries accepting a commodity reference / rejecting one that doesn't exist.

## Notes

- I18n keys were added to all 7 locales in English, matching how the other new logistics keys landed on #4340.
- Commodity type labels are still raw slugs behind `filter.commodity.commodity_type.items.*` with a `titleize` fallback. Storing the game's own type label is coming with #4340 rather than here.
- `Commodity` doesn't get an inverse `has_many` — `Component` doesn't carry one either, and there are now two ledger tables it would have to cover.

🤖
