### PR TITLE
chore(sc_data): drop the icon paths the images replaced

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -7,7 +7,6 @@
 #  id             :uuid             not null, primary key
 #  commodity_type :string
 #  description    :text
-#  icon           :string
 #  name           :string           not null
 #  sc_key         :string
 #  sc_ref         :string

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -13,7 +13,6 @@
 #  g_force_tolerance      :decimal(15, 2)
 #  grade                  :string
 #  hidden                 :boolean          default(FALSE)
-#  icon                   :string
 #  item_type              :string
 #  name                   :string
 #  radiation_protection   :decimal(15, 2)

--- a/db/migrate/20260817090000_drop_icon_paths_now_the_images_are_attached.rb
+++ b/db/migrate/20260817090000_drop_icon_paths_now_the_images_are_attached.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# The column held a path into the game files, which was only ever the parser's
+# way of telling the loader which file to attach. The parsed records still
+# carry it; the database does not need to.
+class DropIconPathsNowTheImagesAreAttached < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :commodities, :icon, :string
+    remove_column :equipment, :icon, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -185,7 +185,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_210000) do
     t.string "commodity_type"
     t.datetime "created_at", null: false
     t.text "description"
-    t.string "icon"
     t.string "name", null: false
     t.string "sc_key"
     t.string "sc_ref"
@@ -276,7 +275,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_210000) do
     t.decimal "g_force_tolerance", precision: 15, scale: 2
     t.string "grade"
     t.boolean "hidden", default: false
-    t.string "icon"
     t.string "item_type"
     t.uuid "manufacturer_id"
     t.string "name"

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -7,7 +7,6 @@
 #  id             :uuid             not null, primary key
 #  commodity_type :string
 #  description    :text
-#  icon           :string
 #  name           :string           not null
 #  sc_key         :string
 #  sc_ref         :string

--- a/test/factories/equipment.rb
+++ b/test/factories/equipment.rb
@@ -13,7 +13,6 @@
 #  g_force_tolerance      :decimal(15, 2)
 #  grade                  :string
 #  hidden                 :boolean          default(FALSE)
-#  icon                   :string
 #  item_type              :string
 #  name                   :string
 #  radiation_protection   :decimal(15, 2)

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -9,7 +9,6 @@ require "test_helper"
 #  id             :uuid             not null, primary key
 #  commodity_type :string
 #  description    :text
-#  icon           :string
 #  name           :string           not null
 #  sc_key         :string
 #  sc_ref         :string

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -15,7 +15,6 @@ require "test_helper"
 #  g_force_tolerance      :decimal(15, 2)
 #  grade                  :string
 #  hidden                 :boolean          default(FALSE)
-#  icon                   :string
 #  item_type              :string
 #  name                   :string
 #  radiation_protection   :decimal(15, 2)


### PR DESCRIPTION
The contract half of the expand/contract that #4409 started. **Do not merge until #4409 has deployed.**

`Commodity#icon` and `Equipment#icon` held a path into the game files, which was only ever the parser's way of telling the loader which file to attach. #4409 attaches the image itself and stops writing the columns; this removes them.

## Why it is a separate deploy

Migrations run in `.kamal/hooks/pre-deploy`, so there is a window where the new schema is live and the old workers have not been replaced. `ScData::CheckJob` runs nightly at 22:00 and enqueues the full catalogue load whenever the configured version has no finished import, and `ApplicationJob` sets `retry: false`.

Dropped in the same deploy as #4409, a load landing in that window would have written `icon:` against columns that no longer exist, failed outright with nothing to retry it, and left the import marked failed until the next night's run picked it up. Once #4409 is out, nothing writes them and this is inert.

Found by Greptile on #4409.

## Testing

`bin/rails test test/models/{commodity,equipment}_test.rb test/loaders/sc_data/commodities_loader_test.rb test/integration/api/v1/commodities_test.rb` → 33 tests, 0 failures. The diff beyond the migration is the schema dump and the annotations that follow from it.

🤖
