### PR TITLE
feat(uex): map commodities to their UEX ids

### DIFF
--- a/app/lib/uex/client.rb
+++ b/app/lib/uex/client.rb
@@ -22,6 +22,10 @@ module Uex
       get("terminals")
     end
 
+    def commodities
+      get("commodities")
+    end
+
     private def get(path)
       # UEX answers 403 to requests without a User-Agent, so it is not optional.
       response = Typhoeus.get(

--- a/app/lib/uex/commodity_mapper.rb
+++ b/app/lib/uex/commodity_mapper.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Uex
+  class CommodityMapper
+    Result = Struct.new(:mapped, :updated, :unmatched, :unmapped) do
+      def to_s
+        "mapped=#{mapped} updated=#{updated} unmatched=#{unmatched.size} unmapped=#{unmapped.size}"
+      end
+    end
+
+    def initialize(client: Uex::Client.new)
+      @client = client
+    end
+
+    def run
+      rows = require_rows(@client.commodities)
+      matcher = Uex::CommodityMatcher.new
+      claimed = {}
+
+      rows.each do |row|
+        commodity = matcher.match(row)
+        next if commodity.blank?
+
+        # Two UEX rows resolving to one commodity would otherwise overwrite each
+        # other silently, leaving whichever came last. The second is reported as
+        # unmatched so the collision is visible rather than arbitrary.
+        if claimed.key?(commodity.id)
+          matcher.misses << row
+          next
+        end
+
+        claimed[commodity.id] = row
+      end
+
+      mapped, updated = persist(claimed)
+
+      Result.new(
+        mapped:, updated:,
+        unmatched: matcher.misses,
+        unmapped: Commodity.where(uex_id: nil).order(:name).to_a
+      )
+    end
+
+    # The matcher hands back records carrying only the columns it matches on, so
+    # the writes need the full rows -- fetched once rather than per match.
+    private def persist(claimed)
+      mapped = 0
+      updated = 0
+
+      Commodity.where(id: claimed.keys).find_each do |commodity|
+        row = claimed[commodity.id]
+        previously_mapped = commodity.uex_id.present?
+
+        commodity.assign_attributes(uex_id: row["id"], uex_code: row["code"].presence)
+        next unless commodity.changed?
+
+        commodity.save!
+        previously_mapped ? updated += 1 : mapped += 1
+      end
+
+      [mapped, updated]
+    end
+
+    # UEX answers an empty feed with HTTP 200 and status "ok". Taking that at
+    # face value would read as "no commodity is tracked any more" and report
+    # every one of ours as unmapped.
+    private def require_rows(rows)
+      return rows if rows.present?
+
+      raise Uex::Error, "UEX returned no commodities; refusing to map against an empty snapshot"
+    end
+
+    # Deliberately free of the run counts: GithubIssueCreator dedupes on a
+    # digest of the body, and a count that moves with the feed would open a
+    # fresh issue on every run.
+    def self.github_issue_body(result)
+      lines = ["## Commodities Without a UEX Mapping (#{result.unmapped.size})", ""]
+      lines << "These commodities carry no `uex_id`, so no price can be joined to them."
+      lines << "If UEX lists an equivalent, add it to `Uex::CommodityMatcher::MAPPINGS`;"
+      lines << "several are mission crates and harvestables UEX does not track at all."
+      lines << ""
+
+      result.unmapped.each do |commodity|
+        lines << "- **#{commodity.name}** — `#{commodity.sc_key}`"
+      end
+
+      lines.join("\n")
+    end
+  end
+end

--- a/app/lib/uex/commodity_matcher.rb
+++ b/app/lib/uex/commodity_matcher.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Uex
+  class CommodityMatcher
+    # UEX commodity id => our Commodity sc_key, for the ones no name form
+    # resolves. Maintained by hand, same as Uex::VehicleMatcher::MAPPINGS.
+    #
+    # Kept to cases where both sides clearly name the same good. UEX also lists
+    # near-neighbours that are NOT the same thing — "Organics" is a bulk trade
+    # good, not our mission-crate "Organs"; "SLAM" is the cut drug, not our
+    # "Uncut SLAM" — and mapping those would attach a price to the wrong item.
+    MAPPINGS = {
+      181 => "items_commodities_constructionmaterialspowder",  # Construction Material Rubble
+      182 => "items_commodities_constructionmaterialsscraps",  # Construction Material Pebbles
+      183 => "items_commodities_constructionmaterialschunks",  # Construction Material Salvage
+      137 => "items_commodities_lastaprene",                   # Lastaphrene, spelled with an h
+      145 => "items_commodities_spiral",                       # Lunes, ours adds "(Spiral Fruit)"
+      161 => "items_commodities_raw_silicon",                  # Silicon (Raw) vs our Raw Silicon
+      40 => "items_commodities_hephaestanite_raw"              # Hephaestanite (Raw), ours truncates to (R)
+    }.freeze
+
+    attr_reader :misses
+
+    def initialize
+      commodities = Commodity.select(:id, :name, :sc_key).to_a
+
+      @by_sc_key = commodities.index_by(&:sc_key)
+      @by_name = commodities.index_by { |commodity| normalize(commodity.name) }
+      @misses = []
+    end
+
+    def match(row)
+      commodity = lookup(row)
+
+      @misses << row if commodity.blank?
+
+      commodity
+    end
+
+    private def lookup(row)
+      mapped = MAPPINGS[row["id"]]
+
+      # The hand-written mapping is an override: it wins over the name match so
+      # a wrong collision can always be corrected.
+      return @by_sc_key[mapped] if mapped.present?
+
+      @by_name[normalize(row["name"])]
+    end
+
+    # Punctuation and case are the only things that differ between the two
+    # catalogues for the names that do line up ("Agricium (Ore)" both sides,
+    # "mobyGlass" ours). Anything further apart than that belongs in MAPPINGS
+    # rather than in a rule inferred from one or two examples.
+    private def normalize(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]/, "")
+    end
+  end
+end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -12,7 +12,7 @@
 #  sc_key         :string
 #  sc_ref         :string
 #  slug           :string           not null
-#  uex_slug       :string
+#  uex_code       :string
 #  version        :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
@@ -23,7 +23,7 @@
 #  index_commodities_on_commodity_type  (commodity_type)
 #  index_commodities_on_sc_key          (sc_key) UNIQUE
 #  index_commodities_on_slug            (slug) UNIQUE
-#  index_commodities_on_uex_slug        (uex_slug)
+#  index_commodities_on_uex_code        (uex_code)
 #
 class Commodity < ApplicationRecord
   paginates_per 60
@@ -52,7 +52,7 @@ class Commodity < ApplicationRecord
   ]
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[name slug commodity_type sc_key uex_slug created_at updated_at]
+    %w[name slug commodity_type sc_key uex_code created_at updated_at]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/db/migrate/20260816120000_rename_commodity_uex_slug_to_uex_code.rb
+++ b/db/migrate/20260816120000_rename_commodity_uex_slug_to_uex_code.rb
@@ -1,0 +1,7 @@
+class RenameCommodityUexSlugToUexCode < ActiveRecord::Migration[8.1]
+  def change
+    # UEX gives vehicles a slug but commodities only an id and a short code
+    # ("GOLD"), so the column was named for a field that does not exist.
+    rename_column :commodities, :uex_slug, :uex_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -165,14 +165,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
     t.string "sc_key"
     t.string "sc_ref"
     t.string "slug", null: false
+    t.string "uex_code"
     t.integer "uex_id"
-    t.string "uex_slug"
     t.datetime "updated_at", null: false
     t.string "version"
     t.index ["commodity_type"], name: "index_commodities_on_commodity_type"
     t.index ["sc_key"], name: "index_commodities_on_sc_key", unique: true
     t.index ["slug"], name: "index_commodities_on_slug", unique: true
-    t.index ["uex_slug"], name: "index_commodities_on_uex_slug"
+    t.index ["uex_code"], name: "index_commodities_on_uex_code"
   end
 
   create_table "compare_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -12,7 +12,7 @@
 #  sc_key         :string
 #  sc_ref         :string
 #  slug           :string           not null
-#  uex_slug       :string
+#  uex_code       :string
 #  version        :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
@@ -23,7 +23,7 @@
 #  index_commodities_on_commodity_type  (commodity_type)
 #  index_commodities_on_sc_key          (sc_key) UNIQUE
 #  index_commodities_on_slug            (slug) UNIQUE
-#  index_commodities_on_uex_slug        (uex_slug)
+#  index_commodities_on_uex_code        (uex_code)
 #
 FactoryBot.define do
   factory :commodity do
@@ -38,7 +38,7 @@ FactoryBot.define do
 
     trait :with_uex_mapping do
       sequence(:uex_id) { |n| n }
-      sequence(:uex_slug) { |n| "uex-commodity-#{n}" }
+      sequence(:uex_code) { |n| "UEXC#{n}" }
     end
   end
 end

--- a/test/fixtures/uex/commodities.json
+++ b/test/fixtures/uex/commodities.json
@@ -1,0 +1,65 @@
+{
+  "status": "ok",
+  "data": [
+    {
+      "id": 33,
+      "name": "Gold",
+      "code": "GOLD",
+      "kind": "Metal",
+      "weight_scu": 1.25,
+      "price_buy": 27527,
+      "price_sell": 28270,
+      "is_available": 1
+    },
+    {
+      "id": 24,
+      "name": "Agricium (Ore)",
+      "code": "AGRIORE",
+      "kind": "Metal",
+      "weight_scu": 1.0,
+      "price_buy": 0,
+      "price_sell": 2245,
+      "is_available": 1
+    },
+    {
+      "id": 137,
+      "name": "Lastaphrene",
+      "code": "LASTA",
+      "kind": "Man-made",
+      "weight_scu": 1.0,
+      "price_buy": 0,
+      "price_sell": 0,
+      "is_available": 1
+    },
+    {
+      "id": 145,
+      "name": "Lunes",
+      "code": "LUNE",
+      "kind": "Food",
+      "weight_scu": 1.0,
+      "price_buy": 0,
+      "price_sell": 0,
+      "is_available": 1
+    },
+    {
+      "id": 186,
+      "name": "Organics",
+      "code": "ORGA",
+      "kind": "Organics",
+      "weight_scu": 1.0,
+      "price_buy": 9799,
+      "price_sell": 12615,
+      "is_available": 1
+    },
+    {
+      "id": 999,
+      "name": "Aslarite",
+      "code": "ASLA",
+      "kind": "Mineral",
+      "weight_scu": 1.0,
+      "price_buy": 0,
+      "price_sell": 5100,
+      "is_available": 1
+    }
+  ]
+}

--- a/test/lib/uex/commodity_mapper_test.rb
+++ b/test/lib/uex/commodity_mapper_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../support/uex_fixtures"
+
+module Uex
+  class CommodityMapperTest < ActiveSupport::TestCase
+    include UexFixtures
+
+    setup do
+      Commodity.delete_all
+      @commodities = create_uex_fixture_commodities
+    end
+
+    test "#run writes the UEX id and code onto the commodities it resolves" do
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+
+      assert_equal 3, result.mapped
+      assert_equal 0, result.updated
+
+      assert_equal [33, "GOLD"], @commodities[:name_match].reload.then { |c| [c.uex_id, c.uex_code] }
+      assert_equal [24, "AGRIORE"], @commodities[:punctuated_match].reload.then { |c| [c.uex_id, c.uex_code] }
+      assert_equal [137, "LASTA"], @commodities[:mapping_match].reload.then { |c| [c.uex_id, c.uex_code] }
+    end
+
+    test "#run leaves a commodity UEX has no row for unmapped" do
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+
+      assert_nil @commodities[:near_neighbour].reload.uex_id
+      assert_equal ["Organs"], result.unmapped.map(&:name)
+    end
+
+    test "#run reports UEX rows that resolve to nothing of ours" do
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+
+      assert_equal ["Aslarite", "Lunes", "Organics"], result.unmatched.map { |row| row["name"] }.sort
+    end
+
+    test "#run counts a changed mapping as an update rather than a new one" do
+      @commodities[:name_match].update!(uex_id: 33, uex_code: "OLD")
+
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+
+      assert_equal 1, result.updated
+      assert_equal "GOLD", @commodities[:name_match].reload.uex_code
+    end
+
+    test "#run is idempotent" do
+      Uex::CommodityMapper.new(client: uex_client_stub).run
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+
+      assert_equal 0, result.mapped
+      assert_equal 0, result.updated
+    end
+
+    test "#run reports the second of two UEX rows claiming one commodity" do
+      duplicate = uex_fixture("commodities") + [{"id" => 1001, "name" => "gold", "code" => "DUPE"}]
+
+      result = Uex::CommodityMapper.new(client: uex_client_stub(commodities: duplicate)).run
+
+      assert_equal 33, @commodities[:name_match].reload.uex_id
+      assert_includes result.unmatched.map { |row| row["id"] }, 1001
+    end
+
+    test "#run refuses an empty snapshot rather than reporting everything unmapped" do
+      error = assert_raises(Uex::Error) do
+        Uex::CommodityMapper.new(client: uex_client_stub(commodities: [])).run
+      end
+
+      assert_match(/refusing to map against an empty snapshot/, error.message)
+      assert_nil @commodities[:name_match].reload.uex_id
+    end
+
+    test ".github_issue_body lists the unmapped commodities without volatile counts" do
+      result = Uex::CommodityMapper.new(client: uex_client_stub).run
+      body = Uex::CommodityMapper.github_issue_body(result)
+
+      assert_match(/Commodities Without a UEX Mapping \(1\)/, body)
+      assert_match(/\*\*Organs\*\* — `items_commodities_organs`/, body)
+      assert_no_match(/mapped=/, body)
+    end
+  end
+end

--- a/test/lib/uex/commodity_matcher_test.rb
+++ b/test/lib/uex/commodity_matcher_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../support/uex_fixtures"
+
+module Uex
+  class CommodityMatcherTest < ActiveSupport::TestCase
+    include UexFixtures
+
+    setup do
+      Commodity.delete_all
+      @commodities = create_uex_fixture_commodities
+      @rows = uex_fixture("commodities").index_by { |row| row["id"] }
+      @matcher = Uex::CommodityMatcher.new
+    end
+
+    test "matches on name" do
+      assert_equal @commodities[:name_match].id, @matcher.match(@rows[33]).id
+    end
+
+    test "matches across punctuation and case" do
+      assert_equal @commodities[:punctuated_match].id, @matcher.match(@rows[24]).id
+    end
+
+    test "matches via the explicit mapping when the spelling differs" do
+      assert_equal @commodities[:mapping_match].id, @matcher.match(@rows[137]).id
+    end
+
+    test "the mapping wins over a name that would resolve elsewhere" do
+      decoy = create(:commodity, name: "Lunes", sc_key: "items_commodities_decoy_lunes")
+      spiral = create(:commodity, name: "Lunes (Spiral Fruit)", sc_key: "items_commodities_spiral")
+
+      matched = Uex::CommodityMatcher.new.match(@rows[145])
+
+      assert_equal spiral.id, matched.id
+      assert_not_equal decoy.id, matched.id
+    end
+
+    test "does not match a near neighbour UEX names differently" do
+      assert_nil @matcher.match(@rows[186])
+      assert_equal ["Organics"], @matcher.misses.map { |row| row["name"] }
+    end
+
+    test "records a miss for a commodity we do not carry" do
+      assert_nil @matcher.match(@rows[999])
+      assert_equal [999], @matcher.misses.map { |row| row["id"] }
+    end
+
+    test "every mapping points at a commodity key the parser produces" do
+      keys = Dir.glob(Rails.root.join("data/sc_data/parsed/live/commodities/*.json"))
+        .map { |file| JSON.parse(File.read(file))["sc_key"] }
+        .to_set
+
+      assert_empty Uex::CommodityMatcher::MAPPINGS.values.reject { |key| keys.include?(key) }
+    end
+  end
+end

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -2,6 +2,31 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: commodities
+#
+#  id             :uuid             not null, primary key
+#  commodity_type :string
+#  description    :text
+#  icon           :string
+#  name           :string           not null
+#  sc_key         :string
+#  sc_ref         :string
+#  slug           :string           not null
+#  uex_code       :string
+#  version        :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  uex_id         :integer
+#
+# Indexes
+#
+#  index_commodities_on_commodity_type  (commodity_type)
+#  index_commodities_on_sc_key          (sc_key) UNIQUE
+#  index_commodities_on_slug            (slug) UNIQUE
+#  index_commodities_on_uex_code        (uex_code)
+#
 class CommodityTest < ActiveSupport::TestCase
   test "generates a slug from the name" do
     commodity = create(:commodity, name: "Agricium (Ore)")

--- a/test/support/uex_fixtures.rb
+++ b/test/support/uex_fixtures.rb
@@ -10,7 +10,8 @@ module UexFixtures
       vehicles: uex_fixture("vehicles"),
       vehicle_purchase_prices: uex_fixture("vehicles_purchases_prices_all"),
       vehicle_rental_prices: uex_fixture("vehicles_rentals_prices_all"),
-      terminals: uex_fixture("terminals")
+      terminals: uex_fixture("terminals"),
+      commodities: uex_fixture("commodities")
     }.merge(overrides)
 
     client = mock("Uex::Client")
@@ -26,6 +27,18 @@ module UexFixtures
       name_match: create(:model, name: "Avenger Titan", manufacturer: create(:manufacturer, code: "AEGS")),
       name_full_match: create(:model, name: "Constellation Andromeda", manufacturer: create(:manufacturer, code: "RSI")),
       mapping_match: create(:model, name: "C2 Hercules", manufacturer: create(:manufacturer, code: "CRUS"))
+    }
+  end
+
+  # The commodities the fixture UEX rows are expected to resolve to: two by
+  # name, one through MAPPINGS, and one UEX offers a near-neighbour for
+  # ("Organics") that must not be taken as a match.
+  def create_uex_fixture_commodities
+    {
+      name_match: create(:commodity, name: "Gold", sc_key: "items_commodities_gold"),
+      punctuated_match: create(:commodity, name: "Agricium (Ore)", sc_key: "items_commodities_agricium_ore"),
+      mapping_match: create(:commodity, name: "Lastaprene", sc_key: "items_commodities_lastaprene"),
+      near_neighbour: create(:commodity, name: "Organs", sc_key: "items_commodities_organs")
     }
   end
 end


### PR DESCRIPTION
Gives every commodity a UEX identifier, so prices have something to join to.

> **Base:** `main` — #4385 merged while this was in progress, so it targets `main` directly.

## What's here

- `Uex::Client#commodities`
- `Uex::CommodityMatcher` — resolves a UEX row to a `Commodity`, same shape as `Uex::VehicleMatcher`
- `Uex::CommodityMapper` — writes `uex_id`/`uex_code`, reports what didn't resolve
- Renames `uex_slug` → `uex_code`

## The rename

UEX gives vehicles a slug, but commodities carry only `id` and a short `code` (`"GOLD"`) — there is no slug field on the feed. The column was named for something that doesn't exist, so it's renamed before anything writes to it.

## How the matching lands

Measured against the live feed (204 UEX rows) and our 168 commodities:

| | |
|---|---|
| Resolved on name, ignoring case and punctuation | 143 |
| Resolved through `MAPPINGS` | 7 |
| **Mapped** | **150** |
| Ours with no UEX equivalent | 18 |
| UEX rows with no commodity of ours | 54 |

The seven hand-mapped ones are where both sides clearly mean the same good but spell it differently: the three construction salvage grades (UEX says Salvage / Rubble / Pebbles where we say Salvage / Rubble / Pieces), `Lastaphrene` vs our `Lastaprene`, `Lunes` vs our `Lunes (Spiral Fruit)`, `Silicon (Raw)` vs our `Raw Silicon`, and `Hephaestanite (Raw)` vs a name the game files truncate to `Hephaestanite (R)`.

I tried generalising the last two into normalisation rules — moving a leading "Raw" to the end, expanding `(R)`. It bought exactly two extra matches, which is a rule inferred from its own two examples, so they went in `MAPPINGS` instead.

## What is deliberately not mapped

UEX lists near-neighbours that are not the same thing, and mapping them would hang a price on the wrong item:

- **Organics** (bulk trade good) is not our **Organs** (mission crate)
- **SLAM** (the cut drug) is not our **Uncut SLAM** — we already map SLAM itself
- **Molina Mold Samples** is not our **Biological Samples**

The 18 that stay unmapped are mission crates, harvestables and vendor items UEX doesn't track: Ammo Crate, Biological Samples, Fotia Seedpod, Genmod Seeds, HLX99 Hyperprocessors, MedPens, Mixed Mining, Organs, OxyPens, Oza, Pingala Seeds, RS1 Odysey Spacesuits, Uncut SLAM, Vent Slug, Virus Cultures, Yormandi Eye, Yormandi Tongue, mobyGlass Personal Computers. `github_issue_body` reports them so the list stays visible as UEX's catalogue grows.

## Safety

- **Empty feed refused.** UEX answers an empty feed with HTTP 200 and `status: ok`; taking that at face value would report every commodity as having lost its mapping. Same guard as `PriceSyncer#require_rows`.
- **Collisions surfaced, not silently resolved.** Two UEX rows resolving to one commodity would otherwise leave whichever came last; the second is reported as unmatched instead.
- **`MAPPINGS` overrides names**, so a wrong collision can always be corrected by hand — and a test asserts every mapped `sc_key` is one the parser actually produces, so a typo there fails rather than silently never matching.

## Testing

15 new tests. `bin/rails test` → 1802 tests, 2 failures + 2 errors, all four pre-existing and unrelated (2 WebMock blocking `vite-test/entrypoints/email.scss`, 2 order-dependent short-link redirects). `standardrb` clean.

## Follow-up

Nothing consumes `uex_id` yet — the price sync itself is the next piece.

**#4386 needs a small follow-up:** it still lists `uex_slug` in `Commodity.ransackable_attributes`, which this PR renames. Whichever lands second picks up the fix.

🤖
