### PR TITLE
fix(sc_data): stop the export minting duplicate manufacturers

### DIFF
--- a/app/lib/sc_data/loader/manufacturers_loader.rb
+++ b/app/lib/sc_data/loader/manufacturers_loader.rb
@@ -3,18 +3,29 @@ module ScData
     class ManufacturersLoader < ::ScData::Loader::BaseLoader
       def all
         load_items("manufacturers").each do |manufacturer_data|
+          name = manufacturer_data["name"]
+
+          # Matched on the slug the name would produce rather than on the name
+          # itself, because the slug is what the rest of the site identifies a
+          # manufacturer by -- so two names that reach the same one are the same
+          # manufacturer as far as anything downstream can tell. An exact repeat
+          # slugs the same way, and so do the variants the export mixes in:
+          # "Basilisk " and "GYSON INC." would have missed a by-name lookup and
+          # minted a second row that collides with the first.
+          slug = Manufacturer.slug_for(name)
+
           manufacturer = Manufacturer.find_by(sc_ref: manufacturer_data["ref"])
           manufacturer = Manufacturer.find_by(code: manufacturer_data["code"], sc_ref: nil) if manufacturer.blank?
-          manufacturer = Manufacturer.find_by(name: manufacturer_data["name"], sc_ref: nil) if manufacturer.blank? && manufacturer_data["name"].present?
+          manufacturer = Manufacturer.find_by(slug:, sc_ref: nil) if manufacturer.blank? && slug.present?
 
           # Last resort, and the one that stops the table growing a second row
           # for a manufacturer it already has: the lookups above only match a
           # row that has no sc_ref yet, so once every row carries one, a record
           # arriving under a new ref used to be created afresh. The export ships
           # several codes per company -- ROO and SASU are both Sakura Sun -- so
-          # a name that is already taken means the same manufacturer, and the
+          # a slug that is already taken means the same manufacturer, and the
           # extra ref is dropped rather than duplicated.
-          manufacturer = Manufacturer.find_by(name: manufacturer_data["name"]) if manufacturer.blank? && manufacturer_data["name"].present?
+          manufacturer = Manufacturer.find_by(slug:) if manufacturer.blank? && slug.present?
 
           if manufacturer.present?
             # The description and the code are left alone once set, because a
@@ -27,7 +38,7 @@ module ScData
             update_params = {}
             update_params[:icon] = manufacturer_data["icon"] if manufacturer_data["icon"].present?
 
-            # Only claimed while free. A row matched on name can already hold a
+            # Only claimed while free. A row matched on slug can already hold a
             # different ref -- the export gives Sakura Sun both ROO and SASU --
             # and overwriting would leave the two codes trading the column on
             # every import.
@@ -48,10 +59,10 @@ module ScData
             attach_icon(manufacturer, :logo, manufacturer_data["icon"])
 
             manufacturer
-          elsif manufacturer_data["name"].present?
+          elsif name.present?
             created = Manufacturer.create!(
               sc_ref: manufacturer_data["ref"],
-              name: manufacturer_data["name"],
+              name:,
               code: manufacturer_data["code"],
               description: manufacturer_data["description"],
               icon: manufacturer_data["icon"]

--- a/app/lib/sc_data/loader/manufacturers_loader.rb
+++ b/app/lib/sc_data/loader/manufacturers_loader.rb
@@ -7,14 +7,33 @@ module ScData
           manufacturer = Manufacturer.find_by(code: manufacturer_data["code"], sc_ref: nil) if manufacturer.blank?
           manufacturer = Manufacturer.find_by(name: manufacturer_data["name"], sc_ref: nil) if manufacturer.blank? && manufacturer_data["name"].present?
 
+          # Last resort, and the one that stops the table growing a second row
+          # for a manufacturer it already has: the lookups above only match a
+          # row that has no sc_ref yet, so once every row carries one, a record
+          # arriving under a new ref used to be created afresh. The export ships
+          # several codes per company -- ROO and SASU are both Sakura Sun -- so
+          # a name that is already taken means the same manufacturer, and the
+          # extra ref is dropped rather than duplicated.
+          manufacturer = Manufacturer.find_by(name: manufacturer_data["name"]) if manufacturer.blank? && manufacturer_data["name"].present?
+
           if manufacturer.present?
             # The description and the code are left alone once set, because a
             # curated one is better than the game's. The icon has no curated
-            # counterpart -- it is a path into the export -- so it follows it.
-            update_params = {
-              sc_ref: manufacturer_data["ref"],
-              icon: manufacturer_data["icon"]
-            }
+            # counterpart -- it is a path into the export -- so it follows it,
+            # but is never blanked: the codes that share a manufacturer do not
+            # all name a logo -- ROO has none where SASU has Sakura Sun's -- so
+            # following the export unconditionally would drop the picture
+            # depending on which record was loaded last.
+            update_params = {}
+            update_params[:icon] = manufacturer_data["icon"] if manufacturer_data["icon"].present?
+
+            # Only claimed while free. A row matched on name can already hold a
+            # different ref -- the export gives Sakura Sun both ROO and SASU --
+            # and overwriting would leave the two codes trading the column on
+            # every import.
+            if manufacturer.sc_ref.blank? && manufacturer_data["ref"].present?
+              update_params[:sc_ref] = manufacturer_data["ref"]
+            end
 
             if manufacturer.description.blank? && manufacturer_data["description"].present?
               update_params[:description] = manufacturer_data["description"]

--- a/app/lib/sc_data/parser/manufacturers_parser.rb
+++ b/app/lib/sc_data/parser/manufacturers_parser.rb
@@ -36,12 +36,19 @@ module ScData
         }
       end
 
-      def overrides
+      # Readable without building a parser, which needs the raw export on disk --
+      # the corrections are a config file, and callers that only want to read them
+      # (the dedupe task, and its test) should not need a game dump to do it.
+      def self.overrides
         @overrides ||= begin
           path = Rails.root.join(OVERRIDES_PATH)
 
           path.exist? ? (YAML.safe_load_file(path) || {}) : {}
         end
+      end
+
+      def overrides
+        @overrides ||= self.class.overrides
       end
 
       # The record's own `manufacturer_Name<CODE>` key wins over the key its

--- a/app/lib/sc_data/parser/manufacturers_parser.rb
+++ b/app/lib/sc_data/parser/manufacturers_parser.rb
@@ -1,6 +1,8 @@
 module ScData
   module Parser
     class ManufacturersParser < ScData::Parser::BaseParser
+      OVERRIDES_PATH = "config/sc_data/manufacturer_overrides.yml"
+
       def all
         manufacturers = load_manufacturer_data.filter_map do |item|
           parse_manufacturer(item[:values])
@@ -16,16 +18,79 @@ module ScData
 
         return if code.blank?
 
+        override = overrides[code].to_h
+
+        return if override["skip"]
+
+        name, description = localization(values, code, override)
+
         {
           code:,
           ref: value_or_nil(values.dig("__ref")),
-          name: value_or_nil(translate(values.dig("Localization", "Name"))),
+          name: value_or_nil(name),
           short_name: value_or_nil(translate(values.dig("Localization", "ShortName"))),
-          description: value_or_nil(translate(values.dig("Localization", "Description"))),
+          description: value_or_nil(description),
           # Downcased to match the icon paths equipment and commodities record,
           # since whatever resolves one of them has to resolve all three.
           icon: value_or_nil(values.dig("Logo"))&.downcase
         }
+      end
+
+      def overrides
+        @overrides ||= begin
+          path = Rails.root.join(OVERRIDES_PATH)
+
+          path.exist? ? (YAML.safe_load_file(path) || {}) : {}
+        end
+      end
+
+      # The record's own `manufacturer_Name<CODE>` key wins over the key its
+      # Localization block names. Several records carry a copy-pasted block
+      # pointing at another manufacturer -- mxox.xml asks for
+      # `@manufacturer_NameAEGS` even though `manufacturer_NameMXOX` ("maxOx")
+      # is right there -- and following the block verbatim is what mints a
+      # duplicate "Aegis Dynamics". Records whose code and key merely spell the
+      # same company differently (GAM/GAMA, MIT/MITE) have no own key, so they
+      # keep falling back and still resolve correctly.
+      private def localization(values, code, override)
+        declared_name_key = values.dig("Localization", "Name")
+        own_name_key = "manufacturer_Name#{code}"
+        own_desc_key = "manufacturer_Desc#{code}"
+
+        # The block points somewhere else on purpose-looking-like-a-mistake only
+        # when the export also defines this code's own name -- mxox.xml asks for
+        # AEGS while `manufacturer_NameMXOX` sits right there. A code whose key
+        # merely spells the company differently (GAM asking for GAMA) defines no
+        # own key, so it is drift rather than a redirect and stays trusted.
+        redirected = translations.key?(own_name_key) && declared_name_key != "@#{own_name_key}"
+
+        name = if override["name"].present?
+          override["name"]
+        elsif translations.key?(own_name_key)
+          translations[own_name_key]
+        else
+          translate(declared_name_key)
+        end
+
+        # A block that named another manufacturer names their description too.
+        # FSKI and PRAR define none of their own, and inheriting Aegis' would put
+        # its history on somebody else's page -- no description beats a wrong one.
+        # Not read from the ",P" variant of the key, which is where the export
+        # keeps most manufacturer descriptions: two thirds of the ones it would
+        # unlock are unfinished stubs ("PH Octagon Description"), so pulling them
+        # in wholesale would put placeholder text on the page. maxOx loses a real
+        # description to that, which is the price of not shipping the other 22.
+        description = if override["description"].present?
+          override["description"]
+        elsif translations.key?(own_desc_key)
+          translations[own_desc_key]
+        elsif override["name"].present? || redirected
+          nil
+        else
+          translate(values.dig("Localization", "Description"))
+        end
+
+        [name, description]
       end
 
       private def load_manufacturer_data

--- a/app/models/concerns/slug_concern.rb
+++ b/app/models/concerns/slug_concern.rb
@@ -1,11 +1,22 @@
 module SlugConcern
   extend ActiveSupport::Concern
 
+  class_methods do
+    # The slug an importer would end up writing, without a record to ask. The
+    # loaders have to find the row a name belongs to before they build anything,
+    # and a second copy of the derivation would drift from this one.
+    def slug_for(value)
+      return if value.blank?
+
+      value.parameterize.presence || value
+    end
+  end
+
   def generate_slug(slug_field)
     return if slug_field.blank?
 
     self.slug = slug_field.parameterize
 
-    slug.presence || slug_field
+    self.class.slug_for(slug_field)
   end
 end

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -30,6 +30,10 @@ class Manufacturer < ApplicationRecord
     dependent: :nullify
   has_many :components,
     dependent: :nullify
+  has_many :equipment,
+    dependent: :nullify
+  has_many :model_modules,
+    dependent: :nullify
 
   before_save :update_slugs
 

--- a/app/services/manufacturers/deduplicator.rb
+++ b/app/services/manufacturers/deduplicator.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+module Manufacturers
+  # Collapses the manufacturers the sc_data loader duplicated before it learned
+  # to reuse a name it already has.
+  #
+  # The export labels several records with another manufacturer's name -- four
+  # of its codes resolve to "Aegis Dynamics" -- and the loader only matched a row
+  # without an sc_ref, so every new ref minted a row. The parser no longer
+  # produces those names and the loader no longer creates the rows, but the ones
+  # already in the table have to be brought together, and the loader never
+  # rewrites `name` so they cannot fix themselves.
+  class Deduplicator
+    # Tables carrying `manufacturer_id`. Checked against the schema on the way in
+    # so a table added later fails loudly here rather than quietly orphaning its
+    # rows.
+    ASSOCIATED_MODELS = [Model, Component, Equipment, ModelModule].freeze
+
+    Result = Struct.new(:renamed, :dropped, :merged)
+
+    def initialize(corrections: {}, dropped_codes: [], logger: nil)
+      @corrections = corrections
+      @dropped_codes = dropped_codes
+      @logger = logger
+      @result = Result.new([], [], [])
+    end
+
+    def call
+      assert_every_association_covered!
+
+      apply_corrections
+      drop_records
+      merge_collisions
+
+      @result
+    end
+
+    # Reports what #call would do, so the same decisions can be reviewed on
+    # production before anything is destroyed.
+    #
+    # Really runs it and rolls back, rather than projecting the outcome: the
+    # steps feed each other -- renaming MXOX is what takes it out of the Aegis
+    # group before the merge looks -- and a projection that read the table as it
+    # stands would report a merge that never happens. Rollback also means the
+    # attachment purges that follow a destroy never commit.
+    def plan
+      lines = []
+      summary = {}
+
+      Manufacturer.transaction do
+        before = Manufacturer.count
+
+        result = self.class.new(
+          corrections: @corrections,
+          dropped_codes: @dropped_codes,
+          logger: ->(message) { lines << message }
+        ).call
+
+        summary = {
+          before:,
+          after: Manufacturer.count,
+          orphaned: ASSOCIATED_MODELS.sum { |model| model.where(manufacturer_id: nil).count },
+          renamed: result.renamed,
+          dropped: result.dropped,
+          merged: result.merged
+        }
+
+        raise ActiveRecord::Rollback
+      end
+
+      summary.merge(log: lines)
+    end
+
+    # The winner keeps the row: whatever an admin curated outweighs what the
+    # export can rebuild, so an rsi_id or an uploaded logo wins before row count
+    # does, and age only breaks a remaining tie.
+    def self.pick_winner(manufacturers)
+      manufacturers.min_by do |manufacturer|
+        [
+          manufacturer.rsi_id.present? ? 0 : 1,
+          manufacturer.logo.attached? ? 0 : 1,
+          -association_count(manufacturer),
+          manufacturer.created_at || Time.zone.at(0)
+        ]
+      end
+    end
+
+    def self.association_count(manufacturer)
+      ASSOCIATED_MODELS.sum { |model| model.where(manufacturer_id: manufacturer.id).count }
+    end
+
+    private def apply_corrections
+      @corrections.each do |code, name|
+        manufacturer = Manufacturer.find_by(code:)
+
+        next if manufacturer.blank? || manufacturer.name == name
+
+        log "renaming #{code} from #{manufacturer.name.inspect} to #{name.inspect}"
+
+        manufacturer.update!(name:)
+        @result.renamed << code
+      end
+    end
+
+    # Only ever removes a row nothing points at. These records are placeholders
+    # the export copied from another manufacturer, but a row that somehow
+    # acquired items is a row somebody is using -- it is left alone and reported
+    # rather than deleted.
+    private def drop_records
+      Manufacturer.where(code: @dropped_codes).find_each do |manufacturer|
+        count = self.class.association_count(manufacturer)
+
+        if count.positive?
+          log "keeping #{manufacturer.code}: #{count} records still point at it"
+          next
+        end
+
+        log "dropping #{manufacturer.code}"
+
+        manufacturer.destroy!
+        @result.dropped << manufacturer.code
+      end
+    end
+
+    # Grouped by slug rather than by name, because the table holds both kinds of
+    # duplicate and the slug is the one that matters: it is what the public API
+    # and the filters identify a manufacturer by, so two rows sharing one are
+    # already ambiguous. Exact-name pairs ("Aegis Dynamics" four times) and the
+    # spelling variants that collapse to the same slug ("Basilisk " and
+    # "Basilisk", "GYSON INC" and "Gyson Inc.") both come out here.
+    private def merge_collisions
+      colliding_slugs.each do |slug|
+        manufacturers = Manufacturer.where(slug:).to_a
+        winner = self.class.pick_winner(manufacturers)
+
+        log "#{slug}: keeping #{winner.name.inspect} " \
+            "code=#{winner.code.inspect} rsi=#{winner.rsi_id.inspect} " \
+            "records=#{self.class.association_count(winner)}"
+
+        (manufacturers - [winner]).each do |loser|
+          log "  merging #{loser.name.inspect} code=#{loser.code.inspect} " \
+              "(#{self.class.association_count(loser)} records move across)"
+
+          repoint(loser, winner)
+          loser.reload.destroy!
+        end
+
+        normalize_name(winner)
+
+        @result.merged << slug
+      end
+    end
+
+    # The surviving row is the curated one, which is not necessarily the one
+    # spelled properly -- three of the pairs differ only by a trailing space.
+    private def normalize_name(winner)
+      stripped = winner.name&.strip
+
+      return if stripped.blank? || stripped == winner.name
+
+      log "trimming #{winner.name.inspect} to #{stripped.inspect}"
+
+      winner.update!(name: stripped)
+    end
+
+    private def repoint(loser, winner)
+      ASSOCIATED_MODELS.each do |model|
+        model.where(manufacturer_id: loser.id).update_all(manufacturer_id: winner.id)
+      end
+    end
+
+    private def colliding_slugs
+      Manufacturer.where.not(slug: nil).group(:slug).having("count(*) > 1").count.keys
+    end
+
+    # `dependent: :nullify` on an association nobody declared does nothing, so a
+    # table missing from ASSOCIATED_MODELS would lose its manufacturer silently.
+    private def assert_every_association_covered!
+      covered = ASSOCIATED_MODELS.map(&:table_name).to_set
+      actual = Manufacturer.connection.tables.select do |table|
+        Manufacturer.connection.columns(table).any? { |column| column.name == "manufacturer_id" }
+      end.to_set
+
+      missing = actual - covered
+
+      return if missing.empty?
+
+      raise "#{missing.to_a.sort.join(", ")} reference manufacturer_id but are not in ASSOCIATED_MODELS"
+    end
+
+    private def log(message)
+      @logger&.call(message)
+    end
+  end
+end

--- a/app/services/manufacturers/deduplicator.rb
+++ b/app/services/manufacturers/deduplicator.rb
@@ -25,12 +25,22 @@ module Manufacturers
       @result = Result.new([], [], [])
     end
 
+    # All or nothing. The three phases feed each other -- a correction takes a row
+    # out of a group before the merge looks at it -- so a failure partway through
+    # would leave some names corrected, some placeholders gone and some collisions
+    # still standing, which is a worse table to recover from than the one we
+    # started with. Nothing here is undoable once committed.
+    #
+    # requires_new so it is a savepoint inside a surrounding transaction: #plan
+    # wraps it in one to roll the whole thing back, and the tests run in one.
     def call
       assert_every_association_covered!
 
-      apply_corrections
-      drop_records
-      merge_collisions
+      Manufacturer.transaction(requires_new: true) do
+        apply_corrections
+        drop_records
+        merge_collisions
+      end
 
       @result
     end

--- a/app/services/models/manual_records.rb
+++ b/app/services/models/manual_records.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Models
+  # The ships the RSI ship matrix does not list, and the manufacturers they need.
+  #
+  # Kept as data in one place because two callers want it: `db/seeds` for a fresh
+  # database, and Maintenance::SeedManualModelsTask for one that already exists
+  # and is missing them.
+  module ManualRecords
+    MANUFACTURERS = [
+      {name: "Origin Jumpworks", slug: "origin-jumpworks", code: "ORIG"},
+      {name: "Drake Interplanetary", slug: "drake-interplanetary", code: "DRAK"},
+      {
+        name: "Musashi Industrial & Starflight Concern",
+        slug: "musashi-industrial-starflight-concern",
+        code: "MISC"
+      }
+    ].freeze
+
+    # Base models come first so a straight run creates them before the editions
+    # that point at them. `base_model` is resolved by name rather than position,
+    # so an out-of-order run still works.
+    MODELS = [
+      {
+        name: "600i Explorer",
+        manufacturer: "Origin Jumpworks",
+        classification: "exploration",
+        production_status: "flight-ready",
+        size: "large"
+      },
+      {
+        name: "Dragonfly Black",
+        manufacturer: "Drake Interplanetary",
+        classification: "competition",
+        production_status: "flight-ready",
+        size: "vehicle"
+      },
+      {
+        name: "600i Executive-Edition",
+        manufacturer: "Origin Jumpworks",
+        rsi_name: "600i Executive Edition",
+        classification: "exploration",
+        production_status: "flight-ready",
+        size: "large",
+        base_model: "600i Explorer"
+      },
+      {
+        name: "Dragonfly Starkitten Edition",
+        manufacturer: "Drake Interplanetary",
+        rsi_name: "Dragonfly Star Kitten Edition",
+        classification: "competition",
+        production_status: "flight-ready",
+        size: "vehicle",
+        base_model: "Dragonfly Black"
+      },
+      {
+        name: "Raptor",
+        manufacturer: "Musashi Industrial & Starflight Concern",
+        hidden: true
+      }
+    ].freeze
+
+    # Everything else in a definition is a plain Model column. Listed so a typo in
+    # a definition raises here instead of being assigned to nothing.
+    ATTRIBUTES = %i[rsi_name classification production_status size hidden].freeze
+
+    def self.call
+      MODELS.each { |definition| upsert_model(definition) }
+    end
+
+    # Only ever fills in what is missing: a model somebody has since corrected by
+    # hand keeps its values, because `find_or_create_by!` only yields the block
+    # for a row it is about to create.
+    def self.upsert_model(definition)
+      Model.find_or_create_by!(name: definition[:name]) do |model|
+        model.manufacturer = upsert_manufacturer(definition[:manufacturer])
+
+        ATTRIBUTES.each do |attribute|
+          model.public_send(:"#{attribute}=", definition[attribute]) if definition.key?(attribute)
+        end
+
+        model.base_model_id = base_model_for(definition[:base_model])&.id if definition[:base_model].present?
+      end
+    end
+
+    def self.upsert_manufacturer(name)
+      definition = MANUFACTURERS.find { |manufacturer| manufacturer[:name] == name }
+
+      raise ArgumentError, "no manual manufacturer named #{name.inspect}" if definition.nil?
+
+      Manufacturer.find_or_create_by!(name: definition[:name]) do |manufacturer|
+        manufacturer.slug = definition[:slug]
+        manufacturer.code = definition[:code]
+      end
+    end
+
+    # Created on demand rather than assumed present, so processing the editions
+    # before their base model leaves a link rather than a nil.
+    def self.base_model_for(name)
+      existing = Model.find_by(name:)
+
+      return existing if existing.present?
+
+      definition = MODELS.find { |model| model[:name] == name }
+
+      raise ArgumentError, "no manual model named #{name.inspect}" if definition.nil?
+
+      upsert_model(definition)
+    end
+  end
+end

--- a/app/tasks/maintenance/dedupe_manufacturers_task.rb
+++ b/app/tasks/maintenance/dedupe_manufacturers_task.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Collapses the manufacturers the sc_data loader duplicated before it learned
+  # to reuse a name it already has, and corrects the names the export mislabelled.
+  #
+  # A maintenance task rather than a data migration: it destroys rows and cannot
+  # be undone, and `data:migrate` runs unattended on every deploy. Here it is run
+  # deliberately, once per environment, with `dry_run` first.
+  class DedupeManufacturersTask < MaintenanceTasks::Task
+    no_collection
+
+    # The rows the loader created under a name the export got wrong. Applied here
+    # rather than by the loader, which deliberately never rewrites `name` because
+    # a curated one beats the game's -- these are the exceptions to that, so they
+    # are named explicitly rather than taken from the parsed data wholesale.
+    CORRECTIONS = {
+      "MXOX" => "maxOx",
+      "PRAR" => "Preacher Armaments",
+      "FSKI" => "Firestorm Kinetics"
+    }.freeze
+
+    # Placeholder records: copies of another manufacturer, logo included, that
+    # nothing in the export references. Dropped only while nothing points at them.
+    DROPPED_CODES = %w[TRAS GHEX].freeze
+
+    # Left on by default so an accidental run reports instead of destroying.
+    attribute :dry_run, :boolean, default: true
+
+    def process
+      dry_run ? report_plan : apply
+    end
+
+    private def apply
+      result = deduplicator(logger: method(:log)).call
+
+      log "renamed #{result.renamed.size}, dropped #{result.dropped.size}, " \
+          "merged #{result.merged.size} slugs"
+    end
+
+    private def report_plan
+      plan = deduplicator.plan
+
+      plan[:log].each { |line| log line }
+
+      log "manufacturers: #{plan[:before]} -> #{plan[:after]}"
+      log "renamed #{plan[:renamed].size}, dropped #{plan[:dropped].size}, " \
+          "merged #{plan[:merged].size} slugs"
+      log "records left without a manufacturer: #{plan[:orphaned]}"
+      log "dry run -- rolled back, no rows were changed"
+    end
+
+    private def deduplicator(logger: nil)
+      ::Manufacturers::Deduplicator.new(
+        corrections: CORRECTIONS,
+        dropped_codes: DROPPED_CODES,
+        logger:
+      )
+    end
+
+    # The task's log is its output in the UI, which is stdout for this engine.
+    private def log(message)
+      puts message
+    end
+  end
+end

--- a/app/tasks/maintenance/seed_manual_models_task.rb
+++ b/app/tasks/maintenance/seed_manual_models_task.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Creates the ships the RSI ship matrix does not list, for a database that
+  # already exists.
+  #
+  # `db/seeds` covers a fresh one, but running it against a live database means
+  # loading every seed file, so the ships that go missing after an import are
+  # topped up from here instead.
+  class SeedManualModelsTask < MaintenanceTasks::Task
+    def collection
+      ::Models::ManualRecords::MODELS
+    end
+
+    def count
+      collection.size
+    end
+
+    def process(definition)
+      model = ::Models::ManualRecords.upsert_model(definition)
+
+      puts "#{model.name} (#{model.manufacturer&.name})" if model.previously_new_record?
+    end
+  end
+end

--- a/config/sc_data/manufacturer_overrides.yml
+++ b/config/sc_data/manufacturer_overrides.yml
@@ -1,0 +1,33 @@
+# Corrections for manufacturer records the game export ships wrong, keyed by the
+# record's `Code`.
+#
+# Several `scitemmanufacturer` records carry a copy-pasted `Localization` block
+# that points at another manufacturer's keys -- `fski.xml` asks for
+# `@manufacturer_NameAEGS` and so resolves to "Aegis Dynamics". Where the export
+# also defines the record's own `manufacturer_Name<CODE>` key the parser prefers
+# that and needs no help here; this file covers the records where it does not.
+#
+# `name:` replaces the resolved name. `skip: true` drops the record entirely.
+#
+# Delete an entry once CIG fixes the record upstream -- the parser prefers the
+# export whenever the record's own key exists, so a fixed record makes its entry
+# redundant rather than conflicting.
+---
+# Logo is `firestormkinetics_256.tif` and its components are the Arrester,
+# Tempest, Ignite and Spark lines.
+FSKI:
+  name: Firestorm Kinetics
+
+# Its components are the Absolution, Condemnation and Salvation Distortion
+# Scatterguns -- Preacher Armaments' naming.
+PRAR:
+  name: Preacher Armaments
+
+# Placeholder records: both are byte-for-byte copies of another manufacturer
+# (logo included) and nothing in the export references either ref, so there is
+# no evidence of what they are meant to be and no item that would lose its
+# manufacturer by dropping them.
+TRAS:
+  skip: true
+GHEX:
+  skip: true

--- a/data/sc_data/parsed/live/manufacturers/fski.json
+++ b/data/sc_data/parsed/live/manufacturers/fski.json
@@ -1,8 +1,8 @@
 {
   "code": "FSKI",
   "ref": "5f81335d-44e6-4104-841e-c5af9df06829",
-  "name": "Aegis Dynamics",
+  "name": "Firestorm Kinetics",
   "short_name": null,
-  "description": "Aegis grew to prominence as a manufacturer of military spacecraft during the First Tevarin War. Favored by Ivar Messer, their orbital bombers grew to public prominence after his infamous victory on Idris IV and became synonymous with the ruthless Messer regime that followed. After the Fall of the Imperator, Aegis' contracts were stripped, their ships fell out of favor with the public, and the company went into a tailspin. They downsized their craft production and turned to manufacturing parts. However, time heals all wounds and today Aegis has risen once again to be a top military contractor of ships and components. ",
+  "description": null,
   "icon": "ui/sharedassets/manufacturerlogos/firestormkinetics_256.tif"
 }

--- a/data/sc_data/parsed/live/manufacturers/ghex.json
+++ b/data/sc_data/parsed/live/manufacturers/ghex.json
@@ -1,8 +1,0 @@
-{
-  "code": "GHEX",
-  "ref": "49e92191-59aa-4a08-b7d6-3b68e0370ea8",
-  "name": "ArcCorp",
-  "short_name": null,
-  "description": "This massive conglomerate owns one of the planets in the Stanton system, but got its start building fusion engines for industrial craft. They also have a division for terraforming that's diverged into more of a mining consortium.",
-  "icon": "ui/sharedassets/manufacturerlogos/arccorp_256.tif"
-}

--- a/data/sc_data/parsed/live/manufacturers/mxox.json
+++ b/data/sc_data/parsed/live/manufacturers/mxox.json
@@ -1,8 +1,8 @@
 {
   "code": "MXOX",
   "ref": "de0d3594-9f18-42c0-8a90-6edd723d80f8",
-  "name": "Aegis Dynamics",
+  "name": "maxOx",
   "short_name": null,
-  "description": "Aegis grew to prominence as a manufacturer of military spacecraft during the First Tevarin War. Favored by Ivar Messer, their orbital bombers grew to public prominence after his infamous victory on Idris IV and became synonymous with the ruthless Messer regime that followed. After the Fall of the Imperator, Aegis' contracts were stripped, their ships fell out of favor with the public, and the company went into a tailspin. They downsized their craft production and turned to manufacturing parts. However, time heals all wounds and today Aegis has risen once again to be a top military contractor of ships and components. ",
+  "description": null,
   "icon": "ui/sharedassets/manufacturerlogos/maxox_256.tif"
 }

--- a/data/sc_data/parsed/live/manufacturers/prar.json
+++ b/data/sc_data/parsed/live/manufacturers/prar.json
@@ -1,8 +1,8 @@
 {
   "code": "PRAR",
   "ref": "a2ba1db6-a7e8-49db-ba52-c61219693531",
-  "name": "Aegis Dynamics",
+  "name": "Preacher Armaments",
   "short_name": null,
-  "description": "Aegis grew to prominence as a manufacturer of military spacecraft during the First Tevarin War. Favored by Ivar Messer, their orbital bombers grew to public prominence after his infamous victory on Idris IV and became synonymous with the ruthless Messer regime that followed. After the Fall of the Imperator, Aegis' contracts were stripped, their ships fell out of favor with the public, and the company went into a tailspin. They downsized their craft production and turned to manufacturing parts. However, time heals all wounds and today Aegis has risen once again to be a top military contractor of ships and components. ",
+  "description": null,
   "icon": "ui/sharedassets/manufacturerlogos/prar_256.tif"
 }

--- a/data/sc_data/parsed/live/manufacturers/tras.json
+++ b/data/sc_data/parsed/live/manufacturers/tras.json
@@ -1,8 +1,0 @@
-{
-  "code": "TRAS",
-  "ref": "d70afa6f-c7aa-4a3f-b222-d2208e6c21a9",
-  "name": "Aegis Dynamics",
-  "short_name": null,
-  "description": "Aegis grew to prominence as a manufacturer of military spacecraft during the First Tevarin War. Favored by Ivar Messer, their orbital bombers grew to public prominence after his infamous victory on Idris IV and became synonymous with the ruthless Messer regime that followed. After the Fall of the Imperator, Aegis' contracts were stripped, their ships fell out of favor with the public, and the company went into a tailspin. They downsized their craft production and turned to manufacturing parts. However, time heals all wounds and today Aegis has risen once again to be a top military contractor of ships and components. ",
-  "icon": "ui/sharedassets/manufacturerlogos/aegis_256.tif"
-}

--- a/data/sc_data/parsed/live/version.json
+++ b/data/sc_data/parsed/live/version.json
@@ -1,5 +1,5 @@
 {
   "version": "4.9.0-live.12344265",
   "environment": "live",
-  "parsed_at": "2026-08-16T23:37:09Z"
+  "parsed_at": "2026-08-17T12:52:50Z"
 }

--- a/db/seeds/01_manual_models.rb
+++ b/db/seeds/01_manual_models.rb
@@ -1,53 +1,5 @@
 # frozen_string_literal: true
 
-origin = Manufacturer.find_or_create_by!(name: "Origin Jumpworks") do |m|
-  m.slug = "origin-jumpworks"
-  m.code = "ORIG"
-end
-
-drake = Manufacturer.find_or_create_by!(name: "Drake Interplanetary") do |m|
-  m.slug = "drake-interplanetary"
-  m.code = "DRAK"
-end
-
-explorer_600i = Model.find_or_create_by!(name: "600i Explorer") do |model|
-  model.manufacturer = origin
-  model.classification = "exploration"
-  model.production_status = "flight-ready"
-  model.size = "large"
-end
-
-dragonfly_black = Model.find_or_create_by!(name: "Dragonfly Black") do |model|
-  model.manufacturer = drake
-  model.classification = "competition"
-  model.production_status = "flight-ready"
-  model.size = "vehicle"
-end
-
-Model.find_or_create_by!(name: "600i Executive-Edition") do |model|
-  model.manufacturer = origin
-  model.rsi_name = "600i Executive Edition"
-  model.classification = "exploration"
-  model.production_status = "flight-ready"
-  model.size = "large"
-  model.base_model_id = explorer_600i.id
-end
-
-Model.find_or_create_by!(name: "Dragonfly Starkitten Edition") do |model|
-  model.manufacturer = drake
-  model.rsi_name = "Dragonfly Star Kitten Edition"
-  model.classification = "competition"
-  model.production_status = "flight-ready"
-  model.size = "vehicle"
-  model.base_model_id = dragonfly_black.id
-end
-
-misc = Manufacturer.find_or_create_by!(name: "Musashi Industrial & Starflight Concern") do |m|
-  m.slug = "musashi-industrial-starflight-concern"
-  m.code = "MISC"
-end
-
-Model.find_or_create_by!(name: "Raptor") do |model|
-  model.manufacturer = misc
-  model.hidden = true
-end
+# The definitions live in Models::ManualRecords so that an existing database can
+# be topped up from /maintenance_tasks without this file being the only copy.
+Models::ManualRecords.call

--- a/test/loaders/sc_data/manufacturers_loader_test.rb
+++ b/test/loaders/sc_data/manufacturers_loader_test.rb
@@ -25,6 +25,61 @@ module ScData
         assert_equal manufacturer_codes.uniq.size, manufacturer_codes.size
       end
 
+      # The export ships several codes per company and the by-code and by-name
+      # lookups only match a row without a ref, so a second code used to create a
+      # second row -- four of them ended up called "Aegis Dynamics".
+      test "#all leaves no two manufacturers sharing a name" do
+        @loader.all
+
+        assert_empty Manufacturer.where.not(name: nil).group(:name).having("count(*) > 1").count
+      end
+
+      test "#all reuses the manufacturer a second code names rather than adding one" do
+        existing = create(:manufacturer, name: "Sakura Sun", code: "SASU", sc_ref: "already-here")
+
+        @loader.all
+
+        assert_equal [existing.id], Manufacturer.where(name: "Sakura Sun").ids
+      end
+
+      # ROO and SASU are both Sakura Sun: whichever loads second must not take
+      # the column over, or the two spend every import trading it.
+      test "#all leaves an existing sc_ref alone when a second code matches by name" do
+        existing = create(:manufacturer, name: "Sakura Sun", code: "SASU", sc_ref: "already-here")
+
+        @loader.all
+
+        assert_equal "already-here", existing.reload.sc_ref
+      end
+
+      # ROO names no logo where SASU names Sakura Sun's, so following the export
+      # unconditionally would drop the picture depending on load order.
+      test "#all keeps the icon when the record that matches names none" do
+        existing = create(
+          :manufacturer,
+          name: "Sakura Sun", code: "SASU", sc_ref: "already-here",
+          icon: "ui/sharedassets/manufacturerlogos/sakurasun_256.tif"
+        )
+
+        @loader.all
+
+        assert_equal "ui/sharedassets/manufacturerlogos/sakurasun_256.tif", existing.reload.icon
+      end
+
+      test "#all skips the records the overrides drop" do
+        @loader.all
+
+        assert_empty Manufacturer.where(code: %w[TRAS GHEX])
+      end
+
+      test "#all loads the corrected name for a record the export mislabels" do
+        @loader.all
+
+        assert_equal "maxOx", Manufacturer.find_by(code: "MXOX").name
+        assert_equal "Preacher Armaments", Manufacturer.find_by(code: "PRAR").name
+        assert_equal ["AEG"], Manufacturer.where(name: "Aegis Dynamics").pluck(:code)
+      end
+
       test "#all attaches the logo the parser carried over" do
         @loader.all
 
@@ -104,7 +159,7 @@ module ScData
           rsi_models_loader.all
         end
 
-        assert_difference -> { Manufacturer.count }, 96 do
+        assert_difference -> { Manufacturer.count }, 93 do
           @loader.all
         end
 

--- a/test/loaders/sc_data/manufacturers_loader_test.rb
+++ b/test/loaders/sc_data/manufacturers_loader_test.rb
@@ -34,12 +34,41 @@ module ScData
         assert_empty Manufacturer.where.not(name: nil).group(:name).having("count(*) > 1").count
       end
 
+      # The slug is the stricter of the two: names that differ only in case or
+      # punctuation pass a by-name check and still collide here.
+      test "#all leaves no two manufacturers sharing a slug" do
+        @loader.all
+
+        assert_empty Manufacturer.where.not(slug: nil).group(:slug).having("count(*) > 1").count
+      end
+
       test "#all reuses the manufacturer a second code names rather than adding one" do
         existing = create(:manufacturer, name: "Sakura Sun", code: "SASU", sc_ref: "already-here")
 
         @loader.all
 
         assert_equal [existing.id], Manufacturer.where(name: "Sakura Sun").ids
+      end
+
+      # An exact name is not the only way the table already holds a manufacturer.
+      # A row whose name differs from the export's only in case slugs to the same
+      # thing, so creating a second one puts two rows behind one public
+      # identifier -- and, once the slug is unique in the database, fails the
+      # import outright.
+      test "#all reuses a manufacturer whose name differs only in case" do
+        existing = create(:manufacturer, name: "SAKURA SUN", code: "SASU", sc_ref: "already-here")
+
+        @loader.all
+
+        assert_equal [existing.id], Manufacturer.where(slug: "sakura-sun").ids
+      end
+
+      test "#all reuses a manufacturer whose name differs only by a trailing space" do
+        existing = create(:manufacturer, name: "Sakura Sun ", code: "SASU", sc_ref: "already-here")
+
+        @loader.all
+
+        assert_equal [existing.id], Manufacturer.where(slug: "sakura-sun").ids
       end
 
       # ROO and SASU are both Sakura Sun: whichever loads second must not take

--- a/test/parsers/sc_data/manufacturers_parser_test.rb
+++ b/test/parsers/sc_data/manufacturers_parser_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module ScData
+  module Parser
+    class ManufacturersParserTest < ActiveSupport::TestCase
+      setup do
+        @base_folder = Dir.mktmpdir
+
+        FileUtils.mkdir_p("#{@base_folder}/raw/1.0.0/Data/Localization/english")
+        File.write("#{@base_folder}/raw/1.0.0/Data/Localization/english/global.ini", "")
+
+        @parser = ::ScData::Parser::ManufacturersParser.new(
+          base_folder: @base_folder, sc_version: "1.0.0", sc_environment: "test"
+        )
+      end
+
+      teardown do
+        FileUtils.remove_entry(@base_folder)
+      end
+
+      # mxox.xml carries a copy-pasted Localization block asking for Aegis'
+      # name, which is how the table grew four rows called "Aegis Dynamics".
+      test "#parse_manufacturer prefers the record's own name over the one its block asks for" do
+        @parser.translations = {
+          "manufacturer_NameAEGS" => "Aegis Dynamics",
+          "manufacturer_NameMXOX" => "maxOx"
+        }
+
+        result = @parser.parse_manufacturer(record("MXOX", name_key: "@manufacturer_NameAEGS"))
+
+        assert_equal "maxOx", result[:name]
+      end
+
+      # GAM asks for GAMA and defines no own key: the two spell one company
+      # differently rather than pointing at another, so it must keep resolving.
+      test "#parse_manufacturer follows the block when the record defines no name of its own" do
+        @parser.translations = {"manufacturer_NameGAMA" => "Gatac Manufacture"}
+
+        result = @parser.parse_manufacturer(record("GAM", name_key: "@manufacturer_NameGAMA"))
+
+        assert_equal "Gatac Manufacture", result[:name]
+      end
+
+      test "#parse_manufacturer takes the name from the overrides when the export defines none" do
+        override("FSKI" => {"name" => "Firestorm Kinetics"})
+        @parser.translations = {"manufacturer_NameAEGS" => "Aegis Dynamics"}
+
+        result = @parser.parse_manufacturer(record("FSKI", name_key: "@manufacturer_NameAEGS"))
+
+        assert_equal "Firestorm Kinetics", result[:name]
+      end
+
+      test "#parse_manufacturer skips a record the overrides mark as skip" do
+        override("TRAS" => {"skip" => true})
+        @parser.translations = {"manufacturer_NameAEGS" => "Aegis Dynamics"}
+
+        assert_nil @parser.parse_manufacturer(record("TRAS", name_key: "@manufacturer_NameAEGS"))
+      end
+
+      # A block that named the wrong manufacturer names their history too, and
+      # Aegis' story under "Firestorm Kinetics" is worse than no story.
+      test "#parse_manufacturer drops the description when the name came from an override" do
+        override("FSKI" => {"name" => "Firestorm Kinetics"})
+        @parser.translations = {
+          "manufacturer_NameAEGS" => "Aegis Dynamics",
+          "manufacturer_DescAEGS" => "Aegis grew to prominence..."
+        }
+
+        result = @parser.parse_manufacturer(
+          record("FSKI", name_key: "@manufacturer_NameAEGS", desc_key: "@manufacturer_DescAEGS")
+        )
+
+        assert_nil result[:description]
+      end
+
+      test "#parse_manufacturer drops the description when the block pointed at another record" do
+        @parser.translations = {
+          "manufacturer_NameAEGS" => "Aegis Dynamics",
+          "manufacturer_DescAEGS" => "Aegis grew to prominence...",
+          "manufacturer_NameMXOX" => "maxOx"
+        }
+
+        result = @parser.parse_manufacturer(
+          record("MXOX", name_key: "@manufacturer_NameAEGS", desc_key: "@manufacturer_DescAEGS")
+        )
+
+        assert_equal "maxOx", result[:name]
+        assert_nil result[:description]
+      end
+
+      test "#parse_manufacturer keeps the description of a record whose block is its own" do
+        @parser.translations = {
+          "manufacturer_NameTALN" => "Talon",
+          "manufacturer_DescTALN" => "Talon builds things."
+        }
+
+        result = @parser.parse_manufacturer(
+          record("TALN", name_key: "@manufacturer_NameTALN", desc_key: "@manufacturer_DescTALN")
+        )
+
+        assert_equal "Talon", result[:name]
+        assert_equal "Talon builds things.", result[:description]
+      end
+
+      test "#parse_manufacturer prefers the record's own description over the block's" do
+        @parser.translations = {
+          "manufacturer_NameGAMA" => "Gatac Manufacture",
+          "manufacturer_DescGAMA" => "Wrong company.",
+          "manufacturer_DescGAM" => "Gatac builds things."
+        }
+
+        result = @parser.parse_manufacturer(
+          record("GAM", name_key: "@manufacturer_NameGAMA", desc_key: "@manufacturer_DescGAMA")
+        )
+
+        assert_equal "Gatac builds things.", result[:description]
+      end
+
+      test "#parse_manufacturer ignores a record without a code" do
+        assert_nil @parser.parse_manufacturer(record(nil))
+      end
+
+      # Guards the shipped file rather than the mechanism: these four entries are
+      # what keeps the export's copy-pasted records out of the table.
+      test "the shipped overrides name the records the export gets wrong" do
+        overrides = ::ScData::Parser::ManufacturersParser.new(
+          base_folder: @base_folder, sc_version: "1.0.0", sc_environment: "test"
+        ).overrides
+
+        assert_equal "Firestorm Kinetics", overrides.dig("FSKI", "name")
+        assert_equal "Preacher Armaments", overrides.dig("PRAR", "name")
+        assert overrides.dig("TRAS", "skip")
+        assert overrides.dig("GHEX", "skip")
+      end
+
+      # Seeds the memo `#overrides` fills from config, so a test names its own
+      # corrections without touching the shipped file.
+      private def override(entries)
+        @parser.instance_variable_set(:@overrides, entries)
+      end
+
+      private def record(code, name_key: "@LOC_EMPTY", desc_key: "@LOC_EMPTY")
+        {
+          "Code" => code,
+          "__ref" => "00000000-0000-0000-0000-00000000beef",
+          "Logo" => "UI/SharedAssets/ManufacturerLogos/Example_256.tif",
+          "Localization" => {
+            "Name" => name_key,
+            "ShortName" => "@LOC_EMPTY",
+            "Description" => desc_key
+          }
+        }
+      end
+    end
+  end
+end

--- a/test/parsers/sc_data/manufacturers_parser_test.rb
+++ b/test/parsers/sc_data/manufacturers_parser_test.rb
@@ -126,9 +126,7 @@ module ScData
       # Guards the shipped file rather than the mechanism: these four entries are
       # what keeps the export's copy-pasted records out of the table.
       test "the shipped overrides name the records the export gets wrong" do
-        overrides = ::ScData::Parser::ManufacturersParser.new(
-          base_folder: @base_folder, sc_version: "1.0.0", sc_environment: "test"
-        ).overrides
+        overrides = ::ScData::Parser::ManufacturersParser.overrides
 
         assert_equal "Firestorm Kinetics", overrides.dig("FSKI", "name")
         assert_equal "Preacher Armaments", overrides.dig("PRAR", "name")

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -176,6 +176,35 @@ module Manufacturers
         ::Manufacturers::Deduplicator::ASSOCIATED_MODELS.map(&:table_name).sort
     end
 
+    # Nothing here is undoable once committed, and the phases feed each other, so
+    # a failure partway through would leave some names corrected, some
+    # placeholders gone and some collisions still standing -- a worse table to
+    # recover from than the one we started with.
+    test "#call undoes the earlier phases when a later one fails" do
+      renamed = create(:manufacturer, code: "MXOX", name: "Aegis Dynamics")
+      placeholder = create(:manufacturer, code: "TRAS", name: "Nothing points here")
+
+      deduplicator = FailingMerge.new(
+        corrections: {"MXOX" => "maxOx"},
+        dropped_codes: ["TRAS"]
+      )
+
+      assert_raises(FailingMerge::Boom) { deduplicator.call }
+
+      assert_equal "Aegis Dynamics", renamed.reload.name
+      assert_equal placeholder, Manufacturer.find_by(code: "TRAS")
+    end
+
+    # Overriding the last phase is the only way in: the merge is where a real
+    # failure would land, since it is the phase that destroys rows.
+    class FailingMerge < ::Manufacturers::Deduplicator
+      Boom = Class.new(StandardError)
+
+      private def merge_collisions
+        raise Boom
+      end
+    end
+
     # The report has to be reviewable on production before anything is
     # destroyed, so it must leave the table exactly as it found it.
     test "#plan reports the merge and rolls it back" do

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Manufacturers
+  class DeduplicatorTest < ActiveSupport::TestCase
+    # The service looks for collisions across the whole table, so anything left
+    # behind by another run would decide the winners instead of the fixtures.
+    setup do
+      Manufacturer.delete_all
+    end
+
+    test "#call renames a record the export mislabelled" do
+      manufacturer = create(:manufacturer, code: "MXOX", name: "Aegis Dynamics")
+
+      result = ::Manufacturers::Deduplicator.new(corrections: {"MXOX" => "maxOx"}).call
+
+      assert_equal "maxOx", manufacturer.reload.name
+      assert_equal ["MXOX"], result.renamed
+    end
+
+    test "#call leaves a name that is already correct" do
+      create(:manufacturer, code: "MXOX", name: "maxOx")
+
+      result = ::Manufacturers::Deduplicator.new(corrections: {"MXOX" => "maxOx"}).call
+
+      assert_empty result.renamed
+    end
+
+    test "#call drops a placeholder record nothing points at" do
+      create(:manufacturer, code: "TRAS", name: "Aegis Dynamics")
+
+      result = ::Manufacturers::Deduplicator.new(dropped_codes: ["TRAS"]).call
+
+      assert_nil Manufacturer.find_by(code: "TRAS")
+      assert_equal ["TRAS"], result.dropped
+    end
+
+    # A placeholder that somehow acquired items is one somebody is using, and
+    # deleting it would nullify their manufacturer.
+    test "#call keeps a record marked for dropping when something points at it" do
+      manufacturer = create(:manufacturer, code: "TRAS", name: "Aegis Dynamics")
+      create(:component, manufacturer:)
+
+      result = ::Manufacturers::Deduplicator.new(dropped_codes: ["TRAS"]).call
+
+      assert_equal manufacturer, Manufacturer.find_by(code: "TRAS")
+      assert_empty result.dropped
+    end
+
+    test "#call merges two manufacturers sharing a name onto one row" do
+      keep = create(:manufacturer, name: "Gatac Manufacture", code: "GAMA", rsi_id: 93)
+      drop = create(:manufacturer, name: "Gatac Manufacture", code: "GAM", rsi_id: nil)
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal [keep.id], Manufacturer.where(name: "Gatac Manufacture").ids
+      assert_nil Manufacturer.find_by(id: drop.id)
+    end
+
+    test "#call repoints every association of a merged manufacturer" do
+      keep = create(:manufacturer, name: "Klaus & Werner", code: "KLA", rsi_id: 1)
+      drop = create(:manufacturer, name: "Klaus & Werner", code: nil)
+
+      component = create(:component, manufacturer: drop)
+      equipment = create(:equipment, manufacturer: drop)
+      model = create(:model, manufacturer: drop)
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal keep, component.reload.manufacturer
+      assert_equal keep, equipment.reload.manufacturer
+      assert_equal keep, model.reload.manufacturer
+    end
+
+    # What an admin curated cannot be rebuilt from the export, so it decides the
+    # winner before row counts do.
+    test "#call keeps the curated row even when the other carries more records" do
+      curated = create(:manufacturer, name: "Sakura Sun", code: "SASU", rsi_id: 7)
+      busier = create(:manufacturer, name: "Sakura Sun", code: "ROO", rsi_id: nil)
+      create_list(:component, 3, manufacturer: busier)
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal [curated.id], Manufacturer.where(name: "Sakura Sun").ids
+      assert_equal 3, curated.reload.components.count
+    end
+
+    test "#call prefers the row carrying more records when neither is curated" do
+      lean = create(:manufacturer, name: "Sakura Sun", code: "ROO", rsi_id: nil)
+      busier = create(:manufacturer, name: "Sakura Sun", code: "SASU", rsi_id: nil)
+      create_list(:component, 2, manufacturer: busier)
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal [busier.id], Manufacturer.where(name: "Sakura Sun").ids
+      assert_nil Manufacturer.find_by(id: lean.id)
+    end
+
+    test "#call collapses a group of four onto a single row" do
+      keep = create(:manufacturer, name: "Aegis Dynamics", code: "AEGS", rsi_id: 12)
+      3.times { |index| create(:manufacturer, name: "Aegis Dynamics", code: "DUP#{index}") }
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal [keep.id], Manufacturer.where(name: "Aegis Dynamics").ids
+    end
+
+    # Eleven of the pairs in the table are this kind rather than an exact repeat,
+    # and grouping by name would walk straight past them.
+    test "#call merges rows whose names differ only by case" do
+      keep = create(:manufacturer, name: "Gyson Inc.", rsi_id: 4)
+      drop = create(:manufacturer, name: "GYSON INC")
+      create(:component, manufacturer: drop)
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal [keep.id], Manufacturer.where(slug: keep.slug).ids
+      assert_equal 1, keep.reload.components.count
+    end
+
+    test "#call merges rows whose names differ only by trailing space" do
+      keep = create(:manufacturer, name: "Basilisk ", rsi_id: 5)
+      drop = create(:manufacturer, name: "Basilisk")
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_nil Manufacturer.find_by(id: drop.id)
+      assert_equal keep.id, Manufacturer.find_by(slug: "basilisk").id
+    end
+
+    # The curated row wins, and it is not always the one spelled properly.
+    test "#call trims the surviving name" do
+      create(:manufacturer, name: "Juno Starwerk ", rsi_id: 6)
+      create(:manufacturer, name: "Juno Starwerk")
+
+      ::Manufacturers::Deduplicator.new.call
+
+      assert_equal "Juno Starwerk", Manufacturer.find_by(slug: "juno-starwerk").name
+    end
+
+    test "#call leaves manufacturers with distinct names alone" do
+      create(:manufacturer, name: "Aegis Dynamics", code: "AEGS")
+      create(:manufacturer, name: "maxOx", code: "MXOX")
+
+      result = ::Manufacturers::Deduplicator.new.call
+
+      assert_equal 2, Manufacturer.where(name: ["Aegis Dynamics", "maxOx"]).count
+      assert_empty result.merged
+    end
+
+    # Corrections run first on purpose: renaming MXOX out of the Aegis group is
+    # what stops the merge folding a different manufacturer into it.
+    test "#call renames before merging so a corrected row is not merged away" do
+      aegis = create(:manufacturer, name: "Aegis Dynamics", code: "AEGS", rsi_id: 12)
+      maxox = create(:manufacturer, name: "Aegis Dynamics", code: "MXOX")
+      create_list(:component, 2, manufacturer: maxox)
+
+      ::Manufacturers::Deduplicator.new(corrections: {"MXOX" => "maxOx"}).call
+
+      assert_equal "maxOx", maxox.reload.name
+      assert_equal 2, maxox.components.count
+      assert_equal [aegis.id], Manufacturer.where(name: "Aegis Dynamics").ids
+    end
+
+    # The merge repoints only the tables it is told about, and `dependent:
+    # :nullify` on an association nobody declared does nothing -- so a table
+    # added later would lose its manufacturer without a word. This is the guard
+    # that turns that into a failing test.
+    test "ASSOCIATED_MODELS covers every table referencing manufacturer_id" do
+      referencing = Manufacturer.connection.tables.select do |table|
+        Manufacturer.connection.columns(table).any? { |column| column.name == "manufacturer_id" }
+      end
+
+      assert_equal referencing.sort,
+        ::Manufacturers::Deduplicator::ASSOCIATED_MODELS.map(&:table_name).sort
+    end
+
+    # The report has to be reviewable on production before anything is
+    # destroyed, so it must leave the table exactly as it found it.
+    test "#plan reports the merge and rolls it back" do
+      keep = create(:manufacturer, name: "Gatac Manufacture", code: "GAMA", rsi_id: 93)
+      drop = create(:manufacturer, name: "Gatac Manufacture", code: "GAM")
+      component = create(:component, manufacturer: drop)
+
+      plan = nil
+
+      assert_no_difference -> { Manufacturer.count } do
+        plan = ::Manufacturers::Deduplicator.new.plan
+      end
+
+      assert_equal 2, plan[:before]
+      assert_equal 1, plan[:after]
+      assert_equal ["gatac-manufacture"], plan[:merged]
+      assert_equal drop, component.reload.manufacturer
+      assert_equal keep, Manufacturer.find(keep.id)
+    end
+
+    test "#plan reports a rename without applying it" do
+      manufacturer = create(:manufacturer, code: "MXOX", name: "Aegis Dynamics")
+
+      plan = ::Manufacturers::Deduplicator.new(corrections: {"MXOX" => "maxOx"}).plan
+
+      assert_equal ["MXOX"], plan[:renamed]
+      assert_equal "Aegis Dynamics", manufacturer.reload.name
+    end
+
+    # Renaming MXOX takes it out of the Aegis group before the merge looks, so a
+    # plan that read the table as it stands would report a merge that never
+    # happens. Running it for real and rolling back is what keeps it honest.
+    test "#plan accounts for the renames when reporting merges" do
+      create(:manufacturer, name: "Aegis Dynamics", code: "AEGS", rsi_id: 12)
+      create(:manufacturer, name: "Aegis Dynamics", code: "MXOX")
+
+      plan = ::Manufacturers::Deduplicator.new(corrections: {"MXOX" => "maxOx"}).plan
+
+      assert_equal ["MXOX"], plan[:renamed]
+      assert_empty plan[:merged]
+      assert_equal 2, plan[:after]
+    end
+
+    test "#plan reports a record it would refuse to drop" do
+      manufacturer = create(:manufacturer, code: "TRAS", name: "Aegis Dynamics")
+      create(:component, manufacturer:)
+
+      plan = ::Manufacturers::Deduplicator.new(dropped_codes: ["TRAS"]).plan
+
+      assert_empty plan[:dropped]
+      assert_includes plan[:log].join("\n"), "1 records still point at it"
+    end
+
+    test "#plan reports no record left without a manufacturer" do
+      keep = create(:manufacturer, name: "Sakura Sun", code: "SASU", rsi_id: 7)
+      drop = create(:manufacturer, name: "Sakura Sun", code: "ROO")
+      create(:component, manufacturer: drop)
+      create(:equipment, manufacturer: drop)
+
+      plan = ::Manufacturers::Deduplicator.new.plan
+
+      assert_equal 0, plan[:orphaned]
+      assert_equal [keep.id], Manufacturer.where(slug: "sakura-sun").ids - [drop.id]
+    end
+  end
+end

--- a/test/services/models/manual_records_test.rb
+++ b/test/services/models/manual_records_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Models
+  class ManualRecordsTest < ActiveSupport::TestCase
+    test ".call creates every manual model and its manufacturer" do
+      ::Models::ManualRecords.call
+
+      ::Models::ManualRecords::MODELS.each do |definition|
+        model = Model.find_by(name: definition[:name])
+
+        assert_not_nil model, "#{definition[:name]} was not created"
+        assert_equal definition[:manufacturer], model.manufacturer.name
+      end
+    end
+
+    test ".call carries the attributes each definition names" do
+      ::Models::ManualRecords.call
+
+      raptor = Model.find_by(name: "Raptor")
+      executive = Model.find_by(name: "600i Executive-Edition")
+
+      assert_predicate raptor, :hidden?
+      assert_equal "600i Executive Edition", executive.rsi_name
+      assert_equal "exploration", executive.classification
+      assert_equal "large", executive.size
+    end
+
+    test ".call links an edition to its base model" do
+      ::Models::ManualRecords.call
+
+      assert_equal Model.find_by(name: "600i Explorer").id,
+        Model.find_by(name: "600i Executive-Edition").base_model_id
+      assert_equal Model.find_by(name: "Dragonfly Black").id,
+        Model.find_by(name: "Dragonfly Starkitten Edition").base_model_id
+    end
+
+    test ".call runs twice without duplicating anything" do
+      ::Models::ManualRecords.call
+
+      assert_no_difference [-> { Model.count }, -> { Manufacturer.count }] do
+        ::Models::ManualRecords.call
+      end
+    end
+
+    # The maintenance task hands definitions over one at a time, and nothing
+    # promises the base model comes first.
+    test ".upsert_model creates the base model when it is not there yet" do
+      definition = ::Models::ManualRecords::MODELS.find { |model| model[:name] == "600i Executive-Edition" }
+
+      ::Models::ManualRecords.upsert_model(definition)
+
+      assert_not_nil Model.find_by(name: "600i Explorer")
+      assert_equal Model.find_by(name: "600i Explorer").id,
+        Model.find_by(name: "600i Executive-Edition").base_model_id
+    end
+
+    # A model somebody corrected by hand must survive a re-run.
+    test ".upsert_model leaves an existing model alone" do
+      existing = create(:model, name: "Raptor", hidden: false)
+      definition = ::Models::ManualRecords::MODELS.find { |model| model[:name] == "Raptor" }
+
+      ::Models::ManualRecords.upsert_model(definition)
+
+      assert_not_predicate existing.reload, :hidden?
+    end
+
+    test ".upsert_manufacturer reuses a manufacturer that is already there" do
+      existing = create(:manufacturer, name: "Origin Jumpworks", code: "ORIG")
+
+      assert_no_difference -> { Manufacturer.count } do
+        assert_equal existing, ::Models::ManualRecords.upsert_manufacturer("Origin Jumpworks")
+      end
+    end
+
+    test ".upsert_manufacturer refuses a name it has no definition for" do
+      assert_raises(ArgumentError) { ::Models::ManualRecords.upsert_manufacturer("Nobody") }
+    end
+
+    # Guards the data, not the mechanism: a definition naming an attribute that
+    # is not in ATTRIBUTES would be dropped on the floor.
+    test "every definition names only attributes the upsert assigns" do
+      known = ::Models::ManualRecords::ATTRIBUTES + %i[name manufacturer base_model]
+
+      ::Models::ManualRecords::MODELS.each do |definition|
+        assert_empty definition.keys - known,
+          "#{definition[:name]} names attributes the upsert ignores"
+      end
+    end
+
+    test "every definition names a manufacturer that has a definition" do
+      names = ::Models::ManualRecords::MANUFACTURERS.map { |manufacturer| manufacturer[:name] }
+
+      ::Models::ManualRecords::MODELS.each do |definition|
+        assert_includes names, definition[:manufacturer]
+      end
+    end
+  end
+end

--- a/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
+++ b/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class DedupeManufacturersTaskTest < ActiveSupport::TestCase
+    setup do
+      Manufacturer.delete_all
+    end
+
+    # An accidental run has to report rather than destroy, so the safe mode is
+    # the one you get by not choosing.
+    test "dry_run is on unless it is turned off" do
+      assert_predicate ::Maintenance::DedupeManufacturersTask.new, :dry_run
+    end
+
+    test "#process leaves every row in place on a dry run" do
+      create(:manufacturer, name: "Gatac Manufacture", code: "GAMA", rsi_id: 93)
+      create(:manufacturer, name: "Gatac Manufacture", code: "GAM")
+
+      assert_no_difference -> { Manufacturer.count } do
+        run_task(dry_run: true)
+      end
+    end
+
+    test "#process reports what it would do on a dry run" do
+      create(:manufacturer, name: "Gatac Manufacture", code: "GAMA", rsi_id: 93)
+      create(:manufacturer, name: "Gatac Manufacture", code: "GAM")
+
+      output = run_task(dry_run: true)
+
+      assert_includes output, "gatac-manufacture"
+      assert_includes output, "manufacturers: 2 -> 1"
+      assert_includes output, "dry run"
+    end
+
+    test "#process merges the duplicates when the dry run is turned off" do
+      keep = create(:manufacturer, name: "Gatac Manufacture", code: "GAMA", rsi_id: 93)
+      drop = create(:manufacturer, name: "Gatac Manufacture", code: "GAM")
+      component = create(:component, manufacturer: drop)
+
+      run_task(dry_run: false)
+
+      assert_equal [keep.id], Manufacturer.where(name: "Gatac Manufacture").ids
+      assert_equal keep, component.reload.manufacturer
+    end
+
+    test "#process corrects the names the export mislabelled" do
+      create(:manufacturer, name: "Aegis Dynamics", code: "AEGS", rsi_id: 12)
+      mislabelled = create(:manufacturer, name: "Aegis Dynamics", code: "MXOX")
+
+      run_task(dry_run: false)
+
+      assert_equal "maxOx", mislabelled.reload.name
+      assert_equal ["AEGS"], Manufacturer.where(name: "Aegis Dynamics").pluck(:code)
+    end
+
+    test "#process drops the placeholder records" do
+      create(:manufacturer, name: "Aegis Dynamics", code: "TRAS")
+
+      run_task(dry_run: false)
+
+      assert_nil Manufacturer.find_by(code: "TRAS")
+    end
+
+    # The corrections have to match the overrides the parser applies, or a fresh
+    # import and a cleaned table would disagree about what a code is called.
+    test "the corrections agree with the shipped parser overrides" do
+      overrides = ::ScData::Parser::ManufacturersParser.new(
+        base_folder: "data/sc_data", sc_version: "4.9.0-live.12344265", sc_environment: "live"
+      ).overrides
+
+      overrides.each do |code, entry|
+        next if entry["name"].blank?
+
+        assert_equal entry["name"], ::Maintenance::DedupeManufacturersTask::CORRECTIONS[code],
+          "#{code} is named #{entry["name"].inspect} by the parser overrides"
+      end
+
+      dropped = overrides.select { |_, entry| entry["skip"] }.keys
+
+      assert_equal dropped.sort, ::Maintenance::DedupeManufacturersTask::DROPPED_CODES.sort
+    end
+
+    private def run_task(dry_run:)
+      task = ::Maintenance::DedupeManufacturersTask.new
+      task.dry_run = dry_run
+
+      capture_io { task.process }.first
+    end
+  end
+end

--- a/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
+++ b/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
@@ -66,9 +66,7 @@ module Maintenance
     # The corrections have to match the overrides the parser applies, or a fresh
     # import and a cleaned table would disagree about what a code is called.
     test "the corrections agree with the shipped parser overrides" do
-      overrides = ::ScData::Parser::ManufacturersParser.new(
-        base_folder: "data/sc_data", sc_version: "4.9.0-live.12344265", sc_environment: "live"
-      ).overrides
+      overrides = ::ScData::Parser::ManufacturersParser.overrides
 
       overrides.each do |code, entry|
         next if entry["name"].blank?


### PR DESCRIPTION
The manufacturers table has 156 rows for what should be 137, and 17 slugs are
shared by more than one row — four answered to `aegis-dynamics`. Since the slug
is what the public API and the filters identify a manufacturer by, those lookups
have been picking one arbitrarily.

## Why

The game export is wrong, and our loader turned that into rows.

`fski.xml`, `mxox.xml`, `prar.xml` and `tras.xml` all carry a copy-pasted
`Localization` block asking for `@manufacturer_NameAEGS`; `ghex.xml` asks for
ArcCorp's. The clincher is `MXOX`: `global.ini` defines
`manufacturer_NameMXOX=maxOx` and the record ignores it.

The loader's by-code and by-name lookups only matched a row **without** an
`sc_ref`, so once every row carried one, a record arriving under a new ref was
created fresh. It also never rewrites `name` — a curated one beats the game's —
which is why rows that already existed (`FSKI`, `ROO`, `ARCC`, `HRST`) kept
correct names while new ones got the bogus one.

## What changed

- **Parser** prefers the record's own `manufacturer_Name<CODE>` key over the one
  its block names. Enough on its own for `MXOX`. A code whose key merely spells
  the company differently (`GAM`→`GAMA`, `MIT`→`MITE`) defines no own key, so it
  still resolves as before.
- **`config/sc_data/manufacturer_overrides.yml`** covers what the export cannot:
  `FSKI`=Firestorm Kinetics and `PRAR`=Preacher Armaments, plus `TRAS`/`GHEX`
  skipped. Delete an entry when CIG fixes the record upstream.
- **Loader** treats a name that is already taken as the same manufacturer. An
  `sc_ref` is only claimed while free and an icon is never blanked, so the codes
  sharing a row don't trade the columns on every import.
- **`Manufacturer`** gained `has_many :equipment` and `:model_modules`. Both
  tables carry a `manufacturer_id` and neither was declared, so a merge would
  have orphaned them.
- **`Maintenance::DedupeManufacturersTask`** collapses what's already there.

## Evidence for the two names

Guesswork would be easy to get wrong here, so: `PRAR`'s components are the
*Absolution*, *Condemnation* and *Salvation Distortion Scatterguns* — Preacher
Armaments' naming. `FSKI`'s are the *Arrester*, *Tempest*, *Ignite* and *Spark*
lines, and its logo is `firestormkinetics_256.tif`.

`TRAS` and `GHEX` get no name: both are byte-for-byte copies of another
manufacturer, logo included, and **nothing in the export references either
ref**. There is no evidence of what they are, and no item that loses its
manufacturer by dropping them. (There is a real `Tarsus` — it has its own code,
`TARS`.)

## Running it

A maintenance task, not a data migration: it destroys rows irreversibly, and
`data:migrate` runs unattended on every deploy. Run it deliberately per
environment from `/maintenance_tasks`, `dry_run` first (it's on by default).

`dry_run` really runs the whole thing in a transaction and rolls back, rather
than projecting the outcome — that distinction matters, because renaming `MXOX`
is what takes it out of the Aegis group before the merge looks, and a projection
reported a merge that never happens.

## Verified

Replayed the real dev table into a scratch database:

- **156 → 137** manufacturers, duplicate slugs **17 → 0**
- all **9264** associated records preserved, **0 orphans**
- a subsequent import is idempotent (137 → 137 → 137) and self-heals the `PRAR`
  code onto the merged row

It also confirmed both renames independently: dev already has a **MaxOx** row and
a curated **Preacher Armaments** row, so the renames collide with them and the
merge unifies them (5 and 3 records moving across).

38 new tests (10 parser, 13 loader, 15 deduplicator + task). `standardrb` clean.

## Also here

The last commit moves the ships the RSI matrix omits out of `db/seeds` into
`Models::ManualRecords` + a maintenance task, for the same reason — topping up a
live database shouldn't mean loading every seed file. Unrelated to the
duplicates; happy to split it out if you'd rather.

## Follow-up

A unique index on `manufacturers.slug` is stacked on this branch rather than
included: it cannot merge before this does, because without the parser/loader fix
the importer still creates four `aegis-dynamics` rows and the index turns that
into a hard crash (7 loader tests fail on `main` + index alone).

Two findings left alone, noted for later: 44 description keys and 4 name keys in
`global.ini` exist only under a `,P` variant that `translate` doesn't handle
(worth having, but 22 of the 34 descriptions it unlocks are unfinished stubs like
"PH Octagon Description", so it needs a junk filter); and code `MIS` is used by
two different companies (MISC and Mirai), where `save_items(key: :code)` lets one
silently overwrite the other.

🤖