### PR TITLE
feat(credits): credit erkul on the ship metrics and in the imprint

### DIFF
--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -22,6 +22,84 @@
     margin-inline-start: auto;
   }
 
+  // The metrics cards are modelled on erkul's formulas, so the credit sits once
+  // under the whole grid instead of being repeated in every card. Right-aligned
+  // to answer the loadout links at the top of the block: the same attribution,
+  // opening and closing the metrics.
+  &__credit {
+    display: flex;
+    justify-content: flex-end;
+    margin: 0 0 16px;
+  }
+
+  // Tokens rather than @apply: sass preprocesses this file first, so tailwind's
+  // at-rules would never reach the minifier (see base/Chip for the same note).
+  &__credit-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 10px;
+    border: 1px solid var(--color-edge-faint, rgb(122 130 136 / 0.16));
+    border-radius: var(--radius-control-bare, 6px);
+    color: var(--color-muted, #7a8288);
+    font-size: 12px;
+    line-height: 1.4;
+    text-decoration: none;
+    transition:
+      background-color 0.15s ease-in-out,
+      border-color 0.15s ease-in-out,
+      color 0.15s ease-in-out;
+
+    i {
+      font-size: 10px;
+      opacity: 0.7;
+    }
+
+    &:hover,
+    &:focus-visible {
+      border-color: var(--color-edge-soft, rgb(122 130 136 / 0.28));
+      background-color: var(--color-control, rgb(39 43 48 / 0.9));
+      color: var(--color-text, #c8c8c8);
+    }
+  }
+
+  // The name carries the credit, so it stays readable while the sentence around
+  // it recedes.
+  &__credit-source {
+    color: var(--color-text, #c8c8c8);
+    transition: color 0.15s ease-in-out;
+  }
+
+  &__credit-link:hover &__credit-source,
+  &__credit-link:focus-visible &__credit-source {
+    color: var(--color-lifted, #eee);
+  }
+
+  &__credit-icon {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    background-image: url("@/images/sc_dps_calculator.png");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 100%;
+    opacity: 0.75;
+    transition: opacity 0.15s ease-in-out;
+  }
+
+  &__credit-link:hover &__credit-icon,
+  &__credit-link:focus-visible &__credit-icon {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &__credit-link,
+    &__credit-source,
+    &__credit-icon {
+      transition-duration: 1ms;
+    }
+  }
+
   // Density stays with the hardpoint groups it controls rather than joining the
   // row above, where it would be nowhere near what it changes.
   &__viewbar {

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -244,6 +244,24 @@ useMetricsMasonry(metricsGrid);
         <ModelExternalFuelTanks :model="model" />
         <ModelRefuelBoom :model="model" />
       </div>
+      <div v-if="showMetrics" class="hardpoints__credit">
+        <a
+          class="hardpoints__credit-link"
+          href="https://www.erkul.games/"
+          target="_blank"
+          rel="noopener"
+        >
+          <span class="hardpoints__credit-icon" aria-hidden="true" />
+          <span>
+            {{ t("labels.hardpoints.metricsCredit") }}
+            <span class="hardpoints__credit-source">erkul.games</span>
+          </span>
+          <i
+            class="fa-regular fa-arrow-up-right-from-square"
+            aria-hidden="true"
+          />
+        </a>
+      </div>
       <div v-if="hardpoints?.length" class="hardpoints__viewbar">
         <BtnGroup segmented :aria-label="t('labels.hardpoint.density.title')">
           <Btn

--- a/app/frontend/frontend/pages/impressum.vue
+++ b/app/frontend/frontend/pages/impressum.vue
@@ -35,6 +35,15 @@ const { t } = useI18n();
           </a>
         </p>
         <br />
+        <h3>Erkul's DPS Calculator</h3>
+        <p>{{ t("texts.impressum.erkul") }}</p>
+        <p>
+          {{ t("texts.impressum.visit") }}
+          <a href="https://www.erkul.games/" target="_blank" rel="noopener">
+            erkul.games
+          </a>
+        </p>
+        <br />
         <h2>{{ t("sublines.impressum.sponsors") }}</h2>
         <h3>AppSignal</h3>
         <p>{{ t("texts.impressum.appSignal") }}</p>

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1070,7 +1070,8 @@
         "prefix": "Konfigurationen testen mit",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "Werte basieren auf den Formeln von"
       },
       "scunpacked": {
         "prefix": "Loadouts based on Gamefiles powered by",

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -74,6 +74,7 @@
       "impressum": {
         "visit": "Besuch",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1475,7 +1475,8 @@
         "prefix": "Tryout Loadouts with",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "Metrics based on the formulas of"
       },
       "scunpacked": {
         "prefix": "Loadouts based on Gamefiles powered by",

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -79,6 +79,7 @@
       "impressum": {
         "visit": "Visit",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1005,7 +1005,8 @@
         "prefix": "Probar configuraciones con",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "Métricas basadas en las fórmulas de"
       },
       "scunpacked": {
         "prefix": "Loadouts based on Gamefiles powered by",

--- a/app/frontend/translations/es/texts.json
+++ b/app/frontend/translations/es/texts.json
@@ -73,6 +73,7 @@
       "impressum": {
         "visit": "Visita",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1005,7 +1005,8 @@
         "prefix": "Essayer les configurations avec",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "Statistiques basées sur les formules de"
       },
       "scunpacked": {
         "prefix": "Configurations basées sur les produits développés par Gamefiles ",

--- a/app/frontend/translations/fr/texts.json
+++ b/app/frontend/translations/fr/texts.json
@@ -73,6 +73,7 @@
       "impressum": {
         "visit": "Visite",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1005,7 +1005,8 @@
         "prefix": "Prova le configurazioni con",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "Metriche basate sulle formule di"
       },
       "scunpacked": {
         "prefix": "Loadouts basato sui Gamefiles powered by",

--- a/app/frontend/translations/it/texts.json
+++ b/app/frontend/translations/it/texts.json
@@ -73,6 +73,7 @@
       "impressum": {
         "visit": "Visita",
         "ytShipImages": "Le bellissime immagini delle navi nella vista Fleetchart sono il lavoro di <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br> Visitate il suo post Spectrum (vedi link qui sotto) e dategli un voto.",
+        "erkul": "Le metriche delle navi su Fleetyards si basano sulle formule e sui valori di Erkul's DPS Calculator. Grazie al team di erkul.games per aver condiviso il proprio lavoro con la comunità.",
         "appSignal": "AppSignal ha fornito un account Open Source sponsorizzato che aiuta a migliorare ulteriormente Fleetyards.net. Grazie :)",
         "copyright": "I contenuti e le opere creati dagli operatori delle pagine, su queste pagine sono soggetti al diritto d'autore tedesco. La duplicazione, il trattamento, la distribuzione e qualsiasi tipo di sfruttamento al di fuori dei limiti del Copyright richiedono il consenso scritto del rispettivo autore o creatore. I download e le copie di questa pagina sono solo per uso privato e non commerciale. Nella misura in cui il contenuto di questa pagina non è stato creato dall'operatore, sono rispettati i diritti d'autore di terze parti, in particolare i contenuti di terze parti in quanto tali. Vi preghiamo di contattarci se notate qualsiasi tipo di violazione del copyright. Rimuoveremo immediatamente qualsiasi contenuto una volta notificati di tali violazioni.",
         "disclaimer": {

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1005,7 +1005,8 @@
         "prefix": "使用以下工具试用配置",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "数据基于以下网站的计算公式"
       },
       "scunpacked": {
         "prefix": "Loadouts based on Gamefiles powered by",

--- a/app/frontend/translations/zh-CN/texts.json
+++ b/app/frontend/translations/zh-CN/texts.json
@@ -73,6 +73,7 @@
       "impressum": {
         "visit": "访问",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1005,7 +1005,8 @@
         "prefix": "使用以下工具試用配置",
         "erkul": "Erkul's DPS Calculator",
         "spviewer": "SP Viewer",
-        "spviewerTitle": "SC Ships Performances Viewer"
+        "spviewerTitle": "SC Ships Performances Viewer",
+        "metricsCredit": "數據基於以下網站的計算公式"
       },
       "scunpacked": {
         "prefix": "Loadouts based on Gamefiles powered by",

--- a/app/frontend/translations/zh-TW/texts.json
+++ b/app/frontend/translations/zh-TW/texts.json
@@ -73,6 +73,7 @@
       "impressum": {
         "visit": "訪問",
         "ytShipImages": "The Awesome Ship Images in the Hangar Fleetchart view are the work of <a href=\"https://twitter.com/WhyTeeZero\" target=\"_blank\" rel=\"noopener\">YT (Twitter: @WhyTeeZero)</a>.<br>Please visit his Spectrum post (see links below) and give him a upvote.",
+        "erkul": "The ship metrics on Fleetyards are modelled on the formulas and readouts of Erkul's DPS Calculator. Thanks to the erkul.games team for sharing their work with the community.",
         "appSignal": "AppSignal provided a sponsored Open Source Account which helps to improve Fleetyards.net even further. Thanks :)",
         "copyright": "The contents and works created by the page operators, on these pages are subject to German copyright. Duplication, processing, distribution and any kind of exploitation outside the limits of Copyright require the written consent of the respective author or creator. Downloads and copies of this page are only for private, non-commercial use. Insofar as the content on This page was not created by the operator, are third-party copyrights respected. In particular, Third-party content as such. Please Contact us if you notice any sort of copyright infringement. We will remove any content immediately as we become aware of such violations.",
         "disclaimer": {


### PR DESCRIPTION
The metrics cards on the ship detail page are modelled on erkul's formulas and readouts, and nothing on the page said so. This credits erkul in the two places that owe it: the metrics block itself, and the imprint's Credits section.

### The credit chip

A single chip under the metrics grid rather than a note per card — the whole block shares one source. It renders only when `showMetrics` does, so a ship-matrix view never claims a source it isn't computing from.

Right-aligned on purpose: it answers the erkul / SP Viewer loadout links at the top of the same block, so the attribution opens and closes the metrics instead of appearing once at the end.

The whole chip is the link, not just the domain — a 12px sentence makes a poor hit target. `erkul.games` stays at `--color-text` while the phrase around it recedes to `--color-muted`, so the name carries the credit and the sentence stays quiet. At rest it's a `--color-edge-faint` hairline with no fill, lifting to `--color-edge-soft` plus a `--color-control` fill on hover and on `:focus-visible`, with the icon going from 0.75 to full opacity. Reduced motion collapses the transitions the way `base/Chip` does. The icon is the existing `sc_dps_calculator.png` the loadout button already uses, so no new asset.

Tokens are read as `var(--color-…)` rather than through `@apply`: sass preprocesses `index.scss` first, so tailwind's at-rules would never reach the minifier — the note `base/Chip` already carries for the same reason.

I rendered it against a mock grid to check hover and the longer German and Chinese strings; the chip is content-width so none of them wrap.

### Imprint

An `Erkul's DPS Calculator` entry in Credits, next to YT Ship Images, following the heading + text + visit-link shape the page already uses. No logo, because no other credit there has one.

### Notes

- `labels.hardpoints.metricsCredit` is translated in all seven locales. `texts.impressum.erkul` is translated for `it` and English elsewhere, matching how the surrounding imprint keys already sit in each file — a German paragraph between two English ones would read worse than uniform English.
- No coverage: it's presentational markup in `Hardpoints`, not a component, so it isn't in `pages/visual-tests/metrics.vue` either. Happy to promote it to a small component with a visual-test entry if you'd rather it were exercised.

🤖
