### PR TITLE
chore(cleanup): prune the components older builds left behind

### DIFF
--- a/app/jobs/cleanup/component_versions_job.rb
+++ b/app/jobs/cleanup/component_versions_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Cleanup
+  # Components are keyed on (sc_key, version), so every imported build adds a
+  # fresh row per component and nothing ever took the old ones away. The rows
+  # cannot simply be dropped: a saved vehicle loadout points at the component it
+  # was built with, and that reference is what keeps the loadout meaning what
+  # its owner chose.
+  #
+  # So this keeps the current build and whatever players still reference, and
+  # takes the rest.
+  class ComponentVersionsJob < ::Cleanup::BaseJob
+    Result = Struct.new(:removed, :kept_for_loadouts) do
+      def to_s
+        "removed=#{removed} kept_for_loadouts=#{kept_for_loadouts}"
+      end
+    end
+
+    def perform
+      version = Rails.configuration.sc_data[:version]
+
+      # Before the current build has been imported every row looks stale, and
+      # the table would be emptied. Nothing to clean up until it lands.
+      return if version.blank? || Component.where(version:).none?
+
+      referenced = VehicleLoadoutHardpoint.where.not(component_id: nil).select(:component_id)
+      stale = Component.where.not(version:).where.not(id: referenced)
+
+      result = Result.new(removed: 0, kept_for_loadouts: Component.where.not(version:).where(id: referenced).count)
+
+      # model_hardpoint_loadouts carries a component_id with no foreign key and
+      # no association back from Component, so nothing would clear it.
+      ModelHardpointLoadout.where(component_id: stale.select(:id)).update_all(component_id: nil)
+
+      # Destroyed rather than deleted: a component owns its sub-hardpoints, and
+      # the hardpoints fitted with it have a foreign key that has to be cleared
+      # before the row can go.
+      stale.find_each do |component|
+        component.destroy
+        result.removed += 1
+      end
+
+      Rails.logger.info("[Cleanup::ComponentVersionsJob] #{result}")
+
+      result
+    end
+  end
+end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -34,6 +34,7 @@
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_version          (version)
 #
 class Component < ApplicationRecord
   include ActiveStorageVariants

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -41,6 +41,10 @@ cleanup_unattached_check_job:
   cron: '0 2 */1 * *' # Daily at 2:00
   class: 'Cleanup::UnattachedCheckJob'
   queue: 'cleanup'
+cleanup_component_versions_job:
+  cron: '0 3 * * 0' # Weekly on Sunday 3:00, after a week of imports have landed
+  class: 'Cleanup::ComponentVersionsJob'
+  queue: 'cleanup'
 loaders_paints_import_job:
   cron: '0 19 * * 0' # Weekly on Sunday 19:00
   class: 'Loaders::PaintsImportJob'

--- a/db/migrate/20260816170000_add_version_index_to_components.rb
+++ b/db/migrate/20260816170000_add_version_index_to_components.rb
@@ -1,0 +1,10 @@
+class AddVersionIndexToComponents < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # Component.current_version narrows every picker and filter query to the
+    # build the game currently ships, over a table that has been collecting a
+    # row per component per import with nothing to index the filter.
+    add_index :components, :version, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -213,6 +213,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
     t.datetime "updated_at", precision: nil
     t.string "version"
     t.index ["manufacturer_id"], name: "index_components_on_manufacturer_id"
+    t.index ["version"], name: "index_components_on_version"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -32,6 +32,7 @@
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_version          (version)
 #
 FactoryBot.define do
   factory :component do

--- a/test/jobs/cleanup/component_versions_job_test.rb
+++ b/test/jobs/cleanup/component_versions_job_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Cleanup
+  class ComponentVersionsJobTest < ActiveJob::TestCase
+    setup do
+      Component.delete_all
+      @version = Rails.configuration.sc_data[:version]
+      @current = create(:component, name: "FR-66 Shield", sc_key: "fr66", version: @version)
+      @stale = create(:component, name: "FR-66 Shield", sc_key: "fr66", version: "0.0.1-live.1")
+    end
+
+    test "#perform takes the components older builds left behind" do
+      result = ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert_equal [@current.id], Component.pluck(:id)
+      assert_equal 1, result.removed
+    end
+
+    # The reference is what keeps a saved loadout meaning what its owner chose,
+    # and the foreign key would refuse the delete anyway.
+    test "#perform keeps a component a saved loadout still points at" do
+      create(:vehicle_loadout_hardpoint, component: @stale)
+
+      result = ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert Component.exists?(@stale.id)
+      assert_equal 0, result.removed
+      assert_equal 1, result.kept_for_loadouts
+    end
+
+    # Nothing else clears this one: it carries a component_id with no foreign
+    # key and no association back from Component.
+    test "#perform clears the component off a model hardpoint loadout" do
+      loadout = create(:model_hardpoint_loadout, component: @stale)
+
+      ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert_nil loadout.reload.component_id
+    end
+
+    # Every row looks stale before the current build has been imported, so the
+    # guard is the difference between a cleanup and an empty table.
+    test "#perform does nothing until the current build has been imported" do
+      Component.where(version: @version).delete_all
+
+      ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert Component.exists?(@stale.id)
+    end
+
+    test "#perform leaves the current build alone when there is nothing stale" do
+      Component.where.not(version: @version).delete_all
+
+      result = ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert_equal [@current.id], Component.pluck(:id)
+      assert_equal 0, result.removed
+    end
+
+    test "#perform takes the sub-hardpoints a stale component owns with it" do
+      hardpoint = create(:hardpoint, parent: @stale)
+
+      ::Cleanup::ComponentVersionsJob.new.perform
+
+      assert_not Hardpoint.exists?(hardpoint.id)
+    end
+  end
+end


### PR DESCRIPTION
Components accumulate a row per build forever. This prunes them, without touching the ones players still depend on.

## The growth

`Component` is keyed on **(sc_key, version)**, not `sc_key`:

```ruby
component = Component.find_by(sc_key: normalized_key, version: sc_version)
...
component = Component.create!(sc_key: normalized_key, sc_ref: ref, version: sc_version) if component.blank?
```

So an import never updates the existing row — it adds a fresh one per component, and nothing has ever taken the old ones away. `Component.current_version` exists precisely because the table is assumed to be full of history; it just grows without bound.

Worth knowing before merging: `Component.group(:version).count` will tell you how much this is actually costing in production. I can't see that from here.

## Why it can't just delete

Four tables carry a `component_id`, and one of them is user data:

| Reference | |
|---|---|
| `hardpoints.component_id` | game data, rebuilt each import; FK to components |
| `model_hardpoints.component_id` | game data, `dependent: :nullify` |
| `model_hardpoint_loadouts.component_id` | game data, **no FK and no association back from Component** |
| **`vehicle_loadout_hardpoints.component_id`** | **players' saved loadouts, FK to components** |

A saved loadout points at the component it was built with, and that reference is what keeps the loadout meaning what its owner chose. The foreign key would refuse the delete in any case — the good failure mode, but it means a naive cleanup would simply error.

So the job **keeps the current build and whatever players still reference**, and takes the rest. That bounds growth to one build plus a small tail.

`model_hardpoint_loadouts` is cleared explicitly, because nothing else would: it has neither a foreign key nor an association back from `Component`. And rows are destroyed rather than deleted, so a component takes its own sub-hardpoints with it and the hardpoints fitted with it get their reference cleared before the row goes.

## The guard

The job refuses to run before the current build has been imported. Without it every row looks stale and the table is emptied — a scheduled job with that failure mode is worse than no job. There's a test for it.

## Also here

**An index on `components.version`.** There wasn't one — only `manufacturer_id` — so every `current_version` scope was a filtered scan over the growing table. Added concurrently.

Scheduled weekly on Sunday at 03:00, after a week of imports have landed.

## Testing

Six tests, covering what a data-deleting job needs to get right: stale rows go, a component a saved loadout references stays, the model-hardpoint-loadout reference is cleared, sub-hardpoints go with their component, nothing happens before the current build is imported, and nothing happens when there is nothing stale.

`bin/rails test` → 2007 tests, 2 failures + 2 errors, all four pre-existing and unrelated.

🤖
