### PR TITLE
feat(equipment): read how much room a piece of gear takes

### DIFF
--- a/app/api_components/shared/v1/schemas/equipment.rb
+++ b/app/api_components/shared/v1/schemas/equipment.rb
@@ -26,6 +26,19 @@ module Shared
             range: {type: [:number, :null]},
             storage: {type: [:number, :null]},
 
+            # What the piece costs a cargo grid or an inventory, and the box it
+            # fills once it snaps to one and stops sharing space.
+            volume: {type: [:number, :null]},
+            volumeDimensions: {
+              type: [:object, :null],
+              properties: {
+                x: {type: :number},
+                y: {type: :number},
+                z: {type: :number}
+              },
+              additionalProperties: false
+            },
+
             damageReduction: {type: [:number, :null]},
             temperatureRating: {type: [:string, :null]},
             radiationProtection: {type: [:number, :null]},

--- a/app/lib/sc_data/loader/equipment_loader.rb
+++ b/app/lib/sc_data/loader/equipment_loader.rb
@@ -42,6 +42,8 @@ module ScData
           g_force_tolerance: equipment_data["g_force_tolerance"],
           core_compatibility: equipment_data["core_compatibility"],
           backpack_compatibility: equipment_data["backpack_compatibility"],
+          volume: equipment_data["volume"],
+          volume_dimensions: equipment_data["volume_dimensions"],
           hidden: equipment_data["hidden"],
           manufacturer: lookup_manufacturer(equipment_data["manufacturer_ref"]),
           version: sc_version

--- a/app/lib/sc_data/parser/equipment_parser.rb
+++ b/app/lib/sc_data/parser/equipment_parser.rb
@@ -43,6 +43,10 @@ module ScData
 
       WEAPON_CLASSES = %w[ballistic energy kinetic].freeze
 
+      # The pair CIG leaves on an unmeasured record: one microSCU in a 0.15m box.
+      UNMEASURED_MICRO_SCU = 1.0
+      UNMEASURED_SIDE = 0.15
+
       # Worn gear names its slot in the AttachDef Type rather than a SubType:
       # Char_Armor_Helmet, Char_Clothing_Feet. The torso carries two clothing
       # layers, which the slot enum already separates into shirt and jacket.
@@ -191,7 +195,8 @@ module ScData
           grade: value_or_nil(attach_def["Grade"]),
           manufacturer_ref: value_or_nil(attach_def["Manufacturer"]),
           tags: attach_def["Tags"].to_s.split,
-          hidden: variant?(key)
+          hidden: variant?(key),
+          **occupancy(attach_def)
         }
       end
 
@@ -203,6 +208,28 @@ module ScData
         return if carried_type.blank?
 
         [carried_type, DATA_DRIVE_KEY.match?(key) ? "data_drive" : carried_item_type]
+      end
+
+      # How much room the piece takes when it is carried rather than worn. The
+      # game states it twice: a volume, which is what a cargo grid and an
+      # inventory charge for it, and the box it physically fills, which is the
+      # ceiling once it snaps to a grid and stops sharing space with anything.
+      #
+      # One microSCU against a 0.15m cube is the value CIG leaves on a record
+      # nobody has measured -- creature bodies and ship storage boxes carry the
+      # same pair -- so it reads as unmeasured rather than as "vanishingly
+      # small", and stays nil.
+      private def occupancy(attach_def)
+        micro_scu = attach_def.dig("inventoryOccupancyVolume", "SMicroCargoUnit", "microSCU").to_f
+        dimensions = attach_def["inventoryOccupancyDimensions"] || {}
+        x, y, z = %w[x y z].map { |axis| dimensions[axis].to_f }
+
+        return {} if micro_scu <= UNMEASURED_MICRO_SCU && [x, y, z].all? { |side| side <= UNMEASURED_SIDE }
+
+        {
+          volume: (micro_scu / 1_000_000 if micro_scu > UNMEASURED_MICRO_SCU),
+          volume_dimensions: ({x:, y:, z:} if [x, y, z].all?(&:positive?))
+        }.compact
       end
 
       # Most descriptions open with a spec block -- "Item Type: Assault Rifle",

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -29,7 +29,8 @@
 #  sub_type               :string
 #  temperature_rating     :string
 #  version                :string
-#  volume                 :decimal(15, 2)
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
 #  weapon_class           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/views/api/v1/equipment/_base.jbuilder
+++ b/app/views/api/v1/equipment/_base.jbuilder
@@ -17,6 +17,9 @@ json.rate_of_fire equipment.rate_of_fire&.to_f
 json.range equipment.range&.to_f
 json.storage equipment.storage&.to_f
 
+json.volume equipment.volume&.to_f
+json.volume_dimensions equipment.volume_dimensions
+
 json.damage_reduction equipment.damage_reduction&.to_f
 json.temperature_rating equipment.temperature_rating
 json.radiation_protection equipment.radiation_protection&.to_f

--- a/db/migrate/20260817120000_add_volume_dimensions_to_equipment.rb
+++ b/db/migrate/20260817120000_add_volume_dimensions_to_equipment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddVolumeDimensionsToEquipment < ActiveRecord::Migration[8.1]
+  def change
+    # Gear is measured in fractions of an SCU — a helmet is 0.0087 — so two
+    # decimal places rounded every piece in the table to zero.
+    change_column :equipment, :volume, :decimal, precision: 15, scale: 6
+
+    add_column :equipment, :volume_dimensions, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -294,7 +294,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_200000) do
     t.string "temperature_rating"
     t.datetime "updated_at", precision: nil, null: false
     t.string "version"
-    t.decimal "volume", precision: 15, scale: 2
+    t.decimal "volume", precision: 15, scale: 6
+    t.jsonb "volume_dimensions"
     t.string "weapon_class"
     t.index ["equipment_type"], name: "index_equipment_on_equipment_type"
     t.index ["item_type"], name: "index_equipment_on_item_type"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8671,6 +8671,22 @@ components:
           type:
           - number
           - 'null'
+        volume:
+          type:
+          - number
+          - 'null'
+        volumeDimensions:
+          type:
+          - object
+          - 'null'
+          properties:
+            x:
+              type: number
+            "y":
+              type: number
+            z:
+              type: number
+          additionalProperties: false
         damageReduction:
           type:
           - number

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9339,6 +9339,22 @@ components:
           type:
           - number
           - 'null'
+        volume:
+          type:
+          - number
+          - 'null'
+        volumeDimensions:
+          type:
+          - object
+          - 'null'
+          properties:
+            x:
+              type: number
+            "y":
+              type: number
+            z:
+              type: number
+          additionalProperties: false
         damageReduction:
           type:
           - number

--- a/test/factories/equipment.rb
+++ b/test/factories/equipment.rb
@@ -29,7 +29,8 @@
 #  sub_type               :string
 #  temperature_rating     :string
 #  version                :string
-#  volume                 :decimal(15, 2)
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
 #  weapon_class           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/test/loaders/sc_data/equipment_loader_test.rb
+++ b/test/loaders/sc_data/equipment_loader_test.rb
@@ -222,6 +222,44 @@ module ScData
         assert_equal current, Equipment.current_version.count
       end
 
+      test "every parsed item states what it costs an inventory" do
+        without = parsed.values.reject { |item| item[:volume].to_f.positive? }
+
+        assert_operator without.size, :<=, 10, "unmeasured: #{without.map { |item| item[:key] }.first(10)}"
+      end
+
+      test "a measured piece carries both the volume and the box it fills" do
+        helmet = parsed["gys_helmet_03_01_01"]
+
+        assert_operator helmet[:volume], :>, 0
+        assert_operator helmet[:volume], :<, 1, "gear is measured in fractions of an SCU"
+        assert_equal %w[x y z], helmet[:volume_dimensions].keys.sort
+        assert(helmet[:volume_dimensions].values.all? { |side| side.to_f.positive? })
+      end
+
+      # One microSCU in a 0.15m box is what CIG leaves on a record nobody has
+      # measured, so it has to read as unknown rather than as almost nothing.
+      test "the unmeasured placeholder is left blank rather than stored" do
+        placeholder = parsed.values.find { |item| item[:volume].blank? }
+
+        assert placeholder, "expected at least one unmeasured record"
+        assert_nil placeholder[:volume]
+      end
+
+      test "#all persists the volume onto the record" do
+        @loader.all
+
+        measured = Equipment.current_version.where.not(volume: nil)
+
+        assert_operator measured.count, :>=, 4_000
+        assert_operator Equipment.current_version.where.not(volume_dimensions: nil).count, :>=, 4_000
+
+        helmet = Equipment.find_by(sc_key: "gys_helmet_03_01_01")
+
+        assert_operator helmet.volume, :>, 0
+        assert_equal %w[x y z], helmet.volume_dimensions.keys.sort
+      end
+
       test "#all is idempotent" do
         @loader.all
         count = Equipment.count

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -31,7 +31,8 @@ require "test_helper"
 #  sub_type               :string
 #  temperature_rating     :string
 #  version                :string
-#  volume                 :decimal(15, 2)
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
 #  weapon_class           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null


### PR DESCRIPTION
> Stacked on #4410, which carries the re-parsed equipment tree. This PR is the code only — 12 files. Base retargets to `main` automatically once #4410 merges.

## What

`equipment.volume` has existed since the armour and clothing import and nothing ever wrote to it — every row was `NULL`. This reads it out of the game files, along with the box each piece physically fills.

## Why two numbers

The game states both on every `AttachDef`, and they answer different questions:

```
inventoryOccupancyVolume    84000 microSCU        -> 0.084 SCU
inventoryOccupancyDimensions 0.447 x 1.106 x 0.802 -> 0.203 SCU as a box
```

The volume is what a cargo grid or an inventory charges for the piece. The box is the ceiling once it snaps to a grid and stops sharing space with its neighbours. Together they bracket "how much room is left", which is what this unblocks — a grid's `capacity_scu` is exactly its own bounding volume over 1.25³, so the units line up.

## Coverage

**4,815 of 4,821** rows measured: armour 2,142, clothing 1,859, weapons 405, undersuits 202, attachments 161, hacking tools 27, medical 19.

The six left out — two clothing, four attachments — declare one microSCU inside a 0.15 m cube, which is the pair CIG leaves on a record nobody has measured; creature bodies and ship storage boxes carry the same one. Stored as `nil` rather than as vanishingly small, so a reader can tell "unmeasured" from "tiny".

## Notes

- The column was `decimal(15, 2)`, which rounded every piece of gear to zero. It moves to six places — a helmet is 0.0032 SCU.
- `volume_dimensions` is new (`jsonb`), matching how `Component#inventory_consumption` already keeps its box.
- Both are exposed on the Equipment API component.

## Testing

`bin/rails test test/loaders/sc_data/equipment_loader_test.rb test/integration/api/v1/equipment_test.rb test/models/equipment_test.rb` — 45 tests, 140 assertions, green, against a test database rebuilt from `schema.rb`.

Five new loader tests cover the coverage floor, that a measured piece carries both numbers, that the placeholder stays blank, and that both persist.

🤖
