### PR TITLE
refactor(components): one row per component, history as versions

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -112,13 +112,15 @@ module ScData
 
           if item["key"].blank? && item["ref"].blank? && parent.is_a?(Model) && item["name"]&.end_with?("_module")
             derived_key = "#{parent.sc_data_identifier}_module"
-            item["key"] = derived_key if Component.exists?(sc_key: derived_key, version: sc_version)
+            item["key"] = derived_key if Component.exists?(sc_key: derived_key)
           end
 
+          # Resolved by key alone: a component is one row now, and `version`
+          # says which build it was last seen in rather than which row to use.
           component = if item["key"].present?
-            Component.find_by(sc_key: item["key"]&.downcase, version: sc_version)
+            Component.find_by(sc_key: item["key"]&.downcase)
           elsif item["ref"].present?
-            Component.find_by(sc_ref: item["ref"], version: sc_version)
+            Component.find_by(sc_ref: item["ref"])
           end
 
           if component.present?
@@ -135,9 +137,9 @@ module ScData
                                  nested = nested_loadout.find { |nl| nl["name"]&.downcase == hp.sc_name }
                                  if nested.present?
                                    sub_component = if nested["key"].present?
-                                     Component.find_by(sc_key: nested["key"]&.downcase, version: sc_version)
+                                     Component.find_by(sc_key: nested["key"]&.downcase)
                                    elsif nested["ref"].present?
-                                     Component.find_by(sc_ref: nested["ref"], version: sc_version)
+                                     Component.find_by(sc_ref: nested["ref"])
                                    end
                                  end
                                end

--- a/app/lib/sc_data/loader/items_loader.rb
+++ b/app/lib/sc_data/loader/items_loader.rb
@@ -62,6 +62,10 @@ module ScData
             end
           end
 
+          # Stamped on every load, not just on create: the row is reused across
+          # builds now, so this is what records the build it was last seen in.
+          update_params[:version] = sc_version
+
           component.update!(update_params)
         end
 
@@ -117,12 +121,17 @@ module ScData
         update_params
       end
 
+      # A component is the same component across builds, so the version is no
+      # longer part of its identity -- a row is updated in place and `version`
+      # records the build it was last seen in. Commodity and Equipment are keyed
+      # the same way; only this loader used to add a row per build, which is why
+      # the table kept every patch it had ever imported.
       private def find_component(normalized_key, key, ref = nil, name = nil)
         return if normalized_key.blank? && ref.blank?
 
-        component = Component.find_by(sc_key: normalized_key, version: sc_version) if normalized_key.present?
-        component = Component.find_by(sc_ref: ref, version: sc_version) if component.blank? && ref.present?
-        component = Component.where(name: name, sc_key: nil, sc_ref: nil, version: sc_version).first if component.blank? && name.present?
+        component = Component.find_by(sc_key: normalized_key) if normalized_key.present?
+        component = Component.find_by(sc_ref: ref) if component.blank? && ref.present?
+        component = Component.where(name: name, sc_key: nil, sc_ref: nil).first if component.blank? && name.present?
 
         component
       end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -35,6 +35,7 @@
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
 #  index_components_on_sc_key           (sc_key) UNIQUE
+#  index_components_on_version          (version)
 #
 class Component < ApplicationRecord
   include ActiveStorageVariants

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -34,12 +34,30 @@
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_sc_key           (sc_key) UNIQUE
 #
 class Component < ApplicationRecord
   include ActiveStorageVariants
 
   paginates_per 50
   max_paginates_per 240
+
+  # One row per component, with the spec history kept as versions rather than as
+  # a row per build. `version` is deliberately not tracked: it moves on every
+  # import, and recording that would write a version per component per run for
+  # nothing. Only a spec that actually changed is worth keeping.
+  #
+  # The associations are renamed because PaperTrail's default `version` reader
+  # shadows this table's `version` column -- left alone, an update writes NULL
+  # over the build a component was last seen in.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name description size grade item_type item_class component_class component_sub_type
+      component_type type_data durability power_connection heat_connection ammunition
+      inventory_consumption tracking_signal manufacturer_id hidden
+    ],
+    version: :paper_trail_version,
+    versions: {name: :paper_trail_versions}
 
   belongs_to :manufacturer, optional: true
 

--- a/app/models/imports/uex_commodity_prices_import.rb
+++ b/app/models/imports/uex_commodity_prices_import.rb
@@ -1,5 +1,35 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: imports
+#
+#  id            :uuid             not null, primary key
+#  aasm_state    :string
+#  failed_at     :datetime
+#  finished_at   :datetime
+#  import_data   :text
+#  info          :text
+#  input         :jsonb
+#  output        :jsonb
+#  started_at    :datetime
+#  type          :string
+#  version       :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  admin_user_id :uuid
+#  user_id       :uuid
+#
+# Indexes
+#
+#  index_imports_on_aasm_state_and_type  (aasm_state,type)
+#  index_imports_on_admin_user_id        (admin_user_id)
+#  index_imports_on_type                 (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_user_id => admin_users.id)
+#
 module Imports
   class UexCommodityPricesImport < ::Import
     belongs_to :admin_user, optional: true

--- a/db/migrate/20260816180000_collapse_component_versions.rb
+++ b/db/migrate/20260816180000_collapse_component_versions.rb
@@ -1,0 +1,107 @@
+class CollapseComponentVersions < ActiveRecord::Migration[8.1]
+  # Components used to be keyed on (sc_key, version), so the table holds a row
+  # per component per imported build. They are one component, so this keeps one
+  # row of each and repoints everything that referenced the others at it.
+  #
+  # The passes follow the loader's own lookup order -- sc_key, then sc_ref for
+  # the rows that have no key, then name for the rows that have neither -- so
+  # what collapses here is what the loader would now treat as one component.
+  # They are scoped not to overlap, so no row is considered twice.
+  PASSES = [
+    {column: "lower(sc_key)", scope: "sc_key IS NOT NULL"},
+    {column: "sc_ref", scope: "sc_key IS NULL AND sc_ref IS NOT NULL"},
+    {column: "name", scope: "sc_key IS NULL AND sc_ref IS NULL AND name IS NOT NULL"}
+  ].freeze
+
+  # Everything holding a component_id. item_prices points at one polymorphically
+  # and is handled on its own.
+  REFERENCES = {
+    "hardpoints" => "component_id",
+    "model_hardpoints" => "component_id",
+    "model_hardpoint_loadouts" => "component_id",
+    "vehicle_loadout_hardpoints" => "component_id"
+  }.freeze
+
+  def up
+    PASSES.each { |pass| collapse(pass) }
+
+    execute("DROP TABLE IF EXISTS component_survivors")
+
+    # Nothing should be able to put the table back the way it was.
+    add_index :components, :sc_key, unique: true
+  end
+
+  def down
+    remove_index :components, :sc_key
+
+    raise ActiveRecord::IrreversibleMigration,
+      "the duplicate rows are gone; a fresh import rebuilds the current build"
+  end
+
+  private def collapse(pass)
+    say_with_time("collapsing components that share the same #{pass[:column]}") do
+      execute("DROP TABLE IF EXISTS component_survivors")
+
+      # The survivor is the row from the build the game currently ships, and
+      # failing that the most recently updated -- version strings sort by text,
+      # where 4.10 would come before 4.9.
+      #
+      # COALESCE rather than a bare comparison: production carries components
+      # with no version at all, and `NULL = 'x'` is NULL, which Postgres sorts
+      # ahead of true under DESC. Those rows would have won.
+      execute(<<~SQL)
+        CREATE TEMPORARY TABLE component_survivors AS
+        SELECT id,
+               FIRST_VALUE(id) OVER (
+                 PARTITION BY #{pass[:column]}
+                 ORDER BY COALESCE(version = #{quote(current_version)}, FALSE) DESC,
+                          version DESC NULLS LAST,
+                          updated_at DESC NULLS LAST,
+                          id
+               ) AS survivor_id
+        FROM components
+        WHERE #{pass[:scope]}
+      SQL
+
+      execute("CREATE INDEX ON component_survivors (id)")
+
+      REFERENCES.each do |table, column|
+        execute(<<~SQL)
+          UPDATE #{table}
+          SET #{column} = survivors.survivor_id
+          FROM component_survivors survivors
+          WHERE #{table}.#{column} = survivors.id
+            AND survivors.id <> survivors.survivor_id
+        SQL
+      end
+
+      execute(<<~SQL)
+        UPDATE item_prices
+        SET item_id = survivors.survivor_id
+        FROM component_survivors survivors
+        WHERE item_prices.item_type = 'Component'
+          AND item_prices.item_id = survivors.id
+          AND survivors.id <> survivors.survivor_id
+      SQL
+
+      # A component owns its sub-hardpoints through a polymorphic parent, and
+      # those carry a foreign key back to components, so they go before the row
+      # they hang off can.
+      execute(<<~SQL)
+        DELETE FROM hardpoints
+        WHERE parent_type = 'Component'
+          AND parent_id IN (SELECT id FROM component_survivors WHERE id <> survivor_id)
+      SQL
+
+      execute("DELETE FROM components WHERE id IN (SELECT id FROM component_survivors WHERE id <> survivor_id)")
+    end
+  end
+
+  private def current_version
+    Rails.configuration.sc_data[:version].to_s
+  end
+
+  private def quote(value)
+    ActiveRecord::Base.connection.quote(value)
+  end
+end

--- a/db/migrate/20260816180000_collapse_component_versions.rb
+++ b/db/migrate/20260816180000_collapse_component_versions.rb
@@ -87,10 +87,25 @@ class CollapseComponentVersions < ActiveRecord::Migration[8.1]
       # A component owns its sub-hardpoints through a polymorphic parent, and
       # those carry a foreign key back to components, so they go before the row
       # they hang off can.
+      #
+      # Hardpoints nest -- a turret owns the guns fitted to it -- and raw SQL
+      # gets none of the `dependent: :destroy` cascade that would normally take
+      # them. Deleting only the top level would leave the children pointing at a
+      # parent that no longer exists, so the whole subtree goes.
       execute(<<~SQL)
-        DELETE FROM hardpoints
-        WHERE parent_type = 'Component'
-          AND parent_id IN (SELECT id FROM component_survivors WHERE id <> survivor_id)
+        WITH RECURSIVE doomed AS (
+          SELECT id
+          FROM hardpoints
+          WHERE parent_type = 'Component'
+            AND parent_id IN (SELECT id FROM component_survivors WHERE id <> survivor_id)
+
+          UNION ALL
+
+          SELECT child.id
+          FROM hardpoints child
+          JOIN doomed ON child.parent_type = 'Hardpoint' AND child.parent_id = doomed.id
+        )
+        DELETE FROM hardpoints WHERE id IN (SELECT id FROM doomed)
       SQL
 
       execute("DELETE FROM components WHERE id IN (SELECT id FROM component_survivors WHERE id <> survivor_id)")

--- a/db/migrate/20260816190000_add_version_index_to_components.rb
+++ b/db/migrate/20260816190000_add_version_index_to_components.rb
@@ -1,0 +1,10 @@
+class AddVersionIndexToComponents < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # Component.current_version narrows every picker and filter query, and
+    # nothing indexed the column it reads. Built after the collapse so it goes
+    # over the table that survives it rather than the one that did not.
+    add_index :components, :version, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -213,6 +213,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
     t.datetime "updated_at", precision: nil
     t.string "version"
     t.index ["manufacturer_id"], name: "index_components_on_manufacturer_id"
+    t.index ["sc_key"], name: "index_components_on_sc_key", unique: true
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_180000) do
     t.string "version"
     t.index ["manufacturer_id"], name: "index_components_on_manufacturer_id"
     t.index ["sc_key"], name: "index_components_on_sc_key", unique: true
+    t.index ["version"], name: "index_components_on_version"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -33,6 +33,7 @@
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
 #  index_components_on_sc_key           (sc_key) UNIQUE
+#  index_components_on_version          (version)
 #
 FactoryBot.define do
   factory :component do

--- a/test/loaders/sc_data/items_loader_test.rb
+++ b/test/loaders/sc_data/items_loader_test.rb
@@ -21,6 +21,20 @@ module ScData
 
         assert_operator Component.where.not(version: nil).count - initial, :>=, 5000
       end
+
+      # A component is the same component across builds. The loader used to key
+      # on (sc_key, version) and add a row per import, which is how the table
+      # came to hold every patch it had ever seen.
+      test "#all updates the component a past build left rather than adding another" do
+        stale = create(:component, sc_key: "aegs_avenger_thruster_main", version: "0.0.1-live.1", name: "Stale")
+
+        assert_no_difference -> { Component.where(sc_key: "aegs_avenger_thruster_main").count } do
+          ::ScData::Loader::ItemsLoader.new.all
+        end
+
+        # The same row, carrying the build it has now been seen in.
+        assert_equal Rails.configuration.sc_data[:version], stale.reload.version
+      end
     end
   end
 end

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -37,6 +37,7 @@ require "test_helper"
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
 #  index_components_on_sc_key           (sc_key) UNIQUE
+#  index_components_on_version          (version)
 #
 class ComponentTest < ActiveSupport::TestCase
   setup do

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
 # == Schema Information
 #
 # Table name: components
@@ -34,35 +38,31 @@
 #  index_components_on_manufacturer_id  (manufacturer_id)
 #  index_components_on_sc_key           (sc_key) UNIQUE
 #
-FactoryBot.define do
-  factory :component do
-    name { Faker::Name.name }
-    component_class { "RSIModular" }
+class ComponentTest < ActiveSupport::TestCase
+  setup do
+    @component = create(:component, name: "FR-66 Shield", sc_key: "fr66", version: "0.0.1-live.1")
+  end
 
-    trait :with_manufacturer do
-      manufacturer
+  test "keeps a version when the spec changes" do
+    assert_difference -> { @component.paper_trail_versions.count }, 1 do
+      @component.update!(name: "FR-66 Shield Generator")
     end
 
-    trait :with_store_image do
-      store_image { Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test.png"), "image/png") }
-    end
+    assert_equal "FR-66 Shield", @component.paper_trail_versions.last.reify.name
+  end
 
-    trait :hidden do
-      hidden { true }
+  # An import touches every component it sees, and `version` moves on all of
+  # them. Tracking it would write a history row per component per run and bury
+  # the changes worth reading.
+  test "keeps no version when only the build it was last seen in moves" do
+    assert_no_difference -> { @component.paper_trail_versions.count } do
+      @component.update!(version: Rails.configuration.sc_data[:version])
     end
+  end
 
-    trait :weapon do
-      item_type { "WeaponGun" }
-      category { "weapon" }
-      component_type { "gun" }
-      size { "S3" }
-    end
-
-    trait :shield do
-      item_type { "Shield" }
-      category { "defense" }
-      component_type { "shield_generator" }
-      size { "S2" }
+  test "rejects a second component with the same sc_key" do
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      Component.create!(name: "Copy", sc_key: "fr66")
     end
   end
 end


### PR DESCRIPTION
A component is one row now, updated in place, with its spec history kept as PaperTrail versions instead of as a row per build.

## What it replaces

Components were keyed on `(sc_key, version)`, so an import never updated a row — it added another. Production is carrying the result:

| version | rows |
|---|---|
| 4.9.0-live.12344265 *(current)* | 7306 |
| 4.8.0-live.11825000 | 7124 |
| 4.7.1-live.11638371 | 6681 |
| 4.7.1-live.11592622 | 6681 |
| 4.7.0-live.11518367 | 6626 |
| *(none)* | 1663 |
| **total** | **36,081** |

That is also why a saved vehicle loadout could end up pointing at a build-specific row, and why `Component.current_version` had to exist at all.

`Commodity` and `Equipment` already work the way this moves `Component` to: one row per `sc_key`, `version` recording the build it was last seen in.

## History without the growth

```ruby
has_paper_trail on: %i[update], only: %i[name description size grade ...]
```

Scoped the way `Model` already does it, and **`version` is deliberately not tracked** — an import touches every component and moves that column on all of them, so recording it would write a history row per component per run and bury the changes worth reading.

## The migration

Collapses the existing rows in three passes following the loader's own lookup order — `sc_key`, then `sc_ref` for rows with no key, then `name` for rows with neither — so what merges is what the loader would now treat as one component. The passes are scoped not to overlap.

The survivor is the row from the current build, falling back to the newest. Everything pointing at the others — `hardpoints`, `model_hardpoints`, `model_hardpoint_loadouts`, `vehicle_loadout_hardpoints`, and `item_prices` — is repointed at it first. A unique index on `sc_key` then stops the table growing back.

**A component the current build no longer ships keeps its row.** Only duplicates of the same component collapse; nothing is dropped for being old, because a saved loadout may still reference it.

## Two bugs worth knowing about

**PaperTrail silently broke the `version` column.** PaperTrail defines a `version` reader, which shadows this table's `version` **column**: `create!` worked, but every `update!` wrote `NULL`. Left in, `current_version` would have matched nothing after the first import. The associations are renamed to `paper_trail_version` / `paper_trail_versions`.

Worth noting for `Commodity` and `Equipment` — both have a `version` column, so the same trap is waiting there if PaperTrail is ever added.

**The survivor ordering picked the wrong row for versionless components.** `ORDER BY (version = 'current') DESC` yields `NULL` for the 1663 rows carrying no version, and Postgres sorts NULLs *first* under `DESC` — so one of those would have beaten the current build. Now `COALESCE(version = 'current', FALSE)`.

That one only surfaced because of the production counts above; it would not have shown up against clean data.

## Verified

Against a fixture built to production's shape — one component across four builds plus a versionless row, a component the current build dropped, and two keyless rows:

- 7 rows → 3
- the current build's row is the survivor, not the versionless one
- the dropped component keeps its row
- prices and sub-hardpoints repointed, orphaned sub-hardpoints removed

Plus tests that a spec change writes a version, that a version-only bump does not, that `sc_key` is now unique, and that the loader updates a past build's row rather than adding another.

`bin/rails test` → 2005 tests, 2 failures + 2 errors, all four pre-existing and unrelated.

## Before merging

Worth running on staging first: the migration ends by creating a **unique** index on `sc_key`, so if production holds duplicates the three passes don't catch, that fails the deploy rather than the migration.

Supersedes #4398, now closed — it pruned rows that should not exist under this model. Its `components.version` index is folded in here, placed after the collapse so it builds over the table that survives.

🤖
