### PR TITLE
chore(feature-flags): use the FeatureFlagName enum in the frontend and retire hardpoints-v2

### DIFF
--- a/app/frontend/frontend/components/Navigation/FleetNav/index.vue
+++ b/app/frontend/frontend/components/Navigation/FleetNav/index.vue
@@ -12,6 +12,7 @@ import {
   useFleet as useFleetQuery,
   usePublicFleet as usePublicFleetQuery,
   useFleetMembership as useFleetMembershipQuery,
+  FeatureFlagName,
 } from "@/services/fyApi";
 import { useSessionStore } from "@/frontend/stores/session";
 import { useFeatures } from "@/frontend/composables/useFeatures";
@@ -119,7 +120,10 @@ onMounted(() => {
           prefix="03"
         />
         <NavItem
-          v-if="hasLogisticsAccess && isFeatureEnabled('fleet_logistics')"
+          v-if="
+            hasLogisticsAccess &&
+            isFeatureEnabled(FeatureFlagName.fleet_logistics)
+          "
           :to="{
             name: 'fleet-logistics',
             params: { slug: currentFleet.slug },

--- a/app/frontend/frontend/components/Navigation/ToolsNav/index.vue
+++ b/app/frontend/frontend/components/Navigation/ToolsNav/index.vue
@@ -8,6 +8,7 @@ export default {
 import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useFeatures } from "@/frontend/composables/useFeatures";
+import { FeatureFlagName } from "@/services/fyApi";
 
 const { t } = useI18n();
 const { isFeatureEnabled } = useFeatures();
@@ -34,13 +35,13 @@ const active = computed(() => {
         icon="fa-duotone fa-browsers"
       />
       <NavItem
-        v-if="isFeatureEnabled('tools_travel_times')"
+        v-if="isFeatureEnabled(FeatureFlagName.tools_travel_times)"
         :to="{ name: 'travel-times' }"
         :label="t('nav.tools.travelTimes')"
         icon="fa-duotone fa-gauge-high"
       />
       <NavItem
-        v-if="isFeatureEnabled('tools_cargo_grids')"
+        v-if="isFeatureEnabled(FeatureFlagName.tools_cargo_grids)"
         :to="{ name: 'cargo-grids' }"
         :label="t('nav.tools.cargoGrids')"
         icon="fa-duotone fa-thin fa-cubes"

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics.vue
@@ -5,7 +5,11 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { type Fleet, type FleetMember } from "@/services/fyApi";
+import {
+  FeatureFlagName,
+  type Fleet,
+  type FleetMember,
+} from "@/services/fyApi";
 import { useFeatures } from "@/frontend/composables/useFeatures";
 
 type Props = {
@@ -24,7 +28,7 @@ const resourceAccess = computed(
 
 <template>
   <router-view
-    v-if="isFeatureEnabled('fleet_logistics')"
+    v-if="isFeatureEnabled(FeatureFlagName.fleet_logistics)"
     :fleet="props.fleet"
     :membership="props.membership"
     :resource-access="resourceAccess"

--- a/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
@@ -28,6 +28,7 @@ import {
   useFleetMembers as useFleetMembersQuery,
   useFleetMembersStats as useFleetMembersStatsQuery,
   getFleetMembersQueryKey,
+  FeatureFlagName,
   type Fleet,
   type FleetMember,
   type FleetMemberQuery,
@@ -58,8 +59,12 @@ const canManageInvites = computed(() =>
 );
 
 const { isFeatureEnabled } = useFeatures();
-const starmapEnabled = computed(() => isFeatureEnabled("fleet_starmap"));
-const worldmapEnabled = computed(() => isFeatureEnabled("fleet_worldmap"));
+const starmapEnabled = computed(() =>
+  isFeatureEnabled(FeatureFlagName.fleet_starmap),
+);
+const worldmapEnabled = computed(() =>
+  isFeatureEnabled(FeatureFlagName.fleet_worldmap),
+);
 
 const { isFilterSelected, getQuery } = useFilters<FleetMemberQuery>({
   updateCallback: async () => {

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -26,6 +26,7 @@ import Paginator from "@/shared/components/Paginator/index.vue";
 import {
   type HangarGroupMetric,
   type HangarGroupPublic,
+  FeatureFlagName,
   HangarGroup,
 } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -401,7 +402,7 @@ const openDisplayOptionsModal = () => {
     </Btn>
 
     <Btn
-      v-if="isFeatureEnabled('hangar_inventories')"
+      v-if="isFeatureEnabled(FeatureFlagName.hangar_inventories)"
       :size="BtnSizesEnum.MD"
       :to="{ name: 'hangar-inventories' }"
     >
@@ -453,7 +454,7 @@ const openDisplayOptionsModal = () => {
           </Btn>
 
           <Btn
-            v-if="isFeatureEnabled('hangar_inventories')"
+            v-if="isFeatureEnabled(FeatureFlagName.hangar_inventories)"
             :to="{ name: 'hangar-inventories' }"
           >
             <i class="fa-duotone fa-boxes-stacked" />

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -35,12 +35,6 @@ hangar_inventories:
   description: "Personal hangar inventories with a deposit/withdrawal ledger"
   self_service: true
 
-# Superseded by the hardpoints redesign; the flag was removed from the code in
-# #4176 and is kept here only so this registry does not prune it as a side
-# effect of being introduced. Delete this entry to retire the flag.
-hardpoints-v2:
-  description: "Legacy hardpoints v2 rollout — no longer referenced in code"
-
 oauth-applications:
   description: "User-owned OAuth applications in settings"
   permanent: true

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9336,7 +9336,6 @@ components:
       - fleet_starmap
       - fleet_worldmap
       - hangar_inventories
-      - hardpoints-v2
       - oauth-applications
       - oauth-bluesky
       - oauth-citizenid

--- a/test/lib/feature_flags/registry_test.rb
+++ b/test/lib/feature_flags/registry_test.rb
@@ -4,6 +4,12 @@ require "test_helper"
 
 module FeatureFlags
   class RegistryTest < ActiveSupport::TestCase
+    # Flags a data migration created that have since been retired on purpose:
+    # dropped from the registry so the next sync prunes them from Flipper.
+    # Listing one here is what tells a deliberate retirement apart from an
+    # entry accidentally left out, which is all the guard below can see.
+    RETIRED_FLAG_NAMES = %w[hardpoints-v2].freeze
+
     def registry(raw)
       Registry.new(raw: raw)
     end
@@ -124,10 +130,16 @@ module FeatureFlags
     end
 
     test "the checked-in registry covers every flag created by a data migration" do
-      missing = migration_flag_names - Registry.new.names
+      missing = migration_flag_names - Registry.new.names - RETIRED_FLAG_NAMES
 
       assert_empty missing,
-        "flags created by data migrations but missing from config/feature_flags.yml (sync would prune them)"
+        "flags created by data migrations but missing from config/feature_flags.yml (sync would prune them). " \
+        "Retiring one on purpose? Add it to RETIRED_FLAG_NAMES."
+    end
+
+    test "a flag listed as retired is really gone from the registry" do
+      assert_empty RETIRED_FLAG_NAMES & Registry.new.names,
+        "declared again in config/feature_flags.yml — drop it from RETIRED_FLAG_NAMES so the guard sees it"
     end
 
     test "the migration scan finds both the literal and %w forms" do


### PR DESCRIPTION
Two pieces of feature-flag housekeeping, one commit each.

## Use the `FeatureFlagName` enum for frontend checks

`FeatureFlagName` landed in #4390 as a generated type, but nothing ever moved to it — every `isFeatureEnabled` call still passed a bare string literal. The literals were already type-checked against the union, so this buys greppability and find-references, not safety.

8 call sites across 5 files now read `FeatureFlagName.<flag>`. Five of them are `v-if` expressions rather than script-block calls; `<script setup>` exposes the imported binding to the template, and none of the six flags involved are hyphenated, so no bracket access was needed.

Deliberately left as literals:

- the 4 `<FeatureGuard feature="…">` props and the 10 route `meta.feature` entries — hyphenated flags there would become `:feature="FeatureFlagName['oauth-applications']"`, which reads worse than the string
- `OauthBtn` and `SocialLogins`, which build the name as `` `oauth-${provider}` `` and cannot use a member lookup at all. These still type-check: the six `OauthBtnProvidersEnum` values expand to exactly the six `oauth-*` members.

## Retire `hardpoints-v2`

#4176 deleted the last code that read this flag. The registry entry only existed so that introducing the registry would not prune a still-live flag as a side effect, with a comment saying to delete it to retire the flag. Nothing in `app/` or `test/` references it, so this does that: the next deploy's `feature_flags:sync` removes the flag and all its gates from Flipper. No data migration needed.

One thing worth a look. `RegistryTest` asserts that every flag any `db/data` migration created is still declared, so dropping the entry turned it red. That assertion structurally cannot tell a deliberate retirement from an entry someone forgot, so retired names are now listed explicitly in `RETIRED_FLAG_NAMES`, and a second guard fails if a listed name is declared again — otherwise a stale entry would quietly mask a genuinely missing flag later. Happy to reshape that if you'd rather the guard worked differently.

## Verification

`vue-tsc`, `tsc`, `eslint`, `prettier --check` clean; 191 vitest tests pass; 46 tests in `test/lib/feature_flags/` plus `features_test.rb` pass; `standardrb` clean on the touched Ruby.

## Notes for the reviewer

`swagger/v1/schema.yaml` is regenerated, but `rake openapi_ruby:generate` currently fails on `main` for an unrelated reason — it requires every `test/**/*_test.rb` outside `test_helper`, so shoulda-matchers is not loaded and `test/models/fleet_membership_test.rb:40` raises `undefined method 'belong_to'` (the file passes fine under `rails test`). I worked around it with `PATTERN="test/integration/**/*_test.rb"` and hand-restored the `servers[0].url` line, which the generator rewrote to `localhost:3000` because I have no `.env`. The committed diff is the single enum line. Both of those are worth fixing separately.

🤖