### PR TITLE
fix(manufacturers): make the slug unique in the database

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -18,6 +18,10 @@
 #  updated_at   :datetime
 #  rsi_id       :integer
 #
+# Indexes
+#
+#  index_manufacturers_on_slug  (slug) UNIQUE
+#
 class Manufacturer < ApplicationRecord
   include ActionView::Helpers::OutputSafetyHelper
   include ActiveStorageVariants

--- a/db/migrate/20260817140000_add_unique_slug_index_to_manufacturers.rb
+++ b/db/migrate/20260817140000_add_unique_slug_index_to_manufacturers.rb
@@ -1,0 +1,40 @@
+class AddUniqueSlugIndexToManufacturers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Nothing stopped two manufacturers sharing a slug, and the export handed us
+  # seventeen pairs that did -- four rows answered to `aegis-dynamics`. The slug
+  # is what the public API and the filters identify a manufacturer by, so a
+  # duplicate makes those lookups pick one arbitrarily.
+  #
+  # Built after Maintenance::DedupeManufacturersTask has collapsed them, which is
+  # a deliberate run rather than part of a deploy. Checked first because a
+  # `concurrently` build that hits a duplicate does not just fail -- it leaves an
+  # INVALID index behind that has to be dropped by hand before the next attempt.
+  def up
+    duplicates = ActiveRecord::Base.connection.select_rows(<<~SQL.squish)
+      SELECT slug, COUNT(*) FROM manufacturers
+      WHERE slug IS NOT NULL
+      GROUP BY slug HAVING COUNT(*) > 1
+      ORDER BY slug
+    SQL
+
+    if duplicates.any?
+      listed = duplicates.map { |slug, count| "#{slug} (#{count})" }.join(", ")
+
+      raise <<~MESSAGE
+        #{duplicates.size} slug(s) are still shared by more than one manufacturer:
+          #{listed}
+
+        Run the "Dedupe manufacturers" maintenance task in this environment first
+        -- with dry_run on to review it, then again with dry_run off -- and
+        migrate afterwards.
+      MESSAGE
+    end
+
+    add_index :manufacturers, :slug, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :manufacturers, :slug, algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/migrate/20260817140000_add_unique_slug_index_to_manufacturers.rb
+++ b/db/migrate/20260817140000_add_unique_slug_index_to_manufacturers.rb
@@ -9,8 +9,16 @@ class AddUniqueSlugIndexToManufacturers < ActiveRecord::Migration[8.1]
   # Built after Maintenance::DedupeManufacturersTask has collapsed them, which is
   # a deliberate run rather than part of a deploy. Checked first because a
   # `concurrently` build that hits a duplicate does not just fail -- it leaves an
-  # INVALID index behind that has to be dropped by hand before the next attempt.
+  # INVALID index behind, and a second attempt would collide with that leftover
+  # rather than report the duplicate that caused it.
+  #
+  # The check cannot make the build safe on its own: the importers write while
+  # the migration runs, so a manufacturer whose name slugs onto an existing one
+  # can still arrive between the two statements. That is what clearing the
+  # leftover is for -- the failure stays a re-run rather than a hand repair.
   def up
+    drop_invalid_index
+
     duplicates = ActiveRecord::Base.connection.select_rows(<<~SQL.squish)
       SELECT slug, COUNT(*) FROM manufacturers
       WHERE slug IS NOT NULL
@@ -36,5 +44,23 @@ class AddUniqueSlugIndexToManufacturers < ActiveRecord::Migration[8.1]
 
   def down
     remove_index :manufacturers, :slug, algorithm: :concurrently, if_exists: true
+  end
+
+  private
+
+  def drop_invalid_index
+    leftover = ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT pg_class.relname FROM pg_index
+      JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+      WHERE pg_index.indrelid = 'manufacturers'::regclass
+        AND pg_class.relname = 'index_manufacturers_on_slug'
+        AND NOT pg_index.indisvalid
+    SQL
+
+    return if leftover.blank?
+
+    say "Dropping #{leftover}, left INVALID by an earlier attempt"
+
+    remove_index :manufacturers, :slug, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -792,6 +792,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.string "sc_ref"
     t.string "slug", limit: 255
     t.datetime "updated_at", precision: nil
+    t.index ["slug"], name: "index_manufacturers_on_slug", unique: true
   end
 
   create_table "message_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/factories/manufacturers.rb
+++ b/test/factories/manufacturers.rb
@@ -16,6 +16,10 @@
 #  updated_at   :datetime
 #  rsi_id       :integer
 #
+# Indexes
+#
+#  index_manufacturers_on_slug  (slug) UNIQUE
+#
 FactoryBot.define do
   factory :manufacturer do
     name { Faker::Name.name }

--- a/test/models/manufacturer_test.rb
+++ b/test/models/manufacturer_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: manufacturers
+#
+#  id           :uuid             not null, primary key
+#  code         :string
+#  code_mapping :string
+#  description  :text
+#  icon         :string
+#  known_for    :string(255)
+#  long_name    :string
+#  name         :string(255)
+#  sc_ref       :string
+#  slug         :string(255)
+#  created_at   :datetime
+#  updated_at   :datetime
+#  rsi_id       :integer
+#
+# Indexes
+#
+#  index_manufacturers_on_slug  (slug) UNIQUE
+#
+class ManufacturerTest < ActiveSupport::TestCase
+  # The slug is what the public API and the filters identify a manufacturer by,
+  # so two rows answering to one made those lookups pick arbitrarily. The export
+  # produced seventeen such pairs before the index existed.
+  test "the database refuses a second manufacturer with the same slug" do
+    create(:manufacturer, name: "Basilisk")
+
+    duplicate = Manufacturer.new(name: "Basilisk")
+
+    assert_raises(ActiveRecord::RecordNotUnique) { duplicate.save!(validate: false) }
+  end
+
+  # Names that differ only in case or punctuation slug identically, which is how
+  # eleven of the pairs got in -- the index has to catch those too, not just
+  # exact repeats.
+  test "the database refuses a name that only differs by case" do
+    create(:manufacturer, name: "Gyson Inc.")
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      Manufacturer.new(name: "GYSON INC.").save!(validate: false)
+    end
+  end
+
+  test "the database refuses a name that only differs by trailing space" do
+    create(:manufacturer, name: "Basilisk")
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      Manufacturer.new(name: "Basilisk ").save!(validate: false)
+    end
+  end
+
+  test "manufacturers with distinct names are unaffected" do
+    create(:manufacturer, name: "Aegis Dynamics")
+
+    assert_difference -> { Manufacturer.count } do
+      create(:manufacturer, name: "maxOx")
+    end
+  end
+
+  # A unique index still allows any number of NULLs, and nothing requires a
+  # manufacturer to carry a slug.
+  test "more than one manufacturer may have no slug at all" do
+    2.times do |index|
+      manufacturer = Manufacturer.new(name: "Nameless #{index}")
+      manufacturer.save!(validate: false)
+      manufacturer.update_columns(slug: nil)
+    end
+
+    assert_equal 2, Manufacturer.where(slug: nil).count
+  end
+end

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require_relative "../../support/legacy_manufacturer_duplicates"
 
 module Manufacturers
   class DeduplicatorTest < ActiveSupport::TestCase
+    include LegacyManufacturerDuplicates
+
     # The service looks for collisions across the whole table, so anything left
     # behind by another run would decide the winners instead of the fixtures.
+    #
+    # The duplicates it cleans up are ones the database now refuses to hold, so
+    # the index comes off for the duration of each test.
     setup do
       Manufacturer.delete_all
+      allow_duplicate_manufacturer_slugs
     end
 
     test "#call renames a record the export mislabelled" do

--- a/test/support/legacy_manufacturer_duplicates.rb
+++ b/test/support/legacy_manufacturer_duplicates.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Lets a test build the duplicate manufacturers that predate
+# index_manufacturers_on_slug.
+#
+# The dedupe task exists to clean up rows the database now refuses to hold, so
+# its tests have to reproduce a table from before the index. Postgres DDL is
+# transactional and each test runs in a transaction that is rolled back, so
+# dropping the index here restores it when the test ends -- no teardown, and no
+# other test sees it missing.
+module LegacyManufacturerDuplicates
+  def allow_duplicate_manufacturer_slugs
+    return unless Manufacturer.connection.index_exists?(:manufacturers, :slug, unique: true)
+
+    Manufacturer.connection.remove_index(:manufacturers, :slug)
+  end
+end

--- a/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
+++ b/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require_relative "../../support/legacy_manufacturer_duplicates"
 
 module Maintenance
   class DedupeManufacturersTaskTest < ActiveSupport::TestCase
+    include LegacyManufacturerDuplicates
+
+    # The duplicates the task cleans up are ones the database now refuses to
+    # hold, so the index comes off for the duration of each test.
     setup do
       Manufacturer.delete_all
+      allow_duplicate_manufacturer_slugs
     end
 
     # An accidental run has to report rather than destroy, so the safe mode is


### PR DESCRIPTION
Stacked on #4432 — **do not merge before it**, and not before the dedupe task has
actually been run in each environment. See *Ordering* below; this is enforced, not
just requested.

Nothing stopped two manufacturers sharing a slug, and the export handed us
seventeen pairs that did. Since the slug is what the public API and the filters
identify a manufacturer by, those lookups have been picking one arbitrarily.

## What's here

- A unique index on `manufacturers.slug`, built `concurrently`.
- A pre-flight check that aborts with the offending slugs if any remain.
- Model tests pinning the constraint, including the case and trailing-space
  variants that made up eleven of the seventeen pairs.

## Why the pre-flight check

A `concurrently`-built unique index that hits a duplicate doesn't merely fail —
it leaves an **INVALID** index behind that has to be dropped by hand before the
next attempt. So the migration looks first and aborts with something readable:

```
1 slug(s) are still shared by more than one manufacturer:
  basilisk (2)

Run the "Dedupe manufacturers" maintenance task in this environment first
-- with dry_run on to review it, then again with dry_run off -- and
migrate afterwards.
```

Verified both ways: it aborts on a seeded duplicate, and builds cleanly once the
table is consistent.

## Ordering

The dependency on #4432 is code-level, not just operational. On `main` + this
index alone, **all 7 manufacturer loader tests fail**:

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation
DETAIL: Key (slug)=(aegis-dynamics) already exists.
```

Without the parser/loader fix the importer still creates four `aegis-dynamics`
rows, so the index turns the sc_data import into a hard crash. With #4432
underneath, those same 18 tests pass.

So the sequence is: merge #4432 → run `DedupeManufacturersTask` in each
environment (`dry_run` first) → merge this.

## One wrinkle worth reviewing

The dedupe service and its task exist to clean up rows the database now refuses
to hold, so their tests can no longer insert their own fixtures — 12 service and
4 task errors, all `UniqueViolation` during setup.

The last commit drops the index inside each of those tests. Postgres DDL is
transactional and Rails rolls each test back, so it restores itself with no
teardown and nothing else sees it missing. It also reads accurately: those tests
are about a table from before the index.

The alternative is deleting the deduplicator and its task in this PR, on the
grounds that the cleanup is done by the time it merges. I didn't, because the
migration's own error message points at that task — removing it would leave a
fresh environment or a restored backup with duplicates, an abort, and nothing to
run. Happy to go that way as a later PR once every environment is known clean.

## Verified

- 18 tests across the index and loader specs
- 293 across services, tasks and models
- full backend suite: 2279 tests, only the two pre-existing failures on this repo
  (`ModelCompareShareTest`, which passes in 0.74s in isolation and stalls 75s
  under full-suite load, and the two `localhost:3000` vite/webmock errors)
- `standardrb` clean

🤖