### PR TITLE
feat(admin): admin notifications and notification center

### DIFF
--- a/app/api_components/admin/v1/schemas/admin_notification.rb
+++ b/app/api_components/admin/v1/schemas/admin_notification.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminNotification
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            notificationType: {"$ref": "#/components/schemas/AdminNotificationTypeEnum"},
+            severity: {"$ref": "#/components/schemas/AdminNotificationSeverityEnum"},
+            title: {type: :string},
+            body: {type: :string},
+            link: {type: :string},
+            icon: {type: :string},
+            occurrences: {type: :integer},
+            lastOccurredAt: {type: :string, format: "date-time"},
+            read: {type: :boolean},
+            readAt: {type: :string, format: "date-time"},
+            expiresAt: {type: :string, format: "date-time"},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id notificationType severity title occurrences lastOccurredAt read expiresAt createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/admin_notification_unread_count.rb
+++ b/app/api_components/admin/v1/schemas/admin_notification_unread_count.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminNotificationUnreadCount
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            count: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[count]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/admin_notifications.rb
+++ b/app/api_components/admin/v1/schemas/admin_notifications.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminNotifications < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/AdminNotification"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
@@ -13,6 +13,7 @@ module Admin
               notificationTypeEq: {"$ref": "#/components/schemas/AdminNotificationTypeEnum"},
               severityEq: {"$ref": "#/components/schemas/AdminNotificationSeverityEnum"},
               readAtNull: {type: :boolean},
+              searchCont: {type: :string},
               sorts: {anyOf: [{
                 type: :array, items: {"$ref": "#/components/schemas/AdminNotificationSortEnum"}
               }, {

--- a/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class AdminNotificationQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              notificationTypeEq: {"$ref": "#/components/schemas/AdminNotificationTypeEnum"},
+              severityEq: {"$ref": "#/components/schemas/AdminNotificationSeverityEnum"},
+              readAtNull: {type: :boolean},
+              sorts: {anyOf: [{
+                type: :array, items: {"$ref": "#/components/schemas/AdminNotificationSortEnum"}
+              }, {
+                "$ref": "#/components/schemas/AdminNotificationSortEnum"
+              }]}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/enums/admin_notification_severity_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/admin_notification_severity_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Enums
+        class AdminNotificationSeverityEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::AdminNotification.severities.keys,
+            "x-enumNames": ::AdminNotification.severities.keys.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/enums/admin_notification_type_enum.rb
+++ b/app/api_components/shared/v1/schemas/enums/admin_notification_type_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Enums
+        class AdminNotificationTypeEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::AdminNotification.notification_types.keys,
+            "x-enumNames": ::AdminNotification.notification_types.keys.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/sorts/admin_notification_sort_enum.rb
+++ b/app/api_components/shared/v1/schemas/sorts/admin_notification_sort_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Sorts
+        class AdminNotificationSortEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::AdminNotification::ALLOWED_SORTING_PARAMS,
+            "x-enumNames": ::AdminNotification::ALLOWED_SORTING_PARAMS.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/channels/admin_notifications_channel.rb
+++ b/app/channels/admin_notifications_channel.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AdminNotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    return reject if current_admin_user.blank?
+
+    stream_for current_admin_user
+  end
+
+  def unsubscribed
+    stop_all_streams
+  end
+end

--- a/app/controllers/admin/api/v1/notifications_controller.rb
+++ b/app/controllers/admin/api/v1/notifications_controller.rb
@@ -11,10 +11,14 @@ module Admin
         def index
           authorize! with: ::Admin::NotificationPolicy
 
-          notification_query_params["sorts"] = sorting_params(AdminNotification, notification_query_params["sorts"])
+          notification_query_params["sorts"] = unread_first(
+            sorting_params(AdminNotification, notification_query_params["sorts"])
+          )
 
           @q = scope.ransack(notification_query_params)
-          @notifications = @q.result(distinct: true)
+          # No distinct: nothing here joins, and SELECT DISTINCT cannot order by
+          # the computed `unread` expression.
+          @notifications = @q.result
             .page(params[:page])
             .per(per_page(AdminNotification))
         end
@@ -65,9 +69,14 @@ module Admin
           @notification = scope.find(params[:id])
         end
 
+        # The requested sort only orders within the unread and read groups.
+        private def unread_first(sorts)
+          ["unread desc", *Array(sorts)]
+        end
+
         private def notification_query_params
           @notification_query_params ||= params.permit(q: [
-            :notification_type_eq, :severity_eq, :read_at_null, :sorts, sorts: []
+            :notification_type_eq, :severity_eq, :read_at_null, :search_cont, :sorts, sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/notifications_controller.rb
+++ b/app/controllers/admin/api/v1/notifications_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class NotificationsController < ::Admin::Api::BaseController
+        after_action -> { pagination_header(:notifications) }, only: %i[index]
+
+        before_action :set_notification, only: %i[read destroy]
+
+        def index
+          authorize! with: ::Admin::NotificationPolicy
+
+          notification_query_params["sorts"] = sorting_params(AdminNotification, notification_query_params["sorts"])
+
+          @q = scope.ransack(notification_query_params)
+          @notifications = @q.result(distinct: true)
+            .page(params[:page])
+            .per(per_page(AdminNotification))
+        end
+
+        def unread_count
+          authorize! with: ::Admin::NotificationPolicy
+
+          @unread_count = scope.unread.count
+        end
+
+        def read
+          authorize! @notification, with: ::Admin::NotificationPolicy
+
+          @notification.mark_as_read!
+
+          render :show
+        end
+
+        def read_all
+          authorize! with: ::Admin::NotificationPolicy
+
+          scope.unread.update_all(read_at: Time.current, updated_at: Time.current)
+
+          head :no_content
+        end
+
+        def destroy
+          authorize! @notification, with: ::Admin::NotificationPolicy
+
+          @notification.destroy!
+
+          head :no_content
+        end
+
+        def destroy_all
+          authorize! with: ::Admin::NotificationPolicy
+
+          scope.delete_all
+
+          head :no_content
+        end
+
+        private def scope
+          authorized_scope(AdminNotification.all, with: ::Admin::NotificationPolicy).active
+        end
+
+        private def set_notification
+          @notification = scope.find(params[:id])
+        end
+
+        private def notification_query_params
+          @notification_query_params ||= params.permit(q: [
+            :notification_type_eq, :severity_eq, :read_at_null, :sorts, sorts: []
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/frontend/admin/components/Navigation/index.vue
+++ b/app/frontend/admin/components/Navigation/index.vue
@@ -10,6 +10,7 @@ import logo from "@/images/admin/favicons/favicon.png";
 import AppNavigation from "@/shared/components/AppNavigation/index.vue";
 import AppNavigationItems from "@/shared/components/AppNavigation/Items/index.vue";
 import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
+import AdminNotificationsNav from "@/admin/components/Notifications/index.vue";
 import { routes } from "@/admin/pages/routes";
 import { storeToRefs } from "pinia";
 import { useSessionStore } from "@/admin/stores/session";
@@ -61,6 +62,7 @@ const hasAccessTo = (access?: string[]) => {
         :has-access-to="hasAccessTo"
       />
       <template v-if="isAuthenticated && currentUser">
+        <AdminNotificationsNav :authenticated="isAuthenticated" />
         <NavItem
           :action="logout"
           menu-key="logout"

--- a/app/frontend/admin/components/Notifications/FilterForm/index.vue
+++ b/app/frontend/admin/components/Notifications/FilterForm/index.vue
@@ -6,6 +6,8 @@ export default {
 
 <script lang="ts" setup>
 import RadioList from "@/shared/components/base/RadioList/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import { InputSizesEnum } from "@/shared/components/base/FormInput/types";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
@@ -19,6 +21,7 @@ const { t } = useI18n();
 
 const prefillFormValues = () => {
   return {
+    searchCont: filters.value.searchCont,
     notificationTypeEq: filters.value.notificationTypeEq,
     severityEq: filters.value.severityEq,
     readAtNull: filters.value.readAtNull,
@@ -68,6 +71,18 @@ watch(
 
 <template>
   <form @submit.prevent="handleSubmit">
+    <Teleport to="#header-left">
+      <FormInput
+        v-model="form.searchCont"
+        :size="InputSizesEnum.MEDIUM"
+        name="search"
+        translation-key="filters.adminNotifications.search"
+        :no-label="true"
+        :clearable="true"
+        inline
+      />
+    </Teleport>
+
     <RadioList
       v-model="form.readAtNull"
       :label="t('labels.adminNotifications.status')"

--- a/app/frontend/admin/components/Notifications/FilterForm/index.vue
+++ b/app/frontend/admin/components/Notifications/FilterForm/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import RadioList from "@/shared/components/base/RadioList/index.vue";
+import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import { InputSizesEnum } from "@/shared/components/base/FormInput/types";
 import Btn from "@/shared/components/base/Btn/index.vue";
@@ -99,12 +100,12 @@ watch(
       name="severityEq"
     />
 
-    <RadioList
+    <FilterGroup
       v-model="form.notificationTypeEq"
       :label="t('labels.adminNotifications.type')"
-      :reset-label="t('labels.all')"
       :options="typeOptions"
       name="notificationTypeEq"
+      :no-label="true"
     />
 
     <br />

--- a/app/frontend/admin/components/Notifications/FilterForm/index.vue
+++ b/app/frontend/admin/components/Notifications/FilterForm/index.vue
@@ -1,0 +1,101 @@
+<script lang="ts">
+export default {
+  name: "AdminNotificationsFilterForm",
+};
+</script>
+
+<script lang="ts" setup>
+import RadioList from "@/shared/components/base/RadioList/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  type AdminNotificationQuery,
+  AdminNotificationSeverityEnum,
+  AdminNotificationTypeEnum,
+} from "@/services/fyAdminApi";
+import { useAdminNotificationFilters } from "@/admin/composables/useAdminNotificationFilters";
+
+const { t } = useI18n();
+
+const prefillFormValues = () => {
+  return {
+    notificationTypeEq: filters.value.notificationTypeEq,
+    severityEq: filters.value.severityEq,
+    readAtNull: filters.value.readAtNull,
+  };
+};
+
+const setupForm = () => {
+  form.value = prefillFormValues();
+};
+
+const { filter, resetFilter, isFilterSelected, filters } =
+  useAdminNotificationFilters(setupForm);
+
+const form = ref<AdminNotificationQuery>(prefillFormValues());
+
+const typeOptions = Object.values(AdminNotificationTypeEnum).map((value) => ({
+  value,
+  label: t(`labels.adminNotifications.types.${value}`),
+}));
+
+const severityOptions = Object.values(AdminNotificationSeverityEnum).map(
+  (value) => ({
+    value,
+    label: t(`labels.adminNotifications.severities.${value}`),
+  }),
+);
+
+const unreadOptions = [
+  {
+    value: "true",
+    label: t("labels.adminNotifications.unreadOnly"),
+  },
+];
+
+const handleSubmit = () => {
+  filter(form.value);
+};
+
+watch(
+  () => form.value,
+  () => {
+    filter(form.value);
+  },
+  { deep: true },
+);
+</script>
+
+<template>
+  <form @submit.prevent="handleSubmit">
+    <RadioList
+      v-model="form.readAtNull"
+      :label="t('labels.adminNotifications.status')"
+      :reset-label="t('labels.all')"
+      :options="unreadOptions"
+      name="readAtNull"
+    />
+
+    <RadioList
+      v-model="form.severityEq"
+      :label="t('labels.adminNotifications.severity')"
+      :reset-label="t('labels.all')"
+      :options="severityOptions"
+      name="severityEq"
+    />
+
+    <RadioList
+      v-model="form.notificationTypeEq"
+      :label="t('labels.adminNotifications.type')"
+      :reset-label="t('labels.all')"
+      :options="typeOptions"
+      name="notificationTypeEq"
+    />
+
+    <br />
+    <Btn :disabled="!isFilterSelected" :block="true" @click="resetFilter">
+      <i class="fa-light fa-times" />
+      {{ t("actions.resetFilter") }}
+    </Btn>
+  </form>
+</template>

--- a/app/frontend/admin/components/Notifications/index.vue
+++ b/app/frontend/admin/components/Notifications/index.vue
@@ -1,0 +1,113 @@
+<script lang="ts">
+export default {
+  name: "AdminNotificationsNav",
+};
+</script>
+
+<script lang="ts" setup>
+import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useRouter } from "vue-router";
+import {
+  useAdminNotifications as useAdminNotificationsQuery,
+  useAdminNotificationsUnreadCount as useAdminNotificationsUnreadCountQuery,
+  readAllAdminNotifications,
+  type AdminNotification,
+} from "@/services/fyAdminApi";
+import { useAdminNotificationUpdates } from "@/admin/composables/useAdminNotificationUpdates";
+
+const RECENT_LIMIT = 5;
+
+type Props = {
+  authenticated?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  authenticated: false,
+});
+
+const { t } = useI18n();
+
+const router = useRouter();
+
+const enabled = computed(() => props.authenticated);
+
+const { invalidate } = useAdminNotificationUpdates(enabled);
+
+const { data: unreadCount } = useAdminNotificationsUnreadCountQuery({
+  query: { enabled, refetchInterval: 60_000 },
+});
+
+const recentParams = computed(() => ({
+  perPage: String(RECENT_LIMIT),
+  q: { readAtNull: true },
+}));
+
+const { data: recentNotifications } = useAdminNotificationsQuery(recentParams, {
+  query: { enabled },
+});
+
+const recent = computed(() => recentNotifications.value?.items || []);
+
+const badge = computed(() => unreadCount.value?.count || 0);
+
+const open = async (notification: AdminNotification) => {
+  if (notification.link) {
+    await router.push(notification.link);
+    return;
+  }
+
+  await router.push({ name: "admin-notifications" });
+};
+
+const markAllRead = async () => {
+  await readAllAdminNotifications();
+
+  invalidate();
+};
+</script>
+
+<template>
+  <NavItem
+    menu-key="admin-notifications"
+    :label="t('nav.admin.notifications.index')"
+    icon="fa-duotone fa-bell"
+    :badge="badge"
+    submenu-direction="up"
+  >
+    <template #submenu>
+      <li v-if="!recent.length" class="admin-notifications__empty">
+        {{ t("labels.adminNotifications.empty") }}
+      </li>
+      <NavItem
+        v-for="notification in recent"
+        :key="notification.id"
+        :menu-key="notification.id"
+        :label="notification.title"
+        :icon="notification.icon"
+        :action="() => open(notification)"
+      />
+      <NavItem
+        v-if="badge"
+        menu-key="admin-notifications-read-all"
+        :label="t('labels.adminNotifications.readAll')"
+        icon="fa-duotone fa-check-double"
+        :action="markAllRead"
+      />
+      <NavItem
+        menu-key="admin-notifications-all"
+        :label="t('labels.adminNotifications.showAll')"
+        icon="fa-duotone fa-list"
+        :to="{ name: 'admin-notifications' }"
+      />
+    </template>
+  </NavItem>
+</template>
+
+<style lang="scss" scoped>
+.admin-notifications__empty {
+  padding: 10px 15px;
+  color: $gray-lighter;
+  font-size: 0.9em;
+}
+</style>

--- a/app/frontend/admin/components/Notifications/index.vue
+++ b/app/frontend/admin/components/Notifications/index.vue
@@ -7,16 +7,8 @@ export default {
 <script lang="ts" setup>
 import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
-import { useRouter } from "vue-router";
-import {
-  useAdminNotifications as useAdminNotificationsQuery,
-  useAdminNotificationsUnreadCount as useAdminNotificationsUnreadCountQuery,
-  readAllAdminNotifications,
-  type AdminNotification,
-} from "@/services/fyAdminApi";
+import { useAdminNotificationsUnreadCount as useAdminNotificationsUnreadCountQuery } from "@/services/fyAdminApi";
 import { useAdminNotificationUpdates } from "@/admin/composables/useAdminNotificationUpdates";
-
-const RECENT_LIMIT = 5;
 
 type Props = {
   authenticated?: boolean;
@@ -28,43 +20,15 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { t } = useI18n();
 
-const router = useRouter();
-
 const enabled = computed(() => props.authenticated);
 
-const { invalidate } = useAdminNotificationUpdates(enabled);
+useAdminNotificationUpdates(enabled);
 
 const { data: unreadCount } = useAdminNotificationsUnreadCountQuery({
   query: { enabled, refetchInterval: 60_000 },
 });
 
-const recentParams = computed(() => ({
-  perPage: String(RECENT_LIMIT),
-  q: { readAtNull: true },
-}));
-
-const { data: recentNotifications } = useAdminNotificationsQuery(recentParams, {
-  query: { enabled },
-});
-
-const recent = computed(() => recentNotifications.value?.items || []);
-
 const badge = computed(() => unreadCount.value?.count || 0);
-
-const open = async (notification: AdminNotification) => {
-  if (notification.link) {
-    await router.push(notification.link);
-    return;
-  }
-
-  await router.push({ name: "admin-notifications" });
-};
-
-const markAllRead = async () => {
-  await readAllAdminNotifications();
-
-  invalidate();
-};
 </script>
 
 <template>
@@ -73,41 +37,6 @@ const markAllRead = async () => {
     :label="t('nav.admin.notifications.index')"
     icon="fa-duotone fa-bell"
     :badge="badge"
-    submenu-direction="up"
-  >
-    <template #submenu>
-      <li v-if="!recent.length" class="admin-notifications__empty">
-        {{ t("labels.adminNotifications.empty") }}
-      </li>
-      <NavItem
-        v-for="notification in recent"
-        :key="notification.id"
-        :menu-key="notification.id"
-        :label="notification.title"
-        :icon="notification.icon"
-        :action="() => open(notification)"
-      />
-      <NavItem
-        v-if="badge"
-        menu-key="admin-notifications-read-all"
-        :label="t('labels.adminNotifications.readAll')"
-        icon="fa-duotone fa-check-double"
-        :action="markAllRead"
-      />
-      <NavItem
-        menu-key="admin-notifications-all"
-        :label="t('labels.adminNotifications.showAll')"
-        icon="fa-duotone fa-list"
-        :to="{ name: 'admin-notifications' }"
-      />
-    </template>
-  </NavItem>
+    :to="{ name: 'admin-notifications' }"
+  />
 </template>
-
-<style lang="scss" scoped>
-.admin-notifications__empty {
-  padding: 10px 15px;
-  color: $gray-lighter;
-  font-size: 0.9em;
-}
-</style>

--- a/app/frontend/admin/composables/useAdminNotificationFilters.ts
+++ b/app/frontend/admin/composables/useAdminNotificationFilters.ts
@@ -1,0 +1,10 @@
+import { type AdminNotificationQuery } from "@/services/fyAdminApi";
+import { useFilters } from "@/shared/composables/useFilters";
+
+export const useAdminNotificationFilters = (
+  updateCallback?: (() => void) | (() => Promise<void>),
+) => {
+  return useFilters<AdminNotificationQuery>({
+    updateCallback,
+  });
+};

--- a/app/frontend/admin/composables/useAdminNotificationUpdates.ts
+++ b/app/frontend/admin/composables/useAdminNotificationUpdates.ts
@@ -1,0 +1,31 @@
+import { type Ref } from "vue";
+import { useQueryClient } from "@tanstack/vue-query";
+import {
+  useSubscription,
+  ChannelsEnum,
+} from "@/shared/composables/useSubscription";
+import {
+  getAdminNotificationsQueryKey,
+  getAdminNotificationsUnreadCountQueryKey,
+} from "@/services/fyAdminApi";
+
+export const useAdminNotificationUpdates = (enabled: Ref<boolean>) => {
+  const queryClient = useQueryClient();
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: getAdminNotificationsQueryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: getAdminNotificationsUnreadCountQueryKey(),
+    });
+  };
+
+  useSubscription({
+    channelName: ChannelsEnum.ADMIN_NOTIFICATIONS,
+    received: invalidate,
+    enabled,
+  });
+
+  return { invalidate };
+};

--- a/app/frontend/admin/composables/useAdminNotificationUpdates.ts
+++ b/app/frontend/admin/composables/useAdminNotificationUpdates.ts
@@ -4,12 +4,15 @@ import {
   useSubscription,
   ChannelsEnum,
 } from "@/shared/composables/useSubscription";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import {
   getAdminNotificationsQueryKey,
   getAdminNotificationsUnreadCountQueryKey,
+  type AdminNotification,
+  AdminNotificationSeverityEnum,
 } from "@/services/fyAdminApi";
 
-export const useAdminNotificationUpdates = (enabled: Ref<boolean>) => {
+export const useAdminNotificationInvalidation = () => {
   const queryClient = useQueryClient();
 
   const invalidate = () => {
@@ -21,9 +24,48 @@ export const useAdminNotificationUpdates = (enabled: Ref<boolean>) => {
     });
   };
 
+  return { invalidate };
+};
+
+// Subscribe once, from the navigation: the invalidation is global, so a page
+// listing notifications refreshes off this subscription too, and a second one
+// would only double every toast.
+export const useAdminNotificationUpdates = (enabled: Ref<boolean>) => {
+  const { invalidate } = useAdminNotificationInvalidation();
+
+  const { displayInfo, displayWarning, displayAlert } = useAppNotifications();
+
+  const announce = (notification: AdminNotification) => {
+    // No timeout: a report that arrives while nobody is looking is the whole
+    // point of the notification center, so the toast waits to be clicked away,
+    // and that click lands in the center rather than only dismissing it.
+    const message = {
+      text: notification.title,
+      timeout: false as const,
+      to: { name: "admin-notifications" },
+    };
+
+    switch (notification.severity) {
+      case AdminNotificationSeverityEnum.ERROR:
+        displayAlert(message);
+        break;
+      case AdminNotificationSeverityEnum.WARNING:
+        displayWarning(message);
+        break;
+      default:
+        displayInfo(message);
+    }
+  };
+
+  const received = (data: string) => {
+    invalidate();
+
+    announce(JSON.parse(data) as AdminNotification);
+  };
+
   useSubscription({
     channelName: ChannelsEnum.ADMIN_NOTIFICATIONS,
-    received: invalidate,
+    received,
     enabled,
   });
 

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -19,7 +19,7 @@ import { usePagination } from "@/shared/composables/usePagination";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useAdminNotificationFilters } from "@/admin/composables/useAdminNotificationFilters";
-import { useAdminNotificationUpdates } from "@/admin/composables/useAdminNotificationUpdates";
+import { useAdminNotificationInvalidation } from "@/admin/composables/useAdminNotificationUpdates";
 import {
   useAdminNotifications as useAdminNotificationsQuery,
   getAdminNotificationsQueryKey,
@@ -66,7 +66,7 @@ const {
   ...asyncStatus
 } = useAdminNotificationsQuery(queryParams);
 
-const { invalidate } = useAdminNotificationUpdates(ref(true));
+const { invalidate } = useAdminNotificationInvalidation();
 
 watch(
   () => sorts.value,

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -1,0 +1,334 @@
+<script lang="ts">
+export default {
+  name: "AdminNotificationsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import FilterForm from "@/admin/components/Notifications/FilterForm/index.vue";
+import { usePagination } from "@/shared/composables/usePagination";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useAdminNotificationFilters } from "@/admin/composables/useAdminNotificationFilters";
+import { useAdminNotificationUpdates } from "@/admin/composables/useAdminNotificationUpdates";
+import {
+  useAdminNotifications as useAdminNotificationsQuery,
+  getAdminNotificationsQueryKey,
+  readAdminNotification,
+  readAllAdminNotifications,
+  destroyAdminNotification,
+  destroyAllAdminNotifications,
+  type AdminNotification,
+  type AdminNotificationSortEnum,
+  AdminNotificationSeverityEnum,
+} from "@/services/fyAdminApi";
+
+const { t, l } = useI18n();
+const { displaySuccess, displayAlert } = useAppNotifications();
+
+const route = useRoute();
+
+const sorts = computed((): AdminNotificationSortEnum[] => {
+  return route.query.s ? [route.query.s as AdminNotificationSortEnum] : [];
+});
+
+const queryKey = computed(() =>
+  getAdminNotificationsQueryKey(queryParams.value),
+);
+
+const { perPage, page, updatePerPage } = usePagination(queryKey);
+
+const { filters, isFilterSelected } = useAdminNotificationFilters(async () => {
+  await refetch();
+});
+
+const queryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+  q: {
+    ...filters.value,
+    sorts: sorts.value,
+  },
+}));
+
+const {
+  data: notifications,
+  refetch,
+  ...asyncStatus
+} = useAdminNotificationsQuery(queryParams);
+
+const { invalidate } = useAdminNotificationUpdates(ref(true));
+
+watch(
+  () => sorts.value,
+  async () => {
+    await refetch();
+  },
+);
+
+const columns: BaseTableCol<AdminNotification>[] = [
+  {
+    name: "severity",
+    label: "Severity",
+    width: "120px",
+    alignment: "center",
+  },
+  {
+    name: "title",
+    label: "Notification",
+    flexGrow: 1,
+  },
+  {
+    name: "type",
+    label: "Type",
+    mobile: false,
+    width: "220px",
+  },
+  {
+    name: "createdAt",
+    label: "Created at",
+    mobile: false,
+    sortable: true,
+    width: "200px",
+  },
+];
+
+const expanded = ref<string[]>([]);
+
+const isExpanded = (notification: AdminNotification) =>
+  expanded.value.includes(notification.id);
+
+const toggle = (notification: AdminNotification) => {
+  if (isExpanded(notification)) {
+    expanded.value = expanded.value.filter((id) => id !== notification.id);
+    return;
+  }
+
+  expanded.value = [...expanded.value, notification.id];
+};
+
+const severityVariant = (severity: AdminNotification["severity"]) => {
+  switch (severity) {
+    case AdminNotificationSeverityEnum.ERROR:
+      return "danger";
+    case AdminNotificationSeverityEnum.WARNING:
+      return "warning";
+    default:
+      return "default";
+  }
+};
+
+const withFeedback = async (
+  action: () => Promise<unknown>,
+  message: string,
+) => {
+  try {
+    await action();
+    invalidate();
+    displaySuccess({ text: message });
+  } catch {
+    displayAlert({ text: t("messages.adminNotifications.error") });
+  }
+};
+
+const markRead = (notification: AdminNotification) =>
+  withFeedback(
+    () => readAdminNotification(notification.id),
+    t("messages.adminNotifications.read"),
+  );
+
+const markAllRead = () =>
+  withFeedback(
+    () => readAllAdminNotifications(),
+    t("messages.adminNotifications.readAll"),
+  );
+
+const destroy = (notification: AdminNotification) =>
+  withFeedback(
+    () => destroyAdminNotification(notification.id),
+    t("messages.adminNotifications.destroyed"),
+  );
+
+const destroyAll = () =>
+  withFeedback(
+    () => destroyAllAdminNotifications(),
+    t("messages.adminNotifications.destroyedAll"),
+  );
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.notifications.index") }}
+    <HeadingSmall v-if="notifications">
+      {{
+        t("headlines.pagination.count", {
+          current: notifications?.items.length,
+          total: notifications?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <Teleport to="#header-right">
+    <Btn
+      :size="BtnSizesEnum.MD"
+      :aria-label="t('actions.adminNotifications.readAll')"
+      mobile-icon-only
+      @click="markAllRead"
+    >
+      <i class="fa-duotone fa-check-double" />
+      {{ t("actions.adminNotifications.readAll") }}
+    </Btn>
+    <Btn
+      :size="BtnSizesEnum.MD"
+      :aria-label="t('actions.adminNotifications.destroyAll')"
+      :tone="BtnTonesEnum.DANGER"
+      mobile-icon-only
+      @click="destroyAll"
+    >
+      <i class="fa-duotone fa-trash" />
+      {{ t("actions.adminNotifications.destroyAll") }}
+    </Btn>
+  </Teleport>
+
+  <FilteredList
+    name="admin-notifications"
+    :records="notifications?.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+    :is-filter-selected="isFilterSelected"
+  >
+    <template #filter>
+      <FilterForm />
+    </template>
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="notifications?.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+        default-sort="createdAt desc"
+      >
+        <template #col-severity="{ record }">
+          <BasePill :variant="severityVariant(record.severity)" uppercase>
+            {{ t(`labels.adminNotifications.severities.${record.severity}`) }}
+          </BasePill>
+        </template>
+        <template #col-title="{ record }">
+          <div
+            class="admin-notification-title"
+            :class="{ 'admin-notification-title--unread': !record.read }"
+          >
+            <button
+              v-if="record.body"
+              type="button"
+              class="admin-notification-toggle"
+              @click="toggle(record)"
+            >
+              <i
+                :class="
+                  isExpanded(record)
+                    ? 'fa-duotone fa-chevron-down'
+                    : 'fa-duotone fa-chevron-right'
+                "
+              />
+            </button>
+            <span>{{ record.title }}</span>
+            <span
+              v-if="record.occurrences > 1"
+              class="admin-notification-count"
+            >
+              &times;{{ record.occurrences }}
+            </span>
+            <router-link v-if="record.link" :to="record.link">
+              <i class="fa-duotone fa-arrow-up-right-from-square" />
+            </router-link>
+          </div>
+          <pre v-if="isExpanded(record)" class="admin-notification-body">{{
+            record.body
+          }}</pre>
+        </template>
+        <template #col-type="{ record }">
+          {{ t(`labels.adminNotifications.types.${record.notificationType}`) }}
+        </template>
+        <template #col-createdAt="{ record }">
+          {{ l(record.createdAt, "datetime.formats.short") }}
+        </template>
+        <template #actions="{ record }">
+          <Btn v-if="!record.read" @click.prevent="markRead(record)">
+            <i class="fa-duotone fa-check" />
+            {{ t("actions.adminNotifications.read") }}
+          </Btn>
+          <Btn :tone="BtnTonesEnum.DANGER" @click.prevent="destroy(record)">
+            <i class="fa-duotone fa-trash" />
+            {{ t("actions.delete") }}
+          </Btn>
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-top>
+      <Paginator
+        v-if="notifications"
+        :query-result-ref="notifications"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="notifications"
+        :query-result-ref="notifications"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>
+
+<style lang="scss" scoped>
+.admin-notification-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &--unread {
+    font-weight: bold;
+  }
+}
+
+.admin-notification-toggle {
+  padding: 0;
+  color: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.admin-notification-count {
+  color: $gray-lighter;
+  font-size: 0.85em;
+}
+
+.admin-notification-body {
+  margin: 8px 0 0;
+  padding: 10px;
+  max-height: 320px;
+  overflow: auto;
+  color: $text-color;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  background-color: rgba($gray-darker, 0.6);
+  border-radius: $border-radius-base;
+}
+</style>

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -192,6 +192,7 @@ const destroyAll = () =>
       :size="BtnSizesEnum.MD"
       :aria-label="t('actions.adminNotifications.destroyAll')"
       :tone="BtnTonesEnum.DANGER"
+      :confirm="t('messages.confirm.adminNotifications.destroyAll')"
       mobile-icon-only
       @click="destroyAll"
     >

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -10,9 +10,13 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
-import BaseTable from "@/shared/components/base/Table/index.vue";
-import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import {
+  PanelTonesEnum,
+  PanelVariantsEnum,
+} from "@/shared/components/base/Panel/types";
 import BasePill from "@/shared/components/base/Pill/index.vue";
+import Markdown from "@/shared/components/Markdown/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import FilterForm from "@/admin/components/Notifications/FilterForm/index.vue";
 import { usePagination } from "@/shared/composables/usePagination";
@@ -40,6 +44,15 @@ const route = useRoute();
 const sorts = computed((): AdminNotificationSortEnum[] => {
   return route.query.s ? [route.query.s as AdminNotificationSortEnum] : [];
 });
+
+const oldestFirst = computed(() => route.query.s === "createdAt asc");
+
+const sortLink = computed(() => ({
+  query: {
+    ...route.query,
+    s: oldestFirst.value ? undefined : "createdAt asc",
+  },
+}));
 
 const queryKey = computed(() =>
   getAdminNotificationsQueryKey(queryParams.value),
@@ -75,33 +88,6 @@ watch(
   },
 );
 
-const columns: BaseTableCol<AdminNotification>[] = [
-  {
-    name: "severity",
-    label: "Severity",
-    width: "120px",
-    alignment: "center",
-  },
-  {
-    name: "title",
-    label: "Notification",
-    flexGrow: 1,
-  },
-  {
-    name: "type",
-    label: "Type",
-    mobile: false,
-    width: "220px",
-  },
-  {
-    name: "createdAt",
-    label: "Created at",
-    mobile: false,
-    sortable: true,
-    width: "200px",
-  },
-];
-
 const expanded = ref<string[]>([]);
 
 const isExpanded = (notification: AdminNotification) =>
@@ -124,6 +110,17 @@ const severityVariant = (severity: AdminNotification["severity"]) => {
       return "warning";
     default:
       return "default";
+  }
+};
+
+const severityTone = (severity: AdminNotification["severity"]) => {
+  switch (severity) {
+    case AdminNotificationSeverityEnum.ERROR:
+      return PanelTonesEnum.ERROR;
+    case AdminNotificationSeverityEnum.WARNING:
+      return PanelTonesEnum.HIGHLIGHT;
+    default:
+      return PanelTonesEnum.NEUTRAL;
   }
 };
 
@@ -205,78 +202,135 @@ const destroyAll = () =>
     name="admin-notifications"
     :records="notifications?.items || []"
     :async-status="asyncStatus"
-    hide-loading
-    hide-empty
     :is-filter-selected="isFilterSelected"
   >
     <template #filter>
       <FilterForm />
     </template>
-    <template #default="{ loading, refetching, emptyVisible }">
-      <BaseTable
-        :records="notifications?.items || []"
-        primary-key="id"
-        :columns="columns"
-        :loading="loading || refetching"
-        :empty-visible="emptyVisible"
-        default-sort="createdAt desc"
-      >
-        <template #col-severity="{ record }">
-          <BasePill :variant="severityVariant(record.severity)" uppercase>
-            {{ t(`labels.adminNotifications.severities.${record.severity}`) }}
-          </BasePill>
-        </template>
-        <template #col-title="{ record }">
-          <div
-            class="admin-notification-title"
-            :class="{ 'admin-notification-title--unread': !record.read }"
+    <template #actions-left>
+      <Btn :to="sortLink" route-active-class="">
+        <i
+          :class="
+            oldestFirst
+              ? 'fa-duotone fa-arrow-down-short-wide'
+              : 'fa-duotone fa-arrow-up-wide-short'
+          "
+        />
+        {{
+          oldestFirst
+            ? t("actions.adminNotifications.sortNewest")
+            : t("actions.adminNotifications.sortOldest")
+        }}
+      </Btn>
+    </template>
+    <template #default="{ records }">
+      <TransitionGroup tag="ul" name="fade-list" class="admin-notifications">
+        <li
+          v-for="notification in records"
+          :key="notification.id"
+          class="fade-list-item"
+        >
+          <Panel
+            :variant="PanelVariantsEnum.SLIM"
+            :tone="severityTone(notification.severity)"
+            :outer-spacing="false"
           >
-            <button
-              v-if="record.body"
-              type="button"
-              class="admin-notification-toggle"
-              @click="toggle(record)"
+            <div
+              class="admin-notification"
+              :class="{
+                'admin-notification--unread': !notification.read,
+              }"
             >
               <i
-                :class="
-                  isExpanded(record)
-                    ? 'fa-duotone fa-chevron-down'
-                    : 'fa-duotone fa-chevron-right'
-                "
+                class="admin-notification__icon"
+                :class="notification.icon || 'fa-duotone fa-bell'"
               />
-            </button>
-            <span>{{ record.title }}</span>
-            <span
-              v-if="record.occurrences > 1"
-              class="admin-notification-count"
-            >
-              &times;{{ record.occurrences }}
-            </span>
-            <router-link v-if="record.link" :to="record.link">
-              <i class="fa-duotone fa-arrow-up-right-from-square" />
-            </router-link>
-          </div>
-          <pre v-if="isExpanded(record)" class="admin-notification-body">{{
-            record.body
-          }}</pre>
-        </template>
-        <template #col-type="{ record }">
-          {{ t(`labels.adminNotifications.types.${record.notificationType}`) }}
-        </template>
-        <template #col-createdAt="{ record }">
-          {{ l(record.createdAt, "datetime.formats.short") }}
-        </template>
-        <template #actions="{ record }">
-          <Btn v-if="!record.read" @click.prevent="markRead(record)">
-            <i class="fa-duotone fa-check" />
-            {{ t("actions.adminNotifications.read") }}
-          </Btn>
-          <Btn :tone="BtnTonesEnum.DANGER" @click.prevent="destroy(record)">
-            <i class="fa-duotone fa-trash" />
-            {{ t("actions.delete") }}
-          </Btn>
-        </template>
-      </BaseTable>
+              <div class="admin-notification__content">
+                <div class="admin-notification__title">
+                  <span>{{ notification.title }}</span>
+                  <span
+                    v-if="notification.occurrences > 1"
+                    class="admin-notification__count"
+                  >
+                    &times;{{ notification.occurrences }}
+                  </span>
+                </div>
+                <div class="admin-notification__meta">
+                  <BasePill
+                    v-if="
+                      notification.severity !==
+                      AdminNotificationSeverityEnum.INFO
+                    "
+                    :variant="severityVariant(notification.severity)"
+                    uppercase
+                  >
+                    {{
+                      t(
+                        `labels.adminNotifications.severities.${notification.severity}`,
+                      )
+                    }}
+                  </BasePill>
+                  <span>
+                    {{
+                      t(
+                        `labels.adminNotifications.types.${notification.notificationType}`,
+                      )
+                    }}
+                  </span>
+                  <span>{{
+                    l(notification.createdAt, "datetime.formats.short")
+                  }}</span>
+                </div>
+                <Markdown
+                  v-if="isExpanded(notification)"
+                  class="admin-notification__body"
+                  :source="notification.body || ''"
+                />
+              </div>
+              <div class="admin-notification__actions">
+                <Btn
+                  v-if="notification.body"
+                  v-tooltip="
+                    isExpanded(notification)
+                      ? t('actions.hideDetails')
+                      : t('actions.showDetails')
+                  "
+                  @click="toggle(notification)"
+                >
+                  <i
+                    :class="
+                      isExpanded(notification)
+                        ? 'fa-duotone fa-chevron-up'
+                        : 'fa-duotone fa-chevron-down'
+                    "
+                  />
+                </Btn>
+                <Btn
+                  v-if="notification.link"
+                  v-tooltip="t('actions.open')"
+                  :to="notification.link"
+                >
+                  <i class="fa-duotone fa-arrow-up-right-from-square" />
+                </Btn>
+                <Btn
+                  v-if="!notification.read"
+                  v-tooltip="t('actions.adminNotifications.read')"
+                  @click="markRead(notification)"
+                >
+                  <i class="fa-duotone fa-check" />
+                </Btn>
+                <Btn
+                  v-tooltip="t('actions.delete')"
+                  :tone="BtnTonesEnum.DANGER"
+                  @click="destroy(notification)"
+                >
+                  <i class="fa-duotone fa-trash" />
+                </Btn>
+              </div>
+            </div>
+          </Panel>
+        </li>
+      </TransitionGroup>
     </template>
     <template #pagination-top>
       <Paginator
@@ -298,37 +352,101 @@ const destroyAll = () =>
 </template>
 
 <style lang="scss" scoped>
-.admin-notification-title {
+.admin-notifications {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  // Matches the margin a Panel carries by itself, which the list turns off in
+  // favour of its own gap - without it the bottom paginator sits flush.
+  margin: 0 0 21px;
+  padding: 0;
+  list-style: none;
+}
+
+// Rows change place under you - marking one read sorts it out of the unread
+// group - so the list slides rather than jumping. The shared `fade-list`
+// classes still carry Vue 2 names, hence the local ones.
+.fade-list-enter-active,
+.fade-list-leave-active,
+.fade-list-move {
+  transition:
+    opacity 200ms ease,
+    transform 250ms ease;
+}
+
+.fade-list-enter-from,
+.fade-list-leave-to {
+  opacity: 0;
+}
+
+// Out of flow, so the rows below close the gap while it fades.
+.fade-list-leave-active {
+  position: absolute;
+  width: 100%;
+}
+
+.admin-notification {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+  padding: 14px 16px;
+}
+
+.admin-notification__icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: $gray-lighter;
+  font-size: 1.3em;
+}
+
+.admin-notification--unread .admin-notification__icon {
+  color: var(--color-primary, #{$primary});
+}
+
+.admin-notification__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.admin-notification__title {
   display: flex;
   align-items: center;
   gap: 8px;
-
-  &--unread {
-    font-weight: bold;
-  }
 }
 
-.admin-notification-toggle {
-  padding: 0;
-  color: inherit;
-  background: none;
-  border: 0;
-  cursor: pointer;
+.admin-notification--unread .admin-notification__title {
+  font-weight: bold;
 }
 
-.admin-notification-count {
+.admin-notification__count {
   color: $gray-lighter;
   font-size: 0.85em;
 }
 
-.admin-notification-body {
-  margin: 8px 0 0;
-  padding: 10px;
+.admin-notification__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+  color: $gray-lighter;
+  font-size: 0.85em;
+}
+
+.admin-notification__actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 5px;
+}
+
+.admin-notification__body {
+  margin: 10px 0 0;
+  padding: 10px 12px;
   max-height: 320px;
   overflow: auto;
   color: $text-color;
-  font-size: 0.85em;
-  white-space: pre-wrap;
+  font-size: 0.9em;
   background-color: rgba($gray-darker, 0.6);
   border-radius: $border-radius-base;
 }

--- a/app/frontend/admin/pages/routes.ts
+++ b/app/frontend/admin/pages/routes.ts
@@ -159,6 +159,17 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "/notifications",
+    name: "admin-notifications",
+    component: () => import("@/admin/pages/notifications.vue"),
+    meta: {
+      title: "admin.notifications.index",
+      needsAuthentication: true,
+      icon: "fa-duotone fa-bell",
+      nav: "hidden",
+    },
+  },
+  {
     path: "/login/",
     name: "admin-login",
     component: () => import("@/admin/pages/login.vue"),

--- a/app/frontend/admin/types/routes.ts
+++ b/app/frontend/admin/types/routes.ts
@@ -11,6 +11,7 @@ type AdminSimpleRoutes =
   | "home"
   | "admin-images"
   | "admin-maintenance"
+  | "admin-notifications"
   | "admin-login"
   | "404"
   // Models

--- a/app/frontend/entrypoints/email.scss
+++ b/app/frontend/entrypoints/email.scss
@@ -313,6 +313,66 @@ p {
   font-family: "Orbitron", sans-serif;
 }
 
+.report-period {
+  margin-top: -8px;
+  color: darken($global-font-color, 20%);
+  font-size: 0.85em;
+}
+
+.report-section {
+  margin-top: 24px;
+  margin-bottom: 4px;
+  color: $global-font-color;
+  font-weight: bold;
+  font-size: 1em;
+  font-family: "Orbitron", sans-serif;
+}
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 6px 8px;
+    border-bottom: 1px solid rgba(200, 200, 200, 0.12);
+    font-size: 0.9em;
+  }
+
+  th {
+    color: darken($global-font-color, 25%);
+    font-weight: normal;
+    font-size: 0.75em;
+    text-transform: uppercase;
+  }
+}
+
+.report-label {
+  text-align: left;
+}
+
+.report-number {
+  width: 90px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.report-muted {
+  color: darken($global-font-color, 25%);
+}
+
+.report-delta-positive {
+  color: #5cb85c;
+}
+
+.report-delta-negative {
+  color: #d9534f;
+}
+
+.report-delta-neutral {
+  color: darken($global-font-color, 25%);
+}
+
 @media (prefers-color-scheme: dark) {
   body,
   html,

--- a/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.scss
+++ b/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.scss
@@ -15,6 +15,26 @@
     overflow-wrap: anywhere;
   }
 
+  .nav-item-badge {
+    min-width: 20px;
+    margin-inline-start: auto;
+    padding: 0 6px;
+    font-size: 11px;
+    font-weight: bold;
+    line-height: 18px;
+    text-align: center;
+    color: #fff;
+    background-color: $danger;
+    border-radius: 10px;
+
+    &--dot {
+      position: absolute;
+      top: -4px;
+      inset-inline-start: 10px;
+      margin-inline-start: 0;
+    }
+  }
+
   .nav-item-prefix {
     min-width: 30px;
     font-family: "Major Mono Display", monospace;

--- a/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.test.ts
+++ b/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.test.ts
@@ -1,0 +1,39 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+import { setActivePinia, createPinia } from "pinia";
+
+describe("NavItemInner", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  const mount = (props: Record<string, unknown>) =>
+    mountWithDefaults<typeof Component>(Component, {
+      props: { label: "Notifications", icon: "fa-duotone fa-bell", ...props },
+    });
+
+  it("hides the badge at zero", async () => {
+    const wrapper = await mount({ badge: 0 });
+
+    expect(wrapper.find(".nav-item-badge").exists()).toBe(false);
+  });
+
+  it("renders the badge count", async () => {
+    const wrapper = await mount({ badge: 3 });
+
+    expect(wrapper.find(".nav-item-badge").text()).toBe("3");
+  });
+
+  it("caps the badge at 99+", async () => {
+    const wrapper = await mount({ badge: 250 });
+
+    expect(wrapper.find(".nav-item-badge").text()).toBe("99+");
+  });
+
+  it("moves the badge onto the icon when slim", async () => {
+    const wrapper = await mount({ badge: 3, slim: true });
+
+    expect(wrapper.find(".nav-item-badge--dot").exists()).toBe(true);
+  });
+});

--- a/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.vue
+++ b/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.vue
@@ -11,6 +11,7 @@ type Props = {
   image?: string;
   slim?: boolean;
   avatar?: boolean;
+  badge?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -19,10 +20,19 @@ const props = withDefaults(defineProps<Props>(), {
   image: undefined,
   slim: false,
   avatar: false,
+  badge: 0,
 });
 
 const firstLetter = computed(() => {
   return props.label?.charAt(0);
+});
+
+const badgeLabel = computed(() => {
+  if (!props.badge) {
+    return undefined;
+  }
+
+  return props.badge > 99 ? "99+" : String(props.badge);
 });
 </script>
 
@@ -50,9 +60,18 @@ const firstLetter = computed(() => {
       <span v-else class="nav-item-image-empty">
         {{ firstLetter }}
       </span>
+      <span
+        v-if="badgeLabel && slim"
+        class="nav-item-badge nav-item-badge--dot"
+      >
+        {{ badgeLabel }}
+      </span>
     </span>
     <span v-if="!slim" class="nav-item-text">
       {{ label }}
+    </span>
+    <span v-if="badgeLabel && !slim" class="nav-item-badge">
+      {{ badgeLabel }}
     </span>
   </div>
 </template>

--- a/app/frontend/shared/components/AppNavigation/NavItem/index.vue
+++ b/app/frontend/shared/components/AppNavigation/NavItem/index.vue
@@ -27,6 +27,7 @@ type Props = {
   prefix?: string;
   submenuActive?: boolean;
   submenuDirection?: string;
+  badge?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -43,6 +44,7 @@ const props = withDefaults(defineProps<Props>(), {
   prefix: undefined,
   submenuActive: false,
   submenuDirection: "down",
+  badge: 0,
 });
 
 const open = ref(false);
@@ -149,6 +151,7 @@ const toggleMenu = () => {
           :image="image"
           :avatar="avatar"
           :slim="slim"
+          :badge="badge"
         />
         <span
           v-if="!slim"
@@ -187,6 +190,7 @@ const toggleMenu = () => {
           :image="image"
           :avatar="avatar"
           :slim="slim"
+          :badge="badge"
         />
       </slot>
     </a>
@@ -216,6 +220,7 @@ const toggleMenu = () => {
             :image="image"
             :avatar="avatar"
             :slim="slim"
+            :badge="badge"
           />
         </slot>
       </a>
@@ -237,6 +242,7 @@ const toggleMenu = () => {
           :image="image"
           :avatar="avatar"
           :slim="slim"
+          :badge="badge"
         />
       </slot>
     </a>
@@ -256,6 +262,7 @@ const toggleMenu = () => {
           :image="image"
           :avatar="avatar"
           :slim="slim"
+          :badge="badge"
         />
       </slot>
     </span>

--- a/app/frontend/shared/components/AppNotifications/Message/index.vue
+++ b/app/frontend/shared/components/AppNotifications/Message/index.vue
@@ -28,8 +28,18 @@ const messageClasses = computed(() => {
 
 const notificationsStore = useNotificationsStore();
 
+const router = useRouter();
+
 const hideMessage = () => {
   notificationsStore.hideMessage(props.message.id);
+};
+
+const handleClick = async () => {
+  hideMessage();
+
+  if (props.message.to) {
+    await router.push(props.message.to);
+  }
 };
 
 const component = computed(() => {
@@ -58,7 +68,7 @@ onMounted(() => {
     class="app-notifications__message"
     :class="messageClasses"
     :data-test="`notification-${type}`"
-    @click="hideMessage"
+    @click="handleClick"
   >
     <component :is="component" v-if="component" v-bind="componentProps" />
     <MessageBody v-else :text="message.text" />

--- a/app/frontend/shared/components/AppNotifications/types.ts
+++ b/app/frontend/shared/components/AppNotifications/types.ts
@@ -5,6 +5,8 @@ export enum MessageTypesEnum {
   ALERT = "alert",
 }
 
+import { type RouteLocationRaw } from "vue-router";
+
 export type AppNotification = {
   id: string;
   type: MessageTypesEnum;
@@ -17,4 +19,6 @@ export type AppNotification = {
   timeout?: number | false;
   background?: boolean;
   icon?: string;
+  // Where clicking the message takes you, on top of dismissing it.
+  to?: RouteLocationRaw;
 };

--- a/app/frontend/shared/components/Markdown/index.test.ts
+++ b/app/frontend/shared/components/Markdown/index.test.ts
@@ -1,0 +1,51 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+
+describe("Markdown", () => {
+  const mount = (source: string) =>
+    mountWithDefaults<typeof Component>(Component, { props: { source } });
+
+  it("renders headings two levels down", async () => {
+    const wrapper = await mount("## Missing Models (2)");
+
+    expect(wrapper.find("h4").text()).toBe("Missing Models (2)");
+  });
+
+  it("groups consecutive items into one list", async () => {
+    const wrapper = await mount("- **Aurora MR**\n- Carrack");
+
+    expect(wrapper.findAll("ul")).toHaveLength(1);
+    expect(wrapper.findAll("li")).toHaveLength(2);
+    expect(wrapper.find("li strong").text()).toBe("Aurora MR");
+  });
+
+  it("renders inline code", async () => {
+    const wrapper = await mount("Add it to `MAPPINGS`.");
+
+    expect(wrapper.find("code").text()).toBe("MAPPINGS");
+  });
+
+  it("splits paragraphs on blank lines", async () => {
+    const wrapper = await mount("First report.\n\nSecond report.");
+
+    expect(wrapper.findAll("p")).toHaveLength(2);
+  });
+
+  it("escapes html in the source", async () => {
+    const wrapper = await mount("<img src=x onerror=alert(1)>");
+
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.text()).toContain("<img src=x onerror=alert(1)>");
+  });
+
+  it("links only http and same-origin targets", async () => {
+    const wrapper = await mount(
+      "[report](https://fleetyards.net) and [nope](javascript:alert(1))",
+    );
+
+    expect(wrapper.find("a").attributes("href")).toBe("https://fleetyards.net");
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    expect(wrapper.text()).toContain("[nope](javascript:alert(1))");
+  });
+});

--- a/app/frontend/shared/components/Markdown/index.vue
+++ b/app/frontend/shared/components/Markdown/index.vue
@@ -1,0 +1,145 @@
+<script lang="ts">
+export default {
+  name: "BaseMarkdown",
+};
+</script>
+
+<script lang="ts" setup>
+// Renders the markdown subset our own generated report bodies use: ATX
+// headings, unordered lists, paragraphs, bold, inline code and inline links.
+// Anything else is passed through as text. Everything is HTML-escaped before a
+// single tag is added, so the result is safe to hand to v-html.
+
+type Props = {
+  source?: string;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  source: "",
+});
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+// Anything but http(s) and same-origin paths - javascript: above all - stays
+// text rather than becoming an href.
+const safeHref = (url: string) => /^(https?:\/\/|\/)/.test(url);
+
+const renderInline = (value: string) =>
+  escapeHtml(value)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, label, url: string) =>
+      safeHref(url)
+        ? `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`
+        : match,
+    );
+
+const html = computed(() => {
+  const blocks: string[] = [];
+
+  let list: string[] = [];
+  let paragraph: string[] = [];
+
+  const flushList = () => {
+    if (!list.length) return;
+
+    blocks.push(`<ul>${list.map((item) => `<li>${item}</li>`).join("")}</ul>`);
+    list = [];
+  };
+
+  const flushParagraph = () => {
+    if (!paragraph.length) return;
+
+    blocks.push(`<p>${paragraph.join("<br>")}</p>`);
+    paragraph = [];
+  };
+
+  props.source.split("\n").forEach((line) => {
+    const trimmed = line.trim();
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(trimmed);
+
+    if (heading) {
+      flushList();
+      flushParagraph();
+
+      const level = Math.min(heading[1].length + 2, 6);
+      blocks.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+      return;
+    }
+
+    const item = /^[-*]\s+(.*)$/.exec(trimmed);
+
+    if (item) {
+      flushParagraph();
+      list.push(renderInline(item[1]));
+      return;
+    }
+
+    if (!trimmed) {
+      flushList();
+      flushParagraph();
+      return;
+    }
+
+    flushList();
+    paragraph.push(renderInline(trimmed));
+  });
+
+  flushList();
+  flushParagraph();
+
+  return blocks.join("");
+});
+</script>
+
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -- escaped above, see renderInline -->
+  <div class="markdown" v-html="html" />
+</template>
+
+<style lang="scss" scoped>
+.markdown {
+  :deep(h3),
+  :deep(h4),
+  :deep(h5),
+  :deep(h6) {
+    margin: 12px 0 6px;
+    font-size: 1em;
+    font-weight: bold;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  :deep(p) {
+    margin: 0 0 8px;
+  }
+
+  :deep(ul) {
+    margin: 0 0 8px;
+    padding-left: 18px;
+  }
+
+  :deep(li) {
+    margin: 2px 0;
+  }
+
+  :deep(code) {
+    padding: 1px 4px;
+    font-size: 0.9em;
+    background-color: rgba($gray-darker, 0.8);
+    border-radius: $border-radius-base;
+  }
+
+  :deep(:last-child) {
+    margin-bottom: 0;
+  }
+}
+</style>

--- a/app/frontend/shared/components/base/RadioList/index.scss
+++ b/app/frontend/shared/components/base/RadioList/index.scss
@@ -10,6 +10,9 @@ $color2: #3197ee;
 
   &__wrapper {
     display: flex;
+    // Items are nowrap by themselves, so without this a list of more than a
+    // few options runs straight out of a filter sidebar.
+    flex-wrap: wrap;
     gap: 15px;
     align-items: center;
   }

--- a/app/frontend/shared/composables/useSubscription.ts
+++ b/app/frontend/shared/composables/useSubscription.ts
@@ -16,6 +16,7 @@ export enum ChannelsEnum {
   FLEET_VEHICLES = "FleetVehiclesChannel",
   NOTIFICATIONS = "NotificationsChannel",
   USER_NOTIFICATIONS = "UserNotificationsChannel",
+  ADMIN_NOTIFICATIONS = "AdminNotificationsChannel",
 }
 
 export const useSubscription = ({

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -275,7 +275,9 @@
       "adminNotifications": {
         "read": "Mark as read",
         "readAll": "Mark all as read",
-        "destroyAll": "Delete all"
+        "destroyAll": "Delete all",
+        "sortOldest": "Oldest first",
+        "sortNewest": "Newest first"
       }
     }
   }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -271,6 +271,11 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory"
+      },
+      "adminNotifications": {
+        "read": "Mark as read",
+        "readAll": "Mark all as read",
+        "destroyAll": "Delete all"
       }
     }
   }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -134,6 +134,9 @@
         },
         "imports": {
           "index": "Imports"
+        },
+        "notifications": {
+          "index": "Notifications"
         }
       },
       "welcome": "Welcome to",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1381,6 +1381,9 @@
           "startedAtGteq": "Started from",
           "startedAtLteq": "Started until"
         },
+        "adminNotifications": {
+          "search": "Search"
+        },
         "images": {
           "station": "Station",
           "model": "Ship"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1707,9 +1707,6 @@
       },
       "hangarInventories": "Inventories",
       "adminNotifications": {
-        "empty": "Nothing open",
-        "showAll": "Show all",
-        "readAll": "Mark all as read",
         "unreadOnly": "Unread only",
         "status": "Status",
         "severity": "Severity",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1705,7 +1705,32 @@
         "qualityRange": "Quality",
         "stockItem": "Stock Item"
       },
-      "hangarInventories": "Inventories"
+      "hangarInventories": "Inventories",
+      "adminNotifications": {
+        "empty": "Nothing open",
+        "showAll": "Show all",
+        "readAll": "Mark all as read",
+        "unreadOnly": "Unread only",
+        "status": "Status",
+        "severity": "Severity",
+        "type": "Type",
+        "severities": {
+          "info": "Info",
+          "warning": "Warning",
+          "error": "Error"
+        },
+        "types": {
+          "paints_import": "Paints Import",
+          "modules_import": "Modules Import",
+          "loaner_sync": "Loaner Sync",
+          "uex_prices_import": "UEX Price Sync",
+          "uex_commodity_prices_import": "UEX Commodity Sync",
+          "new_supporter": "New Supporter",
+          "rsi_api_blocked": "RSI API Blocked",
+          "rsi_api_unblocked": "RSI API Restored",
+          "weekly_stats": "Weekly Report"
+        }
+      }
     }
   }
 }

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -395,6 +395,9 @@
         "adminFleet": {
           "destroy": "Are you sure you want to delete this fleet? This action can't be reverted."
         },
+        "adminNotifications": {
+          "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted."
+        },
         "adminDestroyedFleet": {
           "restore": "Are you sure you want to restore this fleet?",
           "restorePurged": "Are you sure you want to restore this purged fleet? Restoring is best-effort: roles, images, invite links and fleet vehicles are not restored."

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -512,6 +512,13 @@
             "confirm": "Delete this item and all %{count} of its entries? This cannot be undone."
           }
         }
+      },
+      "adminNotifications": {
+        "read": "Notification marked as read",
+        "readAll": "All notifications marked as read",
+        "destroyed": "Notification deleted",
+        "destroyedAll": "All notifications deleted",
+        "error": "Something went wrong"
       }
     }
   }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -197,6 +197,9 @@
           "index": "Funding Goals",
           "new": "New Funding Goal",
           "edit": "Edit Funding Goal"
+        },
+        "notifications": {
+          "index": "Notifications"
         }
       }
     }

--- a/app/frontend/translations/en/placeholders.json
+++ b/app/frontend/translations/en/placeholders.json
@@ -230,6 +230,9 @@
           "startedAtGteq": "2026-01-01",
           "startedAtLteq": "2026-12-31"
         },
+        "adminNotifications": {
+          "search": "Title or content..."
+        },
         "users": {
           "search": "Username or Email",
           "username": "Username",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -190,6 +190,9 @@
         "images": {
           "index": "Images"
         },
+        "notifications": {
+          "index": "Notifications"
+        },
         "maintenance": {
           "index": "Maintenance",
           "pghero": "PgHero",

--- a/app/helpers/admin_report_helper.rb
+++ b/app/helpers/admin_report_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AdminReportHelper
+  def admin_report_metric_value(metric)
+    admin_report_format_value(metric.current, metric.format)
+  end
+
+  def admin_report_previous_value(metric)
+    return unless metric.comparable?
+
+    admin_report_format_value(metric.previous, metric.format)
+  end
+
+  def admin_report_delta(metric)
+    delta = metric.delta
+    return if delta.nil? || delta.zero?
+
+    "#{delta.positive? ? "+" : "-"}#{admin_report_format_value(delta.abs, metric.format)}"
+  end
+
+  # Growth is not universally good — more failed imports or lost supporters are
+  # the same arrow pointing the wrong way, so the metric decides its own polarity.
+  def admin_report_delta_class(metric)
+    delta = metric.delta
+    return "neutral" if delta.nil? || delta.zero?
+
+    improving = AdminWeeklyReport::LOWER_IS_BETTER.include?(metric.key) ? delta.negative? : delta.positive?
+
+    improving ? "positive" : "negative"
+  end
+
+  private def admin_report_format_value(value, format)
+    case format
+    when :currency then Kernel.format("%.2f EUR", value.to_f / 100)
+    else number_with_delimiter(value)
+    end
+  end
+end

--- a/app/jobs/cleanup/notifications_job.rb
+++ b/app/jobs/cleanup/notifications_job.rb
@@ -4,6 +4,7 @@ module Cleanup
   class NotificationsJob < ::Cleanup::BaseJob
     def perform
       Notification.expired.in_batches(of: 1000).delete_all
+      AdminNotification.expired.in_batches(of: 1000).delete_all
     end
   end
 end

--- a/app/jobs/loaders/loaner_job.rb
+++ b/app/jobs/loaders/loaner_job.rb
@@ -15,18 +15,20 @@ module Loaders
 
       Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
 
-      if missing_loaners.present? || missing_models.present?
-        body = missing_loaners_body(missing_loaners, missing_models)
+      actionable = missing_loaners.present? || missing_models.present?
 
-        GithubIssueCreator.new(
-          task_type: "loaner_sync",
-          title: "Missing Loaners",
-          body:
-        ).run
-      end
+      AdminReport.deliver(
+        task_type: "loaner_sync",
+        # The resolve-loaners-import skill finds its issue by this title.
+        title: actionable ? "Missing Loaners" : "Loaner Sync Results",
+        body: missing_loaners_body(missing_loaners, missing_models),
+        actionable:
+      )
     end
 
     private def missing_loaners_body(missing_loaners, missing_models)
+      return "No missing Loaners or Models found" if missing_loaners.blank? && missing_models.blank?
+
       lines = []
 
       if missing_models.present?

--- a/app/jobs/loaders/modules_import_job.rb
+++ b/app/jobs/loaders/modules_import_job.rb
@@ -9,11 +9,13 @@ module Loaders
 
       results = ::ModulesImporter.new.run
 
-      GithubIssueCreator.new(
+      AdminReport.deliver(
         task_type: "modules_import",
         title: "Modules Import Results",
-        body: ::ModulesImporter.github_issue_body(results)
-      ).run
+        body: ::ModulesImporter.github_issue_body(results),
+        actionable: ::ModulesImporter.actionable?(results),
+        record: import
+      )
 
       import.finish!
     rescue => e

--- a/app/jobs/loaders/paints_import_job.rb
+++ b/app/jobs/loaders/paints_import_job.rb
@@ -9,11 +9,13 @@ module Loaders
 
       results = ::PaintsImporter.new.run
 
-      GithubIssueCreator.new(
+      AdminReport.deliver(
         task_type: "paints_import",
         title: "Paints Import Results",
-        body: ::PaintsImporter.github_issue_body(results)
-      ).run
+        body: ::PaintsImporter.github_issue_body(results),
+        actionable: ::PaintsImporter.actionable?(results),
+        record: import
+      )
 
       import.finish!
     rescue => e

--- a/app/jobs/loaders/uex_commodity_prices_job.rb
+++ b/app/jobs/loaders/uex_commodity_prices_job.rb
@@ -12,21 +12,24 @@ module Loaders
       mapping = ::Uex::CommodityMapper.new.run
       result = ::Uex::CommodityPriceSyncer.new.run
 
-      if mapping.unmapped.present?
-        GithubIssueCreator.new(
-          task_type: "uex_commodity_prices_import",
-          title: "UEX Commodity Sync — Unmapped Commodities",
-          body: ::Uex::CommodityMapper.github_issue_body(mapping)
-        ).run
-      end
+      unmapped = mapping.unmapped.present?
+      unknown = result.unknown.present?
 
-      if result.unknown.present?
-        GithubIssueCreator.new(
-          task_type: "uex_commodity_prices_import",
-          title: "UEX Commodity Sync — Priced Commodities We Do Not Carry",
-          body: ::Uex::CommodityPriceSyncer.github_issue_body(result)
-        ).run
-      end
+      AdminReport.deliver(
+        task_type: "uex_commodity_prices_import",
+        title: unmapped ? "UEX Commodity Sync — Unmapped Commodities" : "UEX Commodity Mapping Results",
+        body: ::Uex::CommodityMapper.github_issue_body(mapping),
+        actionable: unmapped,
+        record: import
+      )
+
+      AdminReport.deliver(
+        task_type: "uex_commodity_prices_import",
+        title: unknown ? "UEX Commodity Sync — Priced Commodities We Do Not Carry" : "UEX Commodity Price Sync Results",
+        body: ::Uex::CommodityPriceSyncer.github_issue_body(result),
+        actionable: unknown,
+        record: import
+      )
 
       import.update!(
         output: {

--- a/app/jobs/loaders/uex_prices_job.rb
+++ b/app/jobs/loaders/uex_prices_job.rb
@@ -9,13 +9,15 @@ module Loaders
 
       result = ::Uex::PriceSyncer.new.run
 
-      if result.unmatched.present?
-        GithubIssueCreator.new(
-          task_type: "uex_prices_import",
-          title: "UEX Price Sync — Unmatched Vehicles",
-          body: ::Uex::PriceSyncer.github_issue_body(result)
-        ).run
-      end
+      unmatched = result.unmatched.present?
+
+      AdminReport.deliver(
+        task_type: "uex_prices_import",
+        title: unmatched ? "UEX Price Sync — Unmatched Vehicles" : "UEX Price Sync Results",
+        body: ::Uex::PriceSyncer.github_issue_body(result),
+        actionable: unmatched,
+        record: import
+      )
 
       import.update!(
         output: {

--- a/app/jobs/notifications/admin_job.rb
+++ b/app/jobs/notifications/admin_job.rb
@@ -3,15 +3,38 @@
 module Notifications
   class AdminJob < ::Notifications::BaseJob
     def perform
-      stats = {
-        registrations: User.where(created_at: (1.week.ago)..Time.zone.now).size,
-        ships: Model.where(created_at: (1.week.ago)..Time.zone.now).size,
-        vehicles: Vehicle.where(loaner: false, wanted: false, created_at: (1.week.ago)..Time.zone.now).size,
-        wishes: Vehicle.where(loaner: false, wanted: true, created_at: (1.week.ago)..Time.zone.now).size,
-        fleets: Fleet.where(created_at: (1.week.ago)..Time.zone.now).size
-      }
+      report = AdminWeeklyReport.build
 
-      AdminMailer.weekly(stats).deliver_later
+      AdminUser.where(super_admin: true).find_each do |admin_user|
+        AdminMailer.weekly(admin_user, report).deliver_later
+      end
+
+      AdminNotification.notify!(
+        type: :weekly_stats,
+        title: I18n.t(:"mailer.admin.weekly.headline"),
+        body: notification_body(report),
+        link: "/"
+      )
+    end
+
+    private def notification_body(report)
+      report[:sections].flat_map do |section|
+        [
+          "## #{I18n.t(:"mailer.admin.weekly.sections.#{section.key}")}",
+          "",
+          *section.metrics.map { |metric| metric_line(metric) },
+          ""
+        ]
+      end.join("\n").strip
+    end
+
+    private def metric_line(metric)
+      label = I18n.t(:"mailer.admin.weekly.metrics.#{metric.key}")
+      value = (metric.format == :currency) ? format("%.2f EUR", metric.current.to_f / 100) : metric.current
+
+      return "- #{label}: #{value}" unless metric.comparable?
+
+      "- #{label}: #{value} (#{"+" unless metric.delta.negative?}#{metric.delta})"
     end
   end
 end

--- a/app/jobs/notifications/new_patron_job.rb
+++ b/app/jobs/notifications/new_patron_job.rb
@@ -10,6 +10,14 @@ module Notifications
 
       AdminMailer.new_supporter(supporter).deliver_later
 
+      AdminNotification.notify!(
+        type: :new_supporter,
+        title: "New Patreon Supporter",
+        body: "#{supporter.display_name} — #{supporter.formatted_amount}",
+        link: "/supporter-contributions",
+        record: supporter
+      )
+
       begin
         Discord::NewSupporter.new(supporter:).run
       rescue => e

--- a/app/lib/admin_report.rb
+++ b/app/lib/admin_report.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Single sink for the recurring reports background jobs produce. Every run lands
+# in the admin notification center; a GitHub issue is only opened when the
+# report contains something a human has to act on, so clean runs stop opening
+# issues nobody can close.
+class AdminReport
+  def self.deliver(task_type:, title:, body:, actionable:, link: nil, record: nil)
+    new(task_type:, title:, body:, actionable:, link:, record:).deliver
+  end
+
+  def initialize(task_type:, title:, body:, actionable:, link: nil, record: nil)
+    @task_type = task_type.to_sym
+    @title = title
+    @body = body
+    @actionable = actionable
+    @link = link
+    @record = record
+  end
+
+  def deliver
+    AdminNotification.notify!(
+      type: @task_type,
+      title: @title,
+      body: @body,
+      severity: @actionable ? :warning : :info,
+      link: @link,
+      record: @record,
+      dedupe_key: Digest::SHA256.hexdigest(@body.to_s)
+    )
+
+    return unless @actionable
+
+    GithubIssueCreator.new(task_type: @task_type.to_s, title: @title, body: @body).run
+  end
+end

--- a/app/lib/admin_weekly_report.rb
+++ b/app/lib/admin_weekly_report.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# Collects the numbers behind the weekly admin digest. Metrics come in two
+# shapes: windowed ones counted over the reporting week and compared against the
+# week before, and gauges that describe the state right now and have nothing to
+# compare against.
+class AdminWeeklyReport
+  Metric = Struct.new(:key, :current, :previous, :format) do
+    def delta
+      return if previous.nil?
+
+      current - previous
+    end
+
+    def comparable?
+      !previous.nil?
+    end
+  end
+
+  Section = Struct.new(:key, :metrics)
+
+  LOWER_IS_BETTER = %i[failed_hangar_syncs failed_imports email_rejections ended_supporters].freeze
+
+  def self.build
+    new.build
+  end
+
+  def initialize(now: Time.current)
+    @now = now
+  end
+
+  attr_reader :now
+
+  def build
+    {
+      starts_at: current_range.begin,
+      ends_at: current_range.end,
+      sections: [growth, engagement, supporters, ops, content]
+    }
+  end
+
+  private def current_range
+    @current_range ||= (now - 1.week)...now
+  end
+
+  private def previous_range
+    @previous_range ||= (now - 2.weeks)...(now - 1.week)
+  end
+
+  # Counts the same query over both windows so the template can render a delta.
+  private def windowed(key, format: :integer, &counter)
+    Metric.new(
+      key:,
+      current: counter.call(current_range),
+      previous: counter.call(previous_range),
+      format:
+    )
+  end
+
+  private def gauge(key, value, format: :integer)
+    Metric.new(key:, current: value, previous: nil, format:)
+  end
+
+  private def growth
+    Section.new(
+      key: :growth,
+      metrics: [
+        windowed(:registrations) { |range| User.where(created_at: range).count },
+        windowed(:ships) { |range| Model.where(created_at: range).count },
+        windowed(:vehicles) { |range| Vehicle.where(loaner: false, wanted: false, created_at: range).count },
+        windowed(:wishes) { |range| Vehicle.where(loaner: false, wanted: true, created_at: range).count },
+        windowed(:fleets) { |range| Fleet.where(created_at: range).count }
+      ]
+    )
+  end
+
+  private def engagement
+    Section.new(
+      key: :engagement,
+      metrics: [
+        windowed(:active_users) { |range| User.where(last_active_at: range).count },
+        windowed(:visits) { |range| visits(range).count },
+        windowed(:unique_visitors) { |range| visits(range).distinct.count(:visitor_token) },
+        windowed(:fleet_memberships) { |range| FleetMembership.kept.where(created_at: range).count }
+      ]
+    )
+  end
+
+  private def supporters
+    Section.new(
+      key: :supporters,
+      metrics: [
+        windowed(:new_supporters) { |range| SupporterContribution.where(started_at: range).count },
+        windowed(:supporter_amount, format: :currency) do |range|
+          SupporterContribution.where(started_at: range).sum(:amount_cents)
+        end,
+        windowed(:ended_supporters) do |range|
+          SupporterContribution.where(recurring: true, ended_at: range).count
+        end
+      ]
+    )
+  end
+
+  private def ops
+    Section.new(
+      key: :ops,
+      metrics: [
+        windowed(:hangar_syncs) { |range| Imports::HangarSync.where(created_at: range).count },
+        windowed(:failed_hangar_syncs) do |range|
+          Imports::HangarSync.where(created_at: range, aasm_state: "failed").count
+        end,
+        windowed(:failed_imports) do |range|
+          Import.where(created_at: range, aasm_state: "failed").where.not(type: "Imports::HangarSync").count
+        end,
+        windowed(:email_rejections) { |range| EmailRejection.where(created_at: range).count },
+        gauge(:unresolved_rsi_blocks, RsiRequestLog.where(resolved: false).count)
+      ]
+    )
+  end
+
+  private def content
+    Section.new(
+      key: :content,
+      metrics: [
+        windowed(:star_citizen_updates) { |range| StarCitizenUpdate.where(created_at: range).count },
+        gauge(:models_without_image, curatable_models.where.missing(:store_image_attachment).count),
+        gauge(:models_without_price, curatable_models.where(player_ownable: true, pledge_price: nil).count),
+        gauge(:models_need_position_curation, Model.where(positions_need_curation: true).count)
+      ]
+    )
+  end
+
+  private def visits(range)
+    Ahoy::Visit.without_users(tracking_blocklist).where(started_at: range)
+  end
+
+  private def tracking_blocklist
+    @tracking_blocklist ||= User.where(tracking: false).pluck(:id)
+  end
+
+  private def curatable_models
+    Model.where(active: true, hidden: false)
+  end
+end

--- a/app/lib/modules_importer.rb
+++ b/app/lib/modules_importer.rb
@@ -42,6 +42,12 @@ class ModulesImporter
     }
   end
 
+  # A run that only found new modules is a status update; missing models and
+  # import errors are the parts a human has to resolve.
+  def self.actionable?(results)
+    results[:new_with_error][:items].present? || results[:model_not_found][:items].present?
+  end
+
   def self.github_issue_body(results)
     lines = []
 

--- a/app/lib/paints_importer.rb
+++ b/app/lib/paints_importer.rb
@@ -38,6 +38,12 @@ class PaintsImporter
     }
   end
 
+  # A run that only found new paints is a status update; missing models and
+  # import errors are the parts a human has to resolve.
+  def self.actionable?(results)
+    results[:new_with_error][:items].present? || results[:model_not_found][:items].present?
+  end
+
   def self.github_issue_body(results)
     lines = []
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 class AdminMailer < ApplicationMailer
-  def weekly(stats)
-    @stats = stats
+  helper AdminReportHelper
+
+  OPEN_NOTIFICATIONS_LIMIT = 10
+
+  # Sent per admin rather than to the whole super-admin list at once: the digest
+  # ends on the recipient's own open notifications, which no shared mail can show.
+  def weekly(admin_user, report)
+    @admin_user = admin_user
+    @report = report
+    @notifications = open_notifications_for(admin_user)
+    @notifications_url = "#{ADMIN_ENDPOINT}/notifications"
 
     mail(
-      to: super_admin_emails,
+      to: admin_user.email,
       subject: I18n.t(:"mailer.admin.weekly.subject")
     )
   end
@@ -39,5 +48,14 @@ class AdminMailer < ApplicationMailer
 
   private def super_admin_emails
     AdminUser.where(super_admin: true).pluck(:email)
+  end
+
+  private def open_notifications_for(admin_user)
+    AdminNotification.where(admin_user:)
+      .active
+      .unread
+      .where.not(notification_type: :weekly_stats)
+      .order(created_at: :desc)
+      .limit(OPEN_NOTIFICATIONS_LIMIT)
   end
 end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -118,8 +118,20 @@ class AdminNotification < ApplicationRecord
 
   paginates_per 25
 
+  ransack_alias :search, :title_or_body
+
+  # Sortable rather than filterable: the inbox keeps what has not been dealt
+  # with on top, whichever way the client sorts underneath.
+  ransacker :unread, type: :boolean do
+    Arel.sql("admin_notifications.read_at IS NULL")
+  end
+
   def self.ransackable_attributes(_auth_object = nil)
-    %w[notification_type severity read_at created_at]
+    %w[notification_type severity read_at created_at title body search unread]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
   end
 
   def self.type_config(type)

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -144,6 +144,10 @@ class AdminNotification < ApplicationRecord
     AdminUser.all.select { |admin_user| admin_user.has_access?(access) }
   end
 
+  def self.types_for(admin_user)
+    TYPES.select { |_type, config| admin_user.has_access?(config[:access]) }.keys.map(&:to_s)
+  end
+
   # A dedupe_key folds repeat reports of the same content into the row that is
   # still unread, so a weekly job that keeps finding nothing does not stack up.
   def self.notify!(type:, title:, body: nil, severity: :info, link: nil, icon: nil, record: nil, dedupe_key: nil)

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_notifications
+#
+#  id                :uuid             not null, primary key
+#  body              :text
+#  dedupe_key        :string
+#  expires_at        :datetime         not null
+#  icon              :string
+#  last_occurred_at  :datetime         not null
+#  link              :string
+#  notification_type :string           not null
+#  occurrences       :integer          default(1), not null
+#  read_at           :datetime
+#  record_type       :string
+#  severity          :string           default("info"), not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  admin_user_id     :uuid             not null
+#  record_id         :uuid
+#
+# Indexes
+#
+#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key)
+#  index_admin_notifications_on_expires_at                    (expires_at)
+#  index_admin_notifications_on_notification_type             (notification_type)
+#  index_admin_notifications_on_record                        (record_type,record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_user_id => admin_users.id) ON DELETE => cascade
+#
+class AdminNotification < ApplicationRecord
+  belongs_to :admin_user
+  belongs_to :record, polymorphic: true, optional: true
+
+  enum :notification_type, {
+    paints_import: "paints_import",
+    modules_import: "modules_import",
+    loaner_sync: "loaner_sync",
+    uex_prices_import: "uex_prices_import",
+    uex_commodity_prices_import: "uex_commodity_prices_import",
+    new_supporter: "new_supporter",
+    rsi_api_blocked: "rsi_api_blocked",
+    rsi_api_unblocked: "rsi_api_unblocked",
+    weekly_stats: "weekly_stats"
+  }
+
+  enum :severity, {
+    info: "info",
+    warning: "warning",
+    error: "error"
+  }, prefix: true
+
+  TYPES = {
+    paints_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-palette"
+    },
+    modules_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-microchip"
+    },
+    loaner_sync: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-rocket-launch"
+    },
+    uex_prices_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-tags"
+    },
+    uex_commodity_prices_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-boxes-stacked"
+    },
+    new_supporter: {
+      retention: 90.days,
+      access: [:supporters],
+      icon: "fa-duotone fa-hand-holding-heart"
+    },
+    rsi_api_blocked: {
+      retention: 30.days,
+      access: [:"rsi-api-status"],
+      icon: "fa-duotone fa-plug-circle-xmark"
+    },
+    rsi_api_unblocked: {
+      retention: 30.days,
+      access: [:"rsi-api-status"],
+      icon: "fa-duotone fa-plug-circle-check"
+    },
+    weekly_stats: {
+      retention: 30.days,
+      access: [:stats],
+      icon: "fa-duotone fa-chart-line"
+    }
+  }.freeze
+
+  before_validation :set_expires_at, on: :create
+  before_validation :set_last_occurred_at, on: :create
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+  scope :expired, -> { where(expires_at: ...Time.current) }
+  scope :active, -> { where(expires_at: Time.current..) }
+
+  DEFAULT_SORTING_PARAMS = "created_at desc"
+  ALLOWED_SORTING_PARAMS = ["createdAt asc", "createdAt desc"].freeze
+
+  paginates_per 25
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[notification_type severity read_at created_at]
+  end
+
+  def self.type_config(type)
+    TYPES.fetch(type.to_sym)
+  end
+
+  def self.retention_for(type)
+    type_config(type)[:retention]
+  end
+
+  def self.access_for(type)
+    type_config(type)[:access]
+  end
+
+  def self.icon_for(type)
+    type_config(type)[:icon]
+  end
+
+  def self.recipients_for(type)
+    access = access_for(type)
+
+    AdminUser.all.select { |admin_user| admin_user.has_access?(access) }
+  end
+
+  # A dedupe_key folds repeat reports of the same content into the row that is
+  # still unread, so a weekly job that keeps finding nothing does not stack up.
+  def self.notify!(type:, title:, body: nil, severity: :info, link: nil, icon: nil, record: nil, dedupe_key: nil)
+    recipients_for(type).map do |admin_user|
+      notification = upsert_for(
+        admin_user:, type:, title:, body:, severity:, link:,
+        icon: icon || icon_for(type), record:, dedupe_key:
+      )
+
+      broadcast(notification)
+
+      notification
+    end
+  end
+
+  def self.upsert_for(admin_user:, type:, title:, body:, severity:, link:, icon:, record:, dedupe_key:)
+    existing = dedupe_key.presence && active.unread.find_by(
+      admin_user:, notification_type: type, dedupe_key:
+    )
+
+    if existing
+      existing.update!(
+        title:, body:, severity:, link:, icon:, record:,
+        occurrences: existing.occurrences + 1,
+        last_occurred_at: Time.current,
+        expires_at: Time.current + retention_for(type)
+      )
+
+      return existing
+    end
+
+    create!(
+      admin_user:, notification_type: type, title:, body:, severity:,
+      link:, icon:, record:, dedupe_key:
+    )
+  end
+  private_class_method :upsert_for
+
+  def self.broadcast(notification)
+    AdminNotificationsChannel.broadcast_to(notification.admin_user, notification.to_jbuilder_json)
+  rescue => e
+    Rails.logger.error("Admin notification delivery failed for #{notification.id}: #{e.message}")
+  end
+  private_class_method :broadcast
+
+  # The default derives "api/v1/admin_notifications/admin_notification"; the
+  # admin API namespaces its views one level deeper and drops the prefix.
+  def jbuilder_template_path
+    "admin/api/v1/notifications/notification"
+  end
+
+  def jbuilder_template_instance_name
+    :notification
+  end
+
+  def read?
+    read_at.present?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current)
+  end
+
+  private def set_expires_at
+    self.expires_at ||= Time.current + self.class.retention_for(notification_type)
+  end
+
+  private def set_last_occurred_at
+    self.last_occurred_at ||= Time.current
+  end
+end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -26,7 +26,7 @@
 #
 #  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
 #  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
-#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key)
+#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
 #  index_admin_notifications_on_expires_at                    (expires_at)
 #  index_admin_notifications_on_notification_type             (notification_type)
 #  index_admin_notifications_on_record                        (record_type,record_id)
@@ -160,25 +160,40 @@ class AdminNotification < ApplicationRecord
   end
 
   def self.upsert_for(admin_user:, type:, title:, body:, severity:, link:, icon:, record:, dedupe_key:)
-    existing = dedupe_key.presence && active.unread.find_by(
-      admin_user:, notification_type: type, dedupe_key:
-    )
+    retried = false
 
-    if existing
-      existing.update!(
-        title:, body:, severity:, link:, icon:, record:,
-        occurrences: existing.occurrences + 1,
-        last_occurred_at: Time.current,
-        expires_at: Time.current + retention_for(type)
+    begin
+      existing = dedupe_key.presence && unread.find_by(
+        admin_user:, notification_type: type, dedupe_key:
       )
 
-      return existing
-    end
+      if existing
+        existing.update!(
+          title:, body:, severity:, link:, icon:, record:,
+          occurrences: existing.occurrences + 1,
+          last_occurred_at: Time.current,
+          expires_at: Time.current + retention_for(type)
+        )
 
-    create!(
-      admin_user:, notification_type: type, title:, body:, severity:,
-      link:, icon:, record:, dedupe_key:
-    )
+        return existing
+      end
+
+      # A concurrent report can insert the same dedupe key between the lookup
+      # and the insert; the partial unique index turns that into a conflict we
+      # replay into the update branch above. The savepoint keeps a surrounding
+      # transaction usable after the failed insert.
+      transaction(requires_new: true) do
+        create!(
+          admin_user:, notification_type: type, title:, body:, severity:,
+          link:, icon:, record:, dedupe_key:
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      raise if retried
+
+      retried = true
+      retry
+    end
   end
   private_class_method :upsert_for
 

--- a/app/models/rsi_request_log.rb
+++ b/app/models/rsi_request_log.rb
@@ -20,11 +20,30 @@ class RsiRequestLog < ApplicationRecord
 
   def notify_admin
     AdminMailer.notify_block(url).deliver_later
+
+    AdminNotification.notify!(
+      type: :rsi_api_blocked,
+      title: "RSI blocked a request",
+      body: url,
+      severity: :error,
+      link: "/maintenance/rsi-api-status",
+      record: self,
+      dedupe_key: url
+    )
   end
 
   def notify_admin_resolved
     return unless resolved
 
     AdminMailer.notify_unblock(url).deliver_later
+
+    AdminNotification.notify!(
+      type: :rsi_api_unblocked,
+      title: "RSI unblocked a request",
+      body: url,
+      link: "/maintenance/rsi-api-status",
+      record: self,
+      dedupe_key: url
+    )
   end
 end

--- a/app/policies/admin/notification_policy.rb
+++ b/app/policies/admin/notification_policy.rb
@@ -18,8 +18,11 @@ module Admin
       user.present?
     end
 
+    # Ownership alone would keep a notification readable after the privilege
+    # that made its owner a recipient is revoked, so the type has to be
+    # re-checked against the current privileges on every read.
     relation_scope do |relation|
-      relation.where(admin_user_id: user.id)
+      relation.where(admin_user_id: user.id, notification_type: AdminNotification.types_for(user))
     end
   end
 end

--- a/app/policies/admin/notification_policy.rb
+++ b/app/policies/admin/notification_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  # Not a BasePolicy subclass on purpose: notifications are not a gated resource
+  # but every admin's own inbox, so access is ownership rather than a privilege.
+  class NotificationPolicy < ApplicationPolicy
+    alias_rule :index?, :destroy?, :update?, :read?, :unread_count?, to: :show?
+
+    def show?
+      user.present?
+    end
+
+    def read_all?
+      user.present?
+    end
+
+    def destroy_all?
+      user.present?
+    end
+
+    relation_scope do |relation|
+      relation.where(admin_user_id: user.id)
+    end
+  end
+end

--- a/app/views/admin/api/v1/notifications/_base.jbuilder
+++ b/app/views/admin/api/v1/notifications/_base.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.id notification.id
+json.notification_type notification.notification_type
+json.severity notification.severity
+json.title notification.title
+json.body notification.body
+json.link notification.link
+json.icon notification.icon
+json.occurrences notification.occurrences
+json.last_occurred_at notification.last_occurred_at.utc.iso8601
+json.read notification.read?
+json.read_at notification.read_at&.utc&.iso8601
+json.expires_at notification.expires_at.utc.iso8601
+json.partial! "api/shared/dates", record: notification

--- a/app/views/admin/api/v1/notifications/_notification.jbuilder
+++ b/app/views/admin/api/v1/notifications/_notification.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["admin-v1", notification] do
+  json.partial!("admin/api/v1/notifications/base", notification:)
+end

--- a/app/views/admin/api/v1/notifications/index.jbuilder
+++ b/app/views/admin/api/v1/notifications/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @notifications, partial: "admin/api/v1/notifications/notification", as: :notification
+end
+json.partial! "api/shared/meta", result: @notifications

--- a/app/views/admin/api/v1/notifications/show.jbuilder
+++ b/app/views/admin/api/v1/notifications/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/notifications/notification", notification: @notification

--- a/app/views/admin/api/v1/notifications/unread_count.jbuilder
+++ b/app/views/admin/api/v1/notifications/unread_count.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.count @unread_count

--- a/app/views/admin_mailer/weekly.html.inky
+++ b/app/views/admin_mailer/weekly.html.inky
@@ -1,15 +1,70 @@
 <h4>
   <%= I18n.t("mailer.admin.weekly.headline") %>
 </h4>
-<p>
-  <%= I18n.t("mailer.admin.weekly.registrations") %>: <%= @stats[:registrations] %>
+<p class="report-period">
+  <%= I18n.t("mailer.admin.weekly.period",
+        from: I18n.l(@report[:starts_at].to_date, format: :day_month),
+        to: I18n.l(@report[:ends_at].to_date, format: :day_month)) %>
 </p>
-<p>
-  <%= I18n.t("mailer.admin.weekly.ships") %>: <%= @stats[:ships] %>
-</p>
-<p>
-  <%= I18n.t("mailer.admin.weekly.vehicles") %>: <%= @stats[:vehicles] %>
-</p>
-<p>
-  <%= I18n.t("mailer.admin.weekly.fleets") %>: <%= @stats[:fleets] %>
-</p>
+
+<% @report[:sections].each do |section| %>
+  <h5 class="report-section">
+    <%= I18n.t("mailer.admin.weekly.sections.#{section.key}") %>
+  </h5>
+  <table class="report-table">
+    <tr>
+      <th class="report-label"><%= I18n.t("mailer.admin.weekly.columns.metric") %></th>
+      <th class="report-number"><%= I18n.t("mailer.admin.weekly.columns.current") %></th>
+      <th class="report-number"><%= I18n.t("mailer.admin.weekly.columns.previous") %></th>
+      <th class="report-number"><%= I18n.t("mailer.admin.weekly.columns.delta") %></th>
+    </tr>
+    <% section.metrics.each do |metric| %>
+      <tr>
+        <td class="report-label">
+          <%= I18n.t("mailer.admin.weekly.metrics.#{metric.key}") %>
+        </td>
+        <td class="report-number">
+          <%= admin_report_metric_value(metric) %>
+        </td>
+        <td class="report-number report-muted">
+          <%= admin_report_previous_value(metric) || "&mdash;".html_safe %>
+        </td>
+        <td class="report-number report-delta-<%= admin_report_delta_class(metric) %>">
+          <%= admin_report_delta(metric) || "&mdash;".html_safe %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>
+
+<h5 class="report-section">
+  <%= I18n.t("mailer.admin.weekly.notifications.headline", count: @notifications.size) %>
+</h5>
+<% if @notifications.any? %>
+  <table class="report-table">
+    <% @notifications.each do |notification| %>
+      <tr>
+        <td class="report-label">
+          <%= notification.title %>
+          <% if notification.occurrences > 1 %>
+            <span class="report-muted">&times;<%= notification.occurrences %></span>
+          <% end %>
+        </td>
+        <td class="report-number report-muted">
+          <%= I18n.l(notification.created_at.to_date, format: :day_month) %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% else %>
+  <p class="report-muted">
+    <%= I18n.t("mailer.admin.weekly.notifications.empty") %>
+  </p>
+<% end %>
+
+<spacer size="16"></spacer>
+<center>
+  <a href="<%= @notifications_url %>" class="button" target="_blank">
+    <%= I18n.t("mailer.admin.weekly.notifications.action") %>
+  </a>
+</center>

--- a/config/locales/de/mailer.yml
+++ b/config/locales/de/mailer.yml
@@ -17,12 +17,13 @@ de:
         subject: Verbindung zu RSI wiederhergestellt
         text: Automatische Aktualisierungen von RSI über "%{url}" wurden wiederhergestellt
       weekly:
-        fleets: Neue Flotten
         headline: FleetYards.net Command - Weekly
-        registrations: Neue Registrierungen
-        ships: Neue Schiffe
+        metrics:
+          fleets: Neue Flotten
+          registrations: Neue Registrierungen
+          ships: Neue Schiffe
+          vehicles: Neue Fahrzeuge
         subject: FleetYards.net Command Weekly
-        vehicles: Neue Fahrzeuge
     fleet_membership:
       fleet_accepted:
         action: "%{fleet} Homepage"

--- a/config/locales/en/mailer.yml
+++ b/config/locales/en/mailer.yml
@@ -17,12 +17,49 @@ en:
         subject: Connection to RSI restored
         text: Automated updates from RSI using "%{url}" has been restored
       weekly:
-        fleets: New Fleets
+        columns:
+          current: This Week
+          delta: Change
+          metric: Metric
+          previous: Last Week
         headline: FleetYards.net Command - Weekly
-        registrations: New Registrations
-        ships: New Ships
+        metrics:
+          active_users: Active Users
+          email_rejections: Email Rejections
+          ended_supporters: Supporters Lost
+          failed_hangar_syncs: Failed Hangar Syncs
+          failed_imports: Failed Imports
+          fleet_memberships: New Fleet Members
+          fleets: New Fleets
+          hangar_syncs: Hangar Syncs
+          models_need_position_curation: Models Needing Position Curation
+          models_without_image: Models Without Store Image
+          models_without_price: Models Without Price
+          new_supporters: New Supporters
+          registrations: New Registrations
+          ships: New Ships
+          star_citizen_updates: RSI News Items
+          supporter_amount: Contributions
+          unique_visitors: Unique Visitors
+          unresolved_rsi_blocks: Unresolved RSI Blocks
+          vehicles: New Vehicles
+          visits: Visits
+          wishes: New Wishlist Entries
+        notifications:
+          action: Open Notification Center
+          empty: Nothing open — the notification center is clear.
+          headline:
+            one: Open Notification (%{count})
+            other: Open Notifications (%{count})
+            zero: Open Notifications
+        period: "%{from} – %{to}"
+        sections:
+          content: Content & Data Gaps
+          engagement: Engagement
+          growth: Growth
+          ops: Ops Health
+          supporters: Supporters
         subject: FleetYards.net Command Weekly
-        vehicles: New Vehicles
     fleet_membership:
       fleet_accepted:
         action: "%{fleet} Homepage"

--- a/config/locales/es/mailer.yml
+++ b/config/locales/es/mailer.yml
@@ -13,12 +13,13 @@ es:
         subject: Conexión con RSI restaurada
         text: Las actualizaciones automáticas de RSI usando "%{url}" han sido restauradas
       weekly:
-        fleets: Nuevas flotas
         headline: FleetYards.net Command - Weekly
-        registrations: Nuevos registros
-        ships: Nuevas naves
+        metrics:
+          fleets: Nuevas flotas
+          registrations: Nuevos registros
+          ships: Nuevas naves
+          vehicles: Nuevos vehículos
         subject: FleetYards.net Command Weekly
-        vehicles: Nuevos vehículos
     fleet_membership:
       fleet_accepted:
         action: Página principal de %{fleet}

--- a/config/locales/fr/mailer.yml
+++ b/config/locales/fr/mailer.yml
@@ -13,12 +13,13 @@ fr:
         subject: Connexion à RSI rétablie
         text: Les mises à jour automatiques depuis RSI via "%{url}" ont été rétablies
       weekly:
-        fleets: Nouvelles flottes
         headline: FleetYards.net Command - Weekly
-        registrations: Nouvelles inscriptions
-        ships: Nouveaux vaisseaux
+        metrics:
+          fleets: Nouvelles flottes
+          registrations: Nouvelles inscriptions
+          ships: Nouveaux vaisseaux
+          vehicles: Nouveaux véhicules
         subject: FleetYards.net Command Weekly
-        vehicles: Nouveaux véhicules
     fleet_membership:
       fleet_accepted:
         action: Page d'accueil de %{fleet}

--- a/config/locales/it/mailer.yml
+++ b/config/locales/it/mailer.yml
@@ -13,12 +13,13 @@ it:
         subject: Connessione a RSI ripristinata
         text: Gli aggiornamenti automatici da RSI tramite "%{url}" sono stati ripristinati
       weekly:
-        fleets: Nuove flotte
         headline: FleetYards.net Command - Weekly
-        registrations: Nuove registrazioni
-        ships: Nuove navi
+        metrics:
+          fleets: Nuove flotte
+          registrations: Nuove registrazioni
+          ships: Nuove navi
+          vehicles: Nuovi veicoli
         subject: FleetYards.net Command Weekly
-        vehicles: Nuovi veicoli
     fleet_membership:
       fleet_accepted:
         action: Homepage di %{fleet}

--- a/config/locales/zh-CN/mailer.yml
+++ b/config/locales/zh-CN/mailer.yml
@@ -13,12 +13,13 @@ zh-CN:
         subject: RSI 连接已恢复
         text: 通过 "%{url}" 的 RSI 自动更新已恢复
       weekly:
-        fleets: 新舰队
         headline: FleetYards.net Command - Weekly
-        registrations: 新注册
-        ships: 新飞船
+        metrics:
+          fleets: 新舰队
+          registrations: 新注册
+          ships: 新飞船
+          vehicles: 新载具
         subject: FleetYards.net Command Weekly
-        vehicles: 新载具
       missing_loaners:
         headline: FleetYards.net 缺少贷款
         subject: FleetYards.net 缺少贷款

--- a/config/locales/zh-TW/mailer.yml
+++ b/config/locales/zh-TW/mailer.yml
@@ -13,12 +13,13 @@ zh-TW:
         subject: RSI 連線已恢復
         text: 透過 "%{url}" 的 RSI 自動更新已恢復
       weekly:
-        fleets: 新艦隊
         headline: FleetYards.net Command - Weekly
-        registrations: 新註冊
-        ships: 新飛船
+        metrics:
+          fleets: 新艦隊
+          registrations: 新註冊
+          ships: 新飛船
+          vehicles: 新載具
         subject: FleetYards.net Command Weekly
-        vehicles: 新載具
     fleet_membership:
       fleet_accepted:
         action: "%{fleet} 首頁"

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -139,6 +139,17 @@ v1_admin_api_routes = lambda do
     end
   end
 
+  resources :notifications, only: %i[index destroy] do
+    member do
+      put :read
+    end
+    collection do
+      get "unread-count", to: "notifications#unread_count"
+      put "read-all", to: "notifications#read_all"
+      delete "destroy-all", to: "notifications#destroy_all"
+    end
+  end
+
   # Flag lifecycle belongs to config/feature_flags.yml, so no create/destroy here.
   resources :features, only: %i[index show] do
     member do

--- a/db/migrate/20260816200000_create_admin_notifications.rb
+++ b/db/migrate/20260816200000_create_admin_notifications.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CreateAdminNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :admin_notifications, id: :uuid do |t|
+      t.references :admin_user, type: :uuid, null: false, foreign_key: {on_delete: :cascade}, index: false
+      t.string :notification_type, null: false
+      t.string :severity, null: false, default: "info"
+      t.string :title, null: false
+      t.text :body
+      t.string :link
+      t.string :icon
+      t.string :dedupe_key
+      t.integer :occurrences, null: false, default: 1
+      t.datetime :last_occurred_at, null: false
+      t.references :record, polymorphic: true, type: :uuid, index: true
+      t.datetime :read_at
+      t.datetime :expires_at, null: false
+      t.timestamps
+    end
+
+    add_index :admin_notifications, [:admin_user_id, :created_at], order: {created_at: :desc}
+    add_index :admin_notifications, [:admin_user_id, :read_at]
+    add_index :admin_notifications, [:admin_user_id, :notification_type, :dedupe_key],
+      name: "index_admin_notifications_on_dedupe"
+    add_index :admin_notifications, :expires_at
+    add_index :admin_notifications, :notification_type
+  end
+end

--- a/db/migrate/20260816200000_create_admin_notifications.rb
+++ b/db/migrate/20260816200000_create_admin_notifications.rb
@@ -22,6 +22,7 @@ class CreateAdminNotifications < ActiveRecord::Migration[8.1]
     add_index :admin_notifications, [:admin_user_id, :created_at], order: {created_at: :desc}
     add_index :admin_notifications, [:admin_user_id, :read_at]
     add_index :admin_notifications, [:admin_user_id, :notification_type, :dedupe_key],
+      unique: true, where: "read_at IS NULL AND dedupe_key IS NOT NULL",
       name: "index_admin_notifications_on_dedupe"
     add_index :admin_notifications, :expires_at
     add_index :admin_notifications, :notification_type

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -43,6 +43,31 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admin_notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "admin_user_id", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "dedupe_key"
+    t.datetime "expires_at", null: false
+    t.string "icon"
+    t.datetime "last_occurred_at", null: false
+    t.string "link"
+    t.string "notification_type", null: false
+    t.integer "occurrences", default: 1, null: false
+    t.datetime "read_at"
+    t.uuid "record_id"
+    t.string "record_type"
+    t.string "severity", default: "info", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_user_id", "created_at"], name: "index_admin_notifications_on_admin_user_id_and_created_at", order: { created_at: :desc }
+    t.index ["admin_user_id", "notification_type", "dedupe_key"], name: "index_admin_notifications_on_dedupe"
+    t.index ["admin_user_id", "read_at"], name: "index_admin_notifications_on_admin_user_id_and_read_at"
+    t.index ["expires_at"], name: "index_admin_notifications_on_expires_at"
+    t.index ["notification_type"], name: "index_admin_notifications_on_notification_type"
+    t.index ["record_type", "record_id"], name: "index_admin_notifications_on_record"
   end
 
   create_table "admin_users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -1188,6 +1213,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "admin_notifications", "admin_users", on_delete: :cascade
   add_foreign_key "cargo_hold_container_capacities", "cargo_holds"
   add_foreign_key "fleet_inventories", "fleets"
   add_foreign_key "fleet_inventories", "users", column: "managed_by"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_200000) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["admin_user_id", "created_at"], name: "index_admin_notifications_on_admin_user_id_and_created_at", order: { created_at: :desc }
-    t.index ["admin_user_id", "notification_type", "dedupe_key"], name: "index_admin_notifications_on_dedupe"
+    t.index ["admin_user_id", "notification_type", "dedupe_key"], name: "index_admin_notifications_on_dedupe", unique: true, where: "((read_at IS NULL) AND (dedupe_key IS NOT NULL))"
     t.index ["admin_user_id", "read_at"], name: "index_admin_notifications_on_admin_user_id_and_read_at"
     t.index ["expires_at"], name: "index_admin_notifications_on_expires_at"
     t.index ["notification_type"], name: "index_admin_notifications_on_notification_type"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6760,6 +6760,8 @@ components:
           "$ref": "#/components/schemas/AdminNotificationSeverityEnum"
         readAtNull:
           type: boolean
+        searchCont:
+          type: string
         sorts:
           anyOf:
           - type: array

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5004,6 +5004,161 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications":
+    get:
+      summary: Admin Notifications list
+      tags:
+      - Notifications
+      operationId: adminNotifications
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 25
+        required: false
+      - "$ref": "#/components/parameters/SortingParameter"
+      - name: q
+        in: query
+        schema:
+          "$ref": "#/components/schemas/AdminNotificationQuery"
+        required: false
+      - name: cacheId
+        in: query
+        schema:
+          type: string
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotifications"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/destroy-all":
+    delete:
+      summary: Delete all Admin Notifications
+      tags:
+      - Notifications
+      operationId: destroyAllAdminNotifications
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/notifications/read-all":
+    put:
+      summary: Mark all Admin Notifications as read
+      tags:
+      - Notifications
+      operationId: readAllAdminNotifications
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/notifications/unread-count":
+    get:
+      summary: Unread Admin Notification count
+      tags:
+      - Notifications
+      operationId: adminNotificationsUnreadCount
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationUnreadCount"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/notifications/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: Admin Notification id
+      required: true
+    delete:
+      summary: Delete Admin Notification
+      tags:
+      - Notifications
+      operationId: destroyAdminNotification
+      responses:
+        '204':
+          description: successful
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/{id}/read":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: Admin Notification id
+      required: true
+    put:
+      summary: Mark Admin Notification as read
+      tags:
+      - Notifications
+      operationId: readAdminNotification
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotification"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/oauth-applications":
     post:
       summary: Create OAuth Application
@@ -6546,6 +6701,140 @@ components:
       - name
       - permanent
       title: AdminFleetRole
+    AdminNotification:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        notificationType:
+          "$ref": "#/components/schemas/AdminNotificationTypeEnum"
+        severity:
+          "$ref": "#/components/schemas/AdminNotificationSeverityEnum"
+        title:
+          type: string
+        body:
+          type: string
+        link:
+          type: string
+        icon:
+          type: string
+        occurrences:
+          type: integer
+        lastOccurredAt:
+          type: string
+          format: date-time
+        read:
+          type: boolean
+        readAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - notificationType
+      - severity
+      - title
+      - occurrences
+      - lastOccurredAt
+      - read
+      - expiresAt
+      - createdAt
+      - updatedAt
+      title: AdminNotification
+    AdminNotificationQuery:
+      type: object
+      properties:
+        notificationTypeEq:
+          "$ref": "#/components/schemas/AdminNotificationTypeEnum"
+        severityEq:
+          "$ref": "#/components/schemas/AdminNotificationSeverityEnum"
+        readAtNull:
+          type: boolean
+        sorts:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/AdminNotificationSortEnum"
+          - "$ref": "#/components/schemas/AdminNotificationSortEnum"
+      additionalProperties: false
+      example: {}
+      title: AdminNotificationQuery
+    AdminNotificationSeverityEnum:
+      type: string
+      enum:
+      - info
+      - warning
+      - error
+      x-enumNames:
+      - INFO
+      - WARNING
+      - ERROR
+      title: AdminNotificationSeverityEnum
+    AdminNotificationSortEnum:
+      type: string
+      enum:
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: AdminNotificationSortEnum
+    AdminNotificationTypeEnum:
+      type: string
+      enum:
+      - paints_import
+      - modules_import
+      - loaner_sync
+      - uex_prices_import
+      - uex_commodity_prices_import
+      - new_supporter
+      - rsi_api_blocked
+      - rsi_api_unblocked
+      - weekly_stats
+      x-enumNames:
+      - PAINTS_IMPORT
+      - MODULES_IMPORT
+      - LOANER_SYNC
+      - UEX_PRICES_IMPORT
+      - UEX_COMMODITY_PRICES_IMPORT
+      - NEW_SUPPORTER
+      - RSI_API_BLOCKED
+      - RSI_API_UNBLOCKED
+      - WEEKLY_STATS
+      title: AdminNotificationTypeEnum
+    AdminNotificationUnreadCount:
+      type: object
+      properties:
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - count
+      title: AdminNotificationUnreadCount
+    AdminNotifications:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AdminNotification"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: AdminNotifications
     AdminUser:
       type: object
       properties:
@@ -6831,6 +7120,7 @@ components:
     ChannelsEnum:
       type: string
       enum:
+      - AdminNotificationsChannel
       - AppVersionChannel
       - FleetMembersChannel
       - FleetVehiclesChannel
@@ -6848,6 +7138,7 @@ components:
       - WishlistCreateChannel
       - WishlistDestroyChannel
       x-enumNames:
+      - ADMIN_NOTIFICATIONS_CHANNEL
       - APP_VERSION_CHANNEL
       - FLEET_MEMBERS_CHANNEL
       - FLEET_VEHICLES_CHANNEL

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7630,6 +7630,49 @@ components:
           format: email
       additionalProperties: false
       title: AccountUpdateInput
+    AdminNotificationSeverityEnum:
+      type: string
+      enum:
+      - info
+      - warning
+      - error
+      x-enumNames:
+      - INFO
+      - WARNING
+      - ERROR
+      title: AdminNotificationSeverityEnum
+    AdminNotificationSortEnum:
+      type: string
+      enum:
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: AdminNotificationSortEnum
+    AdminNotificationTypeEnum:
+      type: string
+      enum:
+      - paints_import
+      - modules_import
+      - loaner_sync
+      - uex_prices_import
+      - uex_commodity_prices_import
+      - new_supporter
+      - rsi_api_blocked
+      - rsi_api_unblocked
+      - weekly_stats
+      x-enumNames:
+      - PAINTS_IMPORT
+      - MODULES_IMPORT
+      - LOANER_SYNC
+      - UEX_PRICES_IMPORT
+      - UEX_COMMODITY_PRICES_IMPORT
+      - NEW_SUPPORTER
+      - RSI_API_BLOCKED
+      - RSI_API_UNBLOCKED
+      - WEEKLY_STATS
+      title: AdminNotificationTypeEnum
     BarChartStats:
       type: object
       properties:
@@ -7749,6 +7792,7 @@ components:
     ChannelsEnum:
       type: string
       enum:
+      - AdminNotificationsChannel
       - AppVersionChannel
       - FleetMembersChannel
       - FleetVehiclesChannel
@@ -7766,6 +7810,7 @@ components:
       - WishlistCreateChannel
       - WishlistDestroyChannel
       x-enumNames:
+      - ADMIN_NOTIFICATIONS_CHANNEL
       - APP_VERSION_CHANNEL
       - FLEET_MEMBERS_CHANNEL
       - FLEET_VEHICLES_CHANNEL

--- a/test/factories/admin_notifications.rb
+++ b/test/factories/admin_notifications.rb
@@ -1,5 +1,40 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: admin_notifications
+#
+#  id                :uuid             not null, primary key
+#  body              :text
+#  dedupe_key        :string
+#  expires_at        :datetime         not null
+#  icon              :string
+#  last_occurred_at  :datetime         not null
+#  link              :string
+#  notification_type :string           not null
+#  occurrences       :integer          default(1), not null
+#  read_at           :datetime
+#  record_type       :string
+#  severity          :string           default("info"), not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  admin_user_id     :uuid             not null
+#  record_id         :uuid
+#
+# Indexes
+#
+#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
+#  index_admin_notifications_on_expires_at                    (expires_at)
+#  index_admin_notifications_on_notification_type             (notification_type)
+#  index_admin_notifications_on_record                        (record_type,record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_user_id => admin_users.id) ON DELETE => cascade
+#
 FactoryBot.define do
   factory :admin_notification do
     admin_user

--- a/test/factories/admin_notifications.rb
+++ b/test/factories/admin_notifications.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin_notification do
+    admin_user
+    notification_type { "paints_import" }
+    severity { "info" }
+    title { "Paints Import Results" }
+    body { nil }
+    link { nil }
+    icon { nil }
+
+    trait :read do
+      read_at { Time.current }
+    end
+
+    trait :unread do
+      read_at { nil }
+    end
+
+    trait :expired do
+      expires_at { 1.day.ago }
+    end
+
+    trait :actionable do
+      severity { "warning" }
+      body { "## Missing Models (1)\n\n- **Aurora MR**" }
+    end
+  end
+end

--- a/test/integration/admin/api/v1/notifications_test.rb
+++ b/test/integration/admin/api/v1/notifications_test.rb
@@ -158,6 +158,28 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /notifications searches title and body" do
+    create(:admin_notification, admin_user: @admin_user, title: "Paints Import Results")
+    create(:admin_notification, admin_user: @admin_user, title: "Loaner Sync", body: "Missing **Aurora MR**")
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications", params: {q: {searchCont: "aurora"}} do
+      assert_equal ["Loaner Sync"], parsed_body["items"].pluck("title")
+    end
+  end
+
+  test "GET /notifications keeps unread notifications on top" do
+    create(:admin_notification, :read, admin_user: @admin_user, title: "read newest")
+    travel(-1.hour) do
+      create(:admin_notification, admin_user: @admin_user, title: "unread older")
+    end
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications" do
+      assert_equal ["unread older", "read newest"], parsed_body["items"].pluck("title")
+    end
+  end
+
   test "GET /notifications returns 401 when not signed in" do
     assert_api_response :get, 401, api_path: "/notifications"
   end

--- a/test/integration/admin/api/v1/notifications_test.rb
+++ b/test/integration/admin/api/v1/notifications_test.rb
@@ -139,6 +139,15 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /notifications hides types the admin no longer has access to" do
+    create(:admin_notification, admin_user: @admin_user, notification_type: "new_supporter")
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications" do
+      assert_equal 0, parsed_body["items"].count
+    end
+  end
+
   test "GET /notifications filters by unread" do
     create(:admin_notification, :read, admin_user: @admin_user)
     create(:admin_notification, admin_user: @admin_user)
@@ -179,6 +188,13 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
 
   test "PUT /notifications/:id/read does not reach another admin's notification" do
     notification = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 404, path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/read does not reach a type the admin lost access to" do
+    notification = create(:admin_notification, admin_user: @admin_user, notification_type: "new_supporter")
     sign_in @admin_user
 
     assert_api_response :put, 404, path_params: {id: notification.id}

--- a/test/integration/admin/api/v1/notifications_test.rb
+++ b/test/integration/admin/api/v1/notifications_test.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/notifications" do
+    get("Admin Notifications list") do
+      operationId "adminNotifications"
+      tags "Notifications"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string, default: AdminNotification.default_per_page}, required: false
+      parameter "$ref": "#/components/parameters/SortingParameter"
+      parameter name: "q", in: :query, schema: {"$ref": "#/components/schemas/AdminNotificationQuery"}, required: false
+      parameter name: "cacheId", in: :query, schema: {type: :string}, required: false
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotifications"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/unread-count" do
+    get("Unread Admin Notification count") do
+      operationId "adminNotificationsUnreadCount"
+      tags "Notifications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotificationUnreadCount"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/{id}/read" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "Admin Notification id", required: true
+
+    put("Mark Admin Notification as read") do
+      operationId "readAdminNotification"
+      tags "Notifications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotification"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/read-all" do
+    put("Mark all Admin Notifications as read") do
+      operationId "readAllAdminNotifications"
+      tags "Notifications"
+      produces "application/json"
+
+      response(204, "successful")
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "Admin Notification id", required: true
+
+    delete("Delete Admin Notification") do
+      operationId "destroyAdminNotification"
+      tags "Notifications"
+      produces "application/json"
+
+      response(204, "successful")
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/destroy-all" do
+    delete("Delete all Admin Notifications") do
+      operationId "destroyAllAdminNotifications"
+      tags "Notifications"
+      produces "application/json"
+
+      response(204, "successful")
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @admin_user = create(:admin_user, resource_access: [:models])
+    @other_admin = create(:admin_user, resource_access: [:models])
+  end
+
+  test "GET /notifications lists the signed in admin's notifications" do
+    create(:admin_notification, admin_user: @admin_user)
+    create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications" do
+      assert_equal 1, parsed_body["items"].count
+    end
+  end
+
+  test "GET /notifications hides expired notifications" do
+    create(:admin_notification, :expired, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications" do
+      assert_equal 0, parsed_body["items"].count
+    end
+  end
+
+  test "GET /notifications filters by unread" do
+    create(:admin_notification, :read, admin_user: @admin_user)
+    create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications", params: {q: {readAtNull: true}} do
+      assert_equal 1, parsed_body["items"].count
+    end
+  end
+
+  test "GET /notifications returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: "/notifications"
+  end
+
+  test "GET /notifications/unread-count counts only unread notifications" do
+    create(:admin_notification, admin_user: @admin_user)
+    create(:admin_notification, :read, admin_user: @admin_user)
+    create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications/unread-count" do
+      assert_equal 1, parsed_body["count"]
+    end
+  end
+
+  test "GET /notifications/unread-count returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: "/notifications/unread-count"
+  end
+
+  test "PUT /notifications/:id/read marks it read" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, path_params: {id: notification.id} do
+      assert parsed_body["read"]
+    end
+  end
+
+  test "PUT /notifications/:id/read does not reach another admin's notification" do
+    notification = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 404, path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/read returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :put, 401, path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/read-all leaves other admins untouched" do
+    create(:admin_notification, admin_user: @admin_user)
+    other = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 204
+
+    assert_equal 0, AdminNotification.where(admin_user: @admin_user).unread.count
+    assert_nil other.reload.read_at
+  end
+
+  test "PUT /notifications/read-all returns 401 when not signed in" do
+    assert_api_response :put, 401
+  end
+
+  test "DELETE /notifications/:id removes it" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :delete, 204, path_params: {id: notification.id}
+
+    assert_nil AdminNotification.find_by(id: notification.id)
+  end
+
+  test "DELETE /notifications/:id does not reach another admin's notification" do
+    notification = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :delete, 404, path_params: {id: notification.id}
+  end
+
+  test "DELETE /notifications/:id returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :delete, 401, path_params: {id: notification.id}
+  end
+
+  test "DELETE /notifications/destroy-all leaves other admins untouched" do
+    create(:admin_notification, admin_user: @admin_user)
+    create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :delete, 204
+
+    assert_equal 0, AdminNotification.where(admin_user: @admin_user).count
+    assert_equal 1, AdminNotification.where(admin_user: @other_admin).count
+  end
+
+  test "DELETE /notifications/destroy-all returns 401 when not signed in" do
+    assert_api_response :delete, 401
+  end
+end

--- a/test/jobs/loaders/modules_import_job_test.rb
+++ b/test/jobs/loaders/modules_import_job_test.rb
@@ -4,16 +4,38 @@ require "test_helper"
 
 module Loaders
   class ModulesImportJobTest < ActiveJob::TestCase
-    test "#perform runs the modules importer and creates a GitHub issue" do
-      results = {
-        new: {count: 1, items: [{model_name: "Retaliator", name: "Front Torpedo Bay"}]},
-        new_with_error: {count: 0, items: []},
-        model_not_found: {count: 0, items: []}
-      }
+    setup do
+      @admin_user = create(:admin_user, resource_access: [:models])
+      AdminNotificationsChannel.stubs(:broadcast_to)
+    end
 
+    def stub_importer(results)
       importer = mock("ModulesImporter")
       importer.expects(:run).returns(results)
       ModulesImporter.stubs(:new).returns(importer)
+    end
+
+    def results(new: [], new_with_error: [], model_not_found: [])
+      {
+        new: {count: new.size, items: new},
+        new_with_error: {count: new_with_error.size, items: new_with_error},
+        model_not_found: {count: model_not_found.size, items: model_not_found}
+      }
+    end
+
+    test "#perform notifies admins without opening an issue when nothing needs doing" do
+      stub_importer(results(new: [{model_name: "Retaliator", name: "Front Torpedo Bay"}]))
+      GithubIssueCreator.expects(:new).never
+
+      ::Loaders::ModulesImportJob.new.perform
+
+      notification = AdminNotification.find_by(admin_user: @admin_user, notification_type: "modules_import")
+      assert_not_nil notification
+      assert_equal "info", notification.severity
+    end
+
+    test "#perform opens an issue when models are missing" do
+      stub_importer(results(model_not_found: [{model_name: "Unknown", name: "Front Torpedo Bay"}]))
 
       creator = mock("GithubIssueCreator")
       creator.expects(:run).returns(true)
@@ -24,6 +46,8 @@ module Loaders
       ).returns(creator)
 
       ::Loaders::ModulesImportJob.new.perform
+
+      assert_equal "warning", AdminNotification.find_by(admin_user: @admin_user).severity
     end
   end
 end

--- a/test/jobs/loaders/paints_import_job_test.rb
+++ b/test/jobs/loaders/paints_import_job_test.rb
@@ -4,16 +4,38 @@ require "test_helper"
 
 module Loaders
   class PaintsImportJobTest < ActiveJob::TestCase
-    test "#perform runs the paints importer and creates a GitHub issue" do
-      results = {
-        new: {count: 1, items: [{model_name: "Aurora", name: "Red Alert"}]},
-        new_with_error: {count: 0, items: []},
-        model_not_found: {count: 0, items: []}
-      }
+    setup do
+      @admin_user = create(:admin_user, resource_access: [:models])
+      AdminNotificationsChannel.stubs(:broadcast_to)
+    end
 
+    def stub_importer(results)
       importer = mock("PaintsImporter")
       importer.expects(:run).returns(results)
       PaintsImporter.stubs(:new).returns(importer)
+    end
+
+    def results(new: [], new_with_error: [], model_not_found: [])
+      {
+        new: {count: new.size, items: new},
+        new_with_error: {count: new_with_error.size, items: new_with_error},
+        model_not_found: {count: model_not_found.size, items: model_not_found}
+      }
+    end
+
+    test "#perform notifies admins without opening an issue when nothing needs doing" do
+      stub_importer(results(new: [{model_name: "Aurora", name: "Red Alert"}]))
+      GithubIssueCreator.expects(:new).never
+
+      ::Loaders::PaintsImportJob.new.perform
+
+      notification = AdminNotification.find_by(admin_user: @admin_user, notification_type: "paints_import")
+      assert_not_nil notification
+      assert_equal "info", notification.severity
+    end
+
+    test "#perform opens an issue when models are missing" do
+      stub_importer(results(model_not_found: [{model_name: "Unknown", name: "Red Alert"}]))
 
       creator = mock("GithubIssueCreator")
       creator.expects(:run).returns(true)
@@ -24,6 +46,28 @@ module Loaders
       ).returns(creator)
 
       ::Loaders::PaintsImportJob.new.perform
+
+      assert_equal "warning", AdminNotification.find_by(admin_user: @admin_user).severity
+    end
+
+    test "#perform opens an issue when paints failed to import" do
+      stub_importer(results(new_with_error: [{model_name: "Aurora", name: "Red Alert"}]))
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).returns(true)
+      GithubIssueCreator.expects(:new).returns(creator)
+
+      ::Loaders::PaintsImportJob.new.perform
+    end
+
+    test "#perform folds an unchanged empty report into one notification" do
+      2.times do
+        stub_importer(results)
+        ::Loaders::PaintsImportJob.new.perform
+      end
+
+      assert_equal 1, AdminNotification.where(notification_type: "paints_import").count
+      assert_equal 2, AdminNotification.find_by(notification_type: "paints_import").occurrences
     end
   end
 end

--- a/test/jobs/notifications/admin_job_test.rb
+++ b/test/jobs/notifications/admin_job_test.rb
@@ -4,20 +4,50 @@ require "test_helper"
 
 module Notifications
   class AdminJobTest < ActiveJob::TestCase
-    test "#perform sends weekly admin email with stats" do
-      captured_stats = nil
-      AdminMailer.stubs(:weekly).with do |stats|
-        captured_stats = stats
+    setup do
+      AdminNotificationsChannel.stubs(:broadcast_to)
+    end
+
+    test "#perform mails the digest to every super admin individually" do
+      first = create(:admin_user, :super_admin)
+      second = create(:admin_user, :super_admin)
+      create(:admin_user, resource_access: [:models])
+
+      recipients = []
+      AdminMailer.stubs(:weekly).with do |admin_user, _report|
+        recipients << admin_user
         true
       end.returns(stub(deliver_later: true))
 
       ::Notifications::AdminJob.new.perform
 
-      assert_includes captured_stats.keys, :registrations
-      assert_includes captured_stats.keys, :ships
-      assert_includes captured_stats.keys, :vehicles
-      assert_includes captured_stats.keys, :wishes
-      assert_includes captured_stats.keys, :fleets
+      assert_equal [first, second].map(&:id).sort, recipients.map(&:id).sort
+    end
+
+    test "#perform passes a report covering every section" do
+      create(:admin_user, :super_admin)
+
+      captured = nil
+      AdminMailer.stubs(:weekly).with do |_admin_user, report|
+        captured = report
+        true
+      end.returns(stub(deliver_later: true))
+
+      ::Notifications::AdminJob.new.perform
+
+      assert_equal %i[growth engagement supporters ops content], captured[:sections].map(&:key)
+      assert_includes captured[:sections].first.metrics.map(&:key), :wishes
+    end
+
+    test "#perform records the report as an admin notification" do
+      admin_user = create(:admin_user, resource_access: [:stats])
+      AdminMailer.stubs(:weekly).returns(stub(deliver_later: true))
+
+      ::Notifications::AdminJob.new.perform
+
+      notification = AdminNotification.find_by(admin_user:, notification_type: "weekly_stats")
+      assert_not_nil notification
+      assert_includes notification.body, "New Registrations"
     end
   end
 end

--- a/test/jobs/notifications/new_patron_job_test.rb
+++ b/test/jobs/notifications/new_patron_job_test.rb
@@ -12,6 +12,21 @@ module Notifications
       ::Notifications::NewPatronJob.new.perform(supporter.id)
     end
 
+    test "#perform notifies admins with supporter access" do
+      AdminNotificationsChannel.stubs(:broadcast_to)
+      admin_user = create(:admin_user, resource_access: [:supporters])
+      supporter = create(:supporter_contribution, :patreon, name: "Alice", amount_cents: 500, currency: "EUR")
+      Discord::NewSupporter.expects(:new).with(supporter:).returns(stub(run: true))
+      AdminMailer.expects(:new_supporter).with(supporter).returns(stub(deliver_later: true))
+
+      ::Notifications::NewPatronJob.new.perform(supporter.id)
+
+      notification = AdminNotification.find_by(admin_user:, notification_type: "new_supporter")
+      assert_not_nil notification
+      assert_equal "Alice — 5.00 EUR", notification.body
+      assert_equal supporter, notification.record
+    end
+
     test "#perform still emails when the Discord post fails" do
       supporter = create(:supporter_contribution, :patreon)
       failing = stub

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -8,18 +8,40 @@ class AdminMailerTest < ActionMailer::TestCase
   end
 
   test "#weekly renders the subject" do
-    mail = AdminMailer.weekly(weekly_stats)
+    mail = AdminMailer.weekly(@super_admin, report)
     assert_equal I18n.t(:"mailer.admin.weekly.subject"), mail.subject
   end
 
-  test "#weekly sends to super admin users" do
-    mail = AdminMailer.weekly(weekly_stats)
-    assert_includes mail.to, @super_admin.email
+  test "#weekly addresses the admin it was built for" do
+    mail = AdminMailer.weekly(@super_admin, report)
+    assert_equal [@super_admin.email], mail.to
   end
 
-  test "#weekly renders the body" do
-    mail = AdminMailer.weekly(weekly_stats)
-    assert mail.body.encoded.present?
+  test "#weekly renders every section and the delta columns" do
+    mail = AdminMailer.weekly(@super_admin, report)
+
+    %i[growth engagement supporters ops content].each do |section|
+      assert_includes mail.body.encoded, ERB::Util.html_escape(I18n.t(:"mailer.admin.weekly.sections.#{section}"))
+    end
+    assert_includes mail.body.encoded, I18n.t(:"mailer.admin.weekly.metrics.wishes")
+  end
+
+  test "#weekly lists the admins own open notifications" do
+    create(:admin_notification, admin_user: @super_admin, title: "Paints Import Results")
+    create(:admin_notification, admin_user: create(:admin_user), title: "Someone Elses Report")
+
+    mail = AdminMailer.weekly(@super_admin, report)
+
+    assert_includes mail.body.encoded, "Paints Import Results"
+    assert_not_includes mail.body.encoded, "Someone Elses Report"
+  end
+
+  test "#weekly leaves out the digest notification it is about to create" do
+    create(:admin_notification, admin_user: @super_admin, notification_type: "weekly_stats", title: "Weekly Report")
+
+    mail = AdminMailer.weekly(@super_admin, report)
+
+    assert_includes mail.body.encoded, I18n.t(:"mailer.admin.weekly.notifications.empty")
   end
 
   test "#new_supporter renders the subject" do
@@ -69,8 +91,8 @@ class AdminMailerTest < ActionMailer::TestCase
 
   private
 
-  def weekly_stats
-    {registrations: 10, ships: 5, vehicles: 20, fleets: 2}
+  def report
+    @report ||= AdminWeeklyReport.build
   end
 
   def supporter

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -2,13 +2,7 @@
 
 class AdminMailerPreview < ActionMailer::Preview
   def weekly
-    stats = {
-      registrations: 1,
-      ships: 2,
-      vehicles: 3
-    }
-
-    AdminMailer.weekly(stats)
+    AdminMailer.weekly(AdminUser.where(super_admin: true).first || AdminUser.first, AdminWeeklyReport.build)
   end
 
   def notify_block

--- a/test/models/admin_notification_test.rb
+++ b/test/models/admin_notification_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminNotificationTest < ActiveSupport::TestCase
+  setup do
+    AdminNotificationsChannel.stubs(:broadcast_to)
+  end
+
+  test "fans out to every admin holding the type's privilege" do
+    with_access = create(:admin_user, resource_access: [:models])
+    without_access = create(:admin_user, resource_access: [:users])
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results")
+
+    assert_equal 1, AdminNotification.where(admin_user: with_access).count
+    assert_equal 0, AdminNotification.where(admin_user: without_access).count
+  end
+
+  test "reaches super admins regardless of their resource access" do
+    super_admin = create(:admin_user, :super_admin, resource_access: [])
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results")
+
+    assert_equal 1, AdminNotification.where(admin_user: super_admin).count
+  end
+
+  test "defaults expires_at from the type's retention" do
+    create(:admin_user, resource_access: [:models])
+
+    notification = AdminNotification.notify!(type: :paints_import, title: "Paints Import Results").first
+
+    assert_in_delta 30.days.from_now, notification.expires_at, 5.seconds
+  end
+
+  test "picks up the type's icon when none is given" do
+    create(:admin_user, resource_access: [:models])
+
+    notification = AdminNotification.notify!(type: :paints_import, title: "Paints Import Results").first
+
+    assert_equal "fa-duotone fa-palette", notification.icon
+  end
+
+  test "folds a repeated report into the unread row instead of stacking up" do
+    create(:admin_user, resource_access: [:models])
+
+    3.times do
+      AdminNotification.notify!(
+        type: :paints_import,
+        title: "Paints Import Results",
+        body: "No new Paints found",
+        dedupe_key: "same"
+      )
+    end
+
+    assert_equal 1, AdminNotification.count
+    assert_equal 3, AdminNotification.first.occurrences
+  end
+
+  test "starts a new row once the deduped one has been read" do
+    create(:admin_user, resource_access: [:models])
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same").first.mark_as_read!
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same")
+
+    assert_equal 2, AdminNotification.count
+  end
+
+  test "keeps reports with differing bodies apart" do
+    create(:admin_user, resource_access: [:models])
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "first")
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "second")
+
+    assert_equal 2, AdminNotification.count
+  end
+
+  test "does not raise when the broadcast fails" do
+    create(:admin_user, resource_access: [:models])
+    AdminNotificationsChannel.stubs(:broadcast_to).raises(StandardError, "cable down")
+
+    assert_nothing_raised do
+      AdminNotification.notify!(type: :paints_import, title: "Paints Import Results")
+    end
+
+    assert_equal 1, AdminNotification.count
+  end
+
+  test "active and expired split on expires_at" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    active = create(:admin_notification, admin_user:)
+    expired = create(:admin_notification, :expired, admin_user:)
+
+    assert_includes AdminNotification.active, active
+    assert_includes AdminNotification.expired, expired
+  end
+end

--- a/test/models/admin_notification_test.rb
+++ b/test/models/admin_notification_test.rb
@@ -115,6 +115,15 @@ class AdminNotificationTest < ActiveSupport::TestCase
     assert_equal 2, existing.reload.occurrences
   end
 
+  test "lists only the types the admin currently has access to" do
+    admin_user = create(:admin_user, resource_access: [:models])
+
+    types = AdminNotification.types_for(admin_user)
+
+    assert_includes types, "paints_import"
+    assert_not_includes types, "new_supporter"
+  end
+
   test "keeps reports with differing bodies apart" do
     create(:admin_user, resource_access: [:models])
 

--- a/test/models/admin_notification_test.rb
+++ b/test/models/admin_notification_test.rb
@@ -2,6 +2,41 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: admin_notifications
+#
+#  id                :uuid             not null, primary key
+#  body              :text
+#  dedupe_key        :string
+#  expires_at        :datetime         not null
+#  icon              :string
+#  last_occurred_at  :datetime         not null
+#  link              :string
+#  notification_type :string           not null
+#  occurrences       :integer          default(1), not null
+#  read_at           :datetime
+#  record_type       :string
+#  severity          :string           default("info"), not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  admin_user_id     :uuid             not null
+#  record_id         :uuid
+#
+# Indexes
+#
+#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
+#  index_admin_notifications_on_expires_at                    (expires_at)
+#  index_admin_notifications_on_notification_type             (notification_type)
+#  index_admin_notifications_on_record                        (record_type,record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_user_id => admin_users.id) ON DELETE => cascade
+#
 class AdminNotificationTest < ActiveSupport::TestCase
   setup do
     AdminNotificationsChannel.stubs(:broadcast_to)
@@ -64,6 +99,20 @@ class AdminNotificationTest < ActiveSupport::TestCase
     AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same")
 
     assert_equal 2, AdminNotification.count
+  end
+
+  test "folds into the existing row when a concurrent report wins the insert race" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    existing = create(:admin_notification, admin_user:, dedupe_key: "same")
+
+    # The first lookup misses the way it would for a job that read before the
+    # other one inserted; the unique index then forces the retry.
+    AdminNotification.stubs(:unread).returns(AdminNotification.none, AdminNotification.where(read_at: nil))
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same")
+
+    assert_equal 1, AdminNotification.count
+    assert_equal 2, existing.reload.occurrences
   end
 
   test "keeps reports with differing bodies apart" do

--- a/test/models/rsi_request_log_test.rb
+++ b/test/models/rsi_request_log_test.rb
@@ -2,6 +2,16 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: rsi_request_logs
+#
+#  id         :uuid             not null, primary key
+#  resolved   :boolean          default(FALSE)
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class RsiRequestLogTest < ActiveSupport::TestCase
   setup do
     AdminNotificationsChannel.stubs(:broadcast_to)

--- a/test/models/rsi_request_log_test.rb
+++ b/test/models/rsi_request_log_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RsiRequestLogTest < ActiveSupport::TestCase
+  setup do
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    @admin_user = create(:admin_user, resource_access: [:"rsi-api-status"])
+  end
+
+  test "notifies admins with RSI status access when a request is blocked" do
+    RsiRequestLog.create!(url: "https://robertsspaceindustries.com/test")
+
+    notification = AdminNotification.find_by(admin_user: @admin_user, notification_type: "rsi_api_blocked")
+    assert_not_nil notification
+    assert_equal "error", notification.severity
+    assert_equal "https://robertsspaceindustries.com/test", notification.body
+  end
+
+  test "folds repeat blocks of the same url into one notification" do
+    2.times { RsiRequestLog.create!(url: "https://robertsspaceindustries.com/test") }
+
+    assert_equal 1, AdminNotification.where(notification_type: "rsi_api_blocked").count
+    assert_equal 2, AdminNotification.find_by(notification_type: "rsi_api_blocked").occurrences
+  end
+
+  test "notifies again when the request is unblocked" do
+    log = RsiRequestLog.create!(url: "https://robertsspaceindustries.com/test")
+
+    log.update!(resolved: true)
+
+    assert_not_nil AdminNotification.find_by(admin_user: @admin_user, notification_type: "rsi_api_unblocked")
+  end
+end


### PR DESCRIPTION
## Why

Background jobs had two ways to reach an admin, and both were blunt:

- **GitHub issues** via `GithubIssueCreator`. `PaintsImportJob` and `ModulesImportJob` opened one on *every* run — including the weekly ones whose entire body was "No new Paints found". Nobody could close those, so they piled up (#4400 is the living proof).
- **Emails** via `AdminMailer` — weekly stats, new Patreon supporter, RSI block/unblock.

Neither has a read state, neither is filterable. Meanwhile a full persistent notification system already existed for users with no admin counterpart.

Closes #4379, closes #4400.

## What

**`admin_notifications`** — modelled on the user-facing `notifications` table. Notifications fan out per admin, targeted by the `resource_access` privilege each type declares and resolved through the existing `AdminUser#has_access?`, so recipients match how the admin UI already gates pages. A `dedupe_key` folds a repeated identical report into the row that is still unread and bumps `occurrences` rather than stacking up — that is the anti-spam mechanism.

**`AdminReport`** — the single sink for recurring job reports. Every run lands in the notification center; a GitHub issue is only opened when the report contains something a human has to resolve (missing models, import errors, unmatched vehicles, unmapped commodities). The importers own the definition of "actionable" next to the report body they already build. Titles are unchanged on the actionable path, since the `resolve-*-import` skills find their issue by title.

**Mail mirrors** — RSI block/unblock and new supporters also spawn a notification. The mails stay, so nothing is lost while nobody is logged into admin.

**Weekly report mail, reworked** — it was four bare counts, and the `wishes` count the job computed was never rendered. It is now a digest across growth, engagement, supporters, ops health, and content/data gaps, each metric compared against the previous week with the delta coloured by whether that direction is good for *that* metric. It ends on the recipient's own open notifications and a link to the center, which is why it is now sent per admin rather than to the whole super-admin list at once.

**Notification center** — a bell in the admin nav carrying the unread count with a dropdown of recent unread items, plus a `/notifications` page filtered by type, severity and read state, with bodies expanding in place and read/delete individually or in bulk. Live over `AdminNotificationsChannel` (the admin bundle's first cable consumer) with a polling fallback.

## Verification

- `bin/rails test` — 2056 tests. The 4 failures are pre-existing/environmental: the same `users_resend_confirmation` failure reproduces on a stashed clean tree, and `model_compare_share_test` passes in isolation (parallel-run flake).
- Frontend: 195 vitest tests, `pnpm lint:ts`, `pnpm lint`, `bundle exec standardrb` and `bin/vite build` all clean.
- The regression test that matters: `test/jobs/loaders/paints_import_job_test.rb` asserts `GithubIssueCreator.expects(:new).never` on an empty result, and that a second identical run bumps `occurrences` instead of adding a row.

## Notes for review

- **Not verified in a browser.** The admin UI is 2FA-gated, so the nav bell and page were checked by type-check, build and unit tests rather than by clicking. `test/mailers/previews/admin_mailer_preview.rb#weekly` renders the digest at `/admin/letter_opener` in dev.
- **Notification bodies are plain text**, rendered `white-space: pre-wrap` — they are the Markdown-ish strings the existing `github_issue_body` builders already produce, and the repo has no Markdown renderer. Structured section rendering is a clean follow-up if the `**bold**` asterisks read badly.
- **The three new enums land in the public `swagger/v1/schema.yaml` too.** They live in `Shared::V1::Schemas`, which emits into both schemas — same as the existing admin-only `SupporterContributionSourceEnum` and `ImportStatusEnum`. Existing behaviour, not introduced here.
- Non-en locales keep their four existing weekly metric translations, moved under the new `metrics` key; Crowdin fills the rest.

🤖
