### PR TITLE
feat(uex): sync commodity prices

### DIFF
--- a/app/api_components/shared/v1/schemas/enums/import_type_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/import_type_enum.rb
@@ -11,7 +11,7 @@ module Shared
             Imports::ModelImport Imports::ModelsImport Imports::ScData::AllImport
             Imports::ScData::ModelsImport Imports::ScData::ModelImport Imports::HangarSync
             Imports::HangarImport Imports::ModulesImport Imports::PaintsImport
-            Imports::UexPricesImport
+            Imports::UexPricesImport Imports::UexCommodityPricesImport
           ].freeze
 
           schema({

--- a/app/jobs/loaders/uex_commodity_prices_job.rb
+++ b/app/jobs/loaders/uex_commodity_prices_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Loaders
+  class UexCommodityPricesJob < ::Loaders::BaseJob
+    def perform(admin_user_id = nil)
+      import = Imports::UexCommodityPricesImport.create(admin_user_id:)
+
+      import.start!
+
+      # Prices join on uex_id, so anything the last game-file import added has to
+      # be mapped before the snapshot runs or its prices are dropped as unknown.
+      mapping = ::Uex::CommodityMapper.new.run
+      result = ::Uex::CommodityPriceSyncer.new.run
+
+      if mapping.unmapped.present?
+        GithubIssueCreator.new(
+          task_type: "uex_commodity_prices_import",
+          title: "UEX Commodity Sync — Unmapped Commodities",
+          body: ::Uex::CommodityMapper.github_issue_body(mapping)
+        ).run
+      end
+
+      if result.unknown.present?
+        GithubIssueCreator.new(
+          task_type: "uex_commodity_prices_import",
+          title: "UEX Commodity Sync — Priced Commodities We Do Not Carry",
+          body: ::Uex::CommodityPriceSyncer.github_issue_body(result)
+        ).run
+      end
+
+      import.update!(
+        output: {
+          mapped: mapping.mapped,
+          remapped: mapping.updated,
+          unmapped: mapping.unmapped.map(&:sc_key),
+          created: result.created,
+          updated: result.updated,
+          removed: result.removed,
+          skipped_removals: result.skipped_removals,
+          unknown: result.unknown.map { |row| row["commodity_name"] }
+        }
+      )
+      import.finish!
+    rescue => e
+      import.fail!
+      import.update!(info: e.message)
+
+      raise e
+    end
+  end
+end

--- a/app/lib/uex/client.rb
+++ b/app/lib/uex/client.rb
@@ -26,6 +26,10 @@ module Uex
       get("commodities")
     end
 
+    def commodity_prices
+      get("commodities_prices_all")
+    end
+
     private def get(path)
       # UEX answers 403 to requests without a User-Agent, so it is not optional.
       response = Typhoeus.get(

--- a/app/lib/uex/commodity_price_syncer.rb
+++ b/app/lib/uex/commodity_price_syncer.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Uex
+  class CommodityPriceSyncer
+    include Uex::PriceSnapshot
+
+    ITEM_TYPE = "Commodity"
+    TERMINAL_TYPE = "commodity"
+
+    Result = Struct.new(:created, :updated, :removed, :skipped_removals, :unknown) do
+      def to_s
+        "created=#{created} updated=#{updated} removed=#{removed} " \
+          "skipped_removals=#{skipped_removals} unknown=#{unknown.size}"
+      end
+    end
+
+    def initialize(client: Uex::Client.new)
+      @client = client
+    end
+
+    def run
+      terminals = require_rows(
+        :terminals,
+        @client.terminals.select { |terminal| terminal["type"] == TERMINAL_TYPE }
+      ).index_by { |terminal| terminal["id"] }
+      prices = require_rows(:commodity_prices, @client.commodity_prices)
+
+      # The mapper has already resolved names to ids, so the price feed needs no
+      # matching of its own -- a commodity we never mapped simply has no entry.
+      commodities = Commodity.where.not(uex_id: nil).select(:id, :uex_id).index_by(&:uex_id)
+      unknown = {}
+
+      desired = collect(prices, commodities:, terminals:, unknown:)
+      counts = persist_prices(desired, live: terminals.values.map { |terminal| terminal["name"].to_s.strip }.to_set)
+
+      Result.new(
+        created: counts.created,
+        updated: counts.updated,
+        removed: counts.removed,
+        skipped_removals: counts.skipped_removals,
+        unknown: unknown.values
+      )
+    end
+
+    private def collect(rows, commodities:, terminals:, unknown:)
+      rows.each_with_object({}) do |row, result|
+        terminal = terminals[row["id_terminal"]]
+        next if terminal.blank?
+
+        location = terminal["name"].to_s.strip
+        next if location.blank?
+
+        commodity = commodities[row["id_commodity"]]
+
+        if commodity.blank?
+          unknown[row["id_commodity"]] ||= row
+          next
+        end
+
+        # UEX writes prices from the player's side: what they pay is price_buy,
+        # what they receive is price_sell. Ours is shop-perspective, the way
+        # ItemPrice is read everywhere else, so the two swap over.
+        add(result, row["price_buy"], commodity:, location:, terminal:, price_type: "sell")
+        add(result, row["price_sell"], commodity:, location:, terminal:, price_type: "buy")
+      end
+    end
+
+    private def add(result, value, commodity:, location:, terminal:, price_type:)
+      price = value.to_d
+      return if price <= 0
+
+      attributes = {
+        item_type: ITEM_TYPE,
+        item_id: commodity.id,
+        price_type:,
+        location:,
+        time_range: nil,
+        location_url: web_url(terminal["contact_url"]),
+        price:
+      }
+
+      key = attributes.values_at(:item_id, :price_type, :location, :time_range)
+      existing = result[key]
+
+      return result[key] = attributes if existing.blank?
+
+      # Two UEX terminals can collapse onto one location string, and which of the
+      # pair to keep depends on the direction: of two shops selling the same
+      # cargo the player wants the cheaper, of two buying it the better paid.
+      better = (price_type == "sell") ? price < existing[:price] : price > existing[:price]
+
+      result[key] = attributes if better
+    end
+
+    # Deliberately free of the sync counts: GithubIssueCreator dedupes on a
+    # digest of the body, and prices move every day, so anything volatile in
+    # here would open a fresh issue on every run.
+    def self.github_issue_body(result)
+      lines = ["## Priced UEX Commodities We Do Not Carry (#{result.unknown.size})", ""]
+      lines << "UEX prices these at a commodity terminal but they resolve to no `Commodity`,"
+      lines << "so the prices are dropped. Either the game files do not declare them or"
+      lines << "`Uex::CommodityMatcher::MAPPINGS` is missing an entry."
+      lines << ""
+
+      result.unknown.each do |row|
+        lines << "- **#{row["commodity_name"]}** — UEX id `#{row["id_commodity"]}`"
+      end
+
+      lines.join("\n")
+    end
+  end
+end

--- a/app/lib/uex/price_snapshot.rb
+++ b/app/lib/uex/price_snapshot.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Uex
+  # Reconciling a UEX snapshot against the prices we hold is the same problem
+  # whether the rows are ships or cargo: apply what the feed lists, and work out
+  # which of our leftovers are genuinely gone rather than merely missing from a
+  # short answer. Including classes supply ITEM_TYPE and build their own Result.
+  module PriceSnapshot
+    # How much of a terminal's stock it must still list before we believe its
+    # omissions. A shop dropping over half its stock between two daily runs is
+    # not plausible churn; a feed that came back short looks exactly like that.
+    MIN_TERMINAL_RETENTION = 0.5
+
+    Counts = Struct.new(:created, :updated, :removed, :skipped_removals)
+
+    private def persist_prices(desired, live:)
+      counts = Counts.new(0, 0, 0, 0)
+
+      ItemPrice.transaction do
+        held = ItemPrice.where(item_type: self.class::ITEM_TYPE).to_a
+        held_per_location = held.group_by(&:location).transform_values(&:size)
+        listed_per_location = desired.values.group_by { |row| row[:location] }.transform_values(&:size)
+
+        # Whatever is left in here once every desired row has claimed its match
+        # is a location UEX no longer lists.
+        unclaimed = held.index_by do |item_price|
+          [item_price.item_id, item_price.price_type, item_price.location, item_price.time_range]
+        end
+
+        desired.each do |key, attributes|
+          item_price = unclaimed.delete(key)
+
+          if item_price.blank?
+            ItemPrice.create!(attributes)
+            counts.created += 1
+            next
+          end
+
+          item_price.assign_attributes(attributes.slice(:price, :location_url))
+          next unless item_price.changed?
+
+          item_price.save!
+          counts.updated += 1
+        end
+
+        deletable, ambiguous = unclaimed.values.partition do |item_price|
+          deletable?(item_price.location, listed: listed_per_location, held: held_per_location, live:)
+        end
+
+        # Upserts have already applied either way, so fresh prices still land and
+        # only the destructive half is held back. A later whole snapshot reconciles.
+        counts.skipped_removals = ambiguous.size
+        report_skipped_removals(ambiguous, held.size) if ambiguous.any?
+
+        counts.removed = ItemPrice.where(id: deletable.map(&:id)).destroy_all.size
+      end
+
+      counts
+    end
+
+    # Decided per terminal, because that is the only granularity at which the
+    # question is answerable. A terminal gone from the terminals feed has closed,
+    # so its rows go. Otherwise the test is whether it reported at anything like
+    # its usual volume: a shop discontinuing a line or two still lists the rest,
+    # whereas a truncated feed shows up as a terminal that suddenly lists a
+    # fraction of what we hold for it — or nothing at all. Below the retention
+    # floor we keep its rows and report rather than guess.
+    private def deletable?(location, listed:, held:, live:)
+      return true if live.exclude?(location)
+
+      listed.fetch(location, 0) >= held.fetch(location, 0) * MIN_TERMINAL_RETENTION
+    end
+
+    private def report_skipped_removals(preserved, held_before)
+      message = "UEX snapshot omitted #{preserved.size} of #{held_before} #{self.class::ITEM_TYPE.downcase} prices at " \
+        "#{preserved.map(&:location).uniq.sort.join(", ")}; kept them and applied updates only"
+
+      Rails.logger.warn("[#{self.class.name}] #{message}")
+      Appsignal.report_error(Uex::Error.new(message))
+    end
+
+    # `contact_url` is whatever a UEX contributor typed. Anything that is not a
+    # web link is dropped rather than stored: `ItemPrice` rejects it, and one odd
+    # row must not fail a validation and take the whole snapshot down with it.
+    private def web_url(value)
+      url = value.to_s.strip
+
+      url if url.match?(%r{\Ahttps?://}i)
+    end
+
+    # No feed is ever legitimately empty. An empty one still arrives as HTTP 200
+    # with status "ok", and taking it at face value would read as "every location
+    # closed" and delete the lot.
+    private def require_rows(feed, rows)
+      return rows if rows.present?
+
+      raise Uex::Error, "UEX returned no usable rows for #{feed}; refusing to sync a snapshot that would delete live prices"
+    end
+  end
+end

--- a/app/lib/uex/price_syncer.rb
+++ b/app/lib/uex/price_syncer.rb
@@ -2,6 +2,8 @@
 
 module Uex
   class PriceSyncer
+    include Uex::PriceSnapshot
+
     ITEM_TYPE = "Model"
     TERMINAL_TYPES = %w[vehicle_buy vehicle_rent].freeze
 
@@ -9,11 +11,6 @@ module Uex
     # field. It is the 1-day rate: in game the Avenger Titan rents at 27,165 /
     # 71,308 / 142,616 / 509,344 for 1 / 3 / 7 / 30 days, and UEX reports 27,165.
     RENTAL_TIME_RANGE = "1-day"
-
-    # How much of a terminal's stock it must still list before we believe its
-    # omissions. A shop dropping over half its vehicles between two daily runs is
-    # not plausible churn; a feed that came back short looks exactly like that.
-    MIN_TERMINAL_RETENTION = 0.5
 
     # Stamped on the paper-trail version so a repriced model reads apart from an
     # admin having typed the figure in by hand.
@@ -131,94 +128,16 @@ module Uex
       end
     end
 
-    # `contact_url` is whatever a UEX contributor typed. Anything that is not a
-    # web link is dropped rather than stored: `ItemPrice` rejects it, and one odd
-    # row must not fail a validation and take the whole snapshot down with it.
-    private def web_url(value)
-      url = value.to_s.strip
-
-      url if url.match?(%r{\Ahttps?://}i)
-    end
-
-    # None of the four feeds is ever legitimately empty. An empty one still
-    # arrives as HTTP 200 with status "ok", and taking it at face value would read
-    # as "every location closed" and delete the lot.
-    private def require_rows(feed, rows)
-      return rows if rows.present?
-
-      raise Uex::Error, "UEX returned no usable rows for #{feed}; refusing to sync a snapshot that would delete live prices"
-    end
-
     private def persist(desired, live:, unmatched:)
-      created = 0
-      updated = 0
-      removed = 0
-      skipped_removals = 0
-
-      ItemPrice.transaction do
-        held = ItemPrice.where(item_type: ITEM_TYPE).to_a
-        held_per_location = held.group_by(&:location).transform_values(&:size)
-        listed_per_location = desired.values.group_by { |row| row[:location] }.transform_values(&:size)
-
-        # Whatever is left in here once every desired row has claimed its match
-        # is a location UEX no longer lists.
-        unclaimed = held.index_by do |item_price|
-          [item_price.item_id, item_price.price_type, item_price.location, item_price.time_range]
-        end
-
-        desired.each do |key, attributes|
-          item_price = unclaimed.delete(key)
-
-          if item_price.blank?
-            ItemPrice.create!(attributes)
-            created += 1
-            next
-          end
-
-          item_price.assign_attributes(attributes.slice(:price, :location_url))
-          next unless item_price.changed?
-
-          item_price.save!
-          updated += 1
-        end
-
-        deletable, ambiguous = unclaimed.values.partition do |item_price|
-          deletable?(item_price.location, listed: listed_per_location, held: held_per_location, live:)
-        end
-
-        # Upserts have already applied either way, so fresh prices still land and
-        # only the destructive half is held back. A later whole snapshot reconciles.
-        skipped_removals = ambiguous.size
-        report_skipped_removals(ambiguous, held.size) if ambiguous.any?
-
-        removed = ItemPrice.where(id: deletable.map(&:id)).destroy_all.size
-      end
+      counts = persist_prices(desired, live:)
 
       Result.new(
-        created:, updated:, removed:, skipped_removals:,
+        created: counts.created,
+        updated: counts.updated,
+        removed: counts.removed,
+        skipped_removals: counts.skipped_removals,
         unmatched: unmatched.uniq { |vehicle| vehicle["id"] }
       )
-    end
-
-    # Decided per terminal, because that is the only granularity at which the
-    # question is answerable. A terminal gone from the terminals feed has closed,
-    # so its rows go. Otherwise the test is whether it reported at anything like
-    # its usual volume: a shop discontinuing a ship or two still lists the rest,
-    # whereas a truncated feed shows up as a terminal that suddenly lists a
-    # fraction of what we hold for it — or nothing at all. Below the retention
-    # floor we keep its rows and report rather than guess.
-    private def deletable?(location, listed:, held:, live:)
-      return true if live.exclude?(location)
-
-      listed.fetch(location, 0) >= held.fetch(location, 0) * MIN_TERMINAL_RETENTION
-    end
-
-    private def report_skipped_removals(preserved, held_before)
-      message = "UEX snapshot omitted #{preserved.size} of #{held_before} model prices at " \
-        "#{preserved.map(&:location).uniq.sort.join(", ")}; kept them and applied updates only"
-
-      Rails.logger.warn("[Uex::PriceSyncer] #{message}")
-      Appsignal.report_error(Uex::Error.new(message))
     end
 
     # Deliberately free of the sync counts: GithubIssueCreator dedupes on a

--- a/app/models/imports/uex_commodity_prices_import.rb
+++ b/app/models/imports/uex_commodity_prices_import.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Imports
+  class UexCommodityPricesImport < ::Import
+    belongs_to :admin_user, optional: true
+  end
+end

--- a/app/views/api/v1/imports/uex_commodity_prices_imports/_uex_commodity_prices_import.jbuilder
+++ b/app/views/api/v1/imports/uex_commodity_prices_imports/_uex_commodity_prices_import.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", uex_commodity_prices_import] do
+  json.partial!("api/v1/imports/base", import: uex_commodity_prices_import)
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -20,6 +20,11 @@ loaders_uex_prices_job:
   class: 'Loaders::UexPricesJob'
   queue: 'loaders'
   enabled: <%= Rails.env.production? %>
+loaders_uex_commodity_prices_job:
+  cron: '30 5 */1 * *' # Daily at 5:30, after the vehicle prices
+  class: 'Loaders::UexCommodityPricesJob'
+  queue: 'loaders'
+  enabled: <%= Rails.env.production? %>
 sc_data_check_job:
   cron: '0 22 */1 * *' # Daily at 22:00
   class: 'ScData::CheckJob'

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -9456,6 +9456,7 @@ components:
       - Imports::ModulesImport
       - Imports::PaintsImport
       - Imports::UexPricesImport
+      - Imports::UexCommodityPricesImport
       x-enumNames:
       - IMPORTS_MODEL_IMPORT
       - IMPORTS_MODELS_IMPORT
@@ -9467,6 +9468,7 @@ components:
       - IMPORTS_MODULES_IMPORT
       - IMPORTS_PAINTS_IMPORT
       - IMPORTS_UEX_PRICES_IMPORT
+      - IMPORTS_UEX_COMMODITY_PRICES_IMPORT
       title: ImportTypeEnum
     Imports:
       type: object

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11742,6 +11742,7 @@ components:
       - Imports::ModulesImport
       - Imports::PaintsImport
       - Imports::UexPricesImport
+      - Imports::UexCommodityPricesImport
       x-enumNames:
       - IMPORTS_MODEL_IMPORT
       - IMPORTS_MODELS_IMPORT
@@ -11753,6 +11754,7 @@ components:
       - IMPORTS_MODULES_IMPORT
       - IMPORTS_PAINTS_IMPORT
       - IMPORTS_UEX_PRICES_IMPORT
+      - IMPORTS_UEX_COMMODITY_PRICES_IMPORT
       title: ImportTypeEnum
     InventoryStockPosition:
       type: object

--- a/test/fixtures/uex/commodities_prices_all.json
+++ b/test/fixtures/uex/commodities_prices_all.json
@@ -1,0 +1,51 @@
+{
+  "status": "ok",
+  "http_code": 200,
+  "data": [
+    {
+      "id": 1,
+      "id_commodity": 33,
+      "id_terminal": 104,
+      "price_buy": 27527,
+      "price_sell": 28270,
+      "commodity_name": "Gold",
+      "terminal_name": "TDD - Trade and Development Division - Area 18"
+    },
+    {
+      "id": 2,
+      "id_commodity": 33,
+      "id_terminal": 105,
+      "price_buy": 26000,
+      "price_sell": 29000,
+      "commodity_name": "Gold",
+      "terminal_name": "TDD - Trade and Development Division - Area 18"
+    },
+    {
+      "id": 3,
+      "id_commodity": 24,
+      "id_terminal": 102,
+      "price_buy": 0,
+      "price_sell": 2245,
+      "commodity_name": "Agricium (Ore)",
+      "terminal_name": "Admin - ARC-L1"
+    },
+    {
+      "id": 4,
+      "id_commodity": 999,
+      "id_terminal": 104,
+      "price_buy": 5100,
+      "price_sell": 5100,
+      "commodity_name": "Aslarite",
+      "terminal_name": "TDD - Trade and Development Division - Area 18"
+    },
+    {
+      "id": 5,
+      "id_commodity": 137,
+      "id_terminal": 100,
+      "price_buy": 100,
+      "price_sell": 100,
+      "commodity_name": "Lastaphrene",
+      "terminal_name": "Astro Armada - Area 18"
+    }
+  ]
+}

--- a/test/fixtures/uex/terminals.json
+++ b/test/fixtures/uex/terminals.json
@@ -29,6 +29,20 @@
       "name": "New Deal - Teasa Spaceport - Lorville",
       "nickname": "New Deal Lorville",
       "contact_url": null
+    },
+    {
+      "id": 104,
+      "type": "commodity",
+      "name": "TDD - Trade and Development Division - Area 18",
+      "nickname": "TDD Area 18",
+      "contact_url": "https://example.test/tdd"
+    },
+    {
+      "id": 105,
+      "type": "commodity",
+      "name": "TDD - Trade and Development Division - Area 18",
+      "nickname": "TDD Area 18 Annex",
+      "contact_url": "https://example.test/tdd"
     }
   ]
 }

--- a/test/jobs/loaders/uex_commodity_prices_job_test.rb
+++ b/test/jobs/loaders/uex_commodity_prices_job_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Loaders
+  class UexCommodityPricesJobTest < ActiveJob::TestCase
+    test "#perform maps then syncs and records both sets of counts" do
+      stub_run(unmapped: [], unknown: [])
+
+      GithubIssueCreator.expects(:new).never
+
+      ::Loaders::UexCommodityPricesJob.new.perform
+
+      import = Imports::UexCommodityPricesImport.last
+
+      assert_equal "finished", import.aasm_state
+      assert_equal(
+        {
+          "mapped" => 7, "remapped" => 2, "unmapped" => [],
+          "created" => 4, "updated" => 1, "removed" => 2, "skipped_removals" => 0, "unknown" => []
+        },
+        import.output
+      )
+    end
+
+    # The mapper has to land first: a commodity the last game-file import added
+    # carries no uex_id yet, and the syncer would drop its prices as unknown.
+    test "#perform maps before it syncs" do
+      sequence = sequence("mapping before pricing")
+
+      mapper = mock("Uex::CommodityMapper")
+      mapper.expects(:run).in_sequence(sequence).returns(mapping_result(unmapped: []))
+      ::Uex::CommodityMapper.stubs(:new).returns(mapper)
+
+      syncer = mock("Uex::CommodityPriceSyncer")
+      syncer.expects(:run).in_sequence(sequence).returns(sync_result(unknown: []))
+      ::Uex::CommodityPriceSyncer.stubs(:new).returns(syncer)
+
+      ::Loaders::UexCommodityPricesJob.new.perform
+    end
+
+    test "#perform opens an issue for commodities that carry no UEX id" do
+      stub_run(unknown: [])
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).returns(true)
+      GithubIssueCreator.expects(:new).with(
+        task_type: "uex_commodity_prices_import",
+        title: "UEX Commodity Sync — Unmapped Commodities",
+        body: anything
+      ).returns(creator)
+
+      ::Loaders::UexCommodityPricesJob.new.perform
+
+      assert_equal ["items_commodities_ventslug"], Imports::UexCommodityPricesImport.last.output["unmapped"]
+    end
+
+    test "#perform opens an issue for priced commodities we do not carry" do
+      stub_run(unmapped: [])
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).returns(true)
+      GithubIssueCreator.expects(:new).with(
+        task_type: "uex_commodity_prices_import",
+        title: "UEX Commodity Sync — Priced Commodities We Do Not Carry",
+        body: anything
+      ).returns(creator)
+
+      ::Loaders::UexCommodityPricesJob.new.perform
+
+      assert_equal ["Aslarite"], Imports::UexCommodityPricesImport.last.output["unknown"]
+    end
+
+    test "#perform marks the import as failed when the sync raises" do
+      mapper = mock("Uex::CommodityMapper")
+      mapper.stubs(:run).returns(mapping_result(unmapped: []))
+      ::Uex::CommodityMapper.stubs(:new).returns(mapper)
+
+      syncer = mock("Uex::CommodityPriceSyncer")
+      syncer.stubs(:run).raises(::Uex::Error, "UEX API error 403 for commodities_prices_all")
+      ::Uex::CommodityPriceSyncer.stubs(:new).returns(syncer)
+
+      error = assert_raises(::Uex::Error) { ::Loaders::UexCommodityPricesJob.new.perform }
+
+      import = Imports::UexCommodityPricesImport.last
+
+      assert_equal "failed", import.aasm_state
+      assert_equal error.message, import.info
+    end
+
+    test "the unknown issue body carries nothing that changes when only prices move" do
+      unknown = [{"id_commodity" => 999, "commodity_name" => "Aslarite"}]
+
+      first = ::Uex::CommodityPriceSyncer.github_issue_body(sync_result(unknown:))
+      second = ::Uex::CommodityPriceSyncer.github_issue_body(
+        ::Uex::CommodityPriceSyncer::Result.new(created: 0, updated: 97, removed: 3, skipped_removals: 2, unknown:)
+      )
+
+      assert_equal first, second,
+        "a volatile body would defeat GithubIssueCreator's digest and open an issue every day"
+    end
+
+    private def mapping_result(unmapped: [Commodity.new(name: "Vent Slug", sc_key: "items_commodities_ventslug")])
+      ::Uex::CommodityMapper::Result.new(mapped: 7, updated: 2, unmatched: [], unmapped:)
+    end
+
+    private def sync_result(unknown: [{"id_commodity" => 999, "commodity_name" => "Aslarite"}])
+      ::Uex::CommodityPriceSyncer::Result.new(created: 4, updated: 1, removed: 2, skipped_removals: 0, unknown:)
+    end
+
+    private def stub_run(unmapped: nil, unknown: nil)
+      mapper = mock("Uex::CommodityMapper")
+      mapper.expects(:run).returns(unmapped.nil? ? mapping_result : mapping_result(unmapped:))
+      ::Uex::CommodityMapper.stubs(:new).returns(mapper)
+
+      syncer = mock("Uex::CommodityPriceSyncer")
+      syncer.expects(:run).returns(unknown.nil? ? sync_result : sync_result(unknown:))
+      ::Uex::CommodityPriceSyncer.stubs(:new).returns(syncer)
+    end
+  end
+end

--- a/test/lib/uex/commodity_price_syncer_test.rb
+++ b/test/lib/uex/commodity_price_syncer_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../support/uex_fixtures"
+
+module Uex
+  class CommodityPriceSyncerTest < ActiveSupport::TestCase
+    include UexFixtures
+
+    setup do
+      Commodity.delete_all
+      ItemPrice.where(item_type: "Commodity").delete_all
+      @commodities = create_uex_priced_commodities
+    end
+
+    def sync(overrides = {})
+      Uex::CommodityPriceSyncer.new(client: uex_client_stub(overrides)).run
+    end
+
+    def prices_for(commodity)
+      ItemPrice.where(item_type: "Commodity", item_id: commodity.id)
+    end
+
+    test "#run stores what the shop charges as a sell price" do
+      sync
+
+      price = prices_for(@commodities[:agricium_ore]).find_by(price_type: "buy")
+
+      assert_equal "Admin - ARC-L1", price.location
+      assert_equal 2245, price.price
+    end
+
+    # UEX writes from the player's side, so their price_buy is the shop selling.
+    test "#run swaps the UEX price directions onto our shop perspective" do
+      sync
+
+      gold = prices_for(@commodities[:gold])
+
+      assert_equal 26_000, gold.find_by(price_type: "sell").price
+      assert_equal 29_000, gold.find_by(price_type: "buy").price
+    end
+
+    test "#run keeps the cheaper of two terminals sharing a location for a sell price" do
+      sync
+
+      assert_equal 26_000, prices_for(@commodities[:gold]).find_by(price_type: "sell").price
+    end
+
+    # The mirror of the rule above: of two shops buying the same cargo the
+    # player wants the better paid, so the higher figure is the one to keep.
+    test "#run keeps the better paid of two terminals sharing a location for a buy price" do
+      sync
+
+      assert_equal 29_000, prices_for(@commodities[:gold]).find_by(price_type: "buy").price
+    end
+
+    test "#run skips a price of zero rather than storing it" do
+      sync
+
+      assert_nil prices_for(@commodities[:agricium_ore]).find_by(price_type: "sell")
+    end
+
+    test "#run ignores prices at terminals that do not trade commodities" do
+      sync
+
+      assert_empty ItemPrice.where(item_type: "Commodity", location: "Astro Armada - Area 18")
+    end
+
+    test "#run carries the terminal contact url" do
+      sync
+
+      assert_equal "https://example.test/tdd", prices_for(@commodities[:gold]).first.location_url
+    end
+
+    test "#run reports priced commodities that resolve to nothing of ours" do
+      result = sync
+
+      assert_equal ["Aslarite"], result.unknown.map { |row| row["commodity_name"] }
+    end
+
+    test "#run prices nothing for a commodity that was never mapped" do
+      sync
+
+      assert_empty prices_for(@commodities[:unmapped])
+    end
+
+    test "#run updates a changed price instead of duplicating the row" do
+      sync
+      result = sync(commodity_prices: uex_fixture("commodities_prices_all").map { |row|
+        (row["id"] == 2) ? row.merge("price_buy" => 25_000) : row
+      })
+
+      assert_equal 1, result.updated
+      assert_equal 25_000, prices_for(@commodities[:gold]).find_by(price_type: "sell").price
+      assert_equal 3, ItemPrice.where(item_type: "Commodity").count
+    end
+
+    test "#run is idempotent when nothing changed" do
+      sync
+      result = sync
+
+      assert_equal 0, result.created
+      assert_equal 0, result.updated
+    end
+
+    test "#run removes rows for a location UEX no longer lists" do
+      sync
+
+      remaining = uex_fixture("terminals").reject { |terminal| terminal["id"] == 102 }
+      result = sync(terminals: remaining)
+
+      assert_equal 1, result.removed
+      assert_empty ItemPrice.where(item_type: "Commodity", location: "Admin - ARC-L1")
+    end
+
+    test "#run leaves prices for other item types alone" do
+      model_price = create(:item_price, item: create(:model), price_type: "sell", location: "Admin - ARC-L1")
+
+      sync
+
+      assert ItemPrice.exists?(model_price.id)
+    end
+
+    test "#run refuses to sync when the price feed is empty" do
+      sync
+
+      error = assert_raises(Uex::Error) { sync(commodity_prices: []) }
+
+      assert_match(/refusing to sync/, error.message)
+      assert_equal 3, ItemPrice.where(item_type: "Commodity").count
+    end
+
+    test "#run refuses to sync when no terminal trades commodities" do
+      vehicles_only = uex_fixture("terminals").reject { |terminal| terminal["type"] == "commodity" }
+
+      assert_raises(Uex::Error) { sync(terminals: vehicles_only) }
+    end
+
+    test ".github_issue_body lists the unknown commodities without volatile counts" do
+      body = Uex::CommodityPriceSyncer.github_issue_body(sync)
+
+      assert_match(/Priced UEX Commodities We Do Not Carry \(1\)/, body)
+      assert_match(/\*\*Aslarite\*\* — UEX id `999`/, body)
+      assert_no_match(/created=/, body)
+    end
+  end
+end

--- a/test/support/uex_fixtures.rb
+++ b/test/support/uex_fixtures.rb
@@ -11,7 +11,8 @@ module UexFixtures
       vehicle_purchase_prices: uex_fixture("vehicles_purchases_prices_all"),
       vehicle_rental_prices: uex_fixture("vehicles_rentals_prices_all"),
       terminals: uex_fixture("terminals"),
-      commodities: uex_fixture("commodities")
+      commodities: uex_fixture("commodities"),
+      commodity_prices: uex_fixture("commodities_prices_all")
     }.merge(overrides)
 
     client = mock("Uex::Client")
@@ -39,6 +40,16 @@ module UexFixtures
       punctuated_match: create(:commodity, name: "Agricium (Ore)", sc_key: "items_commodities_agricium_ore"),
       mapping_match: create(:commodity, name: "Lastaprene", sc_key: "items_commodities_lastaprene"),
       near_neighbour: create(:commodity, name: "Organs", sc_key: "items_commodities_organs")
+    }
+  end
+
+  # The price feed joins on uex_id rather than on name, so the price tests need
+  # commodities already carrying the ids the mapper would have written.
+  def create_uex_priced_commodities
+    {
+      gold: create(:commodity, name: "Gold", sc_key: "items_commodities_gold", uex_id: 33, uex_code: "GOLD"),
+      agricium_ore: create(:commodity, name: "Agricium (Ore)", sc_key: "items_commodities_agricium_ore", uex_id: 24, uex_code: "AGRIORE"),
+      unmapped: create(:commodity, name: "Vent Slug", sc_key: "items_commodities_ventslug", uex_id: nil)
     }
   end
 end


### PR DESCRIPTION
Puts commodity prices behind the reference table: a daily sync that maps, then prices.

> **Base:** `main`. #4387 merged, so this was rebased onto it and now stands alone.

## What's here

- `Uex::PriceSnapshot` — the snapshot reconciliation, extracted from `PriceSyncer`
- `Uex::CommodityPriceSyncer` — prices commodities at UEX commodity terminals
- `Loaders::UexCommodityPricesJob` + `Imports::UexCommodityPricesImport`, scheduled daily at 05:30

## The extraction

Applying a snapshot and working out which of our leftovers are genuinely gone — rather than merely missing from a short answer — is the same problem whether the rows are ships or cargo. The retention guard in particular is subtle enough that a second copy would be a second thing to get wrong, so `persist_prices`, `deletable?`, `require_rows`, `web_url` and the skipped-removal reporting now live in one module.

Behaviour is unchanged: **`PriceSyncer`'s 26 tests pass against it untouched.**

## One rule that is not shared

`PriceSyncer` always keeps the cheaper of two terminals that collapse onto one location string, because every price it holds is a cost to the player. Commodities go both ways, so the direction decides:

- **sell** (the shop sells, the player pays) → keep the **cheaper**
- **buy** (the shop buys, the player is paid) → keep the **higher**

Keeping the cheaper in both cases would quietly show the worst place to sell your cargo as the best.

UEX writes from the player's side — their `price_buy` is the shop selling — so the two directions swap onto our shop-perspective `ItemPrice`, the same way `PriceSyncer` maps a UEX purchase price to `sell`.

## Joining

The syncer needs no matcher: it joins on the `uex_id` #4387's mapper already wrote, so a commodity that was never mapped simply has no prices. The job runs the mapper first, because a commodity the last game-file import added carries no `uex_id` yet and its prices would otherwise be dropped as unknown.

Both halves report: unmapped commodities via `CommodityMapper.github_issue_body`, and priced UEX commodities we don't carry via `CommodityPriceSyncer.github_issue_body`. Both bodies are free of the run counts so `GithubIssueCreator`'s digest doesn't open a fresh issue every day — there's a test asserting that.

## Against the live feed

| | |
|---|---|
| Price rows stored | 2286 |
| — shop buys (player sells) | 1794 |
| — shop sells (player buys) | 492 |
| Distinct locations | 135 |
| Priced UEX commodities we don't carry | 18 |

Spot check: Gold's cheapest sell is 24,360 at HDMS-Anderson and its best buy is 31,000 at TDD Area 18 — buy low at an outpost, sell high at the trade division, which is the right shape.

## Testing

22 new tests (16 syncer, 6 job). Re-verified after rebasing onto a `main` that had gained the hangar inventories and the commodity picker: `bin/rails test` → 1989 tests, 2 failures + 2 errors, all four pre-existing and unrelated. Regenerating the OpenAPI schema against the new `main` produced no drift.

One regression caught and fixed on the way: `ImportTest#test_every_broadcasting_import_type_renders_its_jbuilder_partial` failed because a new `Import` subclass needs its own jbuilder partial. Added.

🤖
