### PR TITLE
data(sc_data): ship storage containers from the live build

### DIFF
--- a/data/sc_data/parsed/live/items/inventory_anvl_ballista_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_anvl_ballista_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_anvl_centurion_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_anvl_centurion_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_anvl_spartan_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_anvl_spartan_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_argo_atls_cargogrid_geo.json
+++ b/data/sc_data/parsed/live/items/inventory_argo_atls_cargogrid_geo.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 0.01
+    "storage": 0.1
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_argo_atls_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_argo_atls_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_drak_mule_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_drak_mule_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_grin_ptv_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_grin_ptv_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_ds.json
+++ b/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_ds.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 0.00000865051903114187
+    "storage": 3.4
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_roc.json
+++ b/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_roc.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 0.00006944444444444444
+    "storage": 1.2
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_grin_roc_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_grin_stv_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_grin_stv_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_groundvehicle_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_groundvehicle_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_rsi_ursa_rover_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_rsi_ursa_rover_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_ship_snub.json
+++ b/data/sc_data/parsed/live/items/inventory_ship_snub.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 2.1433470507544582e-29
+    "storage": 0.06
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_ship_tempitemcarryingcapacity_drak_command_module.json
+++ b/data/sc_data/parsed/live/items/inventory_ship_tempitemcarryingcapacity_drak_command_module.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_ship_tempitemcarryingcapacity_rsi_zeus.json
+++ b/data/sc_data/parsed/live/items/inventory_ship_tempitemcarryingcapacity_rsi_zeus.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 0.00002143347050754458
+    "storage": 0.000006
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_tmbl_cyclone_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_tmbl_cyclone_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/items/inventory_tmbl_nova_cargogrid_template.json
+++ b/data/sc_data/parsed/live/items/inventory_tmbl_nova_cargogrid_template.json
@@ -4,6 +4,6 @@
   "category": "inventory",
   "type": "PersonalStorage",
   "type_data": {
-    "storage": 1.0
+    "storage": 0.000001
   }
 }

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_bh.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ_lowfuel.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_civ_lowfuel.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_crusader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_microtech.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_stalker_pu_ai_sec_microtech.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2658"
   },
   "mass": 48986.3,
+  "inventory_container_ref": "7a3e597b-cbc1-4168-9cb0-e13a55cb4309",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5923.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.68,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_titan_renegade_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2343"
   },
   "mass": 48986.42,
+  "inventory_container_ref": "a623a5e1-27db-4e93-af6b-e54912b78e32",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5561.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "inventory_container_ref": "e861c337-8303-43f9-87e6-f0c9dcf5ece2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5929.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "inventory_container_ref": "e861c337-8303-43f9-87e6-f0c9dcf5ece2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5929.0,

--- a/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_avenger_warlock_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2724"
   },
   "mass": 48986.75,
+  "inventory_container_ref": "e861c337-8303-43f9-87e6-f0c9dcf5ece2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5929.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_ai_override.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_ai_override.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bis2950.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s03_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s03_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s05_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s05_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s10_test.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_bmbrck_s10_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_eclipse_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_eclipse_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17643"
   },
   "mass": 45720.0,
+  "inventory_container_ref": "f4c988bd-608e-432a-984e-71791bbdb5bc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7276.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_dunlevy.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_dunlevy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_ea_ai_pir_elite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_cfp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim_ik.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_crim_ik.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_hh.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_hh.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec_hurstondynamics.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_sec_hurstondynamics.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_template.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": null,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_fleetweek2024.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_fleetweek2024.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_restoration.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_restoration.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2335"
   },
   "mass": 48552.06,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_gladius_valiant_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2934"
   },
   "mass": 501.51,
+  "inventory_container_ref": "43ef139d-c341-4b57-8443-d51ee10f3b4c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6923.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_nt_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_gs_unmanned_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12392.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_nt_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_showdown.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_showdown.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_hammerhead_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 4542311.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 39312.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_aos.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_aos.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_ff_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_ff_boardedcombat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_gencrim_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_gencrim_boardedcombat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt_nointerior.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_nt_nointerior.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee_nointerior.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_uee_nointerior.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_boardedcombat.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_boardedcombat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_noneboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_ai_xenothreat_noneboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_gamemaster.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_gamemaster.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_m_pu_invictus.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_m_pu_invictus.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "150990"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_collector_military.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_fw_25.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_fw_25.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_idris_p_tsg.json
+++ b/data/sc_data/parsed/live/models/aegs_idris_p_tsg.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "118580"
   },
   "mass": 37854373.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 31000.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 35000.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 35000.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 35000.0,

--- a/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek_2021.json
+++ b/data/sc_data/parsed/live/models/aegs_javelin_pu_ai_uee_fleetweek_2021.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "84375"
   },
   "mass": 111080494.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 35000.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded_nocargo.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_civ_shipboarded_nocargo.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_bis2024_temp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_a.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_b.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_b.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_c.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_pu_hijacked_c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_showdown.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_showdown.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_teach.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_reclaimer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_reclaimer_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12555"
   },
   "mass": 9509853.5,
+  "inventory_container_ref": "6b484768-a49b-47a9-b5ce-814a0e86107b",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 24656.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "inventory_container_ref": "558590e4-49f6-46e8-9182-8253f0c8a578",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12976.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "inventory_container_ref": "558590e4-49f6-46e8-9182-8253f0c8a578",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12976.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "inventory_container_ref": "558590e4-49f6-46e8-9182-8253f0c8a578",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12976.0,

--- a/data/sc_data/parsed/live/models/aegs_redeemer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_redeemer_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "13199"
   },
   "mass": 420870.26,
+  "inventory_container_ref": "558590e4-49f6-46e8-9182-8253f0c8a578",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12976.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15100.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15100.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_mts.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15100.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15100.0,

--- a/data/sc_data/parsed/live/models/aegs_retaliator_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_retaliator_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "32116"
   },
   "mass": 317870.29,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15100.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_comet_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_ai_template.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_collector_milt.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_collector_milt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_firebird_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_collector_competition.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_collector_competition.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_peregrine_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 73492.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_blacjac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_sec_hurston.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5495.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5495.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_raven_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3934"
   },
   "mass": 68711.32,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5495.0,

--- a/data/sc_data/parsed/live/models/aegs_sabre_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_sabre_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4689"
   },
   "mass": 83092.72,
+  "inventory_container_ref": "0be3820b-ee1c-4af1-b585-6d77badd9985",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6467.0,

--- a/data/sc_data/parsed/live/models/aegs_tiburon.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12841.0,

--- a/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12841.0,

--- a/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_tiburon_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24582"
   },
   "mass": 5158975.0,
+  "inventory_container_ref": "405c46f7-e3e1-4ac1-8a77-03287e1de5a2",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12841.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "inventory_container_ref": "708bb8e3-8776-48bd-84e5-3a54441cdaf8",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17768.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "inventory_container_ref": "708bb8e3-8776-48bd-84e5-3a54441cdaf8",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17768.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "inventory_container_ref": "708bb8e3-8776-48bd-84e5-3a54441cdaf8",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17768.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_harbinger_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8383"
   },
   "mass": 230404.0,
+  "inventory_container_ref": "708bb8e3-8776-48bd-84e5-3a54441cdaf8",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17768.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "inventory_container_ref": "f47172bd-2b36-46e2-b54d-46812e9f025b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16255.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "inventory_container_ref": "f47172bd-2b36-46e2-b54d-46812e9f025b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16255.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "inventory_container_ref": "f47172bd-2b36-46e2-b54d-46812e9f025b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16255.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_hoplite_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6603"
   },
   "mass": 217870.0,
+  "inventory_container_ref": "f47172bd-2b36-46e2-b54d-46812e9f025b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16255.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_blacjac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_crusader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_sec_hurston.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "inventory_container_ref": "7086d297-ed4e-4444-8c57-5839a5e2c831",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16444.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "inventory_container_ref": "7086d297-ed4e-4444-8c57-5839a5e2c831",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16444.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "inventory_container_ref": "7086d297-ed4e-4444-8c57-5839a5e2c831",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16444.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_sentinel_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 225970.0,
+  "inventory_container_ref": "7086d297-ed4e-4444-8c57-5839a5e2c831",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16444.0,

--- a/data/sc_data/parsed/live/models/aegs_vanguard_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/aegs_vanguard_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9113"
   },
   "mass": 238070.26,
+  "inventory_container_ref": "608d3834-64e0-4982-be7b-3e3dc9cf7b00",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 17021.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim_distortion.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_crim_distortion.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_sec_blacjac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_arrow_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_arrow_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3121"
   },
   "mass": 30510.0,
+  "inventory_container_ref": "993d5741-64a2-46df-9095-25ad42900d9f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5647.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 20139.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_collector_military.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 20139.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 20139.0,

--- a/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_asgard_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9430"
   },
   "mass": 610246.06,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 20139.0,

--- a/data/sc_data/parsed/live/models/anvl_ballista.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_dunestalker.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_outlaw.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_ea_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
+++ b/data/sc_data/parsed/live/models/anvl_ballista_snowblind.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8073"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "0b359b36-b9d0-4b38-80d4-ea92b11a220a",
   "hull_health": 37800.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5664.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5664.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5664.0,

--- a/data/sc_data/parsed/live/models/anvl_c8_pisces_tutorial.json
+++ b/data/sc_data/parsed/live/models/anvl_c8_pisces_tutorial.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5664.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "75093502-a71b-4dab-9211-0bf36464296f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5489.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_fw22nfz.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_fw22nfz.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "75093502-a71b-4dab-9211-0bf36464296f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5489.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "75093502-a71b-4dab-9211-0bf36464296f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5489.0,

--- a/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8r_pisces_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2301"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "75093502-a71b-4dab-9211-0bf36464296f",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5489.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5893.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5893.0,

--- a/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_c8x_pisces_expedition_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1806"
   },
   "mass": 45243.0,
+  "inventory_container_ref": "d230ae73-18d0-40e8-8d6f-23c6a2706ae4",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5893.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_bis2950.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_expedition.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_expedition.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_carrack_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_carrack_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19595"
   },
   "mass": 3275858.0,
+  "inventory_container_ref": "78512e89-9cc2-4c19-b1d9-befd1b311ffc",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 26620.0,

--- a/data/sc_data/parsed/live/models/anvl_centurion.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5920"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "dea23aa8-75c0-41f5-a8ae-aae0209083a9",
   "hull_health": 33600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_centurion_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5920"
   },
   "mass": 33276.0,
+  "inventory_container_ref": "dea23aa8-75c0-41f5-a8ae-aae0209083a9",
   "hull_health": 33600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_gladiator.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s03_test.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s03_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s05_test.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_bmbrck_s05_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_gladiator_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 86108.0,
+  "inventory_container_ref": "caab345b-a134-415f-8842-8421810acdc1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8715.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_ai_override.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_ai_override.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_bh.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hawk_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 64166.0,
+  "inventory_container_ref": "f73a2123-39ac-441d-9ed0-2a055e086dbb",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11201.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7_mk2_collector_mod.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7_mk2_collector_mod.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5050"
   },
   "mass": 68317.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk1_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_military.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_mk2_exec_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7a_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7a_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_mk2_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5104"
   },
   "mass": 62117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7c_wildfire.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7c_wildfire.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "3f6304af-a8c0-45cd-86fd-ba35f4b61b05",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt_leader.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_ai_ea_advocacy_stunt_leader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_heartseeker.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_heartseeker.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 76786.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5050"
   },
   "mass": 68317.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2_heartseeker.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_mk2_heartseeker.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5640"
   },
   "mass": 68317.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cm_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4789"
   },
   "mass": 72032.0,
+  "inventory_container_ref": "e70d213d-5abd-41fc-be4c-e4acd4d13dad",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7249.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4070"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee_warlord.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cr_pu_ai_uee_warlord.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4367"
   },
   "mass": 72097.0,
+  "inventory_container_ref": "6a87022a-0847-4f7a-9105-71f4f7c406e3",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5998.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "inventory_container_ref": "a308aeaf-7bf0-4286-b286-4dabc4565531",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5718.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_mk2.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4190"
   },
   "mass": 66117.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7437.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "inventory_container_ref": "a308aeaf-7bf0-4286-b286-4dabc4565531",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5718.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "inventory_container_ref": "a308aeaf-7bf0-4286-b286-4dabc4565531",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5718.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "inventory_container_ref": "a308aeaf-7bf0-4286-b286-4dabc4565531",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5718.0,

--- a/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee_vixen.json
+++ b/data/sc_data/parsed/live/models/anvl_hornet_f7cs_pu_ai_uee_vixen.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4905"
   },
   "mass": 71624.0,
+  "inventory_container_ref": "a308aeaf-7bf0-4286-b286-4dabc4565531",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5718.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_mts.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_hurricane_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4148"
   },
   "mass": 86745.0,
+  "inventory_container_ref": "f2204ac8-b422-4def-9f0c-6a40540c3064",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8361.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_darkblue.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_darkblue.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_grey.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_grey.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_lightblue.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_lightblue.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_white.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_fleetweek_white.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_bis2024_temp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_military.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_collector_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_military.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_exec_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_lightning_f8c_plat.json
+++ b/data/sc_data/parsed/live/models/anvl_lightning_f8c_plat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8020"
   },
   "mass": 153775.0,
+  "inventory_container_ref": "d3917228-8cb2-400a-9001-623f6618ee3b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10173.0,

--- a/data/sc_data/parsed/live/models/anvl_paladin.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "inventory_container_ref": "c86e8472-fe66-419f-8a5d-3a2492bedd40",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12540.0,

--- a/data/sc_data/parsed/live/models/anvl_paladin_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "inventory_container_ref": "c86e8472-fe66-419f-8a5d-3a2492bedd40",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12540.0,

--- a/data/sc_data/parsed/live/models/anvl_paladin_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "inventory_container_ref": "c86e8472-fe66-419f-8a5d-3a2492bedd40",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12540.0,

--- a/data/sc_data/parsed/live/models/anvl_paladin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_paladin_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12940"
   },
   "mass": 500000.0,
+  "inventory_container_ref": "c86e8472-fe66-419f-8a5d-3a2492bedd40",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12540.0,

--- a/data/sc_data/parsed/live/models/anvl_spartan.json
+++ b/data/sc_data/parsed/live/models/anvl_spartan.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2475"
   },
   "mass": 36276.0,
+  "inventory_container_ref": "3542783c-509a-4006-befd-610caafdde36",
   "hull_health": 37801.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/anvl_terrapin.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_bis2024_temp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_ai_template.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_collector_medic.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_collector_medic.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_medic_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4220"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_terrapin_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_terrapin_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3940"
   },
   "mass": 149850.0,
+  "inventory_container_ref": "79f5c82d-ffdc-4f3e-a4cb-423dc2e70fcd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 7562.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_dropship.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_dropship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy_spawn.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_ea_advocacy_spawn.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_cfp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_headhunters.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_headhunters.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_ai_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_bis2950.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_citizencon.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_citizencon.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_indestructible.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_indestructible.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_bh_qig.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_bh_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_nt_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_hurston.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_microtech.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_sec_microtech.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/anvl_valkyrie_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "11910"
   },
   "mass": 597246.06,
+  "inventory_container_ref": "571752ce-d873-463c-bb64-bb64f98ee582",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 18752.0,

--- a/data/sc_data/parsed/live/models/argo_csv_cargo.json
+++ b/data/sc_data/parsed/live/models/argo_csv_cargo.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "190"
   },
   "mass": 1000.0,
+  "inventory_container_ref": "10f318e6-dd40-47f3-a4a4-204ebd1fc78b",
   "hull_health": 8100.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/argo_mole.json
+++ b/data/sc_data/parsed/live/models/argo_mole.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mole_btala.json
+++ b/data/sc_data/parsed/live/models/argo_mole_btala.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mole_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_mole_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mole_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_mole_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mole_teach.json
+++ b/data/sc_data/parsed/live/models/argo_mole_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mole_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/argo_mole_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5715"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "ec7e4c46-cd7f-4cda-b3b3-92594f830265",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_moth.json
+++ b/data/sc_data/parsed/live/models/argo_moth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_moth_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_moth_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_moth_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_moth_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9470"
   },
   "mass": 852686.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 16155.0,

--- a/data/sc_data/parsed/live/models/argo_mpuv.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "205"
   },
   "mass": 9210.0,
+  "inventory_container_ref": "718eab56-f705-45f3-bb36-c1f571160892",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6028.0,

--- a/data/sc_data/parsed/live/models/argo_mpuv_1t.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_1t.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "205"
   },
   "mass": 6195.0,
+  "inventory_container_ref": "2e35bd8c-c53b-425f-9f4b-3e30a08f2217",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 5170.0,

--- a/data/sc_data/parsed/live/models/argo_mpuv_pu_ai_civ_lorville.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_pu_ai_civ_lorville.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "205"
   },
   "mass": 9210.0,
+  "inventory_container_ref": "718eab56-f705-45f3-bb36-c1f571160892",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6028.0,

--- a/data/sc_data/parsed/live/models/argo_mpuv_transport.json
+++ b/data/sc_data/parsed/live/models/argo_mpuv_transport.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "270"
   },
   "mass": 9210.0,
+  "inventory_container_ref": "e314725d-c801-498f-9c0e-1fa0e64e5427",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5977.0,

--- a/data/sc_data/parsed/live/models/argo_raft.json
+++ b/data/sc_data/parsed/live/models/argo_raft.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_raft_collector_indust.json
+++ b/data/sc_data/parsed/live/models/argo_raft_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_raft_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_raft_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_raft_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/argo_raft_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2050"
   },
   "mass": 639886.0,
+  "inventory_container_ref": "84b5eac3-e074-49b4-ad35-d17d2877d6c4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13518.0,

--- a/data/sc_data/parsed/live/models/argo_srv.json
+++ b/data/sc_data/parsed/live/models/argo_srv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "inventory_container_ref": "f970d216-3d90-4566-83d6-b0df6b4275d0",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19700.0,

--- a/data/sc_data/parsed/live/models/argo_srv_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/argo_srv_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19700.0,

--- a/data/sc_data/parsed/live/models/argo_srv_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/argo_srv_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6200"
   },
   "mass": 449970.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19700.0,

--- a/data/sc_data/parsed/live/models/banu_defender.json
+++ b/data/sc_data/parsed/live/models/banu_defender.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "inventory_container_ref": "3aeea911-0ed8-4788-b1d7-cb9f2613bfde",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8493.0,

--- a/data/sc_data/parsed/live/models/banu_defender_bomb_test.json
+++ b/data/sc_data/parsed/live/models/banu_defender_bomb_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "inventory_container_ref": "3aeea911-0ed8-4788-b1d7-cb9f2613bfde",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8493.0,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "inventory_container_ref": "3aeea911-0ed8-4788-b1d7-cb9f2613bfde",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8493.0,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "inventory_container_ref": "3aeea911-0ed8-4788-b1d7-cb9f2613bfde",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8493.0,

--- a/data/sc_data/parsed/live/models/banu_defender_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/banu_defender_pu_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6168"
   },
   "mass": 119930.0,
+  "inventory_container_ref": "3aeea911-0ed8-4788-b1d7-cb9f2613bfde",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8493.0,

--- a/data/sc_data/parsed/live/models/cnou_hoverquad.json
+++ b/data/sc_data/parsed/live/models/cnou_hoverquad.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 4850.0,
+  "inventory_container_ref": "d8ebb993-cbf7-41d9-bfd1-413ec1fca5fb",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 205.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "inventory_container_ref": "c082f263-44b3-4231-8e0f-443262f1003c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_citizencon2018.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_citizencon2018.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "inventory_container_ref": "c082f263-44b3-4231-8e0f-443262f1003c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "inventory_container_ref": "c082f263-44b3-4231-8e0f-443262f1003c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_alpha_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 31221.0,
+  "inventory_container_ref": "c082f263-44b3-4231-8e0f-443262f1003c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "inventory_container_ref": "c8b1acd2-fa03-4e2c-83cc-514567ae4370",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "inventory_container_ref": "c8b1acd2-fa03-4e2c-83cc-514567ae4370",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_beta_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1800"
   },
   "mass": 38113.0,
+  "inventory_container_ref": "c8b1acd2-fa03-4e2c-83cc-514567ae4370",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7772.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "inventory_container_ref": "f336aef9-58c6-403b-9a69-1d3d429ac7cc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6839.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "inventory_container_ref": "f336aef9-58c6-403b-9a69-1d3d429ac7cc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6839.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "inventory_container_ref": "f336aef9-58c6-403b-9a69-1d3d429ac7cc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6839.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "inventory_container_ref": "f336aef9-58c6-403b-9a69-1d3d429ac7cc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6839.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_delta_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1920"
   },
   "mass": 35763.0,
+  "inventory_container_ref": "f336aef9-58c6-403b-9a69-1d3d429ac7cc",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6839.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "inventory_container_ref": "23bd1f1a-6ef7-4a9d-8e30-c033296e7047",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7105.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "inventory_container_ref": "23bd1f1a-6ef7-4a9d-8e30-c033296e7047",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7105.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_gamma_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "inventory_container_ref": "23bd1f1a-6ef7-4a9d-8e30-c033296e7047",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7105.0,

--- a/data/sc_data/parsed/live/models/cnou_mustang_omega.json
+++ b/data/sc_data/parsed/live/models/cnou_mustang_omega.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3230"
   },
   "mass": 28565.0,
+  "inventory_container_ref": "23bd1f1a-6ef7-4a9d-8e30-c033296e7047",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7105.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_teach.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_unmanned.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/cnou_nomad_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/cnou_nomad_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2687"
   },
   "mass": 216323.0,
+  "inventory_container_ref": "65a2586f-12af-44b5-a32b-9942f6b57fb9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6604.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "inventory_container_ref": "617fed64-0fca-496c-bdd3-6edfd98beb67",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15350.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid_collector_indust.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "inventory_container_ref": "617fed64-0fca-496c-bdd3-6edfd98beb67",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15350.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "inventory_container_ref": "617fed64-0fca-496c-bdd3-6edfd98beb67",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15350.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "inventory_container_ref": "617fed64-0fca-496c-bdd3-6edfd98beb67",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15350.0,

--- a/data/sc_data/parsed/live/models/crus_intrepid_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_intrepid_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1850"
   },
   "mass": 66943.0,
+  "inventory_container_ref": "617fed64-0fca-496c-bdd3-6edfd98beb67",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15350.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "5d93cc49-898a-4131-accf-c95fe59c3c2a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "5d93cc49-898a-4131-accf-c95fe59c3c2a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "5d93cc49-898a-4131-accf-c95fe59c3c2a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_a1_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_a1_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "5d93cc49-898a-4131-accf-c95fe59c3c2a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_bis2024_temp.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_bis2024_temp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_civilian.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_civilian.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_spirit_c1_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3375"
   },
   "mass": 259270.5,
+  "inventory_container_ref": "e392f8bd-26c9-49ef-bae8-86930262bf4a",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 19000.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_mission_pir_package.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_mission_pir_package.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_star_runner_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_star_runner_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9393"
   },
   "mass": 680575.0,
+  "inventory_container_ref": "17e58e76-2599-456e-b211-b3a6088f32f5",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 16023.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_collector_military.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_inferno_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_inferno_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_collector_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/crus_starfighter_ion_unmanned_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7311"
   },
   "mass": 325001.0,
+  "inventory_container_ref": "96289f1a-5bc3-46aa-ba51-f1cf729077b1",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 13600.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_bombless.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_bombless.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_collector_military.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_ea_pir.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_ea_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_s3bombs.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_s3bombs.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_a2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_a2_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "20200"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "47c86cd6-2274-4791-b61d-60d3bf119a46",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 27795.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_c2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_c2_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17580"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "a1b12c2a-fc72-4ed2-8820-ce7ea4458164",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 17032.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/crus_starlifter_m2_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/crus_starlifter_m2_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1810"
   },
   "mass": 2339240.06,
+  "inventory_container_ref": "e387e15d-d076-47ba-8597-e0da83929846",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 23448.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_ea_outlaws.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_ea_outlaws.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim_scattergun.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_crim_scattergun.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_raceannouncer_scramble.json
+++ b/data/sc_data/parsed/live/models/drak_buccaneer_pu_ai_raceannouncer_scramble.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 36527.0,
+  "inventory_container_ref": "fe386455-b8c0-42e1-a07a-912956354a59",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9145.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_halfcargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_halfcargomarkup.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_nocargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_civ_shipboarded_nocargomarkup.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_halfcargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_halfcargomarkup.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_nocargomarkup.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_nt_shipboarded_nocargomarkup.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_boarded.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_boarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pirate.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pirate.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_pu_hijacked.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_pu_hijacked.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_shipshowdown.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_shipshowdown.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_caterpillar_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7730"
   },
   "mass": 1508063.0,
+  "inventory_container_ref": "c02a4adc-3816-4c63-8c0f-a2ab54fd3212",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 12362.0,

--- a/data/sc_data/parsed/live/models/drak_clipper.json
+++ b/data/sc_data/parsed/live/models/drak_clipper.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4310.0,

--- a/data/sc_data/parsed/live/models/drak_clipper_collector_military.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4310.0,

--- a/data/sc_data/parsed/live/models/drak_clipper_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4310.0,

--- a/data/sc_data/parsed/live/models/drak_clipper_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_clipper_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6910"
   },
   "mass": 130562.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4310.0,

--- a/data/sc_data/parsed/live/models/drak_command_module.json
+++ b/data/sc_data/parsed/live/models/drak_command_module.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3000"
   },
   "mass": 120677.0,
+  "inventory_container_ref": "58e3ce97-7788-4a6f-b944-bd861b896354",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8950.0,

--- a/data/sc_data/parsed/live/models/drak_corsair.json
+++ b/data/sc_data/parsed/live/models/drak_corsair.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_exec_military.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_exec_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_exec_stealthindustrial.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_exec_stealthindustrial.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_corsair_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_corsair_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6805"
   },
   "mass": 380456.0,
+  "inventory_container_ref": "6abb4bb2-4539-4de1-ab8e-878565048c29",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 12794.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_a.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_nose_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_a.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10368.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_tail_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10368.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_derelict_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_exec_military.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_exec_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_exec_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_mission_pir_package.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_mission_pir_package.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_advocacy_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_cfp.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_cfp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_crim_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_dropship.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_dropship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_headhunters.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_headhunters.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_reinforcements.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_nt_reinforcements.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_elite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_pir_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader_qig.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_sec_crusader_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_boarding.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_boarding.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_pu_pirate_crewless.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_pu_pirate_crewless.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_shipshowdown.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_shipshowdown.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_black_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6251"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8886.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "db19aea3-24d6-4af3-ba9f-aabbb9b12864",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10158.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_ai_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "db19aea3-24d6-4af3-ba9f-aabbb9b12864",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10158.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "db19aea3-24d6-4af3-ba9f-aabbb9b12864",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10158.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_blue_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_blue_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6643"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "db19aea3-24d6-4af3-ba9f-aabbb9b12864",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10158.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_ai_medicalrescue.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_ai_medicalrescue.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_ai_template.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_bis2950.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_bis2950.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_red_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6310"
   },
   "mass": 222300.0,
+  "inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8334.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "d576c037-70dd-49c2-8833-c5244a7b74fd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9320.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "d576c037-70dd-49c2-8833-c5244a7b74fd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9320.0,

--- a/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutlass_steel_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7051"
   },
   "mass": 242177.0,
+  "inventory_container_ref": "d576c037-70dd-49c2-8833-c5244a7b74fd",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9320.0,

--- a/data/sc_data/parsed/live/models/drak_cutter.json
+++ b/data/sc_data/parsed/live/models/drak_cutter.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "aa4ed5ae-30d1-40cf-b6f4-fab09a37b25c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "aa4ed5ae-30d1-40cf-b6f4-fab09a37b25c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "aa4ed5ae-30d1-40cf-b6f4-fab09a37b25c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_rambler_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_rambler_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "480"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "aa4ed5ae-30d1-40cf-b6f4-fab09a37b25c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "inventory_container_ref": "8c70116e-ec9a-42a3-9fc6-2893b370c25b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "inventory_container_ref": "8c70116e-ec9a-42a3-9fc6-2893b370c25b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "inventory_container_ref": "8c70116e-ec9a-42a3-9fc6-2893b370c25b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_scout_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_scout_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2622"
   },
   "mass": 87677.0,
+  "inventory_container_ref": "8c70116e-ec9a-42a3-9fc6-2893b370c25b",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_cutter_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_cutter_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2280"
   },
   "mass": 81677.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4460.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "inventory_container_ref": "6008a41b-d483-4164-9595-3c7b9cea1209",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 452.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_pink.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_pink.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "inventory_container_ref": "6008a41b-d483-4164-9595-3c7b9cea1209",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 452.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "inventory_container_ref": "6008a41b-d483-4164-9595-3c7b9cea1209",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 452.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_unmanned_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "inventory_container_ref": "6008a41b-d483-4164-9595-3c7b9cea1209",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 452.0,

--- a/data/sc_data/parsed/live/models/drak_dragonfly_yellow.json
+++ b/data/sc_data/parsed/live/models/drak_dragonfly_yellow.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 5600.0,
+  "inventory_container_ref": "6008a41b-d483-4164-9595-3c7b9cea1209",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 452.0,

--- a/data/sc_data/parsed/live/models/drak_golem.json
+++ b/data/sc_data/parsed/live/models/drak_golem.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_btala.json
+++ b/data/sc_data/parsed/live/models/drak_golem_btala.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_collector_indust.json
+++ b/data/sc_data/parsed/live/models/drak_golem_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_low_fuel_temporary.json
+++ b/data/sc_data/parsed/live/models/drak_golem_low_fuel_temporary.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 632.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 632.0,

--- a/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_golem_ox_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 76217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 632.0,

--- a/data/sc_data/parsed/live/models/drak_golem_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_golem_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_golem_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_teach.json
+++ b/data/sc_data/parsed/live/models/drak_golem_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1030"
   },
   "mass": 69217.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 17300.0,

--- a/data/sc_data/parsed/live/models/drak_golem_template.json
+++ b/data/sc_data/parsed/live/models/drak_golem_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": null,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "metrics": {

--- a/data/sc_data/parsed/live/models/drak_herald.json
+++ b/data/sc_data/parsed/live/models/drak_herald.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "inventory_container_ref": "c1336037-6461-4d7b-ac7b-aebbb0d80dc9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5146.0,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "inventory_container_ref": "c1336037-6461-4d7b-ac7b-aebbb0d80dc9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5146.0,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ_ftl.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_civ_ftl.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "inventory_container_ref": "c1336037-6461-4d7b-ac7b-aebbb0d80dc9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5146.0,

--- a/data/sc_data/parsed/live/models/drak_herald_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_herald_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 62205.0,
+  "inventory_container_ref": "c1336037-6461-4d7b-ac7b-aebbb0d80dc9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5146.0,

--- a/data/sc_data/parsed/live/models/drak_ironclad.json
+++ b/data/sc_data/parsed/live/models/drak_ironclad.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 720000.0,
+  "inventory_container_ref": "2c186cac-5a8c-444e-9557-e7ec38377fcb",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8800.0,

--- a/data/sc_data/parsed/live/models/drak_ironclad_assault.json
+++ b/data/sc_data/parsed/live/models/drak_ironclad_assault.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 720000.0,
+  "inventory_container_ref": "2c186cac-5a8c-444e-9557-e7ec38377fcb",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8800.0,

--- a/data/sc_data/parsed/live/models/drak_mule.json
+++ b/data/sc_data/parsed/live/models/drak_mule.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "70"
   },
   "mass": 2000.0,
+  "inventory_container_ref": "bd3d3bab-618e-4984-ab03-ebd09adc36d9",
   "hull_health": 10600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/drak_pitbull.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4432.0,

--- a/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4432.0,

--- a/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_pitbull_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1400"
   },
   "mass": 10310.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4432.0,

--- a/data/sc_data/parsed/live/models/drak_vulture.json
+++ b/data/sc_data/parsed/live/models/drak_vulture.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_teach.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/drak_vulture_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/drak_vulture_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 182983.0,
+  "inventory_container_ref": "c4cdb9df-67a8-4a1c-8b61-c5865d05dab1",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6009.0,

--- a/data/sc_data/parsed/live/models/eaobjectivedestructable_mininglaser.json
+++ b/data/sc_data/parsed/live/models/eaobjectivedestructable_mininglaser.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 450000.0,

--- a/data/sc_data/parsed/live/models/eaobjectivedestructable_satellite.json
+++ b/data/sc_data/parsed/live/models/eaobjectivedestructable_satellite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 700001.0,

--- a/data/sc_data/parsed/live/models/espr_prowler.json
+++ b/data/sc_data/parsed/live/models/espr_prowler.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme_spawn.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_ai_ea_supreme_spawn.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9993"
   },
   "mass": 148900.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_collector_indust.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_prowler_utility_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9200"
   },
   "mass": 171700.0,
+  "inventory_container_ref": "8624d002-c8bc-416f-9db2-763d0ec6b01f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6765.0,

--- a/data/sc_data/parsed/live/models/espr_talon.json
+++ b/data/sc_data/parsed/live/models/espr_talon.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "1158055c-a5ac-4a1d-9e44-9e4375247fd0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_talon_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "1158055c-a5ac-4a1d-9e44-9e4375247fd0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_talon_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "1158055c-a5ac-4a1d-9e44-9e4375247fd0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "b14b3d31-7c82-42be-990e-cdb8935c8689",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "b14b3d31-7c82-42be-990e-cdb8935c8689",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "b14b3d31-7c82-42be-990e-cdb8935c8689",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_shrike_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_talon_shrike_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7183"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "b14b3d31-7c82-42be-990e-cdb8935c8689",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/espr_talon_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/espr_talon_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5243"
   },
   "mass": 46242.06,
+  "inventory_container_ref": "1158055c-a5ac-4a1d-9e44-9e4375247fd0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4045.0,

--- a/data/sc_data/parsed/live/models/gama_railen.json
+++ b/data/sc_data/parsed/live/models/gama_railen.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 16897.0,

--- a/data/sc_data/parsed/live/models/gama_railen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_railen_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 16897.0,

--- a/data/sc_data/parsed/live/models/gama_railen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_railen_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5500"
   },
   "mass": 1476352.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 16897.0,

--- a/data/sc_data/parsed/live/models/gama_syulen.json
+++ b/data/sc_data/parsed/live/models/gama_syulen.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_exec_military.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_exec_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_exec_stealth.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_exec_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_syulen_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/gama_syulen_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2000"
   },
   "mass": 77877.0,
+  "inventory_container_ref": "366b095a-6cee-43b9-a728-00bee8e49c3a",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11740.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 19254.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 19254.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6000"
   },
   "mass": 1348962.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 19254.0,

--- a/data/sc_data/parsed/live/models/gama_tyilui_template.json
+++ b/data/sc_data/parsed/live/models/gama_tyilui_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 1348962.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 70460.0,

--- a/data/sc_data/parsed/live/models/glsn_basher.json
+++ b/data/sc_data/parsed/live/models/glsn_basher.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5900.0,

--- a/data/sc_data/parsed/live/models/glsn_basher_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/glsn_basher_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5900.0,

--- a/data/sc_data/parsed/live/models/glsn_basher_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/glsn_basher_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2500"
   },
   "mass": 16527.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5900.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_civ.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_crim.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_ai_template.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosa.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosa.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosb.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosb.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/glsn_shiv_temp_cosc.json
+++ b/data/sc_data/parsed/live/models/glsn_shiv_temp_cosc.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "14820"
   },
   "mass": 206577.0,
+  "inventory_container_ref": "11289951-273e-4b91-9194-ece46fe88783",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 4380.0,

--- a/data/sc_data/parsed/live/models/grin_mdc.json
+++ b/data/sc_data/parsed/live/models/grin_mdc.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5060"
   },
   "mass": 13000.0,
+  "inventory_container_ref": null,
   "hull_health": 16991.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_mtc.json
+++ b/data/sc_data/parsed/live/models/grin_mtc.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "540"
   },
   "mass": 13000.0,
+  "inventory_container_ref": null,
   "hull_health": 16991.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_ptv.json
+++ b/data/sc_data/parsed/live/models/grin_ptv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "115"
   },
   "mass": 1500.0,
+  "inventory_container_ref": "cda4d69a-43cc-4d29-8e99-f8c5260913af",
   "hull_health": 8510.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
+++ b/data/sc_data/parsed/live/models/grin_ptv_nocrimesagainst.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "115"
   },
   "mass": 1500.0,
+  "inventory_container_ref": "cda4d69a-43cc-4d29-8e99-f8c5260913af",
   "hull_health": 8510.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_roc.json
+++ b/data/sc_data/parsed/live/models/grin_roc.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1460"
   },
   "mass": 2000.0,
+  "inventory_container_ref": "756f1fc4-b650-4b6a-80a9-bb0b55ff7cc9",
   "hull_health": 9400.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_roc_ds.json
+++ b/data/sc_data/parsed/live/models/grin_roc_ds.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1825"
   },
   "mass": 2000.0,
+  "inventory_container_ref": "941ec013-061b-4b49-8488-36e0ebe1765d",
   "hull_health": 13902.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_stv.json
+++ b/data/sc_data/parsed/live/models/grin_stv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "540"
   },
   "mass": 2500.0,
+  "inventory_container_ref": null,
   "hull_health": 4250.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/grin_utv.json
+++ b/data/sc_data/parsed/live/models/grin_utv.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "540"
   },
   "mass": 2500.0,
+  "inventory_container_ref": "868e7e70-0ac9-451d-9863-f1ff178925a2",
   "hull_health": 4702.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/krig_l21_wolf.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_collector_military.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_collector_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_l21_wolf_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6190"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_collector_military.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_l22_alphawolf_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7270"
   },
   "mass": 23350.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5000.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "8a9663d1-5bd2-4627-9f49-5e0904deb339",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "8a9663d1-5bd2-4627-9f49-5e0904deb339",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_uee.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_ea_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "8a9663d1-5bd2-4627-9f49-5e0904deb339",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "8a9663d1-5bd2-4627-9f49-5e0904deb339",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_p52_merlin_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "8a9663d1-5bd2-4627-9f49-5e0904deb339",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "3b8694c8-3802-4718-9213-14e2a5c96699",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5906.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_emerald.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_emerald.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "3b8694c8-3802-4718-9213-14e2a5c96699",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5906.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "3b8694c8-3802-4718-9213-14e2a5c96699",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5906.0,

--- a/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/krig_p72_archimedes_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1375"
   },
   "mass": 7599.0,
+  "inventory_container_ref": "3b8694c8-3802-4718-9213-14e2a5c96699",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5906.0,

--- a/data/sc_data/parsed/live/models/misc_fortune.json
+++ b/data/sc_data/parsed/live/models/misc_fortune.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_fortune_collector_industrial.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_collector_industrial.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_fortune_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_fortune_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_fortune_teach.json
+++ b/data/sc_data/parsed/live/models/misc_fortune_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 137700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "e5465987-e166-4725-83d9-b59593c34e9d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10042.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "abf01d30-8af0-4a53-b0fb-8a49b374b37c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10783.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "abf01d30-8af0-4a53-b0fb-8a49b374b37c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10783.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "abf01d30-8af0-4a53-b0fb-8a49b374b37c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10783.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "abf01d30-8af0-4a53-b0fb-8a49b374b37c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10783.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_dur_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_dur_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6035"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "abf01d30-8af0-4a53-b0fb-8a49b374b37c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10783.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "85da4901-2367-451c-85e2-f6b9a62ea3d4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12833.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "85da4901-2367-451c-85e2-f6b9a62ea3d4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12833.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "85da4901-2367-451c-85e2-f6b9a62ea3d4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12833.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "85da4901-2367-451c-85e2-f6b9a62ea3d4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12833.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_max_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_max_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8028"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "85da4901-2367-451c-85e2-f6b9a62ea3d4",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 12833.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_mis_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_mis_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "10465"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "71ad6332-f4d3-4d6c-90d6-775e04500cd2",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10222.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "e5465987-e166-4725-83d9-b59593c34e9d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10042.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "e5465987-e166-4725-83d9-b59593c34e9d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10042.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "e5465987-e166-4725-83d9-b59593c34e9d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10042.0,

--- a/data/sc_data/parsed/live/models/misc_freelancer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_freelancer_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6503"
   },
   "mass": 219396.0,
+  "inventory_container_ref": "e5465987-e166-4725-83d9-b59593c34e9d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10042.0,

--- a/data/sc_data/parsed/live/models/misc_fury.json
+++ b/data/sc_data/parsed/live/models/misc_fury.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "132d298c-2165-40eb-b1e4-21d1f4611b1a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "132d298c-2165-40eb-b1e4-21d1f4611b1a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "132d298c-2165-40eb-b1e4-21d1f4611b1a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/misc_fury_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "132d298c-2165-40eb-b1e4-21d1f4611b1a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_lx.json
+++ b/data/sc_data/parsed/live/models/misc_fury_lx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1400"
   },
   "mass": 12832.0,
+  "inventory_container_ref": "c5b16fb8-5154-41bb-a405-d5538ddf1676",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_lx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_lx_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1400"
   },
   "mass": 12832.0,
+  "inventory_container_ref": "c5b16fb8-5154-41bb-a405-d5538ddf1676",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_miru.json
+++ b/data/sc_data/parsed/live/models/misc_fury_miru.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2299"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "60ea499e-d7ba-433d-b664-abd87a83c3f7",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_miru_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_miru_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2299"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "60ea499e-d7ba-433d-b664-abd87a83c3f7",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_fury_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_fury_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1483"
   },
   "mass": 13939.0,
+  "inventory_container_ref": "132d298c-2165-40eb-b1e4-21d1f4611b1a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4592.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "inventory_container_ref": "c492a371-5f34-4670-97d5-831ccaa31f51",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 91400.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "inventory_container_ref": "c492a371-5f34-4670-97d5-831ccaa31f51",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 91400.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "inventory_container_ref": "c492a371-5f34-4670-97d5-831ccaa31f51",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 91400.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "inventory_container_ref": "c492a371-5f34-4670-97d5-831ccaa31f51",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 91400.0,

--- a/data/sc_data/parsed/live/models/misc_hull_a_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_hull_a_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2700"
   },
   "mass": 107050.0,
+  "inventory_container_ref": "c492a371-5f34-4670-97d5-831ccaa31f51",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 91400.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 14967.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 14967.0,

--- a/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_b_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 472368.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 14967.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "inventory_container_ref": "38fed17c-864c-4a0b-8782-66f8dee118b4",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15791.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "inventory_container_ref": "38fed17c-864c-4a0b-8782-66f8dee118b4",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15791.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "inventory_container_ref": "38fed17c-864c-4a0b-8782-66f8dee118b4",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15791.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c_unmanned.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "inventory_container_ref": "38fed17c-864c-4a0b-8782-66f8dee118b4",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15791.0,

--- a/data/sc_data/parsed/live/models/misc_hull_c_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_hull_c_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "22500"
   },
   "mass": 726530.0,
+  "inventory_container_ref": "38fed17c-864c-4a0b-8782-66f8dee118b4",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 15791.0,

--- a/data/sc_data/parsed/live/models/misc_prospector.json
+++ b/data/sc_data/parsed/live/models/misc_prospector.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_btala.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_btala.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_collector_indust.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt_nonlethal.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_pu_ai_nt_nonlethal.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_prospector_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_prospector_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 122096.0,
+  "inventory_container_ref": "8cbd78f7-ddb8-4906-8b83-a17493037671",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6800.0,

--- a/data/sc_data/parsed/live/models/misc_razor.json
+++ b/data/sc_data/parsed/live/models/misc_razor.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "cc406b87-d7ff-44bd-96bb-70bcc9cf671c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_ex.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "inventory_container_ref": "59b6dc21-f904-4f73-b7be-6c9f7342d190",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "inventory_container_ref": "59b6dc21-f904-4f73-b7be-6c9f7342d190",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_ex_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2740"
   },
   "mass": 10860.0,
+  "inventory_container_ref": "59b6dc21-f904-4f73-b7be-6c9f7342d190",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_lx.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "84ab65b8-029c-432a-ad37-daa14136fede",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "84ab65b8-029c-432a-ad37-daa14136fede",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_lx_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "84ab65b8-029c-432a-ad37-daa14136fede",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_razor_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "cc406b87-d7ff-44bd-96bb-70bcc9cf671c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_razor_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_razor_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 10861.0,
+  "inventory_container_ref": "cc406b87-d7ff-44bd-96bb-70bcc9cf671c",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3690.0,

--- a/data/sc_data/parsed/live/models/misc_reliant.json
+++ b/data/sc_data/parsed/live/models/misc_reliant.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "862f4211-e910-437c-995b-8bb1baaf1c15",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "404e04d2-6bab-47c6-8767-10b003d65a0a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "404e04d2-6bab-47c6-8767-10b003d65a0a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "404e04d2-6bab-47c6-8767-10b003d65a0a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_mako_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2868"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "404e04d2-6bab-47c6-8767-10b003d65a0a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "862f4211-e910-437c-995b-8bb1baaf1c15",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "862f4211-e910-437c-995b-8bb1baaf1c15",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "718bdc00-e953-4af3-815f-3aebfd212b41",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "718bdc00-e953-4af3-815f-3aebfd212b41",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "718bdc00-e953-4af3-815f-3aebfd212b41",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_sen_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2653"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "718bdc00-e953-4af3-815f-3aebfd212b41",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "inventory_container_ref": "9bac0387-efe2-421e-a092-99ff3fa55cb0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_ai_template.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "inventory_container_ref": "9bac0387-efe2-421e-a092-99ff3fa55cb0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "inventory_container_ref": "9bac0387-efe2-421e-a092-99ff3fa55cb0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_tana_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3829"
   },
   "mass": 34968.0,
+  "inventory_container_ref": "9bac0387-efe2-421e-a092-99ff3fa55cb0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_reliant_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_reliant_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "340"
   },
   "mass": 35153.0,
+  "inventory_container_ref": "862f4211-e910-437c-995b-8bb1baaf1c15",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 1601.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded_nocargogridmarkup.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_civ_shipboarded_nocargogridmarkup.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_a.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_b.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_b.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c_lootable.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_c_lootable.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_d.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_d.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_e.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_body_e.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 2583690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_nose.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_nose.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 200000.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_left.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_left.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 400000.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_right.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_derelict_tail_right.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 400000.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_gemini_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "15995"
   },
   "mass": 3494690.0,
+  "inventory_container_ref": "b791799d-24ed-4df6-bd46-ad45509a3f1e",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 11076.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_nointerior.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_nointerior.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel_fast.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_civ_fullfuel_fast.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_teach.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_teach.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_a.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_b.json
+++ b/data/sc_data/parsed/live/models/misc_starfarer_wreck_nodebris_b.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9000"
   },
   "mass": 3466606.0,
+  "inventory_container_ref": "c60deca0-2701-412c-b8fe-a153522d60cd",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13437.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 84200.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_collector_indust.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 84200.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 84200.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_max_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5190"
   },
   "mass": 498070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 84200.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 116600.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_collector_military.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 116600.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 116600.0,

--- a/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlancer_tac_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7190"
   },
   "mass": 738070.5,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 8,
   "signature_cross_section": null,
   "hull_health": 116600.0,

--- a/data/sc_data/parsed/live/models/misc_starlite.json
+++ b/data/sc_data/parsed/live/models/misc_starlite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9693.0,

--- a/data/sc_data/parsed/live/models/misc_starlite_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/misc_starlite_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9693.0,

--- a/data/sc_data/parsed/live/models/misc_starlite_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/misc_starlite_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5530"
   },
   "mass": 346548.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 9693.0,

--- a/data/sc_data/parsed/live/models/misc_starlite_template.json
+++ b/data/sc_data/parsed/live/models/misc_starlite_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": null,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "metrics": {

--- a/data/sc_data/parsed/live/models/mrai_guardian.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_ai_template.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_military.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_mx_collector_military.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_mx_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4200"
   },
   "mass": 43540.37,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5710"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_ai_template.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_collector_indust.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/mrai_guardian_qi_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6180"
   },
   "mass": 37700.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6000.0,

--- a/data/sc_data/parsed/live/models/mrai_pulse.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 401.0,

--- a/data/sc_data/parsed/live/models/mrai_pulse_collector_civ.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse_collector_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 401.0,

--- a/data/sc_data/parsed/live/models/mrai_pulse_lx.json
+++ b/data/sc_data/parsed/live/models/mrai_pulse_lx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 2140.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 401.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_prototype_a_pu_hos.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_prototype_a_pu_hos.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal_size2.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_criminal_size2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails_size2.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_ninetails_size2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_pu_uee.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_pu_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orbital_sentry_securitynetwork.json
+++ b/data/sc_data/parsed/live/models/orbital_sentry_securitynetwork.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 11475.0,

--- a/data/sc_data/parsed/live/models/orig_100i.json
+++ b/data/sc_data/parsed/live/models/orig_100i.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "c533bc29-c20f-445c-8ab0-45338e2f0ba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5117.0,

--- a/data/sc_data/parsed/live/models/orig_100i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_100i_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "c533bc29-c20f-445c-8ab0-45338e2f0ba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5117.0,

--- a/data/sc_data/parsed/live/models/orig_100i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_100i_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "c533bc29-c20f-445c-8ab0-45338e2f0ba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5117.0,

--- a/data/sc_data/parsed/live/models/orig_100i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_100i_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1858"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "c533bc29-c20f-445c-8ab0-45338e2f0ba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5117.0,

--- a/data/sc_data/parsed/live/models/orig_125a.json
+++ b/data/sc_data/parsed/live/models/orig_125a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "2333116f-681c-4b9c-aa72-3ed8be9abb42",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6048.0,

--- a/data/sc_data/parsed/live/models/orig_125a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_125a_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "2333116f-681c-4b9c-aa72-3ed8be9abb42",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6048.0,

--- a/data/sc_data/parsed/live/models/orig_125a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_125a_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2526"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "2333116f-681c-4b9c-aa72-3ed8be9abb42",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6048.0,

--- a/data/sc_data/parsed/live/models/orig_135c.json
+++ b/data/sc_data/parsed/live/models/orig_135c.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "e856487f-6a6c-46fc-9163-08ad59102a63",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6050.0,

--- a/data/sc_data/parsed/live/models/orig_135c_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_135c_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "e856487f-6a6c-46fc-9163-08ad59102a63",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6050.0,

--- a/data/sc_data/parsed/live/models/orig_135c_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_135c_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1830"
   },
   "mass": 45143.0,
+  "inventory_container_ref": "e856487f-6a6c-46fc-9163-08ad59102a63",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6050.0,

--- a/data/sc_data/parsed/live/models/orig_300i.json
+++ b/data/sc_data/parsed/live/models/orig_300i.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_300i_ai_override.json
+++ b/data/sc_data/parsed/live/models/orig_300i_ai_override.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_300i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_300i_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_300i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_300i_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_300i_unmanned_restoration.json
+++ b/data/sc_data/parsed/live/models/orig_300i_unmanned_restoration.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_300i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_300i_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3618"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "785ad460-75c1-427b-8edb-43e0b0661075",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_315p.json
+++ b/data/sc_data/parsed/live/models/orig_315p.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "inventory_container_ref": "ec2db709-bc32-4ae5-9ff0-70da56837839",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5579.0,

--- a/data/sc_data/parsed/live/models/orig_315p_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_315p_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "inventory_container_ref": "ec2db709-bc32-4ae5-9ff0-70da56837839",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5579.0,

--- a/data/sc_data/parsed/live/models/orig_315p_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_315p_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "inventory_container_ref": "ec2db709-bc32-4ae5-9ff0-70da56837839",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5579.0,

--- a/data/sc_data/parsed/live/models/orig_315p_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_315p_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2579"
   },
   "mass": 70592.0,
+  "inventory_container_ref": "ec2db709-bc32-4ae5-9ff0-70da56837839",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5579.0,

--- a/data/sc_data/parsed/live/models/orig_325a.json
+++ b/data/sc_data/parsed/live/models/orig_325a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "inventory_container_ref": "5c4a56ae-3ba1-4f51-bbb9-c75577d6aa7e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "inventory_container_ref": "5c4a56ae-3ba1-4f51-bbb9-c75577d6aa7e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "inventory_container_ref": "5c4a56ae-3ba1-4f51-bbb9-c75577d6aa7e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/orig_325a_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/orig_325a_pu_ai_mts.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "inventory_container_ref": "5c4a56ae-3ba1-4f51-bbb9-c75577d6aa7e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/orig_325a_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_325a_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3900"
   },
   "mass": 69324.0,
+  "inventory_container_ref": "5c4a56ae-3ba1-4f51-bbb9-c75577d6aa7e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5928.0,

--- a/data/sc_data/parsed/live/models/orig_350r.json
+++ b/data/sc_data/parsed/live/models/orig_350r.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "1b9688f6-1eba-4ac8-810a-5ac543c79d72",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_350r_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_350r_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "1b9688f6-1eba-4ac8-810a-5ac543c79d72",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_350r_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_350r_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "1b9688f6-1eba-4ac8-810a-5ac543c79d72",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_350r_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_350r_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4573"
   },
   "mass": 69677.0,
+  "inventory_container_ref": "1b9688f6-1eba-4ac8-810a-5ac543c79d72",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5631.0,

--- a/data/sc_data/parsed/live/models/orig_400i.json
+++ b/data/sc_data/parsed/live/models/orig_400i.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_400i_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_400i_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_400i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_400i_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_400i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_400i_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12027"
   },
   "mass": 400457.06,
+  "inventory_container_ref": "c53f1ea8-d862-4b55-822d-9ad26947920d",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10481.0,

--- a/data/sc_data/parsed/live/models/orig_600i.json
+++ b/data/sc_data/parsed/live/models/orig_600i.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_600i_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_bis2951.json
+++ b/data/sc_data/parsed/live/models/orig_600i_bis2951.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_executive_edition.json
+++ b/data/sc_data/parsed/live/models/orig_600i_executive_edition.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "9db2766a-06da-4a5c-9d23-c9cdc9d5d854",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_600i_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_touring.json
+++ b/data/sc_data/parsed/live/models/orig_600i_touring.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "1c1b7cb7-68de-4e7d-8690-c0fa2d6636ba",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_unmanned.json
+++ b/data/sc_data/parsed/live/models/orig_600i_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_600i_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_600i_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "17550"
   },
   "mass": 1544667.0,
+  "inventory_container_ref": "417e05b1-d424-4b79-a8e6-c8898743a8c6",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 14099.0,

--- a/data/sc_data/parsed/live/models/orig_85x.json
+++ b/data/sc_data/parsed/live/models/orig_85x.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "inventory_container_ref": "bc61b3f7-20fa-4cbb-9765-d43954b4a823",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7279.0,

--- a/data/sc_data/parsed/live/models/orig_85x_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_85x_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "inventory_container_ref": "bc61b3f7-20fa-4cbb-9765-d43954b4a823",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7279.0,

--- a/data/sc_data/parsed/live/models/orig_85x_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_85x_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "510"
   },
   "mass": 18993.5,
+  "inventory_container_ref": "bc61b3f7-20fa-4cbb-9765-d43954b4a823",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7279.0,

--- a/data/sc_data/parsed/live/models/orig_890jump.json
+++ b/data/sc_data/parsed/live/models/orig_890jump.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_ai_civ_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_ai_civ_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_ai_template_shipboarded.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_ai_template_shipboarded.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_drug_01.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_drug_01.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_hijacked.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_hijacked.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_hijacked_pisces.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_hijacked_pisces.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_unmanned.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_890jump_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/orig_890jump_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "33750"
   },
   "mass": 43896159.0,
+  "inventory_container_ref": "81489cc5-9985-4ac4-ac24-2c9f14cd49fa",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 13506.0,

--- a/data/sc_data/parsed/live/models/orig_m50.json
+++ b/data/sc_data/parsed/live/models/orig_m50.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m50_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/orig_m50_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3040"
   },
   "mass": 9772.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5365.0,

--- a/data/sc_data/parsed/live/models/orig_m80.json
+++ b/data/sc_data/parsed/live/models/orig_m80.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4168.0,

--- a/data/sc_data/parsed/live/models/orig_m80_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/orig_m80_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4168.0,

--- a/data/sc_data/parsed/live/models/orig_m80_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/orig_m80_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 135649.0,
+  "inventory_container_ref": "c5efc6cb-bbed-4e9c-a42b-623b30417ab0",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4168.0,

--- a/data/sc_data/parsed/live/models/orig_x1.json
+++ b/data/sc_data/parsed/live/models/orig_x1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 457.0,

--- a/data/sc_data/parsed/live/models/orig_x1_force.json
+++ b/data/sc_data/parsed/live/models/orig_x1_force.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 457.0,

--- a/data/sc_data/parsed/live/models/orig_x1_velocity.json
+++ b/data/sc_data/parsed/live/models/orig_x1_velocity.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "75"
   },
   "mass": 4730.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 457.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_a.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_a.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15727.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_a_psec.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_a_psec.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 200000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15727.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_b_civ.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_b_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15727.0,

--- a/data/sc_data/parsed/live/models/probe_comms_1_ninetails.json
+++ b/data/sc_data/parsed/live/models/probe_comms_1_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 80000.0,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 15727.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_1.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_2.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_3.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_medivac_tier_3.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9370"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_collector_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_1.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_1.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_2.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_3.json
+++ b/data/sc_data/parsed/live/models/rsi_apollo_triage_tier_3.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8970"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "inventory_container_ref": "0215913a-956e-4800-9a60-8c16bc84480a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3367.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_cl_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "inventory_container_ref": "0215913a-956e-4800-9a60-8c16bc84480a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3367.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "inventory_container_ref": "d961541d-7667-402c-876f-760547e3dc6e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4400.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_es_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "inventory_container_ref": "d961541d-7667-402c-876f-760547e3dc6e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 4400.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "inventory_container_ref": "0215913a-956e-4800-9a60-8c16bc84480a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "inventory_container_ref": "0215913a-956e-4800-9a60-8c16bc84480a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_cl_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1408"
   },
   "mass": 24422.0,
+  "inventory_container_ref": "0215913a-956e-4800-9a60-8c16bc84480a",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "inventory_container_ref": "d961541d-7667-402c-876f-760547e3dc6e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "inventory_container_ref": "d961541d-7667-402c-876f-760547e3dc6e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_es_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1298"
   },
   "mass": 24486.0,
+  "inventory_container_ref": "d961541d-7667-402c-876f-760547e3dc6e",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_ln_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "inventory_container_ref": "bab8c647-63d7-49b7-8900-f652302500aa",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "inventory_container_ref": "bab8c647-63d7-49b7-8900-f652302500aa",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_lx_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "inventory_container_ref": "bab8c647-63d7-49b7-8900-f652302500aa",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "inventory_container_ref": "e14685da-990f-48ef-b54e-c82ca83235f9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "inventory_container_ref": "e14685da-990f-48ef-b54e-c82ca83235f9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_mr_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "inventory_container_ref": "e14685da-990f-48ef-b54e-c82ca83235f9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_gs_se.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_gs_se.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2998.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2998.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2998.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_ln_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2005"
   },
   "mass": 26714.0,
+  "inventory_container_ref": "aea07b6b-c1ed-44e2-addc-97cb5828bba2",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2998.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "inventory_container_ref": "bab8c647-63d7-49b7-8900-f652302500aa",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_lx_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1513"
   },
   "mass": 24736.0,
+  "inventory_container_ref": "bab8c647-63d7-49b7-8900-f652302500aa",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 2618.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6700.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_missilemodule_temp.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_missilemodule_temp.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6700.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6700.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mk2_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5480"
   },
   "mass": 63500.0,
+  "inventory_container_ref": "633130a5-a3cf-4e76-bfba-c42f795228ee",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6700.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "inventory_container_ref": "e14685da-990f-48ef-b54e-c82ca83235f9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3367.0,

--- a/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_aurora_mr_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1631"
   },
   "mass": 25893.0,
+  "inventory_container_ref": "e14685da-990f-48ef-b54e-c82ca83235f9",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 3367.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 33100.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_fleetweek_2021.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_fleetweek_2021.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 33100.0,

--- a/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_nointerior.json
+++ b/data/sc_data/parsed/live/models/rsi_bengal_pu_ai_uee_nointerior.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 113000000.0,
+  "inventory_container_ref": "8f4f7045-703a-4932-98c1-e2d56b0f89b1",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 33100.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir_elite.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_ea_ai_pir_elite.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_nt_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_blacjac_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader_qig.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_pu_ai_sec_crusader_qig.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_ninetails.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_andromeda_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "98c0bd9b-5b33-44e7-bde3-ca35cb02126c",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10505.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "f18d5c98-2353-4ea8-b1ec-20b1d410f851",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10083.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "f18d5c98-2353-4ea8-b1ec-20b1d410f851",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10083.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "f18d5c98-2353-4ea8-b1ec-20b1d410f851",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10083.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_aquila_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_aquila_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9171"
   },
   "mass": 386857.0,
+  "inventory_container_ref": "f18d5c98-2353-4ea8-b1ec-20b1d410f851",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10083.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_emerald.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_emerald.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_piano.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_piano.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_phoenix_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "12079"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "c2915c14-d1cd-4005-afb0-2c7e7fc0a109",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 10400.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_military.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/rsi_constellation_taurus_unmanned_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "9531"
   },
   "mass": 383801.0,
+  "inventory_container_ref": "96edc1b2-c7cd-49cc-bbb9-aedcf1d2adce",
   "weapon_pool_size": 8,
   "signature_cross_section": {
     "x": 16484.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_hermes_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_hermes_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "8740"
   },
   "mass": 630456.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11328.0,

--- a/data/sc_data/parsed/live/models/rsi_lynx.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1080"
   },
   "mass": 10372.0,
+  "inventory_container_ref": "632cf6eb-b13a-4795-8a0a-6a980296d3c6",
   "hull_health": 22700.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_lynx_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1080"
   },
   "mass": 10372.0,
+  "inventory_container_ref": "632cf6eb-b13a-4795-8a0a-6a980296d3c6",
   "hull_health": 22700.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_mantis.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_bomb_test.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_bomb_test.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_advocacy.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_advocacy.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bh.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bh.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bjs.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_bjs.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_mts.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_mts.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_ninetails.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_ninetails.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_crusader.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_crusader.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_hurston.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_sec_hurston.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_xenothreat.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_pu_ai_xenothreat.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3374"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "6a561e58-6c87-408b-8ac7-e1b797b5071b",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 6773.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_unmanned.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_mantis_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_mantis_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 224923.0,
+  "inventory_container_ref": "8b90dcb9-41cf-41a0-af8f-4ee7c7130195",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_collector_military.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_collector_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_collector_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_meteor_temp_laserrepeater.json
+++ b/data/sc_data/parsed/live/models/rsi_meteor_temp_laserrepeater.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "6750"
   },
   "mass": 238832.0,
+  "inventory_container_ref": "c25fb549-ef58-4223-b0dc-e1302d611f50",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 7800.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8350.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8350.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8350.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8350.0,

--- a/data/sc_data/parsed/live/models/rsi_perseus_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_perseus_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "24850"
   },
   "mass": 4037000.0,
+  "inventory_container_ref": "4b2dbad4-ca1c-4016-9d1c-7850f565a160",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 8350.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_collector_military.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_collector_military.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff_boyd.json
+++ b/data/sc_data/parsed/live/models/rsi_polaris_pu_ai_ff_boyd.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "44030"
   },
   "mass": 10427000.0,
+  "inventory_container_ref": "2d983aaf-8a73-446b-9c40-6ecde2d865c8",
   "weapon_pool_size": 10,
   "signature_cross_section": {
     "x": 26000.0,

--- a/data/sc_data/parsed/live/models/rsi_salvation.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5936.0,

--- a/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5936.0,

--- a/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5620"
   },
   "mass": 62245.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 5936.0,

--- a/data/sc_data/parsed/live/models/rsi_salvation_template.json
+++ b/data/sc_data/parsed/live/models/rsi_salvation_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 62245.0,
+  "inventory_container_ref": "07b72e0c-74a4-4f62-81b5-da31c2afcb86",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "hull_health": 5503.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "18a0e29f-59b9-4043-9faf-c605f7ec2844",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6647.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "18a0e29f-59b9-4043-9faf-c605f7ec2844",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6647.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "18a0e29f-59b9-4043-9faf-c605f7ec2844",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6647.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_antares_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_antares_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "18a0e29f-59b9-4043-9faf-c605f7ec2844",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6647.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim_distortion.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_crim_distortion.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_uee.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_pu_ai_uee.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_scorpius_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_scorpius_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 91461.54,
+  "inventory_container_ref": "4b5653c9-fe4a-4021-8056-63559f451dce",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6645.0,

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 12667.0,
+  "inventory_container_ref": "9d1a1cbc-580f-425d-acc9-179c6b74cb3a",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_medivac_stealth.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 12667.0,
+  "inventory_container_ref": "9d1a1cbc-580f-425d-acc9-179c6b74cb3a",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_ai_civ_raceannouncer.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_emerald.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_prison.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_ff.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
+++ b/data/sc_data/parsed/live/models/rsi_ursa_rover_unmanned_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1015"
   },
   "mass": 11972.0,
+  "inventory_container_ref": "7429cbbb-412a-41b8-a1bd-4d2551e956ce",
   "hull_health": 25200.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_collector_indust.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ_def.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_civ_def.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_cl_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "4900"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "e2a1e155-7f3e-4a5c-9bdc-7ceb1950e74f",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_ai_template.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_ai_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_collector_indust.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_collector_indust.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/rsi_zeus_es_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3710"
   },
   "mass": 276600.0,
+  "inventory_container_ref": "b1d596cd-e55b-4173-8487-e7664b4bd823",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8000.0,

--- a/data/sc_data/parsed/live/models/spaceship_template.json
+++ b/data/sc_data/parsed/live/models/spaceship_template.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": null,
+  "inventory_container_ref": "04555ac1-dfc1-4181-b847-dcd62f5147da",
   "weapon_pool_size": 4,
   "signature_cross_section": null,
   "metrics": {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "3fdc5058-9de3-480e-846b-031201a330b7",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_aa.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1345"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "0a78cfc6-51be-410d-b71c-0ee0ddc242bb",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_indestructible.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "3fdc5058-9de3-480e-846b-031201a330b7",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_mt.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1605"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "2bc70f6a-6121-44c5-894d-51cd8c710021",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rc.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1135"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "3bf2d8d4-4002-4a3b-beba-863f20a730fb",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_rn.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "fb5711f8-e8b8-47cf-b209-22f10e8fb50e",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
+++ b/data/sc_data/parsed/live/models/tmbl_cyclone_tr.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "810"
   },
   "mass": 3084.0,
+  "inventory_container_ref": "f102c8b9-e216-409f-9385-dd22459aa9af",
   "hull_health": 6910.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_nova.json
+++ b/data/sc_data/parsed/live/models/tmbl_nova.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "7398"
   },
   "mass": 73190.0,
+  "inventory_container_ref": "ff241293-22db-40cc-837e-f706d4b5124a",
   "hull_health": 127600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_storm.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1730"
   },
   "mass": 54230.0,
+  "inventory_container_ref": "54c00ca7-0f69-4d0e-b73f-c4367ee4b8f3",
   "hull_health": 115600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/tmbl_storm_aa.json
+++ b/data/sc_data/parsed/live/models/tmbl_storm_aa.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "1740"
   },
   "mass": 54230.0,
+  "inventory_container_ref": "2225882b-9760-48bb-9aaa-6c09f1c66dcf",
   "hull_health": 115600.0,
   "hull_parts": [
     {

--- a/data/sc_data/parsed/live/models/vncl_blade.json
+++ b/data/sc_data/parsed/live/models/vncl_blade.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "inventory_container_ref": "f8ba94b9-473b-4170-8942-6b39dff83c1c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10418.0,

--- a/data/sc_data/parsed/live/models/vncl_blade_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "inventory_container_ref": "f8ba94b9-473b-4170-8942-6b39dff83c1c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10418.0,

--- a/data/sc_data/parsed/live/models/vncl_blade_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_pu_ai_van.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "inventory_container_ref": "f8ba94b9-473b-4170-8942-6b39dff83c1c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10418.0,

--- a/data/sc_data/parsed/live/models/vncl_blade_swarm.json
+++ b/data/sc_data/parsed/live/models/vncl_blade_swarm.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "5124"
   },
   "mass": 23219.0,
+  "inventory_container_ref": "f8ba94b9-473b-4170-8942-6b39dff83c1c",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 10418.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "inventory_container_ref": "62fc4e01-9499-4d81-bd27-2e67905aa856",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9140.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "inventory_container_ref": "62fc4e01-9499-4d81-bd27-2e67905aa856",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9140.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_ea_ai_van_prime.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_ea_ai_van_prime.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "inventory_container_ref": "62fc4e01-9499-4d81-bd27-2e67905aa856",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9140.0,

--- a/data/sc_data/parsed/live/models/vncl_glaive_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_glaive_pu_ai_van.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 68391.0,
+  "inventory_container_ref": "62fc4e01-9499-4d81-bd27-2e67905aa856",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 9140.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 20,
   "signature_cross_section": {
     "x": 40000.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler_ai.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler_ai.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 20,
   "signature_cross_section": {
     "x": 40000.0,

--- a/data/sc_data/parsed/live/models/vncl_mauler_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_mauler_pu_ai_van.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "333"
   },
   "mass": 70275858.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 20,
   "signature_cross_section": {
     "x": 40000.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8277.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_alpha.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_alpha.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8277.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_hunter.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_ea_ai_van_hunter.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8277.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8277.0,

--- a/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_scythe_pu_ai_van.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2955"
   },
   "mass": 68391.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 8277.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_ai_super_vandull.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_ai_super_vandull.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_van.json
+++ b/data/sc_data/parsed/live/models/vncl_stinger_pu_ai_van.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "19220"
   },
   "mass": 247552.0,
+  "inventory_container_ref": "41b19211-b6a2-4967-a7b7-541806e61127",
   "weapon_pool_size": 6,
   "signature_cross_section": {
     "x": 6705.0,

--- a/data/sc_data/parsed/live/models/xian_nox.json
+++ b/data/sc_data/parsed/live/models/xian_nox.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "inventory_container_ref": "b5a41c0e-4038-44e6-b8c8-04dd949bc03b",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 467.0,

--- a/data/sc_data/parsed/live/models/xian_nox_collector_mod.json
+++ b/data/sc_data/parsed/live/models/xian_nox_collector_mod.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "inventory_container_ref": "b5a41c0e-4038-44e6-b8c8-04dd949bc03b",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 467.0,

--- a/data/sc_data/parsed/live/models/xian_nox_kue.json
+++ b/data/sc_data/parsed/live/models/xian_nox_kue.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "55"
   },
   "mass": 4230.0,
+  "inventory_container_ref": "b5a41c0e-4038-44e6-b8c8-04dd949bc03b",
   "weapon_pool_size": 2,
   "signature_cross_section": {
     "x": 467.0,

--- a/data/sc_data/parsed/live/models/xian_scout.json
+++ b/data/sc_data/parsed/live/models/xian_scout.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super_civ.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xian_scout_ai_super_crim.json
+++ b/data/sc_data/parsed/live/models/xian_scout_ai_super_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xian_scout_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/xian_scout_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xian_scout_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/xian_scout_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "2535"
   },
   "mass": 68311.0,
+  "inventory_container_ref": "e1627fd7-3523-4d9a-a25f-a87fd4e65d25",
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 8222.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11878.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_ai_defendship.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_ai_defendship.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11878.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_civ.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_civ.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11878.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_crim.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_pu_ai_crim.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11878.0,

--- a/data/sc_data/parsed/live/models/xnaa_santokyai_unmanned_salvage.json
+++ b/data/sc_data/parsed/live/models/xnaa_santokyai_unmanned_salvage.json
@@ -14,6 +14,7 @@
     "base_expediting_fee": "3800"
   },
   "mass": 82224.0,
+  "inventory_container_ref": null,
   "weapon_pool_size": 4,
   "signature_cross_section": {
     "x": 11878.0,


### PR DESCRIPTION
Parser output for the ship storage work, split out so the code that reads it stays reviewable. Base for #4375.

## What changed

**1,098 model files gain one field.** A ship's own storage container is named by its `VehicleComponentParams`:

```json
"inventory_container_ref": "74fd8018-4e99-4dd6-a968-4b9c948aa759"
```

The vehicle entity points at it directly rather than hanging it off a hardpoint the way cargo grids do, so recording the ref is what lets the loader resolve the container without walking a chain.

**18 inventory containers change value.** Their capacity is declared in centi- or microSCU, and `parse_inventory` raised the figure to that power instead of converting it:

```
ship_snub          2.14e-29 SCU  ->  0.06 SCU
drak_mule_cargogrid_template   1.0 SCU  ->  0.000001 SCU
```

The containers declaring `SStandardCargoUnit` were always right, which is why this only touches eighteen of them.

## Notes

No code in this PR — the parser and loader changes that produce and consume it are in #4375, which is stacked on this branch.

🤖
