### PR TITLE
fix(setup): give each worktree its own test database

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -130,20 +130,23 @@ def write_superset_ports(port, vite_port)
   File.write(File.join(superset_dir, "ports.json"), JSON.pretty_generate(config) + "\n")
 end
 
-def write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_redis_db, cookie_prefix: nil)
-  env_local = File.join(APP_ROOT, ".env.local")
+def write_managed_env(filename, managed_body)
+  path = File.join(APP_ROOT, filename)
 
   # Preserve user content above the marker
   user_content = ""
-  if File.exist?(env_local)
-    lines = File.readlines(env_local)
+  if File.exist?(path)
+    lines = File.readlines(path)
     marker_idx = lines.index { |l| l.strip == WORKTREE_MARKER }
     user_content = lines[0...marker_idx].join if marker_idx
     user_content = lines.join unless marker_idx
   end
 
-  managed = <<~ENV
-    #{WORKTREE_MARKER}
+  File.write(path, user_content + "#{WORKTREE_MARKER}\n" + managed_body)
+end
+
+def write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_redis_db, cookie_prefix: nil)
+  write_managed_env(".env.local", <<~ENV)
     PORT=#{port}
     DB_PORT=#{db_port}
     REDIS_URL=redis://localhost:#{redis_port}
@@ -155,8 +158,21 @@ def write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_red
     ON_SUBDOMAIN=false
     #{"COOKIE_PREFIX=#{cookie_prefix}" if cookie_prefix}
   ENV
+end
 
-  File.write(env_local, user_content + managed)
+# dotenv deliberately skips `.env.local` in the test environment, so the
+# worktree's suffix never reached `config/database.yml` there and every worktree
+# shared one `fleetyards_test`. Two suites running at once then fight over it,
+# and whichever purges the database first fails with PG::ObjectInUse.
+#
+# Only the variables that decide which database the suite talks to are repeated
+# here: the ports are the same shared containers for every worktree, and the web
+# and cookie settings would change what the tests themselves assert.
+def write_env_test_local(db_port, db_suffix)
+  write_managed_env(".env.test.local", <<~ENV)
+    DB_PORT=#{db_port}
+    WORKTREE_SUFFIX=#{db_suffix}
+  ENV
 end
 
 if ARGV.include?("--help") || ARGV.include?("-h")
@@ -210,7 +226,8 @@ FileUtils.chdir APP_ROOT do
 
     cookie_prefix = "FLTYRD_WT_#{sanitize_worktree_name(effective_name)}"
     write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_db, cookie_prefix:)
-    puts "   Wrote .env.local" if VERBOSE
+    write_env_test_local(db_port, db_suffix)
+    puts "   Wrote .env.local and .env.test.local" if VERBOSE
 
   end
 

--- a/bin/setup
+++ b/bin/setup
@@ -134,14 +134,14 @@ def write_managed_env(filename, managed_body)
   path = File.join(APP_ROOT, filename)
 
   # Preserve user content above the marker. An earlier version of this writer
-  # could glue the marker onto the last user line, so match anywhere in a line
-  # and keep only what precedes it.
+  # could glue the marker onto the end of the last user line, so accept that
+  # shape too and keep only what precedes it.
   user_content = ""
   if File.exist?(path)
     lines = File.readlines(path)
-    marker_idx = lines.index { |l| l.include?(WORKTREE_MARKER) }
+    marker_idx = lines.index { |l| l.rstrip.end_with?(WORKTREE_MARKER) }
     user_content = if marker_idx
-      lines[0...marker_idx].join + lines[marker_idx].split(WORKTREE_MARKER).first.to_s
+      lines[0...marker_idx].join + lines[marker_idx].rstrip.delete_suffix(WORKTREE_MARKER)
     else
       lines.join
     end

--- a/bin/setup
+++ b/bin/setup
@@ -133,18 +133,12 @@ end
 def write_managed_env(filename, managed_body)
   path = File.join(APP_ROOT, filename)
 
-  # Preserve user content above the marker. An earlier version of this writer
-  # could glue the marker onto the end of the last user line, so accept that
-  # shape too and keep only what precedes it.
+  # Preserve user content above the marker
   user_content = ""
   if File.exist?(path)
     lines = File.readlines(path)
-    marker_idx = lines.index { |l| l.rstrip.end_with?(WORKTREE_MARKER) }
-    user_content = if marker_idx
-      lines[0...marker_idx].join + lines[marker_idx].rstrip.delete_suffix(WORKTREE_MARKER)
-    else
-      lines.join
-    end
+    marker_idx = lines.index { |l| l.strip == WORKTREE_MARKER }
+    user_content = marker_idx ? lines[0...marker_idx].join : lines.join
   end
 
   user_content += "\n" unless user_content.empty? || user_content.end_with?("\n")

--- a/bin/setup
+++ b/bin/setup
@@ -133,13 +133,18 @@ end
 def write_managed_env(filename, managed_body)
   path = File.join(APP_ROOT, filename)
 
-  # Preserve user content above the marker
+  # Preserve user content above the marker. An earlier version of this writer
+  # could glue the marker onto the last user line, so match anywhere in a line
+  # and keep only what precedes it.
   user_content = ""
   if File.exist?(path)
     lines = File.readlines(path)
-    marker_idx = lines.index { |l| l.strip == WORKTREE_MARKER }
-    user_content = lines[0...marker_idx].join if marker_idx
-    user_content = lines.join unless marker_idx
+    marker_idx = lines.index { |l| l.include?(WORKTREE_MARKER) }
+    user_content = if marker_idx
+      lines[0...marker_idx].join + lines[marker_idx].split(WORKTREE_MARKER).first.to_s
+    else
+      lines.join
+    end
   end
 
   user_content += "\n" unless user_content.empty? || user_content.end_with?("\n")

--- a/bin/setup
+++ b/bin/setup
@@ -142,6 +142,8 @@ def write_managed_env(filename, managed_body)
     user_content = lines.join unless marker_idx
   end
 
+  user_content += "\n" unless user_content.empty? || user_content.end_with?("\n")
+
   File.write(path, user_content + "#{WORKTREE_MARKER}\n" + managed_body)
 end
 


### PR DESCRIPTION
Worktrees get their own dev database but share one test database, so two suites running at once fight over it.

## The bug

`config/database.yml` already reads the suffix for both environments:

```erb
development:
  database: <%= ENV["DB_NAME"] || "fleetyards_dev#{ENV['WORKTREE_SUFFIX']}" %>
test:
  database: <%= ENV["DB_NAME"] || "fleetyards_test#{ENV['WORKTREE_SUFFIX']}#{ENV['TEST_ENV_NUMBER']}" %>
```

But `bin/setup` writes `WORKTREE_SUFFIX` only to `.env.local`, and **dotenv deliberately skips `.env.local` in the test environment** — that's by design upstream, so local overrides can't quietly change what the suite tests.

The result: dev is correctly isolated (`fleetyards_dev_wt_commodities`) while every worktree's suite runs against one shared `fleetyards_test`. Whichever run tries to purge it second dies:

```
ActiveRecord::StatementInvalid: PG::ObjectInUse:
  ERROR: database "fleetyards_test" is being accessed by other users
  DETAIL: There is 1 other session using the database.
```

Worth noting the port hid half of this: `DB_PORT` never reached the test env either, and it only worked because `8271` happens to be the hardcoded default in `database.yml`.

## The fix

`bin/setup` also writes `.env.test.local`, which dotenv *does* load in test:

```
# -- worktree-managed --
DB_PORT=8271
WORKTREE_SUFFIX=_wt_commodities
```

Only the two variables that decide which database the suite talks to are repeated. The rest of the managed block is deliberately left out — the Redis and Postgres ports are the same shared containers for every worktree, and `DOMAIN`, `PORT` and `COOKIE_PREFIX` would change what the tests themselves assert.

The marker-preserving logic is now shared by both writers rather than duplicated, so user content above `# -- worktree-managed --` is still kept in either file.

## Verification

- `RAILS_ENV=test` now resolves to `fleetyards_test_wt_commodities`
- Ran the suite while another worktree's suite was mid-run — previously an immediate `PG::ObjectInUse`, now it just runs
- `bin/rails test` → 1787 tests, 2 failures + 2 errors, all four pre-existing on `main` and unrelated (2 WebMock blocking `vite-test/entrypoints/email.scss`, 2 order-dependent short-link redirects). Those two errors persist on an isolated database, which confirms they were never contention.

## Notes

- **CI is unaffected** — it has no `.env.test.local` (the whole `.env*` glob is gitignored bar the template) and keeps using `fleetyards_test`.
- **Existing worktrees need `bin/setup` re-run** to get their own test database. The old shared `fleetyards_test` is then orphaned and can be dropped whenever.
- Sidekiq's Redis database is still shared across worktrees in test (`SIDEKIQ_REDIS_DB` is per-worktree but only in `.env.local`). I left that alone rather than widen the change — it hasn't caused a collision, and changing Redis wiring under the suite deserves its own look.

🤖
