### PR TITLE
fix(setup): stop worktrees colliding on dev ports and Redis databases

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -153,8 +153,13 @@ def worktree_db_suffix(name)
   "_wt_#{sanitize_worktree_name(name)}"
 end
 
-def worktree_sidekiq_redis_db(name)
-  2 + (Zlib.crc32(name) % 500)
+# Every worktree points at the one shared Redis container, so the database index
+# is what keeps their Sidekiq queues, cache entries and sessions apart. It runs
+# the default `databases 16`, so anything past 15 is a number Redis would refuse
+# to SELECT; DB 0 is left to the main checkout. With more than 15 worktrees the
+# indexes wrap and two of them share a database again.
+def worktree_redis_db(slot)
+  1 + (slot % 15)
 end
 
 def write_superset_ports(port, vite_port)
@@ -187,15 +192,15 @@ def write_managed_env(filename, managed_body)
   File.write(path, user_content + "#{WORKTREE_MARKER}\n" + managed_body)
 end
 
-def write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_redis_db, cookie_prefix: nil)
+def write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix: nil)
   write_managed_env(".env.local", <<~ENV)
     PORT=#{port}
     DB_PORT=#{db_port}
     REDIS_URL=redis://localhost:#{redis_port}
+    REDIS_DB=#{redis_db}
     VITE_RUBY_HOST=localhost
     VITE_RUBY_PORT=#{vite_port}
     WORKTREE_SUFFIX=#{db_suffix}
-    SIDEKIQ_REDIS_DB=#{sidekiq_redis_db}
     DOMAIN=localhost:#{port}
     ON_SUBDOMAIN=false
     #{"COOKIE_PREFIX=#{cookie_prefix}" if cookie_prefix}
@@ -254,7 +259,7 @@ FileUtils.chdir APP_ROOT do
     redis_port = worktree_redis_port(effective_name)
     vite_port = VITE_PORT_OVERRIDE || slot_vite_port
     db_suffix = worktree_db_suffix(effective_name)
-    sidekiq_db = worktree_sidekiq_redis_db(effective_name)
+    redis_db = worktree_redis_db(slot)
 
     if VERBOSE
       puts "== Worktree detected: #{wt_name}#{" (as #{effective_name})" if NAME_OVERRIDE} =="
@@ -262,14 +267,14 @@ FileUtils.chdir APP_ROOT do
       puts "   Vite port:   #{vite_port}#{" (override)" if VITE_PORT_OVERRIDE}"
       puts "   DB port:     #{db_port}"
       puts "   Redis port:  #{redis_port}"
+      puts "   Redis DB:    #{redis_db}"
       puts "   DB suffix:   #{db_suffix}"
-      puts "   Sidekiq DB:  #{sidekiq_db}"
     else
       puts "  Worktree: #{effective_name} (port #{port})"
     end
 
     cookie_prefix = "FLTYRD_WT_#{sanitize_worktree_name(effective_name)}"
-    write_env_local(port, db_port, redis_port, vite_port, db_suffix, sidekiq_db, cookie_prefix:)
+    write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix:)
     write_env_test_local(db_port, db_suffix)
     puts "   Wrote .env.local and .env.test.local" if VERBOSE
 

--- a/bin/setup
+++ b/bin/setup
@@ -96,30 +96,41 @@ end
 PORT_SLOT_BASE = 8300
 PORT_SLOTS = 200
 
+# Redis 0 belongs to the main checkout, and the shared container runs the
+# default `databases 16`, so worktrees have 1..15 to share.
+REDIS_DATABASES = 15
+
 def slot_ports(slot)
   first = PORT_SLOT_BASE + (slot * 2)
   [first, first + 1]
 end
 
-# Every other worktree's assignment, whichever scheme wrote it. Ports are read
+# Every other worktree's assignment, whichever scheme wrote it. Values are read
 # rather than recomputed so a sibling holding a legacy (pre-slot) pair still
 # blocks the slot that overlaps it.
-def ports_claimed_by_siblings
+def claims_by_siblings
   out, status = Open3.capture2("git", "-C", APP_ROOT, "worktree", "list", "--porcelain")
-  return [] unless status.success?
+  return {ports: [], redis_dbs: []} unless status.success?
 
-  out.lines.flat_map { |line|
-    next [] unless line.start_with?("worktree ")
+  ports = []
+  redis_dbs = []
+
+  out.lines.each do |line|
+    next unless line.start_with?("worktree ")
 
     root = line.split(" ", 2).last.strip
-    next [] if root == APP_ROOT
+    next if root == APP_ROOT
 
     env_path = File.join(root, ".env.local")
-    next [] unless File.file?(env_path)
+    next unless File.file?(env_path)
 
     body = File.read(env_path)
-    [body[/^PORT=(\d+)/, 1], body[/^VITE_RUBY_PORT=(\d+)/, 1]].compact.map(&:to_i)
-  }
+    ports.concat([body[/^PORT=(\d+)/, 1], body[/^VITE_RUBY_PORT=(\d+)/, 1]].compact.map(&:to_i))
+    redis_db = body[/^REDIS_DB=(\d+)/, 1]
+    redis_dbs << redis_db.to_i if redis_db
+  end
+
+  {ports:, redis_dbs:}
 end
 
 # crc32 alone hands identical ports to any two names that share a residue, and
@@ -154,12 +165,22 @@ def worktree_db_suffix(name)
 end
 
 # Every worktree points at the one shared Redis container, so the database index
-# is what keeps their Sidekiq queues, cache entries and sessions apart. It runs
-# the default `databases 16`, so anything past 15 is a number Redis would refuse
-# to SELECT; DB 0 is left to the main checkout. With more than 15 worktrees the
-# indexes wrap and two of them share a database again.
-def worktree_redis_db(slot)
-  1 + (slot % 15)
+# is what keeps their Sidekiq queues, cache entries and sessions apart. Folding
+# the 200 port slots onto 15 indexes collided immediately — four of the six
+# worktrees here shared a database while nine sat unused. As with the port slot
+# the hash now only picks where to start looking, so indexes a sibling already
+# holds get skipped and two worktrees share one only once all 15 are spoken for.
+def allocate_redis_db(name, claimed)
+  start = Zlib.crc32(name) % REDIS_DATABASES
+
+  REDIS_DATABASES.times do |offset|
+    db = 1 + ((start + offset) % REDIS_DATABASES)
+    return db unless claimed.include?(db)
+  end
+
+  fallback = 1 + start
+  puts "   All #{REDIS_DATABASES} Redis databases are claimed — sharing DB #{fallback} with another worktree."
+  fallback
 end
 
 def write_superset_ports(port, vite_port)
@@ -252,14 +273,15 @@ FileUtils.chdir APP_ROOT do
 
   if wt_name
     effective_name = NAME_OVERRIDE || wt_name
-    slot = allocate_port_slot(effective_name, ports_claimed_by_siblings)
+    claims = claims_by_siblings
+    slot = allocate_port_slot(effective_name, claims[:ports])
     slot_port, slot_vite_port = slot_ports(slot)
     port = PORT_OVERRIDE || slot_port
     db_port = worktree_db_port(effective_name)
     redis_port = worktree_redis_port(effective_name)
     vite_port = VITE_PORT_OVERRIDE || slot_vite_port
     db_suffix = worktree_db_suffix(effective_name)
-    redis_db = worktree_redis_db(slot)
+    redis_db = allocate_redis_db(effective_name, claims[:redis_dbs])
 
     if VERBOSE
       puts "== Worktree detected: #{wt_name}#{" (as #{effective_name})" if NAME_OVERRIDE} =="

--- a/bin/setup
+++ b/bin/setup
@@ -48,11 +48,30 @@ def detect_worktree
   File.basename(APP_ROOT)
 end
 
-def main_worktree_root
-  common_dir = `git -C "#{APP_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null`.strip
-  return nil if common_dir.empty? || !File.directory?(common_dir)
+def git_common_dir
+  dir = `git -C "#{APP_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null`.strip
+  return nil if dir.empty? || !File.directory?(dir)
 
-  File.dirname(common_dir)
+  dir
+end
+
+def main_worktree_root
+  dir = git_common_dir
+  dir && File.dirname(dir)
+end
+
+# Allocation reads every sibling's `.env.local` and then writes its own, so two
+# worktrees setting up at once would both scan before either wrote and both
+# claim the same slot. The lock lives in the shared git directory, which every
+# worktree of this repo resolves to the same path.
+def with_allocation_lock
+  common_dir = git_common_dir
+  return yield unless common_dir
+
+  File.open(File.join(common_dir, "fleetyards-setup.lock"), File::CREAT | File::RDWR, 0o644) do |lock|
+    lock.flock(File::LOCK_EX)
+    yield
+  end
 end
 
 def link_shared_paths(main_root)
@@ -270,36 +289,41 @@ FileUtils.chdir APP_ROOT do
   port = 8270
   db_port = 8271
   vite_port = 8274
+  db_suffix = nil
 
   if wt_name
     effective_name = NAME_OVERRIDE || wt_name
-    claims = claims_by_siblings
-    slot = allocate_port_slot(effective_name, claims[:ports])
-    slot_port, slot_vite_port = slot_ports(slot)
-    port = PORT_OVERRIDE || slot_port
-    db_port = worktree_db_port(effective_name)
-    redis_port = worktree_redis_port(effective_name)
-    vite_port = VITE_PORT_OVERRIDE || slot_vite_port
-    db_suffix = worktree_db_suffix(effective_name)
-    redis_db = allocate_redis_db(effective_name, claims[:redis_dbs])
 
-    if VERBOSE
-      puts "== Worktree detected: #{wt_name}#{" (as #{effective_name})" if NAME_OVERRIDE} =="
-      puts "   Rails port:  #{port}#{" (override)" if PORT_OVERRIDE}"
-      puts "   Vite port:   #{vite_port}#{" (override)" if VITE_PORT_OVERRIDE}"
-      puts "   DB port:     #{db_port}"
-      puts "   Redis port:  #{redis_port}"
-      puts "   Redis DB:    #{redis_db}"
-      puts "   DB suffix:   #{db_suffix}"
-    else
-      puts "  Worktree: #{effective_name} (port #{port})"
+    # Scanning the siblings and writing our own claim have to happen under one
+    # lock, or a concurrent setup reads the range before we appear in it.
+    with_allocation_lock do
+      claims = claims_by_siblings
+      slot = allocate_port_slot(effective_name, claims[:ports])
+      slot_port, slot_vite_port = slot_ports(slot)
+      port = PORT_OVERRIDE || slot_port
+      db_port = worktree_db_port(effective_name)
+      redis_port = worktree_redis_port(effective_name)
+      vite_port = VITE_PORT_OVERRIDE || slot_vite_port
+      db_suffix = worktree_db_suffix(effective_name)
+      redis_db = allocate_redis_db(effective_name, claims[:redis_dbs])
+
+      if VERBOSE
+        puts "== Worktree detected: #{wt_name}#{" (as #{effective_name})" if NAME_OVERRIDE} =="
+        puts "   Rails port:  #{port}#{" (override)" if PORT_OVERRIDE}"
+        puts "   Vite port:   #{vite_port}#{" (override)" if VITE_PORT_OVERRIDE}"
+        puts "   DB port:     #{db_port}"
+        puts "   Redis port:  #{redis_port}"
+        puts "   Redis DB:    #{redis_db}"
+        puts "   DB suffix:   #{db_suffix}"
+      else
+        puts "  Worktree: #{effective_name} (port #{port})"
+      end
+
+      cookie_prefix = "FLTYRD_WT_#{sanitize_worktree_name(effective_name)}"
+      write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix:)
+      write_env_test_local(db_port, db_suffix)
+      puts "   Wrote .env.local and .env.test.local" if VERBOSE
     end
-
-    cookie_prefix = "FLTYRD_WT_#{sanitize_worktree_name(effective_name)}"
-    write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix:)
-    write_env_test_local(db_port, db_suffix)
-    puts "   Wrote .env.local and .env.test.local" if VERBOSE
-
   end
 
   write_superset_ports(port, vite_port)

--- a/bin/setup
+++ b/bin/setup
@@ -88,12 +88,53 @@ def link_shared_paths(main_root)
   end
 end
 
-def worktree_port(name)
-  8270 + (Zlib.crc32(name) % 500)
+# A worktree owns one slot, and a slot owns the adjacent port pair
+# (base + 2N, base + 2N + 1). Deriving both ports from a single slot is what
+# keeps one worktree's Vite port from landing on another's Rails port. The base
+# clears the shared Postgres/Redis containers and the main checkout's own ports,
+# so only worktrees ever compete for this range.
+PORT_SLOT_BASE = 8300
+PORT_SLOTS = 200
+
+def slot_ports(slot)
+  first = PORT_SLOT_BASE + (slot * 2)
+  [first, first + 1]
 end
 
-def worktree_vite_port(name)
-  8273 + (Zlib.crc32(name) % 500)
+# Every other worktree's assignment, whichever scheme wrote it. Ports are read
+# rather than recomputed so a sibling holding a legacy (pre-slot) pair still
+# blocks the slot that overlaps it.
+def ports_claimed_by_siblings
+  out, status = Open3.capture2("git", "-C", APP_ROOT, "worktree", "list", "--porcelain")
+  return [] unless status.success?
+
+  out.lines.flat_map { |line|
+    next [] unless line.start_with?("worktree ")
+
+    root = line.split(" ", 2).last.strip
+    next [] if root == APP_ROOT
+
+    env_path = File.join(root, ".env.local")
+    next [] unless File.file?(env_path)
+
+    body = File.read(env_path)
+    [body[/^PORT=(\d+)/, 1], body[/^VITE_RUBY_PORT=(\d+)/, 1]].compact.map(&:to_i)
+  }
+end
+
+# crc32 alone hands identical ports to any two names that share a residue, and
+# whichever worktree booted second then failed to bind. The hash now only picks
+# where to start looking, so a name keeps a stable slot while taken ones get
+# skipped.
+def allocate_port_slot(name, claimed)
+  start = Zlib.crc32(name) % PORT_SLOTS
+
+  PORT_SLOTS.times do |offset|
+    slot = (start + offset) % PORT_SLOTS
+    return slot if (slot_ports(slot) & claimed).empty?
+  end
+
+  abort "All #{PORT_SLOTS} worktree port slots are taken. Free one, or pass --port and --vite-port."
 end
 
 def sanitize_worktree_name(name)
@@ -206,10 +247,12 @@ FileUtils.chdir APP_ROOT do
 
   if wt_name
     effective_name = NAME_OVERRIDE || wt_name
-    port = PORT_OVERRIDE || worktree_port(effective_name)
+    slot = allocate_port_slot(effective_name, ports_claimed_by_siblings)
+    slot_port, slot_vite_port = slot_ports(slot)
+    port = PORT_OVERRIDE || slot_port
     db_port = worktree_db_port(effective_name)
     redis_port = worktree_redis_port(effective_name)
-    vite_port = VITE_PORT_OVERRIDE || worktree_vite_port(effective_name)
+    vite_port = VITE_PORT_OVERRIDE || slot_vite_port
     db_suffix = worktree_db_suffix(effective_name)
     sidekiq_db = worktree_sidekiq_redis_db(effective_name)
 


### PR DESCRIPTION
Two worktrees could not run their dev servers at the same time. `bin/setup` derived ports as `8270 + crc32(name) % 500`, so any two worktree names sharing a residue were handed the same Rails and Vite port — `pr-3893` and `admin-equipment-commodities` both landed on 8343/8346, and whichever booted second died with:

```
vite.1 | error when starting dev server:
vite.1 | Error: Port 8346 is already in use
```

Vite just failed first; Rails 8343 was equally taken.

## Ports

Two further collisions were latent in the same arithmetic:

- The Rails and Vite bases sat **3 apart** over a shared 500-wide range, so one worktree's Vite port could equal another's Rails port whenever their residues differed by 3.
- The range covered the shared **Postgres (8271)** and **Redis (8272)** containers and the main checkout's own **8270**, so residue 0 handed a worktree the main checkout's exact port. That is why `manufacturer-slug-index` currently sits on 8270.

Both ports now come from a single slot owning an adjacent pair (`8300 + 2N`, `8300 + 2N + 1`) — Rails always even, Vite always odd, so a cross-role clash is unrepresentable — and the base clears the shared services. crc32 now only picks where to *start* looking; slots already claimed by a sibling's `.env.local` are skipped, so a name keeps a stable assignment without colliding. Sibling ports are read rather than recomputed, so worktrees still holding a legacy pair block the slots that overlap them.

Simulated across all six local worktrees: 12/12 unique ports, every name stable across re-runs, nothing overlapping the shared services.

## Redis database

`bin/setup` wrote `SIDEKIQ_REDIS_DB`, a name **nothing in the codebase reads**. The knob the app actually consumes is `REDIS_DB` (`config/redis.yml`), which feeds `Rails.configuration.redis.db` to Sidekiq's server and client configs. Every worktree therefore fell through to the `|| 0` default and shared one database — queues, scheduler state and process heartbeats all on top of each other.

The value was unusable regardless: `2 + crc32(name) % 500` produced indexes like 75 and 350, while the shared container runs the default `databases 16` and would refuse to `SELECT` anything past 15.

This writes `REDIS_DB` instead, reusing the existing knob rather than teaching the Sidekiq initializer a second Sidekiq-only variable. It isolates the development cache store and session store along with the queues, since both already read the same value.

The index is allocated the same way the port slot is. Deriving it as `1 + (slot % 15)` folded 200 slots onto 15 residues and so collided immediately rather than only past the 16th worktree — of the six here, `pr-3893` and `manufacturer-duplicates` both landed on 14 and `manufacturer-slug-index` and `worktree-port-collisions` both on 11, while nine databases sat unused. crc32 now picks a starting index and the first one no sibling's `.env.local` claims wins: 6/6 distinct across the local worktrees.

## Concurrency

Allocation reads every sibling's `.env.local` and only then writes its own, so two worktrees setting up at once both scanned before either appeared in the range and both claimed the same slot. An exclusive `flock` now spans the scan and the writes, held on a file in the shared git directory so every worktree of the repo contends for the same one.

## Verification

Ran on this worktree, which moved to Rails 8446 / Vite 8447 / Redis DB 14:

- App serves 200; Vite client asset serves 200; no bind errors.
- Sidekiq logs `db: 14` for both its `internal` and `default` pools, and its keys (`processes`, `schedules`, `sidekiq-scheduler:next_times`) land in DB 14, which was empty beforehand.
- Round-trip confirmed across processes: a separate Rails process reading `Sidekiq::ProcessSet` sees exactly one worker — its own — so client and server agree on the isolated database. DB 0 stopped receiving this worktree's registration.
- Two forked processes taking the allocation lock around a sleep are strictly serialised, with no overlap inside the critical section.
- `standardrb` clean.

## Notes for reviewers

- **Existing worktrees keep their old ports and the stale `SIDEKIQ_REDIS_DB` line until each re-runs `bin/setup`.** No migration is needed — `write_managed_env` rewrites everything below the marker.
- **Above 15 worktrees two of them share a Redis database**, since the shared container only offers 1..15 with DB 0 left to the main checkout. Setup says so when it happens. Six worktrees exist today, so it is headroom rather than a problem; fixing it properly would mean Sidekiq key namespacing instead of database indexes.
- **When two names hash to the same Redis start index, whoever runs `bin/setup` first takes it** and the second scans forward. That order-dependence is inherent to first-free scanning and already applies to the port slots.
- **`rack_attack.rb:8` and `api_usage_tracker.rb:78` pass `redis.url` without `db`**, so throttle counters and API usage tallies stay on DB 0 across all worktrees. Pre-existing and untouched here — worth a follow-up if we want them isolated too.

🤖
