### PR TITLE
feat(fleets): fleet-scoped feature flags with a fleet settings Features tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,13 +236,14 @@ Flags are declared in **`config/feature_flags.yml`** — the single source of tr
 To add a flag:
 
 1. Add an entry with a `description` (plus `permanent: true` for long-lived
-   infrastructure gates like the OAuth providers, and `self_service: true` if
-   users should be able to switch it on themselves):
+   infrastructure gates like the OAuth providers, and `self_service` if the flag
+   should be toggleable outside `/admin/features` — `user` for a personal
+   surface, `fleet` for one a fleet admin owns):
 
    ```yaml
    my_new_flag:
      description: "What this toggles"
-     self_service: true
+     self_service: user
    ```
 
 2. Validate with `bin/feature-flags validate`; CI runs the same command.
@@ -251,9 +252,12 @@ To add a flag:
    `isFeatureEnabled('my_new_flag')` in Vue.
 
 Flags are created **off**, and toggling their gates stays at `/admin/features`.
-`self_service: true` seeds the flag's `FeatureSetting` on sync so it arrives
-user-toggleable; admins own it from then on, so dropping the key later retracts
-nothing — untoggle it at `/admin/features` instead.
+`self_service` seeds the flag's `FeatureSetting` on sync so it arrives
+self-toggleable; admins own that from then on, so dropping the key later retracts
+nothing — untoggle it at `/admin/features` instead. The **scope** is different:
+it is reconciled on every sync, because it says which surface the code reads the
+flag from. Read a fleet-scoped flag against the fleet
+(`isFleetFeatureEnabled(fleet, …)` in Vue, off the fleet payload's `features`).
 
 To remove a flag, delete its entry — the next deploy prunes the Flipper feature,
 all of its gate values and its `FeatureSetting` row (irreversible).

--- a/app/api_components/v1/schemas/fleet_feature.rb
+++ b/app/api_components/v1/schemas/fleet_feature.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class FleetFeature
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          name: {type: :string},
+          enabled: {type: :boolean}
+        },
+        additionalProperties: false,
+        required: %w[name enabled]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet.rb
+++ b/app/api_components/v1/schemas/fleets/fleet.rb
@@ -26,11 +26,12 @@ module V1
             logo: {"$ref": "#/components/schemas/MediaFile"},
             backgroundImage: {"$ref": "#/components/schemas/MediaFile"},
             myFleet: {type: :boolean},
+            features: {type: :array, items: {type: :string}},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id fid name slug publicFleet publicFleetStats createdAt updatedAt]
+          required: %w[id fid name slug publicFleet publicFleetStats features createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/v1/schemas/user_feature.rb
+++ b/app/api_components/v1/schemas/user_feature.rb
@@ -5,14 +5,31 @@ module V1
     class UserFeature
       include OpenapiRuby::Components::Base
 
+      # The enum is safe to declare here in a way FeatureFlagName is not: the
+      # scopes are a closed set, so it will not grow a value on every new flag
+      # and trip the breaking-change check.
       schema({
         type: :object,
         properties: {
           name: {type: :string},
-          enabled: {type: :boolean}
+          enabled: {type: :boolean},
+          enabledForSelf: {type: :boolean},
+          scope: {type: :string, enum: FeatureFlags::Definition::SELF_SERVICE_SCOPES},
+          fleets: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                name: {type: :string},
+                slug: {type: :string}
+              },
+              additionalProperties: false,
+              required: %w[name slug]
+            }
+          }
         },
         additionalProperties: false,
-        required: %w[name enabled]
+        required: %w[name enabled enabledForSelf scope fleets]
       })
     end
   end

--- a/app/controllers/admin/api/v1/features_controller.rb
+++ b/app/controllers/admin/api/v1/features_controller.rb
@@ -88,9 +88,17 @@ module Admin
         def toggle_self_service
           setting = FeatureSetting.find_or_initialize_by(feature_name: @feature.name.to_s)
           setting.self_service = !setting.self_service
+          # Which surface reads the flag is the registry's call, not the admin's:
+          # a row created here would otherwise default to personal settings and
+          # offer a fleet-wide feature to individual members.
+          setting.self_service_scope = registry_self_service_scope || setting.self_service_scope
           setting.save!
 
           render :show
+        end
+
+        private def registry_self_service_scope
+          FeatureFlags::Registry.load.fetch(@feature.name)&.self_service_scope
         end
 
         private def set_feature

--- a/app/controllers/api/v1/features_controller.rb
+++ b/app/controllers/api/v1/features_controller.rb
@@ -7,15 +7,13 @@ module Api
 
       before_action :authenticate_user!, only: %i[]
 
+      # The viewer's own flags only. Flags enabled for a fleet ride on that
+      # fleet's payload instead — folding them in here answered "on for any fleet
+      # you are in", which showed a fleet's features on every other fleet's page.
       def show
-        user_features = Flipper.features.filter_map do |feature|
+        @features = Flipper.features.filter_map do |feature|
           Flipper.enabled?(feature.name, current_resource_owner) ? feature.to_s : nil
         end
-        fleet_features = Flipper.features.filter_map do |feature|
-          (current_resource_owner&.fleets&.any? { |fleet| Flipper.enabled?(feature.name, fleet) }) ? feature.to_s : nil
-        end
-
-        @features = (user_features + fleet_features).uniq
       end
     end
   end

--- a/app/controllers/api/v1/fleet_features_controller.rb
+++ b/app/controllers/api/v1/fleet_features_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetFeaturesController < ::Api::BaseController
+      rescue_from ActiveRecord::RecordNotFound do |_exception|
+        not_found(I18n.t("messages.record_not_found.fleet", slug: params[:fleet_slug]))
+      end
+
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[index]
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?,
+        only: %i[enable disable]
+
+      before_action :set_fleet
+
+      def index
+        @features = fleet_self_service_feature_names.filter_map do |feature_name|
+          feature = Flipper.feature(feature_name)
+
+          next if feature.state == :on
+
+          {
+            name: feature.name,
+            enabled: Flipper.enabled?(feature.name, @fleet)
+          }
+        end
+      end
+
+      def enable
+        return unless toggleable_feature?
+
+        Flipper.feature(params[:id]).enable_actor(@fleet)
+
+        render json: {name: params[:id], enabled: true}
+      end
+
+      def disable
+        return unless toggleable_feature?
+
+        feature_name = params[:id]
+
+        Flipper.feature(feature_name).disable_actor(@fleet)
+
+        render json: {name: feature_name, enabled: Flipper.enabled?(feature_name, @fleet)}
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+
+        authorize! @fleet, to: :manage_features?, with: FleetPolicy
+      end
+
+      # Only flags the registry declared fleet-scoped. A user-scoped flag toggled
+      # here would put a personal surface behind a fleet's admins.
+      private def fleet_self_service_feature_names
+        FeatureSetting.self_service_feature_names(scope: FeatureFlags::Definition::FLEET_SCOPE)
+      end
+
+      private def toggleable_feature?
+        return true if fleet_self_service_feature_names.include?(params[:id])
+
+        render json: {code: "forbidden", message: "This feature cannot be toggled for a fleet"}, status: :forbidden
+
+        false
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/user_features_controller.rb
+++ b/app/controllers/api/v1/user_features_controller.rb
@@ -9,15 +9,35 @@ module Api
       before_action -> { doorkeeper_authorize! "profile:write" },
         unless: :user_signed_in?
 
+      # Every self-service flag, whatever surface owns its fleet-wide switch.
+      #
+      # Two states, because a fleet flag has two switches with different reach:
+      #
+      #   enabled_for_self — this user's own gate, the one the switch here flips.
+      #                      Turning a fleet flag on gives *you* the feature in
+      #                      the fleets you belong to, without it appearing for
+      #                      the rest of the fleet.
+      #   enabled          — what the user actually has, so a feature their fleet
+      #                      switched on for everyone reads as enabled rather
+      #                      than as something they still have to turn on.
+      #
+      # `fleets` names the ones responsible, so a member can see where the feature
+      # came from instead of only that they cannot switch it off.
       def index
-        @features = FeatureSetting.self_service_feature_names.filter_map do |feature_name|
+        @features = FeatureSetting.self_service_scopes.filter_map do |feature_name, scope|
           feature = Flipper.feature(feature_name)
 
           next if feature.state == :on
 
+          enabled_for_self = Flipper.enabled?(feature.name, current_resource_owner)
+          fleets = granting_fleets(feature.name, scope)
+
           {
             name: feature.name,
-            enabled: Flipper.enabled?(feature.name, current_resource_owner)
+            enabled: enabled_for_self || fleets.any?,
+            enabled_for_self:,
+            scope:,
+            fleets: fleets.map { |fleet| {name: fleet.name, slug: fleet.slug} }
           }
         end
       end
@@ -25,9 +45,10 @@ module Api
       def enable
         feature_name = params[:id]
 
-        unless FeatureSetting.self_service_feature_names.include?(feature_name)
+        unless FeatureSetting.self_service_anywhere?(feature_name)
           return render json: {code: "forbidden", message: "This feature cannot be self-activated"}, status: :forbidden
         end
+        return if refuse_fleet_override(feature_name)
 
         Flipper.feature(feature_name).enable_actor(current_resource_owner)
 
@@ -37,13 +58,47 @@ module Api
       def disable
         feature_name = params[:id]
 
-        unless FeatureSetting.self_service_feature_names.include?(feature_name)
+        unless FeatureSetting.self_service_anywhere?(feature_name)
           return render json: {code: "forbidden", message: "This feature cannot be self-deactivated"}, status: :forbidden
         end
+        return if refuse_fleet_override(feature_name)
 
         Flipper.feature(feature_name).disable_actor(current_resource_owner)
 
         render json: {name: feature_name, enabled: Flipper.enabled?(feature_name, current_resource_owner)}
+      end
+
+      # A fleet switched the feature on for every member, and a personal gate
+      # cannot take it away again — the backend ORs both actors. Refusing beats
+      # reporting a change the user will not see.
+      private def refuse_fleet_override(feature_name)
+        return false if granting_fleets(feature_name).empty?
+
+        render json: {code: "forbidden", message: "This feature is enabled for your fleet"}, status: :forbidden
+
+        true
+      end
+
+      # The user's fleets that switched this feature on for their members.
+      #
+      # Only for a fleet-scoped flag: nothing reads a user-scoped one against a
+      # fleet actor, so a gate there would grant the user nothing and must not
+      # count. Accepted memberships only — a pending invitation does not give the
+      # user the feature yet.
+      private def granting_fleets(feature_name, scope = self_service_scope(feature_name))
+        return [] unless scope == FeatureFlags::Definition::FLEET_SCOPE
+
+        accepted_fleets.select { |fleet| Flipper.enabled?(feature_name, fleet) }
+      end
+
+      private def self_service_scope(feature_name)
+        FeatureSetting.find_by(feature_name:)&.self_service_scope
+      end
+
+      private def accepted_fleets
+        @accepted_fleets ||= Fleet.kept.where(
+          id: current_resource_owner.fleet_memberships.kept.accepted.select(:fleet_id)
+        ).to_a
       end
     end
   end

--- a/app/frontend/frontend/components/FeatureGuard.vue
+++ b/app/frontend/frontend/components/FeatureGuard.vue
@@ -11,18 +11,25 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useFeatures } from "@/frontend/composables/useFeatures";
 import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
 import { HeadingSizeEnum } from "@/shared/components/base/Heading/types";
-import type { FeatureFlagName } from "@/services/fyApi";
+import type { FeatureFlagName, Fleet } from "@/services/fyApi";
 
 type Props = {
   feature: FeatureFlagName;
+  // Pass the fleet for a flag a fleet can be gated on, so the answer is about
+  // this fleet and not about every fleet the viewer belongs to.
+  fleet?: Fleet;
 };
 
 const props = defineProps<Props>();
 
 const { t } = useI18n();
-const { isFeatureEnabled } = useFeatures();
+const { isFeatureEnabled, isFleetFeatureEnabled } = useFeatures();
 
-const enabled = computed(() => isFeatureEnabled(props.feature));
+const enabled = computed(() =>
+  props.fleet
+    ? isFleetFeatureEnabled(props.fleet, props.feature)
+    : isFeatureEnabled(props.feature),
+);
 </script>
 
 <template>

--- a/app/frontend/frontend/composables/useFeatures.ts
+++ b/app/frontend/frontend/composables/useFeatures.ts
@@ -2,6 +2,7 @@ import {
   getFeaturesQueryOptions,
   useFeatures as useFeaturesQuery,
   type FeatureFlagName,
+  type Fleet,
 } from "@/services/fyApi";
 import { usePrefetch } from "@/shared/composables/usePrefetch";
 
@@ -34,8 +35,18 @@ export const useFeatures = () => {
   const isFeatureEnabled = (feature: FeatureFlagName) =>
     features.value?.includes(feature) || false;
 
+  // Mirrors the backend gate, `Flipper.enabled?(flag, user, fleet)`: on for the
+  // viewer or on for this fleet. Only for *this* fleet — the viewer's flag list
+  // used to fold in every fleet they belong to, which showed one fleet's
+  // features on every other fleet's page.
+  const isFleetFeatureEnabled = (
+    fleet: Pick<Fleet, "features"> | undefined | null,
+    feature: FeatureFlagName,
+  ) => isFeatureEnabled(feature) || fleet?.features?.includes(feature) || false;
+
   return {
     features,
     isFeatureEnabled,
+    isFleetFeatureEnabled,
   };
 };

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics.vue
@@ -19,7 +19,7 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const { isFeatureEnabled } = useFeatures();
+const { isFleetFeatureEnabled } = useFeatures();
 
 const resourceAccess = computed(
   () => props.membership?.fleetRole?.resourceAccess,
@@ -28,7 +28,7 @@ const resourceAccess = computed(
 
 <template>
   <router-view
-    v-if="isFeatureEnabled(FeatureFlagName.FLEET_LOGISTICS)"
+    v-if="isFleetFeatureEnabled(props.fleet, FeatureFlagName.FLEET_LOGISTICS)"
     :fleet="props.fleet"
     :membership="props.membership"
     :resource-access="resourceAccess"

--- a/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
@@ -58,12 +58,12 @@ const canManageInvites = computed(() =>
   ]),
 );
 
-const { isFeatureEnabled } = useFeatures();
+const { isFleetFeatureEnabled } = useFeatures();
 const starmapEnabled = computed(() =>
-  isFeatureEnabled(FeatureFlagName.FLEET_STARMAP),
+  isFleetFeatureEnabled(props.fleet, FeatureFlagName.FLEET_STARMAP),
 );
 const worldmapEnabled = computed(() =>
-  isFeatureEnabled(FeatureFlagName.FLEET_WORLDMAP),
+  isFleetFeatureEnabled(props.fleet, FeatureFlagName.FLEET_WORLDMAP),
 );
 
 const { isFilterSelected, getQuery } = useFilters<FleetMemberQuery>({

--- a/app/frontend/frontend/pages/fleets/[slug]/members/routes.ts
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/routes.ts
@@ -22,6 +22,7 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
       customTitle: true,
       feature: FeatureFlagName.FLEET_WORLDMAP,
+      featureScope: "fleet",
     },
   },
   {
@@ -34,6 +35,7 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
       customTitle: true,
       feature: FeatureFlagName.FLEET_STARMAP,
+      featureScope: "fleet",
     },
   },
   {

--- a/app/frontend/frontend/pages/fleets/[slug]/members/starmap.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/starmap.vue
@@ -71,7 +71,7 @@ const crumbs = computed(() => [
 </script>
 
 <template>
-  <FeatureGuard :feature="FeatureFlagName.FLEET_STARMAP">
+  <FeatureGuard :feature="FeatureFlagName.FLEET_STARMAP" :fleet="props.fleet">
     <BreadCrumbs :crumbs="crumbs" />
     <Heading>
       {{ t("headlines.fleets.members.starmap") }}

--- a/app/frontend/frontend/pages/fleets/[slug]/settings/features.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings/features.vue
@@ -1,0 +1,144 @@
+<script lang="ts">
+export default {
+  name: "FleetSettingsFeatures",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import { BtnVariantsEnum } from "@/shared/components/base/Btn/types";
+import {
+  useFleetFeatures,
+  getFleetFeaturesQueryKey,
+  getFleetQueryKey,
+  enableFleetFeature,
+  disableFleetFeature,
+  type Fleet,
+  type FleetFeature,
+  type FleetMember,
+} from "@/services/fyApi";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  fleet: Fleet;
+  membership: FleetMember;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const { displaySuccess, displayAlert } = useAppNotifications();
+
+const { data: features, isLoading } = useFleetFeatures(
+  computed(() => props.fleet.slug),
+);
+
+const queryClient = useQueryClient();
+
+// The fleet payload carries the flags, so the tabs and pages gated on them only
+// change once it is refetched.
+const invalidateFeatures = () =>
+  Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getFleetFeaturesQueryKey(props.fleet.slug),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: getFleetQueryKey(props.fleet.slug),
+    }),
+  ]);
+
+interface FeatureItem extends FleetFeature {
+  id: string;
+}
+
+const featureItems = computed<FeatureItem[]>(
+  () =>
+    features.value?.map((feature) => ({ ...feature, id: feature.name })) ?? [],
+);
+
+const toggleFeature = async (feature: FeatureItem) => {
+  try {
+    if (feature.enabled) {
+      await disableFleetFeature(props.fleet.slug, feature.name);
+    } else {
+      await enableFleetFeature(props.fleet.slug, feature.name);
+    }
+    void invalidateFeatures();
+    displaySuccess({ text: t("messages.features.updated") });
+  } catch {
+    displayAlert({ text: t("messages.features.error") });
+  }
+};
+</script>
+
+<template>
+  <p class="features-intro">
+    {{ t("labels.features.fleetSettingsIntro") }}
+  </p>
+
+  <Loader :loading="isLoading" />
+
+  <Empty v-if="!featureItems.length && !isLoading" variant="box" hide-actions>
+    <template #headline>
+      {{ t("empty.headlines.fleetFeatures") }}
+    </template>
+    <template #info>
+      <p>{{ t("empty.info.fleetFeatures") }}</p>
+    </template>
+  </Empty>
+
+  <InlineEditableList
+    v-if="featureItems.length"
+    :items="featureItems"
+    hide-destroy
+    hide-edit
+  >
+    <template #display="{ item }">
+      <BasePill
+        :variant="item.enabled ? 'success' : 'danger'"
+        uppercase
+        margin-right
+      >
+        {{
+          item.enabled
+            ? t("labels.features.stateOn")
+            : t("labels.features.stateOff")
+        }}
+      </BasePill>
+      <span class="feature-name">
+        {{ item.name.replace(/_/g, " ").replace(/-/g, " ") }}
+      </span>
+    </template>
+
+    <template #actions="{ item, mobile }">
+      <Btn
+        v-tooltip="t('labels.features.toggle')"
+        @click="toggleFeature(item)"
+        :variant="BtnVariantsEnum.GHOST"
+      >
+        <i
+          class="fa-duotone fa-power-off"
+          :class="item.enabled ? 'text-success' : 'text-muted'"
+        />
+        <span v-if="mobile">{{ t("labels.features.toggle") }}</span>
+      </Btn>
+    </template>
+  </InlineEditableList>
+</template>
+
+<style lang="scss" scoped>
+.features-intro {
+  margin-bottom: 1.5rem;
+  color: var(--text-muted);
+}
+
+.feature-name {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+</style>

--- a/app/frontend/frontend/pages/fleets/[slug]/settings/routes.ts
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings/routes.ts
@@ -36,4 +36,16 @@ export const routes: RouteRecordRaw[] = [
       customTitle: true,
     },
   },
+  {
+    path: "features/",
+    name: "fleet-settings-features",
+    component: () =>
+      import("@/frontend/pages/fleets/[slug]/settings/features.vue"),
+    meta: {
+      title: "fleets.settings.features",
+      needsAuthentication: true,
+      access: ["fleet:manage"],
+      customTitle: true,
+    },
+  },
 ];

--- a/app/frontend/frontend/pages/settings/features.vue
+++ b/app/frontend/frontend/pages/settings/features.vue
@@ -20,6 +20,7 @@ import {
   getFeaturesQueryKey,
   enableUserFeature,
   disableUserFeature,
+  UserFeatureScope,
   type UserFeature,
 } from "@/services/fyApi";
 import { useQueryClient } from "@tanstack/vue-query";
@@ -44,9 +45,21 @@ const featureItems = computed<FeatureItem[]>(() => {
   return features.value.map((f) => ({ ...f, id: f.name }));
 });
 
+// A fleet feature has two switches with different reach: this one enables it for
+// you alone, and a fleet admin's enables it for everyone in that fleet. The pill
+// and its tooltip are what keep the two apart.
+const isFleetFeature = (feature: FeatureItem) =>
+  feature.scope === UserFeatureScope.fleet;
+
+// The fleet already gives every member the feature, so there is nothing for a
+// personal switch to add — and it cannot take it away either.
+const grantedByFleet = (feature: FeatureItem) => feature.fleets.length > 0;
+
 const toggleFeature = async (feature: FeatureItem) => {
+  if (grantedByFleet(feature)) return;
+
   try {
-    if (feature.enabled) {
+    if (feature.enabledForSelf) {
       await disableUserFeature(feature.name);
     } else {
       await enableUserFeature(feature.name);
@@ -102,11 +115,43 @@ const toggleFeature = async (feature: FeatureItem) => {
       <span class="feature-name">
         {{ item.name.replace(/_/g, " ").replace(/-/g, " ") }}
       </span>
+      <span
+        v-if="isFleetFeature(item)"
+        v-tooltip="
+          grantedByFleet(item)
+            ? t('labels.features.fleetFeatureGranted')
+            : t('labels.features.fleetFeatureInfo')
+        "
+        class="feature-scope"
+      >
+        <BasePill uppercase>
+          {{
+            grantedByFleet(item)
+              ? t("labels.features.fleetFeatureGrantedShort")
+              : t("labels.features.fleetFeature")
+          }}
+        </BasePill>
+      </span>
+      <span v-if="grantedByFleet(item)" class="feature-fleets">
+        <template v-for="(fleet, index) in item.fleets" :key="fleet.slug">
+          <span v-if="index > 0">, </span>
+          <router-link :to="{ name: 'fleet', params: { slug: fleet.slug } }">
+            {{ fleet.name }}
+          </router-link>
+        </template>
+      </span>
     </template>
 
     <template #actions="{ item, mobile }">
       <Btn
-        v-tooltip="t('labels.features.toggle')"
+        v-tooltip="
+          grantedByFleet(item)
+            ? t('labels.features.fleetFeatureGranted')
+            : isFleetFeature(item)
+              ? t('labels.features.toggleForSelf')
+              : t('labels.features.toggle')
+        "
+        :disabled="grantedByFleet(item)"
         @click="toggleFeature(item)"
         :variant="BtnVariantsEnum.GHOST"
       >
@@ -129,5 +174,14 @@ const toggleFeature = async (feature: FeatureItem) => {
 .feature-name {
   font-weight: 600;
   text-transform: capitalize;
+}
+
+.feature-scope {
+  margin-left: 0.5rem;
+}
+
+.feature-fleets {
+  margin-left: 0.5rem;
+  color: var(--text-muted);
 }
 </style>

--- a/app/frontend/frontend/plugins/Router.spec.ts
+++ b/app/frontend/frontend/plugins/Router.spec.ts
@@ -3,15 +3,25 @@ import { setActivePinia, createPinia } from "pinia";
 import type { RouteLocation } from "vue-router";
 import { beforeResolve } from "@/frontend/plugins/Router";
 import { queryClient } from "@/frontend/plugins/QueryClient";
-import { FeatureFlagName, getFeaturesQueryKey } from "@/services/fyApi";
+import {
+  FeatureFlagName,
+  getFeaturesQueryKey,
+  getFleetQueryKey,
+} from "@/services/fyApi";
 
-const route = (meta: RouteLocation["meta"]) =>
+const route = (
+  meta: RouteLocation["meta"],
+  params: RouteLocation["params"] = {},
+) =>
   ({
     meta,
     name: "hangar-vehicle-cargo",
-    params: {},
+    params,
     query: {},
   }) as RouteLocation;
+
+const fleetRoute = (feature: FeatureFlagName) =>
+  route({ feature, featureScope: "fleet" }, { slug: "the-fleet" });
 
 describe("frontend router feature guard", () => {
   beforeEach(() => {
@@ -47,6 +57,53 @@ describe("frontend router feature guard", () => {
     const redirect = await beforeResolve(route({}));
 
     expect(redirect).toBeUndefined();
+  });
+
+  it("lets a fleet route through on the fleet's own flag", async () => {
+    queryClient.setQueryData(getFeaturesQueryKey(), []);
+    queryClient.setQueryData(getFleetQueryKey("the-fleet"), {
+      features: [FeatureFlagName.FLEET_STARMAP],
+    });
+
+    const redirect = await beforeResolve(
+      fleetRoute(FeatureFlagName.FLEET_STARMAP),
+    );
+
+    expect(redirect).toBeUndefined();
+  });
+
+  it("sends a fleet route to the 404 when the flag is off for that fleet", async () => {
+    queryClient.setQueryData(getFeaturesQueryKey(), []);
+    queryClient.setQueryData(getFleetQueryKey("the-fleet"), { features: [] });
+
+    const redirect = await beforeResolve(
+      fleetRoute(FeatureFlagName.FLEET_STARMAP),
+    );
+
+    expect(redirect).toEqual({ routeName: "404" });
+  });
+
+  it("lets a fleet route through on the viewer's own flag", async () => {
+    queryClient.setQueryData(getFeaturesQueryKey(), [
+      FeatureFlagName.FLEET_STARMAP,
+    ]);
+    queryClient.setQueryData(getFleetQueryKey("the-fleet"), { features: [] });
+
+    const redirect = await beforeResolve(
+      fleetRoute(FeatureFlagName.FLEET_STARMAP),
+    );
+
+    expect(redirect).toBeUndefined();
+  });
+
+  it("ignores the slug of a route that is not fleet-scoped", async () => {
+    queryClient.setQueryData(getFeaturesQueryKey(), []);
+
+    const redirect = await beforeResolve(
+      route({ feature: FeatureFlagName.SHIP_INVENTORIES }, { slug: "a-model" }),
+    );
+
+    expect(redirect).toEqual({ routeName: "404" });
   });
 
   it("asks an anonymous visitor to sign in before judging the flag", async () => {

--- a/app/frontend/frontend/plugins/Router.ts
+++ b/app/frontend/frontend/plugins/Router.ts
@@ -7,7 +7,7 @@ import { routes } from "@/frontend/pages/routes";
 import { setupRouter, type FyRedirectRoute } from "@/shared/plugins/Router";
 import { queryClient } from "@/frontend/plugins/QueryClient";
 import { featuresQueryOptions } from "@/frontend/composables/useFeatures";
-import type { FeatureFlagName } from "@/services/fyApi";
+import { getFleetQueryOptions, type FeatureFlagName } from "@/services/fyApi";
 
 const beforeEach = (to: RouteLocation) => {
   const fleetStore = useFleetStore();
@@ -32,11 +32,23 @@ const beforeEach = (to: RouteLocation) => {
 // A route behind a flag that is off does not exist for this user: hiding it
 // from the nav is not enough, a typed-in URL has to land on the 404 rather than
 // render a page whose every request comes back 403.
-const featureEnabled = async (feature: FeatureFlagName) => {
+//
+// A fleet route also consults the fleet being navigated to, because a flag can
+// be enabled for a fleet rather than for the viewer. Only that fleet — reading
+// every fleet the viewer belongs to is what used to show one fleet's features on
+// another fleet's page.
+const featureEnabled = async (feature: FeatureFlagName, fleetSlug?: string) => {
   try {
-    const features = await queryClient.ensureQueryData(featuresQueryOptions());
+    const [features, fleet] = await Promise.all([
+      queryClient.ensureQueryData(featuresQueryOptions()),
+      fleetSlug
+        ? queryClient.ensureQueryData(getFleetQueryOptions(fleetSlug))
+        : undefined,
+    ]);
 
-    return !!features?.includes(feature);
+    return (
+      !!features?.includes(feature) || !!fleet?.features?.includes(feature)
+    );
   } catch {
     // The endpoint is also what the nav reads, so a failure here is already
     // visible. Let the navigation through and leave the API as the real gate
@@ -67,7 +79,10 @@ export const beforeResolve = async (
 
   // After the session checks: flags are read per user, so signing in first is
   // what makes the answer meaningful.
-  if (to.meta.feature && !(await featureEnabled(to.meta.feature))) {
+  const fleetSlug =
+    to.meta.featureScope === "fleet" ? String(to.params.slug) : undefined;
+
+  if (to.meta.feature && !(await featureEnabled(to.meta.feature, fleetSlug))) {
     return {
       routeName: "404",
     };

--- a/app/frontend/translations/de/empty.json
+++ b/app/frontend/translations/de/empty.json
@@ -6,7 +6,8 @@
         "forName": "Keine %{name} gefunden",
         "hangar": "Ihr Hangar ist leer",
         "wishlist": "Ihre Wunschliste ist leer",
-        "features": "Keine Funktionen verfügbar"
+        "features": "Keine Funktionen verfügbar",
+        "fleetFeatures": "Keine Flottenfunktionen verfügbar"
       },
       "actions": {
         "reset": "Filter/Seiten zurücksetzen",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "Derzeit sind keine Self-Service-Funktionen verfügbar. Schauen Sie später wieder vorbei, da regelmäßig neue Funktionen hinzugefügt werden."
+        "features": "Derzeit sind keine Self-Service-Funktionen verfügbar. Schauen Sie später wieder vorbei, da regelmäßig neue Funktionen hinzugefügt werden.",
+        "fleetFeatures": "Derzeit gibt es keine Funktionen, die eine Flotte selbst einschalten kann. Schauen Sie später wieder vorbei, da regelmäßig neue Funktionen hinzugefügt werden."
       }
     }
   }

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -209,7 +209,8 @@
         "settings": {
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "Flottenrollen"
+          "roles": "Flottenrollen",
+          "features": "Flottenfunktionen"
         },
         "inviteMember": "Invite new Member"
       },

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -53,7 +53,12 @@
           "fleet_starmap": "Star Citizen Sternenkarte auf Flottenmitgliederseiten anzeigen."
         },
         "registryHint": "Flags werden in config/feature_flags.yml deklariert und beim Deploy erstellt. Hier steuerst du ihre Gates.",
-        "fleetSettingsIntro": "Aktivieren oder deaktivieren Sie Funktionen für die gesamte Flotte. Was Sie hier einschalten, sehen alle Mitglieder."
+        "fleetSettingsIntro": "Aktivieren oder deaktivieren Sie Funktionen für die gesamte Flotte. Was Sie hier einschalten, sehen alle Mitglieder.",
+        "fleetFeature": "Flottenfunktion",
+        "fleetFeatureInfo": "Hier eingeschaltet gilt sie nur für Sie. Die Admins Ihrer Flotte können sie für die gesamte Flotte aktivieren.",
+        "toggleForSelf": "Nur für Sie umschalten",
+        "fleetFeatureGrantedShort": "Von Flotte aktiviert",
+        "fleetFeatureGranted": "Ihre Flotte hat dies für alle Mitglieder aktiviert, daher kann es hier nicht abgeschaltet werden."
       },
       "oauthApplication": {
         "name": "Anwendungsname",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -52,7 +52,8 @@
           "tools_cargo_grids": "Interaktiven Frachtraster-Viewer für Schiffe anzeigen.",
           "fleet_starmap": "Star Citizen Sternenkarte auf Flottenmitgliederseiten anzeigen."
         },
-        "registryHint": "Flags werden in config/feature_flags.yml deklariert und beim Deploy erstellt. Hier steuerst du ihre Gates."
+        "registryHint": "Flags werden in config/feature_flags.yml deklariert und beim Deploy erstellt. Hier steuerst du ihre Gates.",
+        "fleetSettingsIntro": "Aktivieren oder deaktivieren Sie Funktionen für die gesamte Flotte. Was Sie hier einschalten, sehen alle Mitglieder."
       },
       "oauthApplication": {
         "name": "Anwendungsname",

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -51,7 +51,8 @@
           "index": "Einstellungen",
           "fleet": "Flotteneinstellungen",
           "membership": "Mitgliedschaftseinstellungen",
-          "roles": "Rollen"
+          "roles": "Rollen",
+          "features": "Funktionen"
         }
       },
       "rsiProfile": "RSI-Profil",

--- a/app/frontend/translations/en/empty.json
+++ b/app/frontend/translations/en/empty.json
@@ -6,7 +6,8 @@
         "forName": "No %{name} found",
         "hangar": "Your Hangar is empty",
         "wishlist": "Your Wishlist is empty",
-        "features": "No features available"
+        "features": "No features available",
+        "fleetFeatures": "No fleet features available"
       },
       "actions": {
         "reset": "Reset Filters/Pages",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "There are currently no self-service features available. Check back later as new features are added regularly."
+        "features": "There are currently no self-service features available. Check back later as new features are added regularly.",
+        "fleetFeatures": "There are currently no features a fleet can switch on for itself. Check back later as new features are added regularly."
       }
     }
   }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -223,7 +223,8 @@
         "settings": {
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "Fleet Roles"
+          "roles": "Fleet Roles",
+          "features": "Fleet Features"
         },
         "inviteMember": "Invite new Member"
       },

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -57,7 +57,8 @@
           "tools_cargo_grids": "Show interactive cargo grid viewer for ships.",
           "fleet_starmap": "Show Star Citizen starmap on fleet member pages."
         },
-        "registryHint": "Flags are declared in config/feature_flags.yml and created on deploy. Here you control their gates."
+        "registryHint": "Flags are declared in config/feature_flags.yml and created on deploy. Here you control their gates.",
+        "fleetSettingsIntro": "Enable or disable features for the whole fleet. Every member sees what you switch on here."
       },
       "oauthApplication": {
         "name": "Application Name",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -58,7 +58,12 @@
           "fleet_starmap": "Show Star Citizen starmap on fleet member pages."
         },
         "registryHint": "Flags are declared in config/feature_flags.yml and created on deploy. Here you control their gates.",
-        "fleetSettingsIntro": "Enable or disable features for the whole fleet. Every member sees what you switch on here."
+        "fleetSettingsIntro": "Enable or disable features for the whole fleet. Every member sees what you switch on here.",
+        "fleetFeature": "Fleet feature",
+        "fleetFeatureInfo": "Switching this on here enables it for you alone. Your fleet's admins can enable it for the whole fleet.",
+        "toggleForSelf": "Toggle for yourself only",
+        "fleetFeatureGrantedShort": "Enabled by fleet",
+        "fleetFeatureGranted": "Your fleet enabled this for all members, so it cannot be switched off here."
       },
       "oauthApplication": {
         "name": "Application Name",

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -51,7 +51,8 @@
           "index": "Settings",
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "Roles"
+          "roles": "Roles",
+          "features": "Features"
         }
       },
       "rsiProfile": "RSI Profile",

--- a/app/frontend/translations/es/empty.json
+++ b/app/frontend/translations/es/empty.json
@@ -6,7 +6,8 @@
         "forName": "No se encontró %{name}",
         "hangar": "Su hangar está vacío",
         "wishlist": "Su lista de deseos está vacía",
-        "features": "No hay funciones disponibles"
+        "features": "No hay funciones disponibles",
+        "fleetFeatures": "No hay funciones de flota disponibles"
       },
       "actions": {
         "reset": "Reset Filters/Pages",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "Actualmente no hay funciones de autoservicio disponibles. Vuelva más tarde, ya que se agregan nuevas funciones regularmente."
+        "features": "Actualmente no hay funciones de autoservicio disponibles. Vuelva más tarde, ya que se agregan nuevas funciones regularmente.",
+        "fleetFeatures": "Actualmente no hay funciones que una flota pueda activar por sí misma. Vuelva más tarde, ya que se agregan nuevas funciones regularmente."
       }
     }
   },

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -195,7 +195,8 @@
         "settings": {
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "Roles de flota"
+          "roles": "Roles de flota",
+          "features": "Funciones de flota"
         },
         "inviteMember": "Invite new Member"
       },

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -51,7 +51,8 @@
           "tools_travel_times": "Mostrar tiempos de viaje estimados entre ubicaciones.",
           "tools_cargo_grids": "Mostrar visor interactivo de grilla de carga para naves.",
           "fleet_starmap": "Mostrar mapa estelar de Star Citizen en las páginas de miembros de flota."
-        }
+        },
+        "fleetSettingsIntro": "Habilite o deshabilite funciones para toda la flota. Todos los miembros ven lo que active aquí."
       },
       "oauthApplication": {
         "name": "Nombre de la aplicación",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -52,7 +52,12 @@
           "tools_cargo_grids": "Mostrar visor interactivo de grilla de carga para naves.",
           "fleet_starmap": "Mostrar mapa estelar de Star Citizen en las páginas de miembros de flota."
         },
-        "fleetSettingsIntro": "Habilite o deshabilite funciones para toda la flota. Todos los miembros ven lo que active aquí."
+        "fleetSettingsIntro": "Habilite o deshabilite funciones para toda la flota. Todos los miembros ven lo que active aquí.",
+        "fleetFeature": "Función de flota",
+        "fleetFeatureInfo": "Activarla aquí la habilita solo para usted. Los administradores de su flota pueden habilitarla para toda la flota.",
+        "toggleForSelf": "Activar solo para usted",
+        "fleetFeatureGrantedShort": "Activado por la flota",
+        "fleetFeatureGranted": "Su flota lo activó para todos los miembros, por lo que no se puede desactivar aquí."
       },
       "oauthApplication": {
         "name": "Nombre de la aplicación",

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -51,7 +51,8 @@
           "index": "Configuración",
           "fleet": "Configuración de flota",
           "membership": "Configuración de membresía",
-          "roles": "Roles"
+          "roles": "Roles",
+          "features": "Funciones"
         }
       },
       "rsiProfile": "Perfil RSI",

--- a/app/frontend/translations/fr/empty.json
+++ b/app/frontend/translations/fr/empty.json
@@ -6,7 +6,8 @@
         "forName": "Aucun %{name} trouvé",
         "hangar": "Votre hangar est vide",
         "wishlist": "Votre liste de souhaits est vide",
-        "features": "Aucune fonctionnalité disponible"
+        "features": "Aucune fonctionnalité disponible",
+        "fleetFeatures": "Aucune fonctionnalité de flotte disponible"
       },
       "actions": {
         "reset": "Réinitialiser les filtres/pages",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "Il n'y a actuellement aucune fonctionnalité libre-service disponible. Revenez plus tard car de nouvelles fonctionnalités sont ajoutées régulièrement."
+        "features": "Il n'y a actuellement aucune fonctionnalité libre-service disponible. Revenez plus tard car de nouvelles fonctionnalités sont ajoutées régulièrement.",
+        "fleetFeatures": "Il n'y a actuellement aucune fonctionnalité qu'une flotte peut activer elle-même. Revenez plus tard car de nouvelles fonctionnalités sont ajoutées régulièrement."
       }
     }
   }

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -195,7 +195,8 @@
         "settings": {
           "fleet": "Paramètres de la Flotte",
           "membership": "Paramètres des membres",
-          "roles": "Rôles de flotte"
+          "roles": "Rôles de flotte",
+          "features": "Fonctionnalités de la flotte"
         },
         "inviteMember": "Inviter un nouveau membre"
       },

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -51,7 +51,8 @@
           "tools_travel_times": "Afficher les temps de trajet estimés entre les emplacements.",
           "tools_cargo_grids": "Afficher la visionneuse interactive de grille de cargaison pour les vaisseaux.",
           "fleet_starmap": "Afficher la carte stellaire Star Citizen sur les pages des membres de flotte."
-        }
+        },
+        "fleetSettingsIntro": "Activez ou désactivez des fonctionnalités pour toute la flotte. Tous les membres voient ce que vous activez ici."
       },
       "oauthApplication": {
         "name": "Nom de l'application",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -52,7 +52,12 @@
           "tools_cargo_grids": "Afficher la visionneuse interactive de grille de cargaison pour les vaisseaux.",
           "fleet_starmap": "Afficher la carte stellaire Star Citizen sur les pages des membres de flotte."
         },
-        "fleetSettingsIntro": "Activez ou désactivez des fonctionnalités pour toute la flotte. Tous les membres voient ce que vous activez ici."
+        "fleetSettingsIntro": "Activez ou désactivez des fonctionnalités pour toute la flotte. Tous les membres voient ce que vous activez ici.",
+        "fleetFeature": "Fonctionnalité de flotte",
+        "fleetFeatureInfo": "L'activer ici ne l'active que pour vous. Les administrateurs de votre flotte peuvent l'activer pour toute la flotte.",
+        "toggleForSelf": "Activer pour vous uniquement",
+        "fleetFeatureGrantedShort": "Activé par la flotte",
+        "fleetFeatureGranted": "Votre flotte l'a activé pour tous les membres, il ne peut donc pas être désactivé ici."
       },
       "oauthApplication": {
         "name": "Nom de l'application",

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -51,7 +51,8 @@
           "index": "Paramètres",
           "fleet": "Paramètres de Flotte",
           "membership": "Paramètres d'Adhésion",
-          "roles": "Rôles"
+          "roles": "Rôles",
+          "features": "Fonctionnalités"
         }
       },
       "rsiProfile": "Profil RSI",

--- a/app/frontend/translations/it/empty.json
+++ b/app/frontend/translations/it/empty.json
@@ -6,7 +6,8 @@
         "forName": "Nessun %{name} trovato",
         "hangar": "Il tuo hangar è vuoto",
         "wishlist": "La tua lista dei desideri è vuota",
-        "features": "Nessuna funzione disponibile"
+        "features": "Nessuna funzione disponibile",
+        "fleetFeatures": "Nessuna funzionalità della flotta disponibile"
       },
       "actions": {
         "reset": "Resetta i filtri/pagine",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "Attualmente non sono disponibili funzioni self-service. Torna più tardi poiché vengono aggiunte regolarmente nuove funzioni."
+        "features": "Attualmente non sono disponibili funzioni self-service. Torna più tardi poiché vengono aggiunte regolarmente nuove funzioni.",
+        "fleetFeatures": "Attualmente non ci sono funzionalità che una flotta può attivare da sé. Torna più tardi poiché vengono aggiunte regolarmente nuove funzioni."
       }
     }
   }

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -195,7 +195,8 @@
         "settings": {
           "fleet": "Impostazioni Della Flotta",
           "membership": "Impostazioni dei Membri",
-          "roles": "Ruoli flotta"
+          "roles": "Ruoli flotta",
+          "features": "Funzionalità della flotta"
         },
         "inviteMember": "Invita nuovo membro"
       },

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -51,7 +51,8 @@
           "tools_travel_times": "Mostra i tempi di viaggio stimati tra le posizioni.",
           "tools_cargo_grids": "Mostra il visualizzatore interattivo della griglia di carico per le navi.",
           "fleet_starmap": "Mostra la mappa stellare di Star Citizen nelle pagine dei membri della flotta."
-        }
+        },
+        "fleetSettingsIntro": "Attiva o disattiva le funzionalità per tutta la flotta. Ogni membro vede ciò che attivi qui."
       },
       "oauthApplication": {
         "name": "Nome applicazione",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -52,7 +52,12 @@
           "tools_cargo_grids": "Mostra il visualizzatore interattivo della griglia di carico per le navi.",
           "fleet_starmap": "Mostra la mappa stellare di Star Citizen nelle pagine dei membri della flotta."
         },
-        "fleetSettingsIntro": "Attiva o disattiva le funzionalità per tutta la flotta. Ogni membro vede ciò che attivi qui."
+        "fleetSettingsIntro": "Attiva o disattiva le funzionalità per tutta la flotta. Ogni membro vede ciò che attivi qui.",
+        "fleetFeature": "Funzionalità della flotta",
+        "fleetFeatureInfo": "Attivandola qui vale solo per te. Gli amministratori della tua flotta possono attivarla per tutta la flotta.",
+        "toggleForSelf": "Attiva solo per te",
+        "fleetFeatureGrantedShort": "Attivato dalla flotta",
+        "fleetFeatureGranted": "La tua flotta l'ha attivata per tutti i membri, quindi non può essere disattivata qui."
       },
       "oauthApplication": {
         "name": "Nome applicazione",

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -51,7 +51,8 @@
           "index": "Impostazioni",
           "fleet": "Impostazioni Della Flotta",
           "membership": "Impostazioni dei Membri",
-          "roles": "Ruoli"
+          "roles": "Ruoli",
+          "features": "Funzionalità"
         }
       },
       "rsiProfile": "Profilo RSI",

--- a/app/frontend/translations/zh-CN/empty.json
+++ b/app/frontend/translations/zh-CN/empty.json
@@ -6,7 +6,8 @@
         "forName": "未找到 %{name}",
         "hangar": "您的机库是空的",
         "wishlist": "您的愿望清单是空的",
-        "features": "没有可用功能"
+        "features": "没有可用功能",
+        "fleetFeatures": "没有可用的舰队功能"
       },
       "actions": {
         "reset": "Reset Filters/Pages",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "目前没有可用的自助服务功能。请稍后再查看，我们会定期添加新功能。"
+        "features": "目前没有可用的自助服务功能。请稍后再查看，我们会定期添加新功能。",
+        "fleetFeatures": "目前没有舰队可以自行启用的功能。请稍后再查看，我们会定期添加新功能。"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -195,7 +195,8 @@
         "settings": {
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "舰队角色"
+          "roles": "舰队角色",
+          "features": "舰队功能"
         },
         "inviteMember": "Invite new Member"
       },

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -52,7 +52,12 @@
           "tools_cargo_grids": "显示飞船的交互式货物网格查看器。",
           "fleet_starmap": "在舰队成员页面显示 Star Citizen 星图。"
         },
-        "fleetSettingsIntro": "为整个舰队启用或禁用功能。您在此启用的内容对所有成员可见。"
+        "fleetSettingsIntro": "为整个舰队启用或禁用功能。您在此启用的内容对所有成员可见。",
+        "fleetFeature": "舰队功能",
+        "fleetFeatureInfo": "在此启用仅对您生效。您舰队的管理员可为整个舰队启用。",
+        "toggleForSelf": "仅为自己切换",
+        "fleetFeatureGrantedShort": "舰队已启用",
+        "fleetFeatureGranted": "您的舰队已为所有成员启用此功能，因此无法在此处关闭。"
       },
       "oauthApplication": {
         "name": "应用名称",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -51,7 +51,8 @@
           "tools_travel_times": "显示地点之间的预计旅行时间。",
           "tools_cargo_grids": "显示飞船的交互式货物网格查看器。",
           "fleet_starmap": "在舰队成员页面显示 Star Citizen 星图。"
-        }
+        },
+        "fleetSettingsIntro": "为整个舰队启用或禁用功能。您在此启用的内容对所有成员可见。"
       },
       "oauthApplication": {
         "name": "应用名称",

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -51,7 +51,8 @@
           "index": "设置",
           "fleet": "舰队设置",
           "membership": "成员设置",
-          "roles": "角色"
+          "roles": "角色",
+          "features": "功能"
         }
       },
       "rsiProfile": "RSI 档案",

--- a/app/frontend/translations/zh-TW/empty.json
+++ b/app/frontend/translations/zh-TW/empty.json
@@ -6,7 +6,8 @@
         "forName": "未找到 %{name}",
         "hangar": "您的機庫是空的",
         "wishlist": "您的願望清單是空的",
-        "features": "沒有可用功能"
+        "features": "沒有可用功能",
+        "fleetFeatures": "沒有可用的艦隊功能"
       },
       "actions": {
         "reset": "Reset Filters/Pages",
@@ -20,7 +21,8 @@
         "hangar": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
         "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension.",
         "wishlist": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship.",
-        "features": "目前沒有可用的自助服務功能。請稍後再查看，我們會定期新增新功能。"
+        "features": "目前沒有可用的自助服務功能。請稍後再查看，我們會定期新增新功能。",
+        "fleetFeatures": "目前沒有艦隊可以自行啟用的功能。請稍後再查看，我們會定期新增新功能。"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -195,7 +195,8 @@
         "settings": {
           "fleet": "Fleet Settings",
           "membership": "Membership Settings",
-          "roles": "艦隊角色"
+          "roles": "艦隊角色",
+          "features": "艦隊功能"
         },
         "inviteMember": "Invite new Member"
       },

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -52,7 +52,12 @@
           "tools_cargo_grids": "顯示飛船的互動式貨物網格檢視器。",
           "fleet_starmap": "在艦隊成員頁面顯示 Star Citizen 星圖。"
         },
-        "fleetSettingsIntro": "為整個艦隊啟用或停用功能。您在此啟用的內容對所有成員可見。"
+        "fleetSettingsIntro": "為整個艦隊啟用或停用功能。您在此啟用的內容對所有成員可見。",
+        "fleetFeature": "艦隊功能",
+        "fleetFeatureInfo": "在此啟用僅對您生效。您艦隊的管理員可為整個艦隊啟用。",
+        "toggleForSelf": "僅為自己切換",
+        "fleetFeatureGrantedShort": "艦隊已啟用",
+        "fleetFeatureGranted": "您的艦隊已為所有成員啟用此功能，因此無法在此處關閉。"
       },
       "oauthApplication": {
         "name": "應用程式名稱",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -51,7 +51,8 @@
           "tools_travel_times": "顯示地點之間的預計旅行時間。",
           "tools_cargo_grids": "顯示飛船的互動式貨物網格檢視器。",
           "fleet_starmap": "在艦隊成員頁面顯示 Star Citizen 星圖。"
-        }
+        },
+        "fleetSettingsIntro": "為整個艦隊啟用或停用功能。您在此啟用的內容對所有成員可見。"
       },
       "oauthApplication": {
         "name": "應用程式名稱",

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -51,7 +51,8 @@
           "index": "設定",
           "fleet": "艦隊設定",
           "membership": "成員設定",
-          "roles": "角色"
+          "roles": "角色",
+          "features": "功能"
         }
       },
       "rsiProfile": "RSI 檔案",

--- a/app/frontend/typings.d.ts
+++ b/app/frontend/typings.d.ts
@@ -16,6 +16,8 @@ declare module "vue-router" {
     mobileNav?: number;
     href?: string;
     feature?: FeatureFlagName;
+    // Read `feature` against the fleet in the route rather than the viewer.
+    featureScope?: "fleet";
     hideWhenAuthenticated?: boolean;
     needsNoAuthentication?: boolean;
   }

--- a/app/models/feature_setting.rb
+++ b/app/models/feature_setting.rb
@@ -4,11 +4,12 @@
 #
 # Table name: feature_settings
 #
-#  id           :uuid             not null, primary key
-#  feature_name :string           not null
-#  self_service :boolean          default(FALSE), not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                 :uuid             not null, primary key
+#  feature_name       :string           not null
+#  self_service       :boolean          default(FALSE), not null
+#  self_service_scope :string           default("user"), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 # Indexes
 #
@@ -16,12 +17,30 @@
 #
 class FeatureSetting < ApplicationRecord
   validates :feature_name, presence: true, uniqueness: true
+  validates :self_service_scope, inclusion: {in: FeatureFlags::Definition::SELF_SERVICE_SCOPES}
 
-  def self.self_service?(feature_name)
+  scope :self_service, -> { where(self_service: true) }
+
+  # Scope is a required argument rather than an optional filter: a caller that
+  # serves one surface has to say which, or a fleet's tab would offer flags that
+  # belong in personal settings.
+  def self.self_service?(feature_name, scope:)
+    exists?(feature_name: feature_name.to_s, self_service: true, self_service_scope: scope.to_s)
+  end
+
+  def self.self_service_feature_names(scope:)
+    where(self_service: true, self_service_scope: scope.to_s).pluck(:feature_name)
+  end
+
+  # Scope-agnostic, for the two callers that genuinely have no surface in mind:
+  # /admin/features showing whether a toggle exists at all, and the personal
+  # toggle, which may switch any self-service flag on for its own user.
+  def self.self_service_anywhere?(feature_name)
     exists?(feature_name: feature_name.to_s, self_service: true)
   end
 
-  def self.self_service_feature_names
-    where(self_service: true).pluck(:feature_name)
+  # Every self-service flag with the surface that owns its fleet-wide switch.
+  def self.self_service_scopes
+    self_service.pluck(:feature_name, :self_service_scope)
   end
 end

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -183,6 +183,15 @@ class Fleet < ApplicationRecord
     vehicles.where(model_id:, loaner: false).size
   end
 
+  # Every flag enabled for this fleet as a Flipper actor — deliberately not the
+  # ones a member enabled for themselves, so a fleet page can tell whether a
+  # feature is on for *this* fleet rather than for any fleet the viewer is in.
+  def features
+    Flipper.features.filter_map do |feature|
+      Flipper.enabled?(feature.name, self) ? feature.name.to_s : nil
+    end
+  end
+
   private def update_slugs
     self.slug = generate_slug(fid)
   end

--- a/app/policies/fleet_policy.rb
+++ b/app/policies/fleet_policy.rb
@@ -25,6 +25,10 @@ class FleetPolicy < FleetBasePolicy
     accepted_fleet_membership&.has_access?(["fleet:manage"])
   end
 
+  def manage_features?
+    manage?
+  end
+
   def update?
     accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:update", "fleet:update:description", "fleet:update:images"])
   end

--- a/app/views/admin/api/v1/features/_feature.jbuilder
+++ b/app/views/admin/api/v1/features/_feature.jbuilder
@@ -3,7 +3,7 @@
 json.name feature.name
 json.state feature.state.to_s
 
-json.selfService FeatureSetting.self_service?(feature.name)
+json.selfService FeatureSetting.self_service_anywhere?(feature.name)
 
 json.percentageOfActors feature.percentage_of_actors_value
 json.percentageOfTime feature.percentage_of_time_value

--- a/app/views/api/v1/fleet_features/index.jbuilder
+++ b/app/views/api/v1/fleet_features/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.array! @features do |feature|
+  json.name feature[:name]
+  json.enabled feature[:enabled]
+end

--- a/app/views/api/v1/fleets/_fleet.jbuilder
+++ b/app/views/api/v1/fleets/_fleet.jbuilder
@@ -5,3 +5,8 @@ json.cache! ["v1", fleet] do
 end
 
 json.my_fleet(local_assigns.fetch(:my_fleet, false))
+
+# Outside the cache block above on purpose: flag state is not part of the fleet
+# record, so a cached copy would keep serving the old answer until the fleet
+# itself changed.
+json.features fleet.features

--- a/app/views/api/v1/user_features/index.jbuilder
+++ b/app/views/api/v1/user_features/index.jbuilder
@@ -3,4 +3,10 @@
 json.array! @features do |feature|
   json.name feature[:name]
   json.enabled feature[:enabled]
+  json.enabled_for_self feature[:enabled_for_self]
+  json.scope feature[:scope]
+  json.fleets feature[:fleets] do |fleet|
+    json.name fleet[:name]
+    json.slug fleet[:slug]
+  end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -11,11 +11,17 @@
 #     description: "…"           # REQUIRED — what does the flag toggle?
 #     permanent: true            # optional — long-lived infrastructure gate
 #                                #   rather than a temporary rollout
-#     self_service: true         # optional — ships user-toggleable from
-#                                #   Settings > Features. Sync seeds the setting
-#                                #   once and never overwrites it, so admins keep
-#                                #   ownership and dropping the key retracts
-#                                #   nothing.
+#     self_service: user         # optional — ships with a self-service toggle.
+#                                #   `user` puts it in Settings > Features;
+#                                #   `fleet` puts it in a fleet's settings, for
+#                                #   holders of fleet:manage, so one member
+#                                #   cannot switch a feature on for everyone.
+#                                #   `true` is an alias for `user`. Sync seeds
+#                                #   the setting once and never overwrites it, so
+#                                #   admins keep ownership and dropping the key
+#                                #   retracts nothing — but the scope is
+#                                #   reconciled every sync, because it belongs to
+#                                #   the code reading the flag, not to a rollout.
 #
 # Rules are enforced by `bin/feature-flags validate`, which CI runs on every
 # push. Seeded from the flags live in Flipper at the time the registry was
@@ -23,7 +29,7 @@
 
 fleet_logistics:
   description: "Fleet logistics — fleet inventories with a deposit/withdrawal ledger"
-  self_service: true
+  self_service: fleet
 
 fleet_starmap:
   description: "Starmap on the fleet page"
@@ -33,13 +39,13 @@ fleet_worldmap:
 
 hangar_inventories:
   description: "Personal hangar inventories with a deposit/withdrawal ledger"
-  self_service: true
+  self_service: user
 
 # Rides its own gate rather than hangar_inventories: a ship's cargo is a
 # separate surface and rolls out on its own schedule.
 ship_inventories:
   description: "Ship inventories — the cargo aboard a vehicle"
-  self_service: true
+  self_service: user
 
 oauth-applications:
   description: "User-owned OAuth applications in settings"

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -32,6 +32,13 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
 
   resources :fleet_roles, path: "roles", only: %i[index]
 
+  resources :fleet_features, path: "features", only: %i[index] do
+    member do
+      put :enable
+      put :disable
+    end
+  end
+
   get "inventory-items", to: "fleet_all_inventory_items#index"
   get "inventory-stock", to: "fleet_all_inventory_stock#index"
 

--- a/db/migrate/20260818120000_add_self_service_scope_to_feature_settings.rb
+++ b/db/migrate/20260818120000_add_self_service_scope_to_feature_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSelfServiceScopeToFeatureSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :feature_settings, :self_service_scope, :string, null: false, default: "user"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -318,6 +318,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_130000) do
     t.datetime "created_at", null: false
     t.string "feature_name", null: false
     t.boolean "self_service", default: false, null: false
+    t.string "self_service_scope", default: "user", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_name"], name: "index_feature_settings_on_feature_name", unique: true
   end

--- a/docs/exec-plans/4440-fleet-scoped-feature-flags.md
+++ b/docs/exec-plans/4440-fleet-scoped-feature-flags.md
@@ -1,0 +1,183 @@
+# Make fleet_logistics a fleet-scoped feature flag with a fleet settings Features tab
+
+## Goal
+
+A fleet admin can switch fleet-wide features on for their own fleet from a Features tab in the fleet settings, each flag resolves per fleet rather than across every fleet the user belongs to, and individual members can no longer self-activate a fleet-wide feature from their personal settings.
+
+## Context
+
+`fleet_logistics` is already evaluated against the fleet as a Flipper actor: every logistics controller calls `feature_enabled?("fleet_logistics", @fleet)`, and `Api::BaseController#feature_enabled?` expands that to `Flipper.enabled?(flag, current_resource_owner, @fleet)` — user OR fleet. What is missing is the ownership model around that gate.
+
+Three problems follow from it:
+
+1. **`GET /features` leaks flags across fleets.** `Api::V1::FeaturesController#show` unions the user's flags with flags enabled for *any* fleet they belong to. One fleet with `fleet_logistics` on makes `isFeatureEnabled(FLEET_LOGISTICS)` true on every fleet page, so `logistics.vue` renders the tab for fleets that do not have it and the API then 403s. It also loops `Flipper.features × fleets` per request.
+2. **A plain member can switch on a fleet-wide feature.** `fleet_logistics` is `self_service: true`, so it appears in every user's Settings → Features and `UserFeaturesController#enable` calls `enable_actor(current_resource_owner)`. Because the backend ORs the user actor in, any member unlocks fleet logistics across all their fleets without holding `fleet:manage`.
+3. **There is no fleet-scoped self-service surface.** Only `/admin/features` can `enable_actor(flag, fleet)`.
+
+Resolves #4440
+
+## Decisions
+
+### D1 — The registry declares *who owns* the toggle, not just that one exists
+
+`self_service: true` conflates "a toggle exists" with "the user owns it". Replace the boolean with a scope so the registry answers both questions:
+
+```yaml
+fleet_logistics:
+  description: "Fleet logistics — fleet inventories with a deposit/withdrawal ledger"
+  self_service: fleet
+```
+
+`self_service` accepts `user` or `fleet`; `true` stays accepted as an alias for `user` so the other entries need no churn and old registries keep validating. `Definition` exposes `self_service?` (unchanged meaning: a toggle exists) plus `self_service_scope`, and `Registry::KNOWN_KEYS` gains no new key.
+
+Rejected: a separate `scope:` key. It would be legal to write `scope: fleet` without `self_service`, which means nothing, and the validator would have to reject that combination — a constraint the single key makes unrepresentable.
+
+### D2 — `FeatureSetting` carries the scope, so the admin UI keeps ownership
+
+`FeatureSetting.self_service` is what the admin toggles at `/admin/features`, and the synchronizer deliberately seeds it once and never overwrites it. Scope has to live next to it or the two disagree after an admin toggle. Add a `self_service_scope` string column (default `"user"`, not null) and seed it alongside `self_service`.
+
+The synchronizer keeps its never-overwrite rule for `self_service`, but **does** reconcile `self_service_scope` on every sync: scope is a property of the code that reads the flag, not a rollout decision an admin makes, so a flag that becomes fleet-scoped in a release must not stay user-toggleable because a row already existed.
+
+### D3 — Fleet flags come from the fleet payload, not from `GET /features`
+
+`GET /features` cannot answer "is this flag on for *this* fleet" without a fleet parameter, and adding one makes a per-page request out of something already fetched. Instead `_fleet.jbuilder` exposes `features` — the fleet-scoped flags enabled for that fleet — and `useFeatures` gains a fleet-aware companion.
+
+`json.features` must sit **outside** the `json.cache!` block, next to `my_fleet`. Inside it the flag state would be cached under `["v1", fleet]` and an admin toggle would not show up until the fleet record itself changed.
+
+`GET /features` then drops its fleet union entirely and returns only what is enabled for the user actor.
+
+Rejected: `GET /fleets/:slug/features` as the read path for rendering. It is the write path's natural sibling and will exist for the settings tab, but making every fleet page wait on a second request to decide whether to render a tab is worse than a field on a payload that is already loaded.
+
+### D4 — The backend keeps the user actor in the OR
+
+`Flipper.enabled?(flag, current_resource_owner, @fleet)` stays as it is. It is how a single person is trialled onto a feature from `/admin/features`, and removing it would break that. What changes is that the user actor is no longer reachable through self-service for a fleet-scoped flag, so a member cannot put themselves in that gate.
+
+### D5 — Removing the union forced every fleet-page flag read to become fleet-aware
+
+`fleet_starmap` and `fleet_worldmap` are not self-service, but they *can* be enabled for a fleet actor from `/admin/features` — and the union was the only thing carrying that to the frontend. Deleting it would have silently switched those features off for any fleet gated that way.
+
+So the fleet-aware read is not limited to `fleet_logistics`: `isFleetFeatureEnabled(fleet, flag)` mirrors the backend gate exactly (`Flipper.enabled?(flag, user, fleet)` — on for the viewer *or* for this fleet), and every fleet-page read goes through it. `FeatureGuard` takes an optional `fleet`, and the router guard consults the fleet named in the route.
+
+The guard needs to know *when* a route's flag is fleet-scoped, because `:slug` also names models and ships — fetching the fleet endpoint with a model slug would throw, and the guard's fail-open `catch` would then wave every flagged model route through. A `featureScope: "fleet"` route meta makes that explicit at the route definition rather than inferring it from the path.
+
+### D6 — A fleet flag has two switches, and personal settings keeps its own
+
+The original framing of problem 2 above was wrong, and worth recording. Enabling a fleet flag on the **user** actor does not switch the feature on for the fleet: for another member B, `Flipper.enabled?(flag, B, fleet)` is still false. It is a preview for one person, not a fleet-wide change. So the personal toggle stays — it is how someone tries a beta before their fleet commits to it — and the fleet tab is the separate switch that turns it on for every member.
+
+`enable`/`disable` therefore accept **any** self-service flag (`FeatureSetting.self_service_anywhere?`), always toggling the user's own actor. The scope decides where the *fleet-wide* switch lives, not whether a personal one exists.
+
+That gives one flag two states, so `GET /user-features` reports both:
+
+| field | meaning | drives |
+| --- | --- | --- |
+| `enabledForSelf` | the user's own gate | which way the switch flips |
+| `enabled` | what the user actually has, own gate **or** a fleet's | the state pill |
+| `fleets` | the user's fleets that switched it on | the "Enabled by fleet" marker and its links |
+| `scope` | which surface owns the fleet-wide switch | whether to mark the row at all |
+
+A fleet's grant cannot be overridden per user — the backend ORs both actors, so a personal `disable` could not take it away. Rather than return 200 for a change the user will not see, `enable`/`disable` **403** while any of their fleets has the flag on, and the page disables the switch for those rows. `fleets` names them, linked to the fleet page, so a member can see where the feature came from instead of only that they cannot turn it off.
+
+Only fleet-scoped flags consult the fleets: nothing reads a user-scoped flag against a fleet actor, so a gate there would grant nothing and must not read as enabled. Accepted memberships only — a pending invitation is not membership.
+
+The `scope` enum is safe to declare on the response where `FeatureFlagName` is not: the scopes are a closed set, so they will not grow a value on every new flag and trip `response-property-enum-value-added`.
+
+### D7 — `fleet:manage` gates the tab, no new privilege
+
+`app/models/fleet.rb:45` already treats `fleet:manage` as the admin privilege and the settings routes already use it (`fleet-settings-fleet`). A dedicated `fleet:features:manage` privilege would need a `FleetRole` migration and a permanent-role edit path for no gain — turning features on and off for the whole fleet is squarely an admin act.
+
+## What changed
+
+### Phase 1 — Registry scope
+
+1. `lib/feature_flags/definition.rb` — `self_service` accepts `user`, `fleet`, `true` (alias for `user`) or `false`; exposes `self_service?`, `self_service_scope`, `self_service_user?`, `self_service_fleet?`.
+2. `lib/feature_flags/registry.rb` — `self_service` left `BOOLEAN_KEYS` for a dedicated value check, `Registry#self_service(scope)` selects the definitions for one surface.
+3. `config/feature_flags.yml` — `fleet_logistics` is `self_service: fleet`; `hangar_inventories` and `ship_inventories` spell out `user`; the header documents the scopes.
+4. `test/lib/feature_flags/registry_test.rb` — every form plus an unknown scope.
+
+### Phase 2 — Persist the scope
+
+1. `db/migrate/20260818120000_add_self_service_scope_to_feature_settings.rb` — string, not null, default `"user"`.
+2. `app/models/feature_setting.rb` — `self_service?(name, scope:)` and `self_service_feature_names(scope:)` take the scope as a **required** keyword so no caller can cross surfaces by omission; `self_service_anywhere?` serves the one genuinely scope-agnostic caller, the admin view.
+3. `lib/feature_flags/synchronizer.rb` — seeds `self_service` once as before, reconciles `self_service_scope` on every run.
+4. `app/controllers/admin/api/v1/features_controller.rb` — the admin toggle takes the scope from the registry, so a row it creates for a fleet-scoped flag does not default to personal settings.
+5. `test/lib/feature_flags/synchronizer_test.rb` — seeding, re-scoping, and an admin's `self_service: false` surviving a re-scope.
+
+### Phase 3 — Fleet-scoped self-service API
+
+1. `app/controllers/api/v1/user_features_controller.rb` — `index` lists every self-service flag with `enabled`, `enabledForSelf`, `scope` and the granting `fleets`; `enable`/`disable` toggle the user's own actor for any self-service flag but 403 once one of their fleets grants it (D6).
+2. `app/policies/fleet_policy.rb` — `manage_features?`.
+3. `app/controllers/api/v1/fleet_features_controller.rb` + `app/views/api/v1/fleet_features/index.jbuilder` — index/enable/disable on the fleet actor.
+4. `config/routes/api/fleets_routes.rb` — `/fleets/:slug/features` with the two member `put`s.
+5. `app/api_components/v1/schemas/fleet_feature.rb`, `scope` added to `user_feature.rb`, `features` added to `app/api_components/v1/schemas/fleets/fleet.rb`.
+6. `app/controllers/api/v1/features_controller.rb` — union deleted.
+7. `app/models/fleet.rb` — `Fleet#features`.
+8. `app/views/api/v1/fleets/_fleet.jbuilder` — `json.features`, outside `json.cache!`.
+9. Integration tests: `fleets_features_{index,enable,disable}_test.rb` (24 cases), plus new cases in `features_test.rb`, `fleets_show_test.rb`, and all three `user_features_*` tests.
+10. `./bin/generate-schema` + Orval.
+
+### Phase 4 — Frontend
+
+1. `app/frontend/frontend/composables/useFeatures.ts` — `isFleetFeatureEnabled(fleet, flag)`.
+2. `app/frontend/frontend/components/FeatureGuard.vue` — optional `fleet` prop.
+3. `app/frontend/typings.d.ts` — `featureScope?: "fleet"` route meta.
+4. `app/frontend/frontend/plugins/Router.ts` — the guard consults the route's fleet when the route declares the fleet scope.
+5. `app/frontend/frontend/pages/fleets/[slug]/logistics.vue`, `members/index.vue`, `members/starmap.vue`, `members/routes.ts` — fleet-aware reads.
+6. `app/frontend/frontend/pages/fleets/[slug]/settings/features.vue` + `settings/routes.ts` — the tab, `access: ["fleet:manage"]`.
+7. `app/frontend/frontend/pages/settings/features.vue` — a fleet-scoped row is still toggleable for the viewer alone, marked "Fleet feature"; once a fleet grants it the row reads "Enabled by fleet", names the fleets as links, and the switch is disabled.
+8. Translations for `nav`, `headlines`, `labels.features.{fleetSettingsIntro,fleetManaged,fleetManagedInfo}` and the empty state across all seven locales.
+9. `app/frontend/frontend/plugins/Router.spec.ts` — four cases for the fleet-scoped guard.
+
+## Intent Verification
+
+- [ ] **Registry expresses toggle ownership** — `bin/feature-flags validate` accepts `self_service: fleet`, rejects `self_service: squadron`
+- [ ] **`fleet_logistics` is fleet-scoped** — absent from `GET /user-features`; `hangar_inventories` and `ship_inventories` still present
+- [ ] **Personal settings cannot toggle it** — `PUT /user-features/fleet_logistics/enable` returns 403
+- [ ] **Personal preview survives** — a member may enable a fleet flag for themselves; the fleet actor and other members are untouched
+- [ ] **A fleet grant reads as enabled and cannot be overridden** — the row shows enabled, names the granting fleets, and `enable`/`disable` return 403
+- [ ] **A fleet admin can toggle it** — `PUT /fleets/:slug/features/fleet_logistics/enable` succeeds for `fleet:manage`, 403 for a plain member
+- [ ] **No cross-fleet leak** — with the flag on for fleet A only, `GET /features` omits it and fleet B's payload reports `features: []`
+- [ ] **Flag state is not cached** — toggling for a fleet changes the next `GET /fleets/:slug` without touching the fleet record
+- [ ] **The tab appears per fleet** — logistics renders on fleet A, not on fleet B
+- [ ] **Features tab is admin-only** — present in fleet settings for `fleet:manage`, absent otherwise
+
+## Key files
+
+| File | Role |
+|------|------|
+| `config/feature_flags.yml` | Registry — gains the `self_service` scope value |
+| `lib/feature_flags/{definition,registry,synchronizer}.rb` | Parse, validate and reconcile the scope |
+| `app/models/feature_setting.rb` | Persisted self-service state, now scoped |
+| `app/controllers/api/v1/features_controller.rb` | Drops the cross-fleet union |
+| `app/controllers/api/v1/user_features_controller.rb` | User-scoped flags only |
+| `app/controllers/api/v1/fleet_features_controller.rb` | New — fleet-scoped self-service |
+| `app/models/fleet.rb` | `features` + the `fleet:manage` privilege |
+| `app/views/api/v1/fleets/_fleet.jbuilder` | Exposes `features` outside the cache block |
+| `app/frontend/frontend/composables/useFeatures.ts` | Fleet-aware flag resolution |
+| `app/frontend/frontend/pages/fleets/[slug]/logistics.vue` | Gates on the fleet's flags |
+| `app/frontend/frontend/pages/fleets/[slug]/settings/features.vue` | New — the tab |
+| `app/frontend/frontend/pages/settings/features.vue` | Template for the tab |
+
+## Not in scope (deferred)
+
+- **Migrating existing user-actor gates on `fleet_logistics`** — anyone who already self-enabled it keeps the gate until an admin clears it at `/admin/features`. Worth a follow-up cleanup once the fleet toggle is live, but silently revoking access on deploy is worse than a stale gate.
+- **Making the other fleet flags fleet-scoped** — `fleet_starmap` and `fleet_worldmap` are not self-service at all today. Once the mechanism exists, declaring them is a one-line change and a separate decision.
+- **A `fleet:features:manage` privilege** — see D7.
+- **Admin UI scope display** — `/admin/features` will keep showing a single self-service toggle; surfacing the scope there is cosmetic.
+
+## Discovery Log
+
+- **2026-08-18** Initial research and plan creation. Established that the fleet-actor half of the gate already exists (`Api::BaseController#feature_enabled?`, tested in `test/integration/api/v1/fleets_inventories_index_test.rb:66-91`), so this issue is about ownership and resolution, not about teaching the backend to read a fleet flag. Found the cross-fleet union in `FeaturesController#show` and the `json.cache!` hazard in `_fleet.jbuilder`.
+- **2026-08-18** Two things the plan had not accounted for surfaced during implementation, both recorded above as D5 and in Phase 2:
+  - The admin view asks "is this flag self-service?" with no surface in mind, which a required `scope:` keyword cannot answer — hence `self_service_anywhere?` rather than making the scope optional everywhere.
+  - Deleting the union would have switched `fleet_starmap`/`fleet_worldmap` off for any fleet gated on the fleet actor, because the union was the only path carrying those to the frontend. Fixed by making every fleet-page read fleet-aware, not just `fleet_logistics`.
+- **2026-08-18** The personal-settings side went through three revisions before landing, all recorded in D6:
+  1. Fleet-scoped flags were dropped from Settings → Features entirely. Too blunt — it hid the feature's existence from the very members who would ask about it.
+  2. Listed read-only. Also wrong: it removed a legitimate path, since a user-actor gate is a preview for one person and never switches the feature on for the fleet. The framing in problem 2 above overstated the defect.
+  3. Landed: the personal toggle stays for previewing, the fleet tab is the fleet-wide switch, and a fleet's grant wins — reported as enabled, attributed to the fleets responsible, and not overridable per user.
+
+## Progress
+
+- [x] Phase 1 — Registry scope
+- [x] Phase 2 — Persist the scope
+- [x] Phase 3 — Fleet-scoped self-service API
+- [x] Phase 4 — Frontend

--- a/lib/feature_flags/README.md
+++ b/lib/feature_flags/README.md
@@ -12,11 +12,11 @@ code that read it — `hardpoints-v2` sat in Flipper for months after #4176 dele
 its last reference. A version-controlled registry makes the inventory a PR diff
 and lets a deploy reconcile reality with it.
 
-The registry owns the flag **list** and the self-service each flag **starts**
-with. The admin UI still owns each flag's **gates** (boolean, actors, groups,
-percentages) and its `feature_settings.self_service` from then on, which is what
-decides whether users may toggle the flag for themselves from Settings →
-Features.
+The registry owns the flag **list**, the self-service each flag **starts** with,
+and which surface that self-service lives on. The admin UI still owns each flag's
+**gates** (boolean, actors, groups, percentages) and its
+`feature_settings.self_service` from then on, which is what decides whether the
+flag may be toggled outside `/admin/features` at all.
 
 Creating and deleting flags through the admin UI was removed along with this
 change. It could not coexist with pruning: a flag added there has no registry
@@ -26,9 +26,9 @@ entry, so the next deploy deleted it and every gate configured on it.
 
 | File | Purpose |
 | --- | --- |
-| `config/feature_flags.yml` | Registry — per flag: `description`, optional `permanent`, `self_service` |
+| `config/feature_flags.yml` | Registry — per flag: `description`, optional `permanent`, `self_service` (`user` or `fleet`) |
 | `FeatureFlags::Registry` | Loads and validates the YAML (naming, required/known keys) |
-| `FeatureFlags::Definition` | Value object for one flag (`name`, `description`, `permanent?`, `self_service?`) |
+| `FeatureFlags::Definition` | Value object for one flag (`name`, `description`, `permanent?`, `self_service?`, `self_service_scope`) |
 | `FeatureFlags::Synchronizer` | Reconciles Flipper with the registry: adds missing, seeds self-service, prunes orphaned |
 | `bin/feature-flags` | CLI: `validate`, `plan`, `sync`, `export` |
 
@@ -52,7 +52,7 @@ bin/feature-flags export     # print a YAML skeleton of the live Flipper state
    ```yaml
    my_new_flag:
      description: "What this toggles"
-     self_service: true  # optional — users may switch it on themselves
+     self_service: user  # optional — see Self-service scopes below
    ```
 
 2. Validate: `bin/feature-flags validate`.
@@ -63,6 +63,45 @@ bin/feature-flags export     # print a YAML skeleton of the live Flipper state
 Sync seeds `self_service` once and never overwrites it, so the admin toggle at
 `/admin/features` survives every deploy — and dropping the key from the registry
 retracts nothing. Untoggle it there instead.
+
+## Self-service scopes
+
+`self_service` says *who* owns the toggle, not just that one exists:
+
+| Value | Fleet-wide switch lives at | Who may flip it |
+| --- | --- | --- |
+| `user` | nowhere — the flag is personal | — |
+| `fleet` | a fleet's Settings → Features | members holding `fleet:manage` |
+| `true` | alias for `user` | — |
+| omitted | nowhere | `/admin/features` only |
+
+The scope says where the **fleet-wide** switch lives. Every self-service flag,
+whatever its scope, also keeps a **personal** toggle in Settings → Features:
+enabling a fleet flag there is a preview for that one user and never switches the
+feature on for the rest of the fleet, because Flipper gates each actor
+separately.
+
+The two do not fight. A fleet's grant covers every member and cannot be
+overridden per user — the backend ORs both actors — so once a user's fleet has
+the flag on, `GET /user-features` reports the row as `enabled`, names the fleets
+responsible in `fleets`, and `enable`/`disable` return 403 rather than reporting
+a change the user would not see.
+
+Pick `fleet` when the feature belongs to a whole fleet. A member must not be able
+to switch one on for everyone, and because the backend gate ORs the user actor in
+(`Flipper.enabled?(flag, user, fleet)`), a user-scoped toggle on a fleet feature
+would let them do exactly that in every fleet they belong to.
+
+Unlike `self_service`, the **scope is reconciled on every sync**: it describes
+which surface the code reads the flag from, so a release that moves a flag from
+personal settings to a fleet's has to take effect rather than wait for an admin.
+
+Read a fleet-scoped flag against the fleet — `Flipper.enabled?(:my_flag, fleet)`
+in Ruby (or `feature_enabled?(:my_flag, @fleet)` in a controller, which ORs the
+current user in), and `isFleetFeatureEnabled(fleet, FeatureFlagName.MY_FLAG)` in
+Vue off the fleet payload's `features`. A route behind one needs
+`featureScope: "fleet"` in its meta so the router guard consults the fleet rather
+than the viewer.
 
 Read it in code exactly as before: `Flipper.enabled?(:my_new_flag, actor)` in Ruby,
 `isFeatureEnabled('my_new_flag')` in Vue.

--- a/lib/feature_flags/definition.rb
+++ b/lib/feature_flags/definition.rb
@@ -9,13 +9,17 @@ module FeatureFlags
   # Kept to plain Ruby (no Rails, no ActiveSupport) because
   # `bin/feature-flags validate` loads this file without booting the application.
   class Definition
-    attr_reader :name, :description
+    USER_SCOPE = "user"
+    FLEET_SCOPE = "fleet"
+    SELF_SERVICE_SCOPES = [USER_SCOPE, FLEET_SCOPE].freeze
+
+    attr_reader :name, :description, :self_service_scope
 
     def initialize(name:, description:, permanent: false, self_service: false)
       @name = name.to_s
       @description = description
       @permanent = permanent == true
-      @self_service = self_service == true
+      @self_service_scope = normalize_scope(self_service)
     end
 
     # Long-lived infrastructure gates (OAuth providers, for example) rather than
@@ -24,11 +28,31 @@ module FeatureFlags
       @permanent
     end
 
-    # The flag ships user-toggleable: it arrives with a FeatureSetting so users
-    # can switch it on from Settings > Features. This is the starting point
-    # only — admins own it from there, see Synchronizer.
+    # The flag ships with a self-service toggle: it arrives with a FeatureSetting
+    # so it can be switched on outside /admin/features. This is the starting
+    # point only — admins own it from there, see Synchronizer.
     def self_service?
-      @self_service
+      !@self_service_scope.nil?
+    end
+
+    # Who owns the toggle: the user for a personal surface, the fleet for a
+    # fleet-wide one. A fleet-scoped flag never reaches personal settings, so a
+    # member cannot switch on a feature for a whole fleet.
+    def self_service_user?
+      @self_service_scope == USER_SCOPE
+    end
+
+    def self_service_fleet?
+      @self_service_scope == FLEET_SCOPE
+    end
+
+    # `true` predates the scopes and meant "users toggle this themselves", so it
+    # keeps that meaning rather than forcing every personal flag to be rewritten.
+    private def normalize_scope(self_service)
+      case self_service
+      when true then USER_SCOPE
+      when String then SELF_SERVICE_SCOPES.include?(self_service) ? self_service : nil
+      end
     end
   end
 end

--- a/lib/feature_flags/registry.rb
+++ b/lib/feature_flags/registry.rb
@@ -10,7 +10,11 @@ module FeatureFlags
   #
   #   hangar_inventories:
   #     description: "Personal hangar inventories"
-  #     self_service: true
+  #     self_service: user
+  #
+  #   fleet_logistics:
+  #     description: "Fleet inventories"
+  #     self_service: fleet
   #
   #   oauth-discord:
   #     description: "Discord login"
@@ -25,7 +29,8 @@ module FeatureFlags
     MAX_NAME_LENGTH = 60
     REQUIRED_KEYS = %w[description].freeze
     KNOWN_KEYS = %w[description permanent self_service].freeze
-    BOOLEAN_KEYS = %w[permanent self_service].freeze
+    BOOLEAN_KEYS = %w[permanent].freeze
+    SELF_SERVICE_VALUES = (Definition::SELF_SERVICE_SCOPES + [true, false]).freeze
 
     class InvalidRegistryError < StandardError; end
 
@@ -58,6 +63,10 @@ module FeatureFlags
 
     def fetch(name)
       definitions.find { |definition| definition.name == name.to_s }
+    end
+
+    def self_service(scope)
+      definitions.select { |definition| definition.self_service_scope == scope.to_s }
     end
 
     def validate!
@@ -104,7 +113,17 @@ module FeatureFlags
         errors << "#{name}: #{key} must be a boolean"
       end
 
-      errors
+      errors.concat(self_service_errors(name, attrs))
+    end
+
+    # `true` is still accepted as an alias for the user scope, so a typo like
+    # `self_service: fleets` fails loudly instead of quietly dropping the flag
+    # out of every self-service surface.
+    private def self_service_errors(name, attrs)
+      value = attrs["self_service"]
+      return [] if value.nil? || SELF_SERVICE_VALUES.include?(value)
+
+      ["#{name}: self_service must be one of #{SELF_SERVICE_VALUES.inspect}"]
     end
 
     private def build_definition(name, attrs)
@@ -114,7 +133,7 @@ module FeatureFlags
         name: name,
         description: attrs["description"],
         permanent: attrs["permanent"] == true,
-        self_service: attrs["self_service"] == true
+        self_service: attrs["self_service"]
       )
     end
 

--- a/lib/feature_flags/synchronizer.rb
+++ b/lib/feature_flags/synchronizer.rb
@@ -94,14 +94,23 @@ module FeatureFlags
     end
 
     # The registry seeds self-service, it does not own it: admins flip it at
-    # /admin/features, and a deploy must not undo that. So an existing row is
-    # left exactly as it is, and dropping the key from the registry retracts
-    # nothing — only removing the flag does, through the prune above.
+    # /admin/features, and a deploy must not undo that. So `self_service` on an
+    # existing row is left exactly as it is, and dropping the key from the
+    # registry retracts nothing — only removing the flag does, through the prune
+    # above.
+    #
+    # The scope is different: it says which surface reads the flag, which is a
+    # property of the code, not a rollout decision. A release that moves a flag
+    # from personal settings to a fleet's has to take effect, so it is reconciled
+    # on every run.
     def seed_self_service_settings
       registry.definitions.select(&:self_service?).each do |definition|
-        FeatureSetting.find_or_create_by!(feature_name: definition.name) do |setting|
-          setting.self_service = true
+        setting = FeatureSetting.find_or_initialize_by(feature_name: definition.name) do |new_setting|
+          new_setting.self_service = true
         end
+
+        setting.self_service_scope = definition.self_service_scope
+        setting.save! if setting.changed?
       end
     end
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10350,6 +10350,18 @@ components:
       - fid
       - name
       title: FleetCreateInput
+    FleetFeature:
+      type: object
+      properties:
+        name:
+          type: string
+        enabled:
+          type: boolean
+      additionalProperties: false
+      required:
+      - name
+      - enabled
+      title: FleetFeature
     FleetInventoriesList:
       type: object
       properties:
@@ -15765,10 +15777,33 @@ components:
           type: string
         enabled:
           type: boolean
+        enabledForSelf:
+          type: boolean
+        scope:
+          type: string
+          enum:
+          - user
+          - fleet
+        fleets:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              slug:
+                type: string
+            additionalProperties: false
+            required:
+            - name
+            - slug
       additionalProperties: false
       required:
       - name
       - enabled
+      - enabledForSelf
+      - scope
+      - fleets
       title: UserFeature
     UserPublic:
       type: object

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -672,6 +672,164 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/features":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      description: Fleet slug
+      required: true
+    get:
+      summary: Fleet Features List
+      tags:
+      - FleetFeatures
+      operationId: fleetFeatures
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/FleetFeature"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/features/{id}/disable":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      description: Fleet slug
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      description: Feature name
+      required: true
+    put:
+      summary: Disable Fleet Feature
+      tags:
+      - FleetFeatures
+      operationId: disableFleetFeature
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetFeature"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/features/{id}/enable":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      description: Fleet slug
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      description: Feature name
+      required: true
+    put:
+      summary: Enable Fleet Feature
+      tags:
+      - FleetFeatures
+      operationId: enableFleetFeature
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetFeature"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/inventories":
     parameters:
     - name: fleetSlug
@@ -10131,6 +10289,10 @@ components:
           "$ref": "#/components/schemas/MediaFile"
         myFleet:
           type: boolean
+        features:
+          type: array
+          items:
+            type: string
         createdAt:
           type: string
           format: date-time
@@ -10145,6 +10307,7 @@ components:
       - slug
       - publicFleet
       - publicFleetStats
+      - features
       - createdAt
       - updatedAt
       title: Fleet

--- a/test/integration/api/v1/features_test.rb
+++ b/test/integration/api/v1/features_test.rb
@@ -28,4 +28,28 @@ class Api::V1::FeaturesTest < ActionDispatch::IntegrationTest
       assert_equal ["NewFeature"], parsed_body
     end
   end
+
+  test "GET /features includes a flag enabled for the signed-in user" do
+    user = create(:user)
+    Flipper.add("PersonalFeature")
+    Flipper.enable_actor("PersonalFeature", user)
+    sign_in user
+
+    assert_api_response :get, 200 do
+      assert_includes parsed_body, "PersonalFeature"
+    end
+  end
+
+  test "GET /features omits a flag enabled only for one of the user's fleets" do
+    user = create(:user)
+    fleet = create(:fleet, admins: [user])
+    Flipper.add("FleetWideFeature")
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in user
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body, "FleetWideFeature",
+        "a fleet's flags belong to that fleet's payload, or they leak onto every other fleet's page"
+    end
+  end
 end

--- a/test/integration/api/v1/fleets_features_disable_test.rb
+++ b/test/integration/api/v1/fleets_features_disable_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsFeaturesDisableTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/features/{id}/disable" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+    parameter name: "id", in: :path, schema: {type: :string}, description: "Feature name", required: true
+
+    put("Disable Fleet Feature") do
+      operationId "disableFleetFeature"
+      tags "FleetFeatures"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetFeature"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    Flipper.enable_actor("FleetWideFeature", @fleet)
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable disables the feature for the fleet" do
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+      assert_not Flipper.enabled?("FleetWideFeature", @fleet)
+      assert_not parsed_body["enabled"]
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable reports still enabled when the flag is on globally" do
+    Flipper.enable("FleetWideFeature")
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+      assert parsed_body["enabled"], "a fleet admin cannot switch off a global rollout"
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable with valid OAuth token" do
+    token = create(:oauth_access_token, resource_owner_id: @admin.id, scopes: ["fleet"])
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"},
+      headers: {"Authorization" => "Bearer #{token.token}"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable returns 403 for a member without fleet:manage" do
+    sign_in @member
+
+    assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+      assert Flipper.enabled?("FleetWideFeature", @fleet)
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable returns 403 for a user-scoped feature" do
+    Flipper.add("PersonalFeature")
+    FeatureSetting.create!(feature_name: "PersonalFeature", self_service: true, self_service_scope: "user")
+    sign_in @admin
+
+    assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "PersonalFeature"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable returns 401 when not signed in" do
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/disable returns 404 for a fleet the user is not in" do
+    sign_in create(:user)
+
+    assert_api_response :put, 404, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
+  end
+end

--- a/test/integration/api/v1/fleets_features_enable_test.rb
+++ b/test/integration/api/v1/fleets_features_enable_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsFeaturesEnableTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/features/{id}/enable" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+    parameter name: "id", in: :path, schema: {type: :string}, description: "Feature name", required: true
+
+    put("Enable Fleet Feature") do
+      operationId "enableFleetFeature"
+      tags "FleetFeatures"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetFeature"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable enables the feature for the fleet" do
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+      assert Flipper.enabled?("FleetWideFeature", @fleet)
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable leaves other fleets alone" do
+    other_fleet = create(:fleet, admins: [@admin])
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+      assert_not Flipper.enabled?("FleetWideFeature", other_fleet)
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable with valid OAuth token" do
+    token = create(:oauth_access_token, resource_owner_id: @admin.id, scopes: ["fleet"])
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"},
+      headers: {"Authorization" => "Bearer #{token.token}"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 403 for a member without fleet:manage" do
+    sign_in @member
+
+    assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 403 for a user-scoped feature" do
+    Flipper.add("PersonalFeature")
+    FeatureSetting.create!(feature_name: "PersonalFeature", self_service: true, self_service_scope: "user")
+    sign_in @admin
+
+    assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "PersonalFeature"} do
+      assert_not Flipper.enabled?("PersonalFeature", @fleet)
+    end
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 403 for a feature that is not self-service" do
+    Flipper.add("AdminOnlyFeature")
+    sign_in @admin
+
+    assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "AdminOnlyFeature"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 401 when not signed in" do
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
+  end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 404 for a fleet the user is not in" do
+    sign_in create(:user)
+
+    assert_api_response :put, 404, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
+  end
+end

--- a/test/integration/api/v1/fleets_features_index_test.rb
+++ b/test/integration/api/v1/fleets_features_index_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsFeaturesIndexTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/features" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+
+    get("Fleet Features List") do
+      operationId "fleetFeatures"
+      tags "FleetFeatures"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :array, items: {"$ref": "#/components/schemas/FleetFeature"}
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+  end
+
+  test "GET /fleets/:slug/features lists the fleet-scoped features with their state" do
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal [{"name" => "FleetWideFeature", "enabled" => false}], parsed_body
+    end
+  end
+
+  test "GET /fleets/:slug/features reports a feature enabled for the fleet actor" do
+    Flipper.enable_actor("FleetWideFeature", @fleet)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert parsed_body.first["enabled"]
+    end
+  end
+
+  test "GET /fleets/:slug/features ignores a member's own gate on the flag" do
+    Flipper.enable_actor("FleetWideFeature", @admin)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_not parsed_body.first["enabled"],
+        "the tab reports the fleet's state, not the viewer's"
+    end
+  end
+
+  test "GET /fleets/:slug/features excludes user-scoped features" do
+    Flipper.add("PersonalFeature")
+    FeatureSetting.create!(feature_name: "PersonalFeature", self_service: true, self_service_scope: "user")
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal %w[FleetWideFeature], parsed_body.map { |feature| feature["name"] }
+    end
+  end
+
+  test "GET /fleets/:slug/features excludes globally enabled features" do
+    Flipper.enable("FleetWideFeature")
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_empty parsed_body, "nothing left for a fleet admin to decide"
+    end
+  end
+
+  test "GET /fleets/:slug/features with valid OAuth token" do
+    token = create(:oauth_access_token, resource_owner_id: @admin.id, scopes: ["fleet"])
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: {"Authorization" => "Bearer #{token.token}"}
+  end
+
+  test "GET /fleets/:slug/features returns 403 for a member without fleet:manage" do
+    sign_in @member
+
+    assert_api_response :get, 403, path_params: {fleetSlug: @fleet.slug}
+  end
+
+  test "GET /fleets/:slug/features returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+
+  test "GET /fleets/:slug/features returns 404 for a fleet the user is not in" do
+    sign_in create(:user)
+
+    assert_api_response :get, 404, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_show_test.rb
+++ b/test/integration/api/v1/fleets_show_test.rb
@@ -84,4 +84,40 @@ class Api::V1::FleetsShowTest < ActionDispatch::IntegrationTest
       path_params: {slug: @fleet.slug},
       headers: oauth_headers_for(@admin, scopes: ["public"])
   end
+
+  test "GET /fleets/:slug reports the flags enabled for this fleet" do
+    Flipper.add("FleetWideFeature")
+    Flipper.enable_actor("FleetWideFeature", @fleet)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {slug: @fleet.slug} do
+      assert_equal %w[FleetWideFeature], parsed_body["features"]
+    end
+  end
+
+  test "GET /fleets/:slug omits a flag enabled only for the viewer" do
+    Flipper.add("PersonalFeature")
+    Flipper.enable_actor("PersonalFeature", @admin)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {slug: @fleet.slug} do
+      assert_empty parsed_body["features"]
+    end
+  end
+
+  test "GET /fleets/:slug picks up a flag toggled after the fleet was last cached" do
+    Flipper.add("FleetWideFeature")
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {slug: @fleet.slug} do
+      assert_empty parsed_body["features"]
+    end
+
+    Flipper.enable_actor("FleetWideFeature", @fleet)
+
+    assert_api_response :get, 200, path_params: {slug: @fleet.slug} do
+      assert_equal %w[FleetWideFeature], parsed_body["features"],
+        "flag state must sit outside the fragment cache keyed on the fleet record"
+    end
+  end
 end

--- a/test/integration/api/v1/user_features_disable_test.rb
+++ b/test/integration/api/v1/user_features_disable_test.rb
@@ -74,4 +74,44 @@ class Api::V1::UserFeaturesDisableTest < ActionDispatch::IntegrationTest
 
     assert_api_response :put, 403, path_params: {id: "NonSelfServiceFeature"}
   end
+
+  test "PUT /user-features/:id/disable disables a fleet-scoped feature for the user alone" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    Flipper.enable_actor("FleetWideFeature", @user)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: "FleetWideFeature"} do
+      assert_not Flipper.enabled?("FleetWideFeature", @user)
+    end
+  end
+
+  test "PUT /user-features/:id/disable returns 403 when the user's fleet enabled it" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in @user
+
+    assert_api_response :put, 403, path_params: {id: "FleetWideFeature"} do
+      assert Flipper.enabled?("FleetWideFeature", fleet),
+        "a member cannot override what their fleet turned on, so the API refuses " \
+        "rather than reporting a change they will not see"
+    end
+  end
+
+  test "PUT /user-features/:id/disable ignores a fleet the user has only been invited to" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet)
+    create(:fleet_membership, :invited, fleet:, user: @user)
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    Flipper.enable_actor("FleetWideFeature", @user)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: "FleetWideFeature"} do
+      assert_not Flipper.enabled?("FleetWideFeature", @user),
+        "a pending invitation does not hand the fleet control of the user's toggle"
+    end
+  end
 end

--- a/test/integration/api/v1/user_features_enable_test.rb
+++ b/test/integration/api/v1/user_features_enable_test.rb
@@ -73,4 +73,33 @@ class Api::V1::UserFeaturesEnableTest < ActionDispatch::IntegrationTest
 
     assert_api_response :put, 403, path_params: {id: "NonSelfServiceFeature"}
   end
+
+  test "PUT /user-features/:id/enable enables a fleet-scoped feature for the user alone" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    other_member = create(:user)
+    fleet = create(:fleet, members: [@user, other_member])
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: "FleetWideFeature"} do
+      assert Flipper.enabled?("FleetWideFeature", @user)
+      assert_not Flipper.enabled?("FleetWideFeature", fleet),
+        "previewing it must not switch it on for the fleet"
+      assert_not Flipper.enabled?("FleetWideFeature", other_member),
+        "and must not reach another member"
+    end
+  end
+
+  test "PUT /user-features/:id/enable returns 403 when the user's fleet already enabled it" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in @user
+
+    assert_api_response :put, 403, path_params: {id: "FleetWideFeature"} do
+      assert_not_includes Flipper.feature("FleetWideFeature").actors_value, @user.flipper_id,
+        "there is nothing to enable — the fleet already grants it"
+    end
+  end
 end

--- a/test/integration/api/v1/user_features_index_test.rb
+++ b/test/integration/api/v1/user_features_index_test.rb
@@ -69,4 +69,130 @@ class Api::V1::UserFeaturesIndexTest < ActionDispatch::IntegrationTest
       assert_empty parsed_body
     end
   end
+
+  test "GET /user-features marks the viewer's own features as user-scoped" do
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_equal "user", parsed_body.first["scope"]
+    end
+  end
+
+  test "GET /user-features lists a fleet-scoped feature the user may preview" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    create(:fleet, members: [@user])
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      fleet_feature = parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }
+
+      assert_not_nil fleet_feature
+      assert_equal "fleet", fleet_feature["scope"],
+        "the scope is what tells the page this switch only covers the viewer"
+      assert_not fleet_feature["enabled"]
+      assert_not fleet_feature["enabledForSelf"]
+    end
+  end
+
+  test "GET /user-features reports a fleet-scoped feature the user previews as enabled" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    Flipper.enable_actor("FleetWideFeature", @user)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      fleet_feature = parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }
+
+      assert fleet_feature["enabled"]
+      assert fleet_feature["enabledForSelf"], "the switch stays theirs to flip back"
+    end
+  end
+
+  test "GET /user-features reports a feature the fleet enabled as enabled" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      fleet_feature = parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }
+
+      assert fleet_feature["enabled"],
+        "the member has the feature, so the list must not ask them to turn it on"
+      assert_not fleet_feature["enabledForSelf"],
+        "and the page needs to know it came from the fleet, to disable the switch"
+      assert_equal [{"name" => fleet.name, "slug" => fleet.slug}], fleet_feature["fleets"],
+        "naming the fleet tells the member where the feature came from"
+    end
+  end
+
+  test "GET /user-features names every fleet of the user's that enabled the feature" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    granting = create(:fleet, members: [@user])
+    other_granting = create(:fleet, members: [@user])
+    create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", granting)
+    Flipper.enable_actor("FleetWideFeature", other_granting)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      slugs = parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }["fleets"]
+        .map { |fleet| fleet["slug"] }
+
+      assert_equal [granting.slug, other_granting.slug].sort, slugs.sort,
+        "the fleet that has it switched off is not responsible for anything"
+    end
+  end
+
+  test "GET /user-features names no fleet for a feature the user enabled themselves" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", @user)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }["fleets"],
+        "their own preview is not their fleet's doing, and stays theirs to switch off"
+    end
+  end
+
+  test "GET /user-features ignores a fleet the user has only been invited to" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet)
+    create(:fleet_membership, :invited, fleet:, user: @user)
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not parsed_body.find { |feature| feature["name"] == "FleetWideFeature" }["enabled"],
+        "a pending invitation is not membership"
+    end
+  end
+
+  test "GET /user-features does not count a fleet gate on a user-scoped feature" do
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("TestFeature", fleet)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not parsed_body.find { |feature| feature["name"] == "TestFeature" }["enabled"],
+        "nothing reads a user-scoped flag against a fleet, so such a gate grants nothing"
+    end
+  end
+
+  test "GET /user-features lists a fleet-scoped feature for a user in no fleet" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_includes parsed_body.map { |feature| feature["name"] }, "FleetWideFeature",
+        "the toggle covers the viewer, so it does not depend on which fleets they are in"
+    end
+  end
 end

--- a/test/lib/feature_flags/registry_test.rb
+++ b/test/lib/feature_flags/registry_test.rb
@@ -62,17 +62,53 @@ module FeatureFlags
     test "reads self_service, defaulting to off" do
       definitions = registry(
         "plain" => {"description" => "A"},
-        "toggleable" => {"description" => "B", "self_service" => true}
+        "toggleable" => {"description" => "B", "self_service" => "user"}
       ).definitions
 
       assert_not_predicate definitions.first, :self_service?
+      assert_nil definitions.first.self_service_scope
       assert_predicate definitions.last, :self_service?
+      assert_predicate definitions.last, :self_service_user?
     end
 
-    test "rejects a non-boolean self_service" do
-      errors = registry("my_flag" => {"description" => "x", "self_service" => "yes"}).validation_errors
+    test "reads the fleet self_service scope" do
+      definition = registry("fleet_flag" => {"description" => "A", "self_service" => "fleet"}).fetch("fleet_flag")
 
-      assert_includes errors.join, "self_service must be a boolean"
+      assert_predicate definition, :self_service?
+      assert_predicate definition, :self_service_fleet?
+      assert_not_predicate definition, :self_service_user?
+      assert_equal "fleet", definition.self_service_scope
+    end
+
+    test "treats self_service true as the user scope" do
+      definition = registry("legacy" => {"description" => "A", "self_service" => true}).fetch("legacy")
+
+      assert_predicate definition, :self_service_user?
+      assert_equal "user", definition.self_service_scope
+    end
+
+    test "treats self_service false as no toggle" do
+      definition = registry("plain" => {"description" => "A", "self_service" => false}).fetch("plain")
+
+      assert_not_predicate definition, :self_service?
+      assert_empty registry("plain" => {"description" => "A", "self_service" => false}).validation_errors
+    end
+
+    test "self_service selects the definitions for one scope" do
+      subject = registry(
+        "personal" => {"description" => "A", "self_service" => "user"},
+        "fleet_wide" => {"description" => "B", "self_service" => "fleet"},
+        "admin_only" => {"description" => "C"}
+      )
+
+      assert_equal %w[personal], subject.self_service("user").map(&:name)
+      assert_equal %w[fleet_wide], subject.self_service("fleet").map(&:name)
+    end
+
+    test "rejects an unknown self_service scope" do
+      errors = registry("my_flag" => {"description" => "x", "self_service" => "squadron"}).validation_errors
+
+      assert_includes errors.join, "self_service must be one of"
     end
 
     test "allows hyphens so the oauth provider gates stay valid" do

--- a/test/lib/feature_flags/synchronizer_test.rb
+++ b/test/lib/feature_flags/synchronizer_test.rb
@@ -35,8 +35,8 @@ module FeatureFlags
       Registry.new(raw: names.to_h { |name| [name, {"description" => name}] })
     end
 
-    def self_service_registry(*names)
-      Registry.new(raw: names.to_h { |name| [name, {"description" => name, "self_service" => true}] })
+    def self_service_registry(*names, scope: "user")
+      Registry.new(raw: names.to_h { |name| [name, {"description" => name, "self_service" => scope}] })
     end
 
     def sync(registry:, flipper:, **options)
@@ -69,9 +69,9 @@ module FeatureFlags
 
       sync(registry: registry("keeper"), flipper: FakeFlipper.new(%w[keeper orphan]))
 
-      assert_not FeatureSetting.self_service?("orphan"),
+      assert_not FeatureSetting.self_service?("orphan", scope: "user"),
         "a re-declared flag would otherwise come back user-toggleable"
-      assert FeatureSetting.self_service?("keeper")
+      assert FeatureSetting.self_service?("keeper", scope: "user")
     end
 
     test "cleans up settings for flags flipper no longer knows about" do
@@ -89,7 +89,7 @@ module FeatureFlags
     test "seeds the setting of a flag declared self-service" do
       sync(registry: self_service_registry("hangar_inventories"), flipper: FakeFlipper.new)
 
-      assert FeatureSetting.self_service?("hangar_inventories"),
+      assert FeatureSetting.self_service?("hangar_inventories", scope: "user"),
         "a self-service flag must arrive user-toggleable without a data migration"
     end
 
@@ -98,8 +98,36 @@ module FeatureFlags
 
       sync(registry: self_service_registry("hangar_inventories"), flipper: FakeFlipper.new(["hangar_inventories"]))
 
-      assert_not FeatureSetting.self_service?("hangar_inventories"),
+      assert_not FeatureSetting.self_service?("hangar_inventories", scope: "user"),
         "the registry seeds self-service; a deploy must not undo the admin"
+    end
+
+    test "seeds a fleet-scoped flag with the fleet scope" do
+      sync(registry: self_service_registry("fleet_logistics", scope: "fleet"), flipper: FakeFlipper.new)
+
+      assert FeatureSetting.self_service?("fleet_logistics", scope: "fleet")
+      assert_not FeatureSetting.self_service?("fleet_logistics", scope: "user"),
+        "a fleet-wide feature must not be offered in personal settings"
+    end
+
+    test "reconciles the scope of an existing setting" do
+      FeatureSetting.create!(feature_name: "fleet_logistics", self_service: true, self_service_scope: "user")
+
+      sync(registry: self_service_registry("fleet_logistics", scope: "fleet"), flipper: FakeFlipper.new(["fleet_logistics"]))
+
+      assert_equal "fleet", FeatureSetting.find_by(feature_name: "fleet_logistics").self_service_scope,
+        "the scope belongs to the code reading the flag, so a release moving it must take effect"
+    end
+
+    test "reconciling the scope leaves an admin's self-service decision alone" do
+      FeatureSetting.create!(feature_name: "fleet_logistics", self_service: false, self_service_scope: "user")
+
+      sync(registry: self_service_registry("fleet_logistics", scope: "fleet"), flipper: FakeFlipper.new(["fleet_logistics"]))
+
+      setting = FeatureSetting.find_by(feature_name: "fleet_logistics")
+
+      assert_equal "fleet", setting.self_service_scope
+      assert_not setting.self_service, "the registry seeds self-service; a deploy must not undo the admin"
     end
 
     test "leaves flags that do not declare self-service without a setting" do
@@ -119,7 +147,7 @@ module FeatureFlags
 
       sync(registry: registry("keeper"), flipper: FakeFlipper.new(%w[keeper orphan]), dry_run: true)
 
-      assert FeatureSetting.self_service?("orphan")
+      assert FeatureSetting.self_service?("orphan", scope: "user")
     end
 
     test "prune: false leaves self-service settings alone" do
@@ -127,7 +155,7 @@ module FeatureFlags
 
       sync(registry: registry("keeper"), flipper: FakeFlipper.new(%w[keeper orphan]), prune: false)
 
-      assert FeatureSetting.self_service?("orphan")
+      assert FeatureSetting.self_service?("orphan", scope: "user")
     end
 
     test "reports no changes when flipper already matches" do


### PR DESCRIPTION
Fleet-wide features are now a fleet's own decision, made from a Features tab in its settings — while each member keeps a personal switch to preview one first.

Resolves #4440

## Where this started

`fleet_logistics` was already evaluated against the fleet as a Flipper actor: every logistics controller calls `feature_enabled?("fleet_logistics", @fleet)`, which expands to `Flipper.enabled?(flag, user, fleet)`. What was missing was the ownership model around that gate.

- **`GET /features` leaked flags across fleets.** It folded in the flags of *any* fleet the viewer belonged to, so one fleet with a feature on made it look enabled on every other fleet's page — where the API then refused every request.
- **No fleet-scoped surface existed.** Only `/admin/features` could enable a flag for a fleet actor, so a fleet's admins could not switch a feature on for their own members.

## What changed

**The registry says who owns a toggle.** `self_service` takes a value now — `user` or `fleet` (`true` stays an alias for `user`). It decides where the *fleet-wide* switch lives, not whether a personal one exists.

**`FeatureSetting` carries the scope.** Sync keeps its never-overwrite rule for `self_service`, since an admin owns that at `/admin/features`, but reconciles the **scope** on every run — the scope says which surface reads the flag, so a release that moves a flag has to take effect rather than wait for someone to notice.

**Fleet admins get the switch:** `/fleets/:slug/features` (index/enable/disable), gated on `fleet:manage`, with a Features tab in the fleet settings.

**Flags resolve per fleet.** `GET /features` drops the cross-fleet union; a fleet's flags ride on that fleet's own payload, and `isFleetFeatureEnabled(fleet, flag)` mirrors the backend gate — on for the viewer *or* for this fleet, and only this fleet.

## Two switches, and how they interact

A fleet flag has a personal switch and a fleet-wide one, and both belong. Enabling one on the user actor does **not** switch the feature on for the fleet — for another member, `Flipper.enabled?(flag, them, fleet)` is still false — so it stays the way someone previews a beta before their fleet commits to it.

Where they overlap, the fleet wins:

| Your gate | Fleet's gate | Personal list shows | Switch |
| --- | --- | --- | --- |
| off | off | Disabled | enables it **for you only** |
| on | off | Enabled | disables it for you |
| either | **on** | Enabled, "Enabled by fleet" + the fleets named | **disabled** |

A fleet's grant cannot be overridden per user, because the gate ORs both actors. Rather than return 200 for a change the user would not see, `enable`/`disable` **403** while any of their fleets has the flag on. `GET /user-features` names the fleets responsible, linked to their pages, so a member can see where a feature came from instead of only that they cannot turn it off.

## Worth a reviewer's attention

- **`json.features` sits outside `json.cache!`** in `_fleet.jbuilder` on purpose. Flag state is not part of the fleet record, so inside the block a cached copy would keep serving the old answer until the fleet itself changed.
- **Removing the union reached further than `fleet_logistics`.** `fleet_starmap` and `fleet_worldmap` are not self-service but *can* be enabled for a fleet actor, and the union was the only thing carrying that to the frontend — dropping it would have switched them off for any fleet gated that way. So every fleet-page read is fleet-aware, not just logistics.
- **`featureScope: "fleet"` route meta** is why the router guard knows when to consult the fleet. `:slug` also names models and ships, and fetching the fleet endpoint with a model slug would throw — which the guard's fail-open rescue would turn into "let it through" for every flagged model route.
- **The `scope` enum is declared on the response** where `FeatureFlagName` deliberately is not: the scopes are a closed set, so they will not grow a value on every new flag and trip `response-property-enum-value-added`.
- **Only fleet-scoped flags consult the fleets.** Nothing reads a user-scoped flag against a fleet actor, so a gate there grants nothing and must not read as enabled. Accepted memberships only — a pending invitation is not membership.

## Deliberately left out

- **Existing user-actor gates on `fleet_logistics` are not revoked.** Anyone who self-enabled it keeps it until an admin clears it at `/admin/features`. A stale gate beats cutting someone off on deploy, and frontend and backend agree on it either way.
- **`fleet_starmap` / `fleet_worldmap` stay non-self-service.** Declaring them is a one-line change once someone wants it.
- **`/admin/features` does not display the scope.** Cosmetic; the toggle itself already takes the scope from the registry.

## Testing

- 115 feature-related backend tests, including the new `fleets_features_{index,enable,disable}` suites and per-fleet coverage on `features`, `fleets_show` and all three `user_features` endpoints
- 222 frontend tests, with four router-guard cases for the fleet scope
- `standardrb`, `pnpm lint:ts`, `pnpm run format`, `bin/feature-flags validate` clean
- `oasdiff` against `main`: no breaking changes
- Translations in all seven locales

Full plan and the decisions behind it: `docs/exec-plans/4440-fleet-scoped-feature-flags.md`.

🤖
