### PR TITLE
fix(sc_data): retire catalogue records a re-imported build no longer ships

### DIFF
--- a/app/api_components/v1/schemas/queries/commodity_query.rb
+++ b/app/api_components/v1/schemas/queries/commodity_query.rb
@@ -13,7 +13,8 @@ module V1
             idIn: {type: :array, items: {type: :string, format: :uuid}},
             nameIn: {type: :array, items: {type: :string}},
             slugIn: {type: :array, items: {type: :string}},
-            commodityTypeIn: {type: :array, items: {type: :string}}
+            commodityTypeIn: {type: :array, items: {type: :string}},
+            currentVersion: {type: :boolean}
           },
           additionalProperties: false,
           example: {}

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -10,16 +10,25 @@ module Api
       def index
         commodities_query_params["sorts"] = "name asc"
 
-        @q = Commodity.ransack(commodities_query_params)
+        # Commodities a later patch stopped shipping are left out unless
+        # currentVersion=false asks for them -- the rows stay so old ledger
+        # entries still resolve, they are just not offered for new ones.
+        @q = Commodity.current_version(current_version).ransack(commodities_query_params)
 
         @commodities = @q.result
           .page(params[:page])
           .per(per_page(Commodity))
       end
 
+      # Taken out of the ransack params rather than left in them: it is a scope,
+      # not a column, and ransack would try to match a `current_version` field.
+      private def current_version
+        commodities_query_params.delete(:current_version) { true }
+      end
+
       private def commodities_query_params
         @commodities_query_params ||= params.permit(q: [
-          :name_cont,
+          :name_cont, :current_version,
           id_in: [], name_in: [], slug_in: [], commodity_type_in: []
         ]).fetch(:q, {})
       end

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -42,6 +42,25 @@ module ScData
         Manufacturer.find_by(sc_ref: ref)
       end
 
+      # A record the export dropped keeps its row -- a ledger entry or a loadout
+      # made against it still has to resolve -- but it must stop claiming a
+      # build it is no longer part of, or `current_version` would go on
+      # offering it.
+      #
+      # Re-importing the same build is what makes this necessary: a new build
+      # leaves the row on its old version, but a reload of the one we are
+      # already on leaves it looking current.
+      #
+      # A run that loaded nothing retires nothing. `where.not(id: [])` is
+      # `1=1`, so an export that failed to sync -- or an environment whose tree
+      # does not carry this catalogue at all -- would otherwise take the whole
+      # of it in one statement.
+      def retire_absent(model, loaded)
+        return if loaded.blank?
+
+        model.where(version: sc_version).where.not(id: loaded).update_all(version: nil)
+      end
+
       def update_cargo_holds(hardpoints, update_params)
         cargo_holds = extract_cargo_holds(hardpoints)
 

--- a/app/lib/sc_data/loader/commodities_loader.rb
+++ b/app/lib/sc_data/loader/commodities_loader.rb
@@ -2,9 +2,9 @@ module ScData
   module Loader
     class CommoditiesLoader < ::ScData::Loader::BaseLoader
       def all
-        load_items("commodities").each do |commodity_data|
-          one(commodity_data)
-        end
+        loaded = load_items("commodities").filter_map { |commodity_data| one(commodity_data)&.id }
+
+        retire_absent(Commodity, loaded)
       end
 
       def one(commodity_data)

--- a/app/lib/sc_data/loader/items_loader.rb
+++ b/app/lib/sc_data/loader/items_loader.rb
@@ -3,6 +3,7 @@ module ScData
     class ItemsLoader < ::ScData::Loader::BaseLoader
       def all
         items = load_items("items").reject { |item| item["category"] == "inventory" }
+        loaded = []
 
         # Pass 1: create/update all components so they exist for cross-references
         items.each do |item|
@@ -67,6 +68,8 @@ module ScData
           update_params[:version] = sc_version
 
           component.update!(update_params)
+
+          loaded << component.id
         end
 
         # Pass 2: link loadouts (all components now exist for cross-references)
@@ -77,6 +80,8 @@ module ScData
           component = find_component(normalized_key, item["key"], item["ref"])
           add_loadout(item, component)
         end
+
+        retire_absent(Component, loaded)
       end
 
       private def add_loadout(item, component)

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -120,6 +120,8 @@ module ScData
 
         items_path = "#{export_path}/#{folder}"
 
+        clear_once(items_path)
+
         FileUtils.mkdir_p(items_path) unless File.directory?(items_path)
 
         items.each do |item|
@@ -129,6 +131,23 @@ module ScData
 
           File.write("#{items_path}/#{file_name}.json", JSON.pretty_generate(item))
         end
+      end
+
+      # Writing is otherwise additive: a record the game files stopped carrying
+      # keeps the file an earlier run wrote for it, and every later step reads
+      # it back as part of the build -- which is what a loader retiring absent
+      # records cannot see past.
+      #
+      # Emptied on the first write of a run rather than per call, because
+      # `items` and `models` are filled by several passes and the later ones
+      # must not wipe the earlier ones. That first write is also past the blank
+      # check, so a pass that parsed nothing leaves what is on disk alone.
+      private def clear_once(items_path)
+        @cleared_paths ||= Set.new
+
+        return unless @cleared_paths.add?(items_path)
+
+        FileUtils.rm_rf(items_path)
       end
 
       private def parse_translations

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -44,6 +44,18 @@ class Commodity < ApplicationRecord
     processed_goods quantum_fuel rmc scrap vice waste
   ].freeze
 
+  # Commodities of past patches stay in the table -- a ledger entry made last
+  # patch still has to resolve its item -- so anything meant for a picker
+  # narrows to the version the game currently ships. Component and Equipment
+  # keep the same scope.
+  scope :current_version, ->(flag = true) {
+    if ActiveModel::Type::Boolean.new.cast(flag)
+      where(version: Rails.configuration.sc_data[:version])
+    else
+      all
+    end
+  }
+
   DEFAULT_SORTING_PARAMS = ["name asc"]
   ALLOWED_SORTING_PARAMS = [
     "name asc", "name desc",
@@ -61,7 +73,7 @@ class Commodity < ApplicationRecord
   end
 
   def self.commodity_types
-    where.not(commodity_type: nil).distinct.order(:commodity_type).pluck(:commodity_type)
+    current_version.where.not(commodity_type: nil).distinct.order(:commodity_type).pluck(:commodity_type)
   end
 
   def self.type_filters

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7869,6 +7869,8 @@ components:
           type: array
           items:
             type: string
+        currentVersion:
+          type: boolean
       additionalProperties: false
       example: {}
       title: CommodityQuery

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     sequence(:sc_key) { |n| "items_commodities_test_#{n}" }
     commodity_type { "metal" }
     description { Faker::Lorem.sentence }
+    version { Rails.configuration.sc_data[:version] }
 
     trait :mineral do
       commodity_type { "mineral" }

--- a/test/integration/api/v1/commodities_test.rb
+++ b/test/integration/api/v1/commodities_test.rb
@@ -60,6 +60,22 @@ class Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /commodities leaves out commodities the current build no longer ships" do
+    create(:commodity, name: "Astatine", version: "0.0.1-live.1")
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body["items"].map { |item| item["name"] }, "Astatine"
+    end
+  end
+
+  test "GET /commodities includes older patches when currentVersion is false" do
+    create(:commodity, name: "Astatine", version: "0.0.1-live.1")
+
+    assert_api_response :get, 200, params: {q: {"currentVersion" => false}} do
+      assert_includes parsed_body["items"].map { |item| item["name"] }, "Astatine"
+    end
+  end
+
   test "GET /commodities exposes the fields the picker needs" do
     assert_api_response :get, 200 do
       gold = parsed_body["items"].find { |item| item["name"] == "Gold" }

--- a/test/loaders/sc_data/base_loader_test.rb
+++ b/test/loaders/sc_data/base_loader_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ScData
+  module Loader
+    class BaseLoaderTest < ActiveSupport::TestCase
+      setup do
+        Commodity.delete_all
+        @loader = ::ScData::Loader::BaseLoader.new
+        @version = Rails.configuration.sc_data[:version]
+      end
+
+      # The row has to stay: a ledger entry made against it still has to
+      # resolve. It just stops claiming a build it is no longer part of.
+      test "#retire_absent clears the build off rows the run did not load" do
+        loaded = create(:commodity, version: @version)
+        dropped = create(:commodity, version: @version)
+
+        @loader.retire_absent(Commodity, [loaded.id])
+
+        assert_equal @version, loaded.reload.version
+        assert_nil dropped.reload.version
+        assert Commodity.exists?(dropped.id), "the row has to stay for existing references"
+      end
+
+      # Only the build being loaded is reconciled. What an earlier build shipped
+      # is history, and rewriting it would lose the build a row was last seen in.
+      test "#retire_absent leaves rows of an earlier build alone" do
+        earlier = create(:commodity, version: "3.24.0")
+
+        @loader.retire_absent(Commodity, [create(:commodity, version: @version).id])
+
+        assert_equal "3.24.0", earlier.reload.version
+      end
+
+      # `where.not(id: [])` is `1=1`, so without this an export that failed to
+      # sync -- or an environment whose tree does not carry the catalogue at all
+      # -- would retire every row claiming the current build in one statement.
+      test "#retire_absent retires nothing when the run loaded nothing" do
+        current = create(:commodity, version: @version)
+
+        @loader.retire_absent(Commodity, [])
+
+        assert_equal @version, current.reload.version
+      end
+    end
+  end
+end

--- a/test/loaders/sc_data/commodities_loader_test.rb
+++ b/test/loaders/sc_data/commodities_loader_test.rb
@@ -63,6 +63,28 @@ module ScData
         assert_equal count, Commodity.count
       end
 
+      # A new build leaves a dropped record on its old version, so
+      # current_version filters it out. Re-importing the build we are already on
+      # does not: the row keeps claiming it, and the picker keeps offering it.
+      test "#all stops a dropped commodity claiming the build it is no longer in" do
+        @loader.all
+
+        retired = create(:commodity, sc_key: "items_commodities_gone", version: Rails.configuration.sc_data[:version])
+
+        @loader.all
+
+        assert Commodity.exists?(retired.id), "the row has to stay for existing references"
+        assert_nil retired.reload.version
+        assert_not Commodity.current_version.exists?(retired.id)
+      end
+
+      test "#all leaves the commodities still in the export on the current build" do
+        @loader.all
+        @loader.all
+
+        assert_operator Commodity.current_version.count, :>=, 160
+      end
+
       test "#all keeps a commodity that already exists without an sc_key" do
         existing = create(:commodity, name: "Gold", sc_key: nil, commodity_type: nil)
 

--- a/test/loaders/sc_data/items_loader_test.rb
+++ b/test/loaders/sc_data/items_loader_test.rb
@@ -35,6 +35,22 @@ module ScData
         # The same row, carrying the build it has now been seen in.
         assert_equal Rails.configuration.sc_data[:version], stale.reload.version
       end
+
+      # A new build leaves a dropped component on its old version, so
+      # current_version filters it out. Re-importing the build we are already on
+      # does not: the row keeps claiming it, and every picker keeps offering it.
+      test "#all stops a dropped component claiming the build it is no longer in" do
+        ::ScData::Loader::ItemsLoader.new.all
+
+        retired = create(:component, sc_key: "gone_from_the_export", version: Rails.configuration.sc_data[:version])
+        kept = Component.where.not(id: retired.id).where(version: Rails.configuration.sc_data[:version]).first
+
+        ::ScData::Loader::ItemsLoader.new.all
+
+        assert Component.exists?(retired.id), "the row has to stay for the loadouts pointing at it"
+        assert_nil retired.reload.version
+        assert_equal Rails.configuration.sc_data[:version], kept.reload.version
+      end
     end
   end
 end

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -71,4 +71,22 @@ class CommodityTest < ActiveSupport::TestCase
 
     assert_equal %w[gas metal], Commodity.commodity_types
   end
+
+  # A type nothing in the current build carries is a filter that returns
+  # nothing, so the options follow the same scope the list does.
+  test "leaves a type only past builds carry out of the filter options" do
+    create(:commodity, commodity_type: "metal")
+    create(:commodity, commodity_type: "vice", version: "0.0.1-live.1")
+
+    assert_equal %w[metal], Commodity.commodity_types
+  end
+
+  test "narrows to the build the game currently ships" do
+    current = create(:commodity)
+    dropped = create(:commodity, version: "0.0.1-live.1")
+
+    assert_includes Commodity.current_version, current
+    assert_not_includes Commodity.current_version, dropped
+    assert_includes Commodity.current_version(false), dropped
+  end
 end

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module ScData
+  module Parser
+    class BaseParserTest < ActiveSupport::TestCase
+      setup do
+        @base_folder = Dir.mktmpdir
+        @export_path = "#{@base_folder}/parsed/test"
+
+        # The only file the constructor insists on.
+        FileUtils.mkdir_p("#{@base_folder}/raw/1.0.0/Data/Localization/english")
+        File.write("#{@base_folder}/raw/1.0.0/Data/Localization/english/global.ini", "")
+
+        @parser = ::ScData::Parser::BaseParser.new(
+          base_folder: @base_folder, sc_version: "1.0.0", sc_environment: "test"
+        )
+      end
+
+      teardown do
+        FileUtils.remove_entry(@base_folder)
+      end
+
+      # Without this the file survives every later parse, the loader keeps
+      # reading it as part of the build, and nothing downstream can tell it
+      # apart from a record the game files still carry.
+      test "#save_items drops the file of a record the run no longer parses" do
+        write_parsed("items", "gone")
+
+        @parser.send(:save_items, [{key: "kept"}], folder: "items")
+
+        assert_equal ["kept.json"], parsed_files("items")
+      end
+
+      # `items` and `models` are filled by several passes, so clearing per call
+      # would leave only whatever the last pass wrote.
+      test "#save_items keeps what an earlier pass of the same run wrote" do
+        @parser.send(:save_items, [{key: "first"}], folder: "items")
+        @parser.send(:save_items, [{key: "second"}], folder: "items")
+
+        assert_equal ["first.json", "second.json"], parsed_files("items")
+      end
+
+      test "#save_items leaves the folder alone when a pass parsed nothing" do
+        write_parsed("items", "kept")
+
+        @parser.send(:save_items, [], folder: "items")
+
+        assert_equal ["kept.json"], parsed_files("items")
+      end
+
+      test "#save_items clears each folder on its own first write" do
+        write_parsed("items", "gone")
+        write_parsed("models", "also_gone")
+
+        @parser.send(:save_items, [{key: "kept"}], folder: "items")
+        @parser.send(:save_items, [{key: "kept_model"}], folder: "models")
+
+        assert_equal ["kept.json"], parsed_files("items")
+        assert_equal ["kept_model.json"], parsed_files("models")
+      end
+
+      private def write_parsed(folder, name)
+        FileUtils.mkdir_p("#{@export_path}/#{folder}")
+        File.write("#{@export_path}/#{folder}/#{name}.json", "{}")
+      end
+
+      private def parsed_files(folder)
+        Dir.children("#{@export_path}/#{folder}").sort
+      end
+    end
+  end
+end


### PR DESCRIPTION
Greptile's finding on #4396 was that a re-imported build leaves gear the export dropped still claiming that build. It was right, and it was never only about equipment: the same loader shape backs commodities and components.

## The mechanism, and where it stops working

`version` records the build a record was last seen in, and `current_version` narrows a list to the build the game currently ships. Across builds that reconciles removals by itself — a record the export drops keeps its old stamp and falls out. Re-importing the build we are already on is where it breaks: the row already carries that build, the loader only ever writes the keys the export still carries, so nothing takes the stamp back off.

The pass is shared in `BaseLoader` rather than written per loader, because the guard it needs is easy to leave out:

```
SELECT "equipment".* FROM "equipment" WHERE "equipment"."version" = '4.2.1' AND 1=1
```

`where.not(id: [])` is `1=1`. A run that parsed nothing — a failed sync, or an environment whose tree does not carry the catalogue at all — would retire the whole of it in one statement, silently, until a good import ran. That is not hypothetical here: of the three parsed trees, only `live` carries `commodities` and `equipment`; `live-preview` carries neither and `probe` carries nothing. Verified by removing the guard, at which point the equipment catalogue goes from 4775 rows to 0.

Rows are never deleted. A ledger entry or a loadout pointing at one still has to resolve; they just stop being offered for new ones.

## Commodities were the bigger gap

`Commodity` has carried a `version` column all along and nothing read it. There is no `current_version` scope and no filtering in the controller, so the picker from #4386 has been offering every commodity the app has ever parsed, including ones dropped patches ago. That is the same bug Greptile flagged, except not as an edge case.

It gets the scope Component and Equipment already have, and the type filter options follow the same scope so a filter cannot come back empty.

> **The commodities list now defaults to the current build.** `q[currentVersion]=false` asks for the rest, matching what #4396 does for equipment. The endpoint is public, so this is a visible change for anything reading it directly — in this codebase only the inventory picker does.

## The layer above it

Reconciling in the loader is not enough on its own, which Greptile pointed out on #4396 once the loader pass was in: parsing was additive on disk too. `save_items` only ever created the folder and wrote into it, so a record CIG removed kept the JSON an earlier run had written, the next import read it back, and it was stamped with the current build again. The loader cannot see past that — as far as it is concerned the record is still in the export.

Each folder is now emptied on the first write of a run. Once, because `items` and `models` are filled by several passes and a later pass must not wipe an earlier one; and only after the blank check, so a pass that parsed nothing leaves what is on disk alone. Both halves are asserted, and both assertions fail without the fix.

> **The first parse run after this lands will delete stale files.** That is the point, but it means a data diff larger than the patch itself, and it is worth reading rather than committing blind.

## Follow-up

#4396 carries its own private `retire` in `EquipmentLoader`, written before this one. Whichever of the two lands second should collapse it into `retire_absent` — the behaviour is the same, minus the empty-run guard, which #4396 has since picked up separately.

## Testing

`bin/rails test` → 2015 tests, 2 failures + 2 errors, all four pre-existing and unrelated (2 WebMock blocking `vite-test/entrypoints/email.scss`, 2 order-dependent short-link redirects that pass in isolation). `standardrb` clean.

🤖
