### PR TITLE
chore(deps): patch @tresjs/core for @types/three 0.185

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,9 @@
       "serialize-javascript": ">=7.0.5",
       "vite": ">=7.3.2"
     },
+    "patchedDependencies": {
+      "@tresjs/core@5.8.1": "patches/@tresjs__core@5.8.1.patch"
+    },
     "peerDependencyRules": {
       "allowedVersions": {
         "vite-plugin-pwa>vite": "8"

--- a/patches/@tresjs__core@5.8.1.patch
+++ b/patches/@tresjs__core@5.8.1.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/tres.d.ts b/dist/tres.d.ts
+index e9b7f7e9ca98d521fc5a38fa3b91f319f0178057..120d7156afb9e5e5dea93d32848f354b54c2b188 100644
+--- a/dist/tres.d.ts
++++ b/dist/tres.d.ts
+@@ -445,7 +445,12 @@ interface TresScene extends THREE.Scene {
+   };
+ }
+ interface MathRepresentation {
+-  set(...args: number[] | [THREE.ColorRepresentation]): any;
++  // @types/three 0.185 made the trailing arg of Vector2/3/4.set optional, matching
++  // three's runtime (`if (z === undefined) z = this.z`). Vector3 therefore no longer
++  // satisfies the original signature, so WithMathProps silently dropped the tuple
++  // widening and every `:position="[x, y, z]"` stopped type-checking.
++  // Remove once tresjs/tres loosens this upstream.
++  set(...args: any[]): any;
+ }
+ interface VectorRepresentation extends MathRepresentation {
+   setScalar(s: number): any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,11 @@ overrides:
   serialize-javascript: '>=7.0.5'
   vite: '>=7.3.2'
 
+patchedDependencies:
+  '@tresjs/core@5.8.1':
+    hash: 51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2
+    path: patches/@tresjs__core@5.8.1.patch
+
 importers:
 
   .:
@@ -44,10 +49,10 @@ importers:
         version: 5.101.4(vue@3.5.41(typescript@6.0.3))
       '@tresjs/cientos':
         specifier: ^5.7.2
-        version: 5.7.2(@tresjs/core@5.8.1(three@0.185.1)(vue@3.5.41(typescript@6.0.3)))(@types/three@0.184.1)(react@19.1.0)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
+        version: 5.7.2(@tresjs/core@5.8.1(patch_hash=51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2)(three@0.185.1)(vue@3.5.41(typescript@6.0.3)))(@types/three@0.184.1)(react@19.1.0)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
       '@tresjs/core':
         specifier: ^5.8.1
-        version: 5.8.1(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
+        version: 5.8.1(patch_hash=51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
       '@vee-validate/rules':
         specifier: ^4.15.1
         version: 4.15.1(vue@3.5.41(typescript@6.0.3))
@@ -7898,9 +7903,9 @@ snapshots:
       vue: 3.5.41(typescript@6.0.3)
       vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
 
-  '@tresjs/cientos@5.7.2(@tresjs/core@5.8.1(three@0.185.1)(vue@3.5.41(typescript@6.0.3)))(@types/three@0.184.1)(react@19.1.0)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))':
+  '@tresjs/cientos@5.7.2(@tresjs/core@5.8.1(patch_hash=51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2)(three@0.185.1)(vue@3.5.41(typescript@6.0.3)))(@types/three@0.184.1)(react@19.1.0)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@tresjs/core': 5.8.1(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
+      '@tresjs/core': 5.8.1(patch_hash=51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))
       '@vueuse/core': 13.9.0(vue@3.5.41(typescript@6.0.3))
       camera-controls: 2.10.1(three@0.185.1)
       stats-gl: 2.4.2(@types/three@0.184.1)(three@0.185.1)
@@ -7915,7 +7920,7 @@ snapshots:
       - '@types/three'
       - react
 
-  '@tresjs/core@5.8.1(three@0.185.1)(vue@3.5.41(typescript@6.0.3))':
+  '@tresjs/core@5.8.1(patch_hash=51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2)(three@0.185.1)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@pmndrs/pointer-events': 6.6.29
       '@vue/devtools-api': 7.7.9


### PR DESCRIPTION
Unblocks #4421, which is red on `tsc` with 18 errors across `CargoGridViewer`, `Fleets/MembersStarMap` and `shared/HoloViewer`.

## Why

`@types/three` 0.185 made the trailing argument of `Vector2/3/4.set` optional:

```diff
-set(x: number, y: number, z: number): this;
+set(x: number, y: number, z?: number): this;
```

That is a *correct* change — it matches three's runtime, which does `if ( z === undefined ) z = this.z;`.

`@tresjs/core` gates its prop widening on a structural interface:

```ts
interface MathRepresentation {
  set(...args: number[] | [THREE.ColorRepresentation]): any;
}
```

With the argument required, `Vector3` satisfies it; with it optional, it no longer does. So `WithMathProps` silently stops applying `MathType` to `position`/`scale`, leaving the bare `readonly position: Vector3` and collapsing the prop type to `Vector3 | Readonly<Vector3 | undefined>`. Every idiomatic `:position="[x, y, z]"` then fails to type-check.

TresJS is the too-strict party here, so that is the layer patched. `@tresjs/core` 5.8.3 (latest) carries the identical definition — verified, still fails — and there is no upstream issue open for it yet.

## What

One-line loosening of `MathRepresentation.set`, with a comment explaining the constraint and when to drop it. No application code changes — all 18 call sites stay idiomatic TresJS.

## Verification

Against the current `@types/three` 0.184.1 (this branch): `vite build`, `vue-tsc`, `tsc` all clean, 218 tests pass, `--frozen-lockfile` install works.

Against 0.185.4 (#4421's branch): same three steps clean, error count down by exactly 18 with none introduced.

The patch is version-agnostic, so this can land on its own; #4421 then just needs a `@dependabot rebase` to go green. Worth doing — runtime `three` is pinned at 0.185.1 while the types sat at 0.184.1, so this finally aligns them.

🤖