### PR TITLE
test(models): cover the manual manufacturer code, drop the dead slugs

### DIFF
--- a/app/services/models/manual_records.rb
+++ b/app/services/models/manual_records.rb
@@ -60,8 +60,10 @@ module Models
       }
     ].freeze
 
-    # Everything else in a definition is a plain Model column. Listed so a typo in
-    # a definition raises here instead of being assigned to nothing.
+    # Everything else in a definition is a plain Model column. Assignment walks
+    # this list rather than the definition, so a key that is not here is dropped
+    # in silence -- the test that every definition names only these is what
+    # catches a typo.
     ATTRIBUTES = %i[rsi_name classification production_status size hidden].freeze
 
     def self.call

--- a/app/services/models/manual_records.rb
+++ b/app/services/models/manual_records.rb
@@ -7,14 +7,12 @@ module Models
   # database, and Maintenance::SeedManualModelsTask for one that already exists
   # and is missing them.
   module ManualRecords
+    # No slug: `update_slugs` derives it from the name on every save, so one
+    # declared here would be overwritten before it reached the row.
     MANUFACTURERS = [
-      {name: "Origin Jumpworks", slug: "origin-jumpworks", code: "ORIG"},
-      {name: "Drake Interplanetary", slug: "drake-interplanetary", code: "DRAK"},
-      {
-        name: "Musashi Industrial & Starflight Concern",
-        slug: "musashi-industrial-starflight-concern",
-        code: "MISC"
-      }
+      {name: "Origin Jumpworks", code: "ORIG"},
+      {name: "Drake Interplanetary", code: "DRAK"},
+      {name: "Musashi Industrial & Starflight Concern", code: "MISC"}
     ].freeze
 
     # Base models come first so a straight run creates them before the editions
@@ -91,7 +89,6 @@ module Models
       raise ArgumentError, "no manual manufacturer named #{name.inspect}" if definition.nil?
 
       Manufacturer.find_or_create_by!(name: definition[:name]) do |manufacturer|
-        manufacturer.slug = definition[:slug]
         manufacturer.code = definition[:code]
       end
     end

--- a/test/services/models/manual_records_test.rb
+++ b/test/services/models/manual_records_test.rb
@@ -66,6 +66,27 @@ module Models
       assert_not_predicate existing.reload, :hidden?
     end
 
+    # Nothing derives the code, so a manufacturer created here is the only place
+    # it comes from -- an import matching on code finds nothing if it is missing.
+    test ".upsert_manufacturer gives a manufacturer it creates its code" do
+      ::Models::ManualRecords::MANUFACTURERS.each do |definition|
+        manufacturer = ::Models::ManualRecords.upsert_manufacturer(definition[:name])
+
+        assert_equal definition[:code], manufacturer.code, "#{definition[:name]} was created without its code"
+      end
+    end
+
+    # The slug is not the definition's to give: `update_slugs` derives it from the
+    # name on every save, so the declared slug never reaches the row. Pinned
+    # because a rename would silently move the slug every URL is built from.
+    test ".upsert_manufacturer slugs a manufacturer it creates from its name" do
+      ::Models::ManualRecords::MANUFACTURERS.each do |definition|
+        manufacturer = ::Models::ManualRecords.upsert_manufacturer(definition[:name])
+
+        assert_equal definition[:name].parameterize, manufacturer.slug
+      end
+    end
+
     test ".upsert_manufacturer reuses a manufacturer that is already there" do
       existing = create(:manufacturer, name: "Origin Jumpworks", code: "ORIG")
 


### PR DESCRIPTION
Follow-up to #4432. `Models::ManualRecords.upsert_manufacturer` is the only place the manual manufacturers get their `code` — nothing derives it — but no test covered the creation branch. Removing `manufacturer.code = definition[:code]` left the whole suite green.

Testing that turned up a second thing: the `slug:` keys in `MANUFACTURERS` were dead, so they go too.

## Changes

1. **`test(models)`** — two tests on `upsert_manufacturer`'s creation branch:
   - `gives a manufacturer it creates its code` — walks `MANUFACTURERS`, asserts each created row carries its code. Verified by mutation: with the assignment removed this is the only failure; the 10 pre-existing tests still pass.
   - `slugs a manufacturer it creates from its name` — pins the slug as *derived*, not taken from the definition.
2. **`docs(models)`** — corrected the `ATTRIBUTES` comment. It claimed a typo "raises here", but assignment iterates `ATTRIBUTES` and guards on `definition.key?`, so an unknown key is silently ignored. What catches it is the existing `every definition names only attributes the upsert assigns` test — the comment now says so.
3. **`refactor(models)`** — dropped the `slug:` keys and the `manufacturer.slug =` that read them.

## Why the slugs were dead

`before_save :update_slugs` in `ApplicationRecord` does `self.slug = generate_slug(name)`, so it overwrites `slug` on every save and the declared one never reached the row:

```
Manufacturer.create!(name: "Origin Jumpworks", code: "ORIG", slug: "deliberately-wrong").slug
# => "origin-jumpworks"
```

The only reader of `definition[:slug]` was the assignment that lost that race. All three names parameterize to exactly the slug they declared, so no slug moves — and the new `slugs a manufacturer it creates from its name` test is what holds that down, which is why it lands in the same PR as the removal rather than after it.

## Testing

- `test/services/models/manual_records_test.rb` → 12 tests, 54 assertions, 0 failures.
- Neighbouring manufacturer suites (deduplicator, sc_data loader + parser, dedupe task) → 66 tests, 176 assertions, 0 failures.
- `standardrb` clean.

🤖