### PR TITLE
chore(greptile): skip generated sc_data dumps in review

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": "data/sc_data/**\n"
+}


### PR DESCRIPTION
Greptile refuses to review any PR touching the parsed game-data dumps — an sc_data re-import changes thousands of files at once, which blows past its 100-file limit. #4407 got `Too many files changed for review (3000 files, 100 file limit)` despite containing only 12 hand-written files.

This adds a root `greptile.json` that ignores `data/sc_data/**`, so re-imports stop crowding out the code that actually needs review. (`data/sc_data/raw` is already gitignored; this covers the committed `parsed/` tree.)

Note: the docs only state that `ignorePatterns` excludes files from review, not that it lifts the file-count cap — so this is the likely fix rather than a guaranteed one. If #4407 still gets refused once this lands, the fallback is splitting data re-imports into their own PRs. 🤖