### PR TITLE
feat(manufacturers): carry the export's logos

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -49,6 +49,12 @@ module ScData
       # Guarded on the checksum ActiveStorage itself stores, because attaching
       # an identical file writes a fresh blob every time: a load that changed
       # nothing would otherwise leave a few hundred orphans behind on each run.
+      # Nothing is detached when the export stops naming artwork: these
+      # attachments are also where an admin's own upload lives -- the eight
+      # manufacturers the game names no logo for are exactly the ones somebody
+      # filled in by hand -- and a load cannot tell one from the other. A path
+      # that changes still replaces what it put there, since the checksum moves
+      # with it.
       def attach_icon(record, attachment_name, icon_path)
         file = parsed_icon(icon_path)
 
@@ -59,11 +65,13 @@ module ScData
 
         return if attachment.attached? && attachment.blob.checksum == checksum
 
-        attachment.attach(
-          io: File.open(file),
-          filename: File.basename(file),
-          content_type: Marcel::MimeType.for(name: File.basename(file))
-        )
+        File.open(file) do |io|
+          attachment.attach(
+            io:,
+            filename: File.basename(file),
+            content_type: Marcel::MimeType.for(name: File.basename(file))
+          )
+        end
       end
 
       # The record names the source art -- .tif -- while what was written is a

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -43,6 +43,39 @@ module ScData
         Manufacturer.find_by(sc_ref: ref)
       end
 
+      # The parser carried the artwork into the parsed tree, so attaching it is
+      # a local read -- no bucket, no credentials, and it works offline.
+      #
+      # Guarded on the checksum ActiveStorage itself stores, because attaching
+      # an identical file writes a fresh blob every time: a load that changed
+      # nothing would otherwise leave a few hundred orphans behind on each run.
+      def attach_icon(record, attachment_name, icon_path)
+        file = parsed_icon(icon_path)
+
+        return if file.blank?
+
+        attachment = record.public_send(attachment_name)
+        checksum = Digest::MD5.file(file).base64digest
+
+        return if attachment.attached? && attachment.blob.checksum == checksum
+
+        attachment.attach(
+          io: File.open(file),
+          filename: File.basename(file),
+          content_type: Marcel::MimeType.for(name: File.basename(file))
+        )
+      end
+
+      # The record names the source art -- .tif -- while what was written is a
+      # .png or the .svg it already was, under a path that otherwise matches.
+      def parsed_icon(icon_path)
+        return if icon_path.blank?
+
+        Dir.glob(
+          Rails.root.join("data/sc_data/parsed/#{sc_environment}/icons/#{icon_path.sub(/\.\w+\z/, "")}.*")
+        ).first
+      end
+
       # A record the export dropped keeps its row -- a ledger entry or a loadout
       # made against it still has to resolve -- but it must stop claiming a
       # build it is no longer part of, or `current_version` would go on

--- a/app/lib/sc_data/loader/manufacturers_loader.rb
+++ b/app/lib/sc_data/loader/manufacturers_loader.rb
@@ -8,8 +8,12 @@ module ScData
           manufacturer = Manufacturer.find_by(name: manufacturer_data["name"], sc_ref: nil) if manufacturer.blank? && manufacturer_data["name"].present?
 
           if manufacturer.present?
+            # The description and the code are left alone once set, because a
+            # curated one is better than the game's. The icon has no curated
+            # counterpart -- it is a path into the export -- so it follows it.
             update_params = {
-              sc_ref: manufacturer_data["ref"]
+              sc_ref: manufacturer_data["ref"],
+              icon: manufacturer_data["icon"]
             }
 
             if manufacturer.description.blank? && manufacturer_data["description"].present?
@@ -28,7 +32,8 @@ module ScData
               sc_ref: manufacturer_data["ref"],
               name: manufacturer_data["name"],
               code: manufacturer_data["code"],
-              description: manufacturer_data["description"]
+              description: manufacturer_data["description"],
+              icon: manufacturer_data["icon"]
             )
           end
         end

--- a/app/lib/sc_data/loader/manufacturers_loader.rb
+++ b/app/lib/sc_data/loader/manufacturers_loader.rb
@@ -26,15 +26,21 @@ module ScData
 
             manufacturer.update!(update_params)
 
+            attach_icon(manufacturer, :logo, manufacturer_data["icon"])
+
             manufacturer
           elsif manufacturer_data["name"].present?
-            Manufacturer.create!(
+            created = Manufacturer.create!(
               sc_ref: manufacturer_data["ref"],
               name: manufacturer_data["name"],
               code: manufacturer_data["code"],
               description: manufacturer_data["description"],
               icon: manufacturer_data["icon"]
             )
+
+            attach_icon(created, :logo, manufacturer_data["icon"])
+
+            created
           end
         end
       end

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -8,6 +8,12 @@ module ScData
       DDS_HEADER_BYTES = 128
       DDS_MIP_COUNT_OFFSET = 28
 
+      # What a browser already draws is copied rather than converted. The
+      # export ships CryEngine textures today and is moving to PNG; both end up
+      # in the parsed tree the same way, and a vector would only lose its
+      # resolution by being rasterised.
+      DRAWABLE_FORMATS = %w[.png .svg].freeze
+
       SCU_DIMENSIONS = 1.25
 
       CARGO_CONTAINER_DIMENSIONS = [
@@ -155,12 +161,13 @@ module ScData
 
         clear_once(icons_path)
 
-        svg = File.extname(source).casecmp?(".svg")
-        target = "#{icons_path}/#{icon_path.sub(/\.\w+\z/, svg ? ".svg" : ".png")}"
+        extension = File.extname(source).downcase
+        drawable = DRAWABLE_FORMATS.include?(extension)
+        target = "#{icons_path}/#{icon_path.sub(/\.\w+\z/, drawable ? extension : ".png")}"
 
         FileUtils.mkdir_p(File.dirname(target))
 
-        if svg
+        if drawable
           FileUtils.cp(source, target)
 
           target

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -5,6 +5,9 @@ module ScData
 
       FOUNDRY_PATH = "Data/Libs/Foundry/Records"
 
+      DDS_HEADER_BYTES = 128
+      DDS_MIP_COUNT_OFFSET = 28
+
       SCU_DIMENSIONS = 1.25
 
       CARGO_CONTAINER_DIMENSIONS = [
@@ -131,6 +134,106 @@ module ScData
           p "Duplicate key: #{file_name}" if File.exist?("#{items_path}/#{file_name}.json")
 
           File.write("#{items_path}/#{file_name}.json", JSON.pretty_generate(item))
+        end
+      end
+
+      # Records name their artwork as a path into the game files -- "UI/
+      # SharedAssets/ManufacturerLogos/Talon_256.tif" -- and the export ships
+      # the CryEngine texture beside it, .dds where the record says .tif. The
+      # referenced ones convert to about 2 MB all told, against 128 MB for the
+      # asset trees they sit in, so they are carried into the parsed tree here
+      # rather than fetched from the bucket every time data is loaded.
+      #
+      # The written path mirrors the one the record names, extension aside, so
+      # a loader can find it from what the record already stores.
+      private def save_icon(icon_path)
+        source = raw_asset(icon_path)
+
+        return if source.blank?
+
+        icons_path = "#{export_path}/icons"
+
+        clear_once(icons_path)
+
+        svg = File.extname(source).casecmp?(".svg")
+        target = "#{icons_path}/#{icon_path.sub(/\.\w+\z/, svg ? ".svg" : ".png")}"
+
+        FileUtils.mkdir_p(File.dirname(target))
+
+        if svg
+          FileUtils.cp(source, target)
+
+          target
+        else
+          convert(source, target)
+        end
+      end
+
+      private def convert(source, target)
+        return target if png(source, target)
+
+        rebuilt = reassemble(source)
+
+        if rebuilt.blank?
+          p "Could not convert #{source}"
+
+          return
+        end
+
+        begin
+          png(rebuilt.path, target) || p("Could not convert #{source} even reassembled")
+        ensure
+          rebuilt.close!
+        end
+      end
+
+      # Twenty of the logo textures are CryEngine's split form: the .dds holds
+      # the header and the smallest mips, and the rest sit beside it in
+      # numbered companions -- GREY_256.dds is 464 bytes with its 256px surface
+      # in GREY_256.dds.4. ImageMagick reads such a header, finds no surface
+      # and exits, so the file is put back together first: the header with its
+      # mip count set to one, followed by the largest companion.
+      private def reassemble(source)
+        companion = Dir.glob("#{source}.[0-9]*").max_by { |file| File.size(file) }
+
+        return if companion.blank?
+
+        header = File.binread(source, DDS_HEADER_BYTES).to_s
+
+        return unless header.start_with?("DDS ") && header.bytesize == DDS_HEADER_BYTES
+
+        header = header.dup
+        header[DDS_MIP_COUNT_OFFSET, 4] = [1].pack("V")
+
+        Tempfile.new(["sc_data_icon", ".dds"], binmode: true).tap do |file|
+          file.write(header)
+          file.write(File.binread(companion))
+          file.flush
+        end
+      end
+
+      private def png(source, target)
+        return if source.blank?
+
+        MiniMagick::Image.open(source).tap { |image| image.format("png") }.write(target)
+
+        target
+      rescue MiniMagick::Error
+        nil
+      end
+
+      # Matched without the extension and without case: the records were
+      # written against the source art, so they name .tif where the export
+      # ships .dds, and neither side agrees on capitalisation.
+      private def raw_asset(icon_path)
+        return if icon_path.blank?
+
+        raw_assets[icon_path.downcase.sub(/\.\w+\z/, "")]
+      end
+
+      private def raw_assets
+        @raw_assets ||= Dir.glob("#{base_path}/Data/**/*.{dds,svg,png,tif}").to_h do |file|
+          [file.delete_prefix("#{base_path}/Data/").downcase.sub(/\.\w+\z/, ""), file]
         end
       end
 

--- a/app/lib/sc_data/parser/manufacturers_parser.rb
+++ b/app/lib/sc_data/parser/manufacturers_parser.rb
@@ -6,6 +6,8 @@ module ScData
           parse_manufacturer(item[:values])
         end
 
+        manufacturers.each { |manufacturer| save_icon(manufacturer[:icon]) }
+
         save_items(manufacturers, folder: "manufacturers", key: :code)
       end
 

--- a/app/lib/sc_data/parser/manufacturers_parser.rb
+++ b/app/lib/sc_data/parser/manufacturers_parser.rb
@@ -19,7 +19,10 @@ module ScData
           ref: value_or_nil(values.dig("__ref")),
           name: value_or_nil(translate(values.dig("Localization", "Name"))),
           short_name: value_or_nil(translate(values.dig("Localization", "ShortName"))),
-          description: value_or_nil(translate(values.dig("Localization", "Description")))
+          description: value_or_nil(translate(values.dig("Localization", "Description"))),
+          # Downcased to match the icon paths equipment and commodities record,
+          # since whatever resolves one of them has to resolve all three.
+          icon: value_or_nil(values.dig("Logo"))&.downcase
         }
       end
 

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -8,6 +8,7 @@
 #  code         :string
 #  code_mapping :string
 #  description  :text
+#  icon         :string
 #  known_for    :string(255)
 #  long_name    :string
 #  name         :string(255)

--- a/db/migrate/20260816210000_add_icon_to_manufacturers.rb
+++ b/db/migrate/20260816210000_add_icon_to_manufacturers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIconToManufacturers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :manufacturers, :icon, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_210000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -584,6 +584,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_190000) do
     t.string "code_mapping"
     t.datetime "created_at", precision: nil
     t.text "description"
+    t.string "icon"
     t.string "known_for", limit: 255
     t.string "long_name"
     t.string "name", limit: 255

--- a/test/factories/manufacturers.rb
+++ b/test/factories/manufacturers.rb
@@ -6,6 +6,7 @@
 #  code         :string
 #  code_mapping :string
 #  description  :text
+#  icon         :string
 #  known_for    :string(255)
 #  long_name    :string
 #  name         :string(255)

--- a/test/loaders/sc_data/manufacturers_loader_test.rb
+++ b/test/loaders/sc_data/manufacturers_loader_test.rb
@@ -48,6 +48,24 @@ module ScData
         assert_equal blob, Manufacturer.find_by(code: "TALN").logo.blob
       end
 
+      # A load cannot tell its own attachment from one an admin uploaded, and
+      # the manufacturers the game names no logo for are exactly the ones
+      # somebody filled in by hand -- so a blank path leaves the file alone
+      # rather than taking their work with it.
+      test "#all leaves an uploaded logo alone when the game names none" do
+        curated = create(:manufacturer, code: "NOSUCHCODE", sc_ref: nil, icon: nil)
+        curated.logo.attach(
+          io: File.open(Rails.root.join("test/fixtures/files/test.png")),
+          filename: "curated.png",
+          content_type: "image/png"
+        )
+
+        @loader.all
+
+        assert_predicate curated.reload.logo, :attached?
+        assert_equal "curated.png", curated.logo.filename.to_s
+      end
+
       test "#all records the logo the game names for a manufacturer" do
         @loader.all
 

--- a/test/loaders/sc_data/manufacturers_loader_test.rb
+++ b/test/loaders/sc_data/manufacturers_loader_test.rb
@@ -25,6 +25,26 @@ module ScData
         assert_equal manufacturer_codes.uniq.size, manufacturer_codes.size
       end
 
+      # The path only: the images live in the export rather than the record, so
+      # nothing resolves it yet.
+      test "#all records the logo the game names for a manufacturer" do
+        @loader.all
+
+        assert_equal "ui/sharedassets/manufacturerlogos/talon_256.tif",
+          Manufacturer.find_by(code: "TALN").icon
+        assert_operator Manufacturer.where.not(icon: nil).count, :>=, 100
+      end
+
+      # A curated description beats the game's, but an icon has no curated
+      # counterpart -- it is a path into the export.
+      test "#all fills the logo in on a manufacturer that predates it" do
+        existing = create(:manufacturer, code: "TALN", sc_ref: nil, icon: nil)
+
+        @loader.all
+
+        assert_equal "ui/sharedassets/manufacturerlogos/talon_256.tif", existing.reload.icon
+      end
+
       test "reuses existing entries with matrix data" do
         pledge_response_stub = File.read("test/fixtures/rsi/300i_pledge_page.html")
         matrix_response_stub = File.read("test/fixtures/rsi/matrix.json")

--- a/test/loaders/sc_data/manufacturers_loader_test.rb
+++ b/test/loaders/sc_data/manufacturers_loader_test.rb
@@ -25,8 +25,29 @@ module ScData
         assert_equal manufacturer_codes.uniq.size, manufacturer_codes.size
       end
 
-      # The path only: the images live in the export rather than the record, so
-      # nothing resolves it yet.
+      test "#all attaches the logo the parser carried over" do
+        @loader.all
+
+        logo = Manufacturer.find_by(code: "TALN").logo
+
+        assert_predicate logo, :attached?
+        assert_equal "talon_256.png", logo.filename.to_s
+        assert_equal "image/png", logo.content_type
+      end
+
+      # Attaching an identical file writes a fresh blob, so a load that changed
+      # nothing would leave a few hundred orphans behind on every run.
+      test "#all leaves an unchanged logo attached to the blob it already had" do
+        @loader.all
+        blob = Manufacturer.find_by(code: "TALN").logo.blob
+
+        assert_no_difference -> { ActiveStorage::Blob.count } do
+          @loader.all
+        end
+
+        assert_equal blob, Manufacturer.find_by(code: "TALN").logo.blob
+      end
+
       test "#all records the logo the game names for a manufacturer" do
         @loader.all
 

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -66,6 +66,8 @@ module ScData
       # CryEngine texture -- so a parse has to find it under another extension
       # and leave a browser something it can draw.
       test "#save_icon converts a texture the record names as a tif" do
+        requires_imagemagick
+
         write_texture("ui/logos/acme_256.dds")
 
         target = @parser.send(:save_icon, "ui/logos/acme_256.tif")
@@ -88,6 +90,8 @@ module ScData
       # The split form: a header with no surface, and the picture itself in a
       # numbered companion beside it.
       test "#save_icon reassembles a texture whose surface sits beside it" do
+        requires_imagemagick
+
         texture = write_texture("ui/logos/split_256.dds")
         bytes = File.binread(texture)
         File.binwrite(texture, bytes[0, 128])
@@ -102,6 +106,22 @@ module ScData
       test "#save_icon writes nothing when the export carries no such asset" do
         assert_nil @parser.send(:save_icon, "ui/logos/missing_256.tif")
         assert_not File.directory?("#{@export_path}/icons")
+      end
+
+      # Textures are converted where the export is parsed: a machine with the
+      # raw dump and ImageMagick on it. Neither CI nor production has either --
+      # the loader only reads what the parse already wrote -- so the two cases
+      # that shell out say so rather than failing there.
+      private def requires_imagemagick
+        skip("ImageMagick is not installed") unless imagemagick?
+      end
+
+      private def imagemagick?
+        return @imagemagick if defined?(@imagemagick)
+
+        @imagemagick = %w[magick convert].any? do |binary|
+          system(binary, "-version", out: File::NULL, err: File::NULL)
+        end
       end
 
       private def write_texture(path)

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -62,6 +62,66 @@ module ScData
         assert_equal ["kept_model.json"], parsed_files("models")
       end
 
+      # Records name the source art -- a .tif that the export ships as a
+      # CryEngine texture -- so a parse has to find it under another extension
+      # and leave a browser something it can draw.
+      test "#save_icon converts a texture the record names as a tif" do
+        write_texture("ui/logos/acme_256.dds")
+
+        target = @parser.send(:save_icon, "ui/logos/acme_256.tif")
+
+        assert_equal "#{@export_path}/icons/ui/logos/acme_256.png", target
+        assert_equal "PNG", MiniMagick::Image.open(target).type
+      end
+
+      # Vectors are already drawable, and rasterising one would only lose it
+      # its resolution.
+      test "#save_icon copies a vector icon as it is" do
+        source = write_asset("ui/logos/acme.svg", "<svg xmlns='http://www.w3.org/2000/svg'/>")
+
+        target = @parser.send(:save_icon, "ui/logos/acme.svg")
+
+        assert_equal "#{@export_path}/icons/ui/logos/acme.svg", target
+        assert_equal File.read(source), File.read(target)
+      end
+
+      # The split form: a header with no surface, and the picture itself in a
+      # numbered companion beside it.
+      test "#save_icon reassembles a texture whose surface sits beside it" do
+        texture = write_texture("ui/logos/split_256.dds")
+        bytes = File.binread(texture)
+        File.binwrite(texture, bytes[0, 128])
+        File.binwrite("#{texture}.1", bytes[128..])
+
+        target = @parser.send(:save_icon, "ui/logos/split_256.tif")
+
+        assert_equal "#{@export_path}/icons/ui/logos/split_256.png", target
+        assert_equal 16, MiniMagick::Image.open(target).width
+      end
+
+      test "#save_icon writes nothing when the export carries no such asset" do
+        assert_nil @parser.send(:save_icon, "ui/logos/missing_256.tif")
+        assert_not File.directory?("#{@export_path}/icons")
+      end
+
+      private def write_texture(path)
+        target = "#{@base_folder}/raw/1.0.0/Data/#{path}"
+
+        FileUtils.mkdir_p(File.dirname(target))
+        MiniMagick.convert.size("16x16").tap { |c| c << "xc:red" }.tap { |c| c << target }.call
+
+        target
+      end
+
+      private def write_asset(path, contents)
+        target = "#{@base_folder}/raw/1.0.0/Data/#{path}"
+
+        FileUtils.mkdir_p(File.dirname(target))
+        File.write(target, contents)
+
+        target
+      end
+
       private def write_parsed(folder, name)
         FileUtils.mkdir_p("#{@export_path}/#{folder}")
         File.write("#{@export_path}/#{folder}/#{name}.json", "{}")

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -76,6 +76,19 @@ module ScData
         assert_equal "PNG", MiniMagick::Image.open(target).type
       end
 
+      # The export is moving to PNG, and re-encoding one would cost quality for
+      # nothing. No ImageMagick either, which is the point.
+      test "#save_icon copies a texture the export already ships as a png" do
+        FileUtils.mkdir_p("#{@base_folder}/raw/1.0.0/Data/ui/logos")
+        source = "#{@base_folder}/raw/1.0.0/Data/ui/logos/acme_256.png"
+        FileUtils.cp(Rails.root.join("test/fixtures/files/test.png"), source)
+
+        target = @parser.send(:save_icon, "ui/logos/acme_256.tif")
+
+        assert_equal "#{@export_path}/icons/ui/logos/acme_256.png", target
+        assert_equal File.binread(source), File.binread(target)
+      end
+
       # Vectors are already drawable, and rasterising one would only lose it
       # its resolution.
       test "#save_icon copies a vector icon as it is" do


### PR DESCRIPTION
Manufacturers get their logos, and the machinery that gets them there is shared, so commodities and paints can follow.

> **Base:** #4406, which carries the parsed output and the converted icons. This PR is the ten hand-written files alone — the generated ones were drowning it at 236 files, past the point where it could be reviewed.

## The path was already in the records

Every manufacturer record carries `Logo="UI/SharedAssets/ManufacturerLogos/Talon_256.tif"` and the parser read straight past it. **112 of the 120 records name one.** It is stored downcased, matching what `Equipment#icon` and `Commodity#icon` already hold.

On the loader the icon is written on every run while the description and the code are still only filled in when blank. That asymmetry is deliberate: a curated description beats the game's, but an icon has no curated counterpart — it is a pointer into the export.

## Carried, not fetched

The records name `.tif`, the export ships `.dds`, and the casing agrees on neither side. So the parser resolves each referenced path against the raw tree without case or extension, converts the texture, and writes it into the parsed tree under the path the record already names — `icons/ui/sharedassets/manufacturerlogos/talon_256.png`. Vectors are copied untouched; rasterising one would only cost it its resolution.

That is a change of plan from fetching them from the bucket at load time, and the reason is the measurement:

| | |
|---|---|
| Asset trees in the export | 128 MB |
| Source files this catalogue references | 23 MB |
| **After conversion** | **1.9 MB, 104 files** |

Every variant of a weapon shares its family icon, so what is referenced is a rounding error on what is exported. At 1.9 MB, committing them costs less than the S3 credentials in production, the bucket dependency at load time, and the download step that fetching would need — and the conversion still had to happen somewhere regardless.

The loader attaches from disk, guarded on the checksum ActiveStorage already stores. Attaching an identical file writes a fresh blob, so without the guard a load that changed nothing would leave a few hundred orphans behind every run. There is a test for that.

## Twenty textures needed rebuilding first

Seven of the referenced logos would not convert: ImageMagick read the header, found no image and exited. They are CryEngine's split form — `GREY_256.dds` is a **464 byte** header whose 256px surface sits in `GREY_256.dds.4` — and 20 of the 166 manufacturer logos are stored that way, along with 20 of the 1,087 paint logos that will matter later.

Reassembling them is cheap: the 128-byte header with its mip count set to one, followed by the largest companion. That takes this catalogue from 97 of 104 to **104 of 104**, and it is covered by a test that builds a split texture and reads it back.

## What is still missing, and why it is not here

`Equipment#icon` still resolves to nothing for every FPS item. `Data/UI/Textures/` came across with only `Vector/` under it, so `ui/textures/ea/loadouticons/*` — 28 distinct files behind ~2,015 records — is absent from the export in any format. Reported in fleetyards/sc-tools#1 along with the `.tif` → `.dds` and split-mip findings. When that lands, those icons flow through this same path with no code change.

Commodities and paints are follow-ups: commodities need an attachment and API surface of their own, and paint logos are dropped at parse for having no `Code`, so they need a second pass plus a match onto `ModelPaint`.

## Testing

`bin/rails test test/loaders/sc_data test/parsers/sc_data` green, including the new reassembly and re-attachment cases. `standardrb` clean. `Manufacturer#logo` was already serialized, so the API carries the logo with no schema change.

🤖
