### PR TITLE
feat(fleets): fleet missions

### DIFF
--- a/app/api_components/v1/schemas/fleets/missions/mission.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class Mission
+          include OpenapiRuby::Components::Base
+
+          CATEGORIES = %w[
+            other
+            ship_combat
+            ground_combat
+            combined_combat
+            mining
+            salvage
+            cargo_hauling
+            exploration
+          ].freeze
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              title: {type: :string},
+              slug: {type: :string},
+              description: {type: :string},
+              category: {type: :string, enum: CATEGORIES},
+              scenario: {type: :string},
+              coverImagePreset: {type: :string},
+              coverImage: {"$ref": "#/components/schemas/MediaFile"},
+              archived: {type: :boolean},
+              archivedAt: {type: :string, format: "date-time"},
+              createdBy: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  username: {type: :string}
+                }
+              },
+              teamCount: {type: :integer},
+              shipCount: {type: :integer},
+              createdAt: {type: :string, format: "date-time"},
+              updatedAt: {type: :string, format: "date-time"}
+            },
+            required: %w[id title slug category archived teamCount shipCount createdAt updatedAt]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/missions/mission_extended.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_extended.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class MissionExtended
+          include OpenapiRuby::Components::Base
+
+          schema({
+            allOf: [
+              {"$ref": "#/components/schemas/Mission"},
+              {
+                type: :object,
+                properties: {
+                  teams: {
+                    type: :array,
+                    items: {"$ref": "#/components/schemas/MissionTeam"}
+                  }
+                },
+                required: %w[teams]
+              }
+            ]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class MissionShip
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              missionTeamId: {type: :string, format: :uuid},
+              title: {type: :string},
+              displayTitle: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              strict: {type: :boolean},
+              model: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  name: {type: :string},
+                  slug: {type: :string},
+                  minCrew: {type: :integer},
+                  maxCrew: {type: :integer},
+                  image: {"$ref": "#/components/schemas/MediaFile"}
+                },
+                required: %w[id name slug]
+              },
+              filters: {
+                type: :object,
+                properties: {
+                  classification: {type: :string},
+                  focus: {type: :string},
+                  minSize: {type: :string},
+                  maxSize: {type: :string},
+                  minCrew: {type: :integer},
+                  minCargo: {type: :number}
+                }
+              },
+              slots: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/MissionSlot"}
+              }
+            },
+            required: %w[id missionTeamId position strict slots],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
@@ -17,17 +17,12 @@ module V1
               description: {type: :string},
               position: {type: :integer},
               strict: {type: :boolean},
-              model: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  name: {type: :string},
-                  slug: {type: :string},
-                  minCrew: {type: :integer},
-                  maxCrew: {type: :integer},
-                  image: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                required: %w[id name slug]
+              model: {"$ref": "#/components/schemas/ShipModel"},
+              # The models a spot will take when it names several rather than
+              # one; empty for the other two kinds of spot.
+              allowedModels: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/ShipModel"}
               },
               filters: {
                 type: :object,
@@ -45,7 +40,7 @@ module V1
                 items: {"$ref": "#/components/schemas/MissionSlot"}
               }
             },
-            required: %w[id missionTeamId position strict slots],
+            required: %w[id missionTeamId position strict allowedModels slots],
             additionalProperties: false
           })
         end

--- a/app/api_components/v1/schemas/fleets/missions/mission_slot.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_slot.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class MissionSlot
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              slottableType: {type: :string, enum: %w[MissionTeam MissionShip]},
+              slottableId: {type: :string, format: :uuid},
+              title: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              derived: {type: :boolean},
+              positionType: {type: :string}
+            },
+            required: %w[id slottableType slottableId title position derived],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/missions/mission_team.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_team.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class MissionTeam
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              missionId: {type: :string, format: :uuid},
+              title: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              slots: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/MissionSlot"}
+              },
+              ships: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/MissionShip"}
+              }
+            },
+            required: %w[id missionId title position slots ships],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/missions/missions_list.rb
+++ b/app/api_components/v1/schemas/fleets/missions/missions_list.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Missions
+        class MissionsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              items: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/Mission"}
+              },
+              meta: {"$ref": "#/components/schemas/Meta"}
+            },
+            required: %w[items meta]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/ship_model.rb
+++ b/app/api_components/v1/schemas/fleets/ship_model.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      # The trimmed model a ship spot points at. Declared once because a spot can
+      # name one model or list several, on a mission and on an event alike — the
+      # shape was written out four times before this.
+      class ShipModel
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            slug: {type: :string},
+            minCrew: {type: :integer},
+            maxCrew: {type: :integer},
+            image: {"$ref": "#/components/schemas/MediaFile"}
+          },
+          required: %w[id name slug]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_create_input.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            category: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Missions::Mission::CATEGORIES
+            },
+            scenario: {type: [:string, :null]},
+            coverImagePreset: {type: [:string, :null]},
+            coverImage: {type: [:string, :null]}
+          },
+          required: %w[title],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_ship_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_ship_create_input.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionShipCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: [:string, :null]},
+            description: {type: [:string, :null]},
+            modelId: {type: [:string, :null], format: :uuid},
+            classification: {type: [:string, :null]},
+            focus: {type: [:string, :null]},
+            minSize: {type: [:string, :null]},
+            maxSize: {type: [:string, :null]},
+            minCrew: {type: [:integer, :null]},
+            minCargo: {type: [:number, :null]},
+            positionIds: {
+              type: :array,
+              items: {type: :string, format: :uuid},
+              description: "Optional list of ModelPosition IDs to materialize as slots when modelId is set"
+            }
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_ship_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_ship_create_input.rb
@@ -18,6 +18,11 @@ module V1
             maxSize: {type: [:string, :null]},
             minCrew: {type: [:integer, :null]},
             minCargo: {type: [:number, :null]},
+            allowedModelIds: {
+              type: :array,
+              items: {type: :string, format: :uuid},
+              description: "Models this spot will accept, when it names several rather than one"
+            },
             positionIds: {
               type: :array,
               items: {type: :string, format: :uuid},

--- a/app/api_components/v1/schemas/inputs/mission_ship_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_ship_update_input.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionShipUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: [:string, :null]},
+            description: {type: [:string, :null]},
+            modelId: {type: [:string, :null], format: :uuid},
+            classification: {type: [:string, :null]},
+            focus: {type: [:string, :null]},
+            minSize: {type: [:string, :null]},
+            maxSize: {type: [:string, :null]},
+            minCrew: {type: [:integer, :null]},
+            minCargo: {type: [:number, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_ship_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_ship_update_input.rb
@@ -17,7 +17,12 @@ module V1
             minSize: {type: [:string, :null]},
             maxSize: {type: [:string, :null]},
             minCrew: {type: [:integer, :null]},
-            minCargo: {type: [:number, :null]}
+            minCargo: {type: [:number, :null]},
+            allowedModelIds: {
+              type: :array,
+              items: {type: :string, format: :uuid},
+              description: "Models this spot will accept, when it names several rather than one"
+            }
           },
           additionalProperties: false
         })

--- a/app/api_components/v1/schemas/inputs/mission_slot_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_slot_create_input.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionSlotCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slottableType: {type: :string, enum: %w[MissionTeam MissionShip]},
+            slottableId: {type: :string, format: :uuid},
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          required: %w[slottableType slottableId title],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_slot_sort_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_slot_sort_input.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionSlotSortInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slottableType: {type: :string, enum: %w[MissionTeam MissionShip]},
+            slottableId: {type: :string, format: :uuid},
+            sorting: {
+              type: :array,
+              items: {type: :string, format: :uuid}
+            }
+          },
+          required: %w[slottableType slottableId sorting],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_slot_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_slot_update_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionSlotUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_team_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_team_create_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionTeamCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          required: %w[title],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_team_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_team_update_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionTeamUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_update_input.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class MissionUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            category: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Missions::Mission::CATEGORIES
+            },
+            scenario: {type: [:string, :null]},
+            coverImagePreset: {type: [:string, :null]},
+            coverImage: {type: [:string, :null]},
+            archivedAt: {type: [:string, :null], format: "date-time"}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/mission_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/mission_update_input.rb
@@ -17,8 +17,7 @@ module V1
             },
             scenario: {type: [:string, :null]},
             coverImagePreset: {type: [:string, :null]},
-            coverImage: {type: [:string, :null]},
-            archivedAt: {type: [:string, :null], format: "date-time"}
+            coverImage: {type: [:string, :null]}
           },
           additionalProperties: false
         })

--- a/app/api_components/v1/schemas/inputs/sort_input.rb
+++ b/app/api_components/v1/schemas/inputs/sort_input.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class SortInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            sorting: {
+              type: :array,
+              items: {type: :string, format: :uuid}
+            }
+          },
+          required: %w[sorting],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/mission_ships_controller.rb
+++ b/app/controllers/api/v1/mission_ships_controller.rb
@@ -11,7 +11,7 @@ module Api
       before_action :check_fleet_mission_builder_feature
       before_action :set_mission
       before_action :set_team
-      before_action :set_ship, only: %i[update destroy]
+      before_action :set_ship, only: %i[update destroy duplicate]
 
       def create
         @ship = @team.mission_ships.new(ship_params)
@@ -59,6 +59,34 @@ module Api
         end
 
         render json: {success: true}
+      end
+
+      # A copy of the ship at the end of the same team, slots included. Those
+      # slots carry titles and descriptions an organiser may have edited, so
+      # rebuilding them from the model would quietly discard that work — the
+      # rows are copied as they stand.
+      def duplicate
+        authorize! @ship, with: MissionShipPolicy, to: :duplicate?, context: {mission: @mission}
+
+        ActiveRecord::Base.transaction do
+          @copy = @team.mission_ships.create!(
+            @ship.slice(
+              :title, :description, :model_id,
+              :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
+            ).merge(position: next_position)
+          )
+
+          @ship.mission_slots.order(:position).each do |slot|
+            @copy.mission_slots.create!(
+              slot.slice(:title, :description, :model_position_id, :position)
+            )
+          end
+        end
+
+        @ship = @copy
+        render :show, status: :created
+      rescue ActiveRecord::RecordInvalid
+        render json: ValidationError.new("mission_ships.duplicate", errors: @copy&.errors || @ship.errors), status: :bad_request
       end
 
       private def ship_params

--- a/app/controllers/api/v1/mission_ships_controller.rb
+++ b/app/controllers/api/v1/mission_ships_controller.rb
@@ -80,16 +80,21 @@ module Api
         authorize! @ship, with: MissionShipPolicy, to: :duplicate?, context: {mission: @mission}
 
         ActiveRecord::Base.transaction do
-          @copy = @team.mission_ships.create!(
+          @copy = @team.mission_ships.new(
             @ship.slice(
               :title, :description, :model_id,
               :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
             ).merge(position: next_position)
           )
 
+          # Before the save, not after: a spot whose whole spec is a list of ships
+          # has nothing in its columns, so creating the copy first left
+          # model_or_filter_required with nothing to accept.
           @ship.mission_ship_models.order(:position).each_with_index do |allowed, index|
-            @copy.mission_ship_models.create!(model_id: allowed.model_id, position: index)
+            @copy.mission_ship_models.build(model_id: allowed.model_id, position: index)
           end
+
+          @copy.save!
 
           @ship.mission_slots.order(:position).each do |slot|
             @copy.mission_slots.create!(

--- a/app/controllers/api/v1/mission_ships_controller.rb
+++ b/app/controllers/api/v1/mission_ships_controller.rb
@@ -16,6 +16,10 @@ module Api
       def create
         @ship = @team.mission_ships.new(ship_params)
         @ship.position = next_position
+        # Built rather than written: model_or_filter_required runs on save and a
+        # spot that names only a list has nothing else to satisfy it, so the rows
+        # have to exist in memory by then.
+        build_allowed_models(@ship, allowed_model_ids_param)
 
         authorize! @ship, with: MissionShipPolicy, context: {mission: @mission}
 
@@ -23,6 +27,10 @@ module Api
           @ship.save!
           materialize_position_slots(@ship, position_ids_param)
         end
+
+        # The associations were read during validation, when the rows were still
+        # in memory, so the response would otherwise serialise that stale view.
+        @ship.reload
 
         render :show, status: :created
       rescue ActiveRecord::RecordInvalid
@@ -32,11 +40,14 @@ module Api
       def update
         authorize! @ship, with: MissionShipPolicy, context: {mission: @mission}
 
-        if @ship.update(ship_params)
-          render :show
-        else
-          render json: ValidationError.new("mission_ships.update", errors: @ship.errors), status: :bad_request
+        ActiveRecord::Base.transaction do
+          sync_allowed_models!(@ship, allowed_model_ids_param)
+          @ship.update!(ship_params)
         end
+
+        render :show
+      rescue ActiveRecord::RecordInvalid
+        render json: ValidationError.new("mission_ships.update", errors: @ship.errors), status: :bad_request
       end
 
       def destroy
@@ -76,6 +87,10 @@ module Api
             ).merge(position: next_position)
           )
 
+          @ship.mission_ship_models.order(:position).each_with_index do |allowed, index|
+            @copy.mission_ship_models.create!(model_id: allowed.model_id, position: index)
+          end
+
           @ship.mission_slots.order(:position).each do |slot|
             @copy.mission_slots.create!(
               slot.slice(:title, :description, :model_position_id, :position)
@@ -90,7 +105,39 @@ module Api
       end
 
       private def ship_params
-        authorized(params, with: MissionShipPolicy)
+        authorized(params, with: MissionShipPolicy).except(:allowed_model_ids)
+      end
+
+      # nil when the client did not mention the list at all, which leaves it
+      # alone; [] is a client clearing it.
+      private def allowed_model_ids_param
+        permitted = authorized(params, with: MissionShipPolicy)
+        return unless permitted.key?(:allowed_model_ids)
+
+        Array(permitted[:allowed_model_ids]).map(&:to_s).compact_blank.uniq
+      end
+
+      private def build_allowed_models(ship, ids)
+        return if ids.blank?
+
+        ids.each_with_index do |model_id, index|
+          ship.mission_ship_models.build(model_id: model_id, position: index)
+        end
+      end
+
+      # A supplied list is the whole answer to "which ships fit here", so rows
+      # that are not in it go. Reset afterwards so the validation on update reads
+      # the list as it now stands rather than as it was loaded.
+      private def sync_allowed_models!(ship, ids)
+        return if ids.nil?
+
+        ship.mission_ship_models.where.not(model_id: ids).destroy_all
+        ids.each_with_index do |model_id, index|
+          record = ship.mission_ship_models.find_or_initialize_by(model_id: model_id)
+          record.position = index
+          record.save! if record.changed?
+        end
+        ship.mission_ship_models.reset
       end
 
       private def position_ids_param

--- a/app/controllers/api/v1/mission_ships_controller.rb
+++ b/app/controllers/api/v1/mission_ships_controller.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MissionShipsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_mission
+      before_action :set_team
+      before_action :set_ship, only: %i[update destroy]
+
+      def create
+        @ship = @team.mission_ships.new(ship_params)
+        @ship.position = next_position
+
+        authorize! @ship, with: MissionShipPolicy, context: {mission: @mission}
+
+        ActiveRecord::Base.transaction do
+          @ship.save!
+          materialize_position_slots(@ship, position_ids_param)
+        end
+
+        render :show, status: :created
+      rescue ActiveRecord::RecordInvalid
+        render json: ValidationError.new("mission_ships.create", errors: @ship.errors), status: :bad_request
+      end
+
+      def update
+        authorize! @ship, with: MissionShipPolicy, context: {mission: @mission}
+
+        if @ship.update(ship_params)
+          render :show
+        else
+          render json: ValidationError.new("mission_ships.update", errors: @ship.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @ship, with: MissionShipPolicy, context: {mission: @mission}
+
+        unless @ship.destroy
+          render json: ValidationError.new("mission_ships.destroy", errors: @ship.errors), status: :bad_request
+        end
+      end
+
+      def sort
+        authorize! @mission, with: MissionShipPolicy, to: :sort?, context: {mission: @mission}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        MissionShip.transaction do
+          sorting.each_with_index do |id, index|
+            @team.mission_ships.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def ship_params
+        authorized(params, with: MissionShipPolicy)
+      end
+
+      private def position_ids_param
+        Array(params[:position_ids]).map(&:to_s)
+      end
+
+      private def materialize_position_slots(ship, position_ids)
+        return if position_ids.blank?
+        return if ship.model_id.blank?
+
+        positions = ship.model.model_positions.where(id: position_ids).order(:position)
+        next_slot_position = -1
+        positions.each do |mp|
+          next_slot_position += 1
+          ship.mission_slots.create!(
+            title: mp.name,
+            model_position_id: mp.id,
+            position: next_slot_position
+          )
+        end
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_mission
+        @mission = @fleet.missions.find_by!(slug: params[:mission_slug])
+      end
+
+      private def set_team
+        @team = @mission.mission_teams.find(params[:mission_team_id])
+      end
+
+      private def set_ship
+        @ship = @team.mission_ships.find(params[:id])
+      end
+
+      private def next_position
+        (@team.mission_ships.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/mission_slots_controller.rb
+++ b/app/controllers/api/v1/mission_slots_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MissionSlotsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_slottable, only: %i[create]
+      before_action :set_slot, only: %i[update destroy]
+      before_action :check_fleet_mission_builder_feature
+
+      def create
+        @slot = @slottable.mission_slots.new(slot_attrs)
+        @slot.position = next_position
+
+        authorize! @slot, with: MissionSlotPolicy, context: {mission: @slottable.mission}
+
+        if @slot.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("mission_slots.create", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @slot, with: MissionSlotPolicy, context: {mission: @slot.mission}
+
+        if @slot.update(slot_attrs)
+          render :show
+        else
+          render json: ValidationError.new("mission_slots.update", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @slot, with: MissionSlotPolicy, context: {mission: @slot.mission}
+
+        unless @slot.destroy
+          render json: ValidationError.new("mission_slots.destroy", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def sort
+        slottable = find_slottable(params[:slottable_type], params[:slottable_id])
+        return render json: {code: "not_found"}, status: :not_found unless slottable
+
+        authorize! slottable, with: MissionSlotPolicy, to: :sort?, context: {mission: slottable.mission}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        MissionSlot.transaction do
+          sorting.each_with_index do |id, index|
+            slottable.mission_slots.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def slot_attrs
+        authorized(params, with: MissionSlotPolicy)
+          .except(:slottable_type, :slottable_id)
+      end
+
+      private def set_slottable
+        @slottable = find_slottable(params[:slottable_type], params[:slottable_id])
+        raise ActiveRecord::RecordNotFound, "slottable not found" unless @slottable
+      end
+
+      private def set_slot
+        @slot = MissionSlot.find(params[:id])
+      end
+
+      private def find_slottable(type, id)
+        case type
+        when "MissionTeam" then MissionTeam.find_by(id: id)
+        when "MissionShip" then MissionShip.find_by(id: id)
+        end
+      end
+
+      private def next_position
+        (@slottable.mission_slots.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        # Slots are addressed directly, without a fleet in the path, so the
+        # actor comes off whichever record this action loaded.
+        fleet = (@slottable || @slot)&.mission&.fleet
+        return if feature_enabled?("fleet_mission_builder", fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/mission_teams_controller.rb
+++ b/app/controllers/api/v1/mission_teams_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MissionTeamsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_mission
+      before_action :set_team, only: %i[update destroy]
+
+      def create
+        @team = @mission.mission_teams.new(team_params)
+        @team.position = next_position
+
+        authorize! @team, with: MissionTeamPolicy, context: {mission: @mission}
+
+        if @team.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("mission_teams.create", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @team, with: MissionTeamPolicy, context: {mission: @mission}
+
+        if @team.update(team_params)
+          render :show
+        else
+          render json: ValidationError.new("mission_teams.update", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @team, with: MissionTeamPolicy, context: {mission: @mission}
+
+        unless @team.destroy
+          render json: ValidationError.new("mission_teams.destroy", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def sort
+        authorize! @mission, with: MissionTeamPolicy, to: :sort?, context: {mission: @mission}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        MissionTeam.transaction do
+          sorting.each_with_index do |id, index|
+            @mission.mission_teams.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def team_params
+        authorized(params, with: MissionTeamPolicy)
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_mission
+        @mission = @fleet.missions.find_by!(slug: params[:mission_slug])
+      end
+
+      private def set_team
+        @team = @mission.mission_teams.find(params[:id])
+      end
+
+      private def next_position
+        (@mission.mission_teams.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/missions_controller.rb
+++ b/app/controllers/api/v1/missions_controller.rb
@@ -11,11 +11,11 @@ module Api
         only: %i[index show]
       before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
         unless: :user_signed_in?,
-        only: %i[create update destroy]
+        only: %i[create update destroy unarchive]
 
       before_action :set_fleet
       before_action :check_fleet_mission_builder_feature
-      before_action :set_mission, only: %i[show update destroy]
+      before_action :set_mission, only: %i[show update destroy unarchive]
 
       def index
         authorize! with: MissionPolicy, context: {fleet: @fleet}
@@ -71,6 +71,16 @@ module Api
           render :show
         else
           render json: ValidationError.new("missions.destroy", errors: @mission.errors), status: :bad_request
+        end
+      end
+
+      def unarchive
+        authorize! @mission, to: :unarchive?
+
+        if @mission.unarchive!
+          render :show
+        else
+          render json: ValidationError.new("missions.unarchive", errors: @mission.errors), status: :bad_request
         end
       end
 

--- a/app/controllers/api/v1/missions_controller.rb
+++ b/app/controllers/api/v1/missions_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MissionsController < ::Api::BaseController
+      after_action -> { pagination_header(:missions) }, only: %i[index]
+
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[index show]
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?,
+        only: %i[create update destroy]
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_mission, only: %i[show update destroy]
+
+      def index
+        authorize! with: MissionPolicy, context: {fleet: @fleet}
+
+        scope = @fleet.missions
+        scope = (params[:archived] == "true") ? scope.archived : scope.active
+
+        query_params = params.fetch(:q, {}).permit(:title_cont, :s)
+        normalize_sort_params(query_params)
+        query_params["sorts"] = sorting_params(Mission, query_params["sorts"])
+
+        @q = scope.ransack(query_params)
+        result = @q.result(distinct: true)
+
+        @missions = result_with_pagination(result, per_page(Mission))
+      end
+
+      def show
+        authorize! @mission
+      end
+
+      def create
+        @mission = @fleet.missions.new(mission_params)
+        @mission.created_by = current_resource_owner
+
+        authorize! @mission
+
+        if @mission.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("missions.create", errors: @mission.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @mission
+
+        if @mission.update(mission_params)
+          render :show
+        else
+          render json: ValidationError.new("missions.update", errors: @mission.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @mission
+
+        if @mission.archived?
+          unless @mission.destroy
+            render json: ValidationError.new("missions.destroy", errors: @mission.errors), status: :bad_request
+          end
+        elsif @mission.archive!
+          render :show
+        else
+          render json: ValidationError.new("missions.destroy", errors: @mission.errors), status: :bad_request
+        end
+      end
+
+      private def mission_params
+        authorized(params, with: MissionPolicy)
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_mission
+        @mission = @fleet.missions.find_by!(slug: params[:slug])
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -4,31 +4,34 @@
 #
 # Table name: fleets
 #
-#  id                 :uuid             not null, primary key
-#  created_by         :uuid
-#  description        :text
-#  discarded_at       :datetime
-#  discord            :string
-#  fid                :string
-#  guilded            :string
-#  homepage           :string
-#  name               :string
-#  normalized_fid     :string
-#  public_fleet       :boolean          default(FALSE)
-#  public_fleet_stats :boolean          default(FALSE)
-#  rsi_sid            :string
-#  sid                :string
-#  slug               :string
-#  ts                 :string
-#  twitch             :string
-#  youtube            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                  :uuid             not null, primary key
+#  calendar_feed_token :string
+#  created_by          :uuid
+#  default_timezone    :string           default("UTC"), not null
+#  description         :text
+#  discarded_at        :datetime
+#  discord             :string
+#  fid                 :string
+#  guilded             :string
+#  homepage            :string
+#  name                :string
+#  normalized_fid      :string
+#  public_fleet        :boolean          default(FALSE)
+#  public_fleet_stats  :boolean          default(FALSE)
+#  rsi_sid             :string
+#  sid                 :string
+#  slug                :string
+#  ts                  :string
+#  twitch              :string
+#  youtube             :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 # Indexes
 #
-#  index_fleets_on_discarded_at  (discarded_at)
-#  index_fleets_on_fid           (fid) UNIQUE WHERE (discarded_at IS NULL)
+#  index_fleets_on_calendar_feed_token  (calendar_feed_token) UNIQUE
+#  index_fleets_on_discarded_at         (discarded_at)
+#  index_fleets_on_fid                  (fid) UNIQUE WHERE (discarded_at IS NULL)
 #
 class Fleet < ApplicationRecord
   include Discard::Model

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -64,6 +64,7 @@ class Fleet < ApplicationRecord
   has_many :fleet_invite_urls,
     dependent: :destroy
   has_many :fleet_inventories, dependent: :destroy
+  has_many :missions, dependent: :destroy
   has_many :fleet_vehicles, dependent: :destroy
   has_many :vehicles, through: :fleet_vehicles, source: :vehicle
   has_many :models, through: :vehicles, source: :model

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -48,7 +48,8 @@ class FleetRole < ApplicationRecord
       FleetInviteUrl::AVAILABLE_PRIVILEGES,
       FleetVehicle::AVAILABLE_PRIVILEGES,
       FleetRole::AVAILABLE_PRIVILEGES,
-      FleetInventory::AVAILABLE_PRIVILEGES
+      FleetInventory::AVAILABLE_PRIVILEGES,
+      Mission::AVAILABLE_PRIVILEGES
     ].flatten.uniq
   end
 
@@ -73,7 +74,8 @@ class FleetRole < ApplicationRecord
         FleetInviteUrl::DEFAULT_PRIVILEGES[:admin],
         FleetVehicle::DEFAULT_PRIVILEGES[:admin],
         FleetRole::DEFAULT_PRIVILEGES[:admin],
-        FleetInventory::DEFAULT_PRIVILEGES[:admin]
+        FleetInventory::DEFAULT_PRIVILEGES[:admin],
+        Mission::DEFAULT_PRIVILEGES[:admin]
       ].flatten.uniq,
       officer: [
         Fleet::DEFAULT_PRIVILEGES[:officer],
@@ -81,7 +83,8 @@ class FleetRole < ApplicationRecord
         FleetInviteUrl::DEFAULT_PRIVILEGES[:officer],
         FleetVehicle::DEFAULT_PRIVILEGES[:officer],
         FleetRole::DEFAULT_PRIVILEGES[:officer],
-        FleetInventory::DEFAULT_PRIVILEGES[:officer]
+        FleetInventory::DEFAULT_PRIVILEGES[:officer],
+        Mission::DEFAULT_PRIVILEGES[:officer]
       ].flatten.uniq,
       member: [
         Fleet::DEFAULT_PRIVILEGES[:member],
@@ -89,7 +92,8 @@ class FleetRole < ApplicationRecord
         FleetInviteUrl::DEFAULT_PRIVILEGES[:member],
         FleetVehicle::DEFAULT_PRIVILEGES[:member],
         FleetRole::DEFAULT_PRIVILEGES[:member],
-        FleetInventory::DEFAULT_PRIVILEGES[:member]
+        FleetInventory::DEFAULT_PRIVILEGES[:member],
+        Mission::DEFAULT_PRIVILEGES[:member]
       ].flatten.uniq
     }
   end

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: missions
+#
+#  id                 :uuid             not null, primary key
+#  archived_at        :datetime
+#  category           :integer          default(0), not null
+#  cover_image_preset :string
+#  description        :text
+#  scenario           :string
+#  slug               :string           not null
+#  title              :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_id      :uuid             not null
+#  fleet_id           :uuid             not null
+#
+# Indexes
+#
+#  index_missions_on_fleet_id_and_archived_at  (fleet_id,archived_at)
+#  index_missions_on_fleet_id_and_category     (fleet_id,category)
+#  index_missions_on_fleet_id_and_scenario     (fleet_id,scenario)
+#  index_missions_on_fleet_id_and_slug         (fleet_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (fleet_id => fleets.id)
+#
+class Mission < ApplicationRecord
+  include ActiveStorageVariants
+
+  paginates_per 30
+
+  belongs_to :fleet, touch: true
+  belongs_to :created_by, class_name: "User"
+  has_many :mission_teams, dependent: :destroy
+  has_many :mission_ships, through: :mission_teams
+
+  has_one_attached :cover_image
+
+  enum :category, {
+    other: 0,
+    ship_combat: 1,
+    ground_combat: 2,
+    combined_combat: 3,
+    mining: 4,
+    salvage: 5,
+    cargo_hauling: 6,
+    exploration: 7
+  }
+
+  validates :title, presence: true, uniqueness: {case_sensitive: false, scope: :fleet_id}
+
+  before_save :update_slug
+
+  scope :active, -> { where(archived_at: nil) }
+  scope :archived, -> { where.not(archived_at: nil) }
+
+  AVAILABLE_PRIVILEGES = [
+    "fleet:missions:read",
+    "fleet:missions:create",
+    "fleet:missions:update",
+    "fleet:missions:delete",
+    "fleet:missions:manage"
+  ].freeze
+
+  DEFAULT_PRIVILEGES = {
+    admin: [],
+    officer: ["fleet:missions:manage"],
+    member: ["fleet:missions:read"]
+  }.freeze
+
+  DEFAULT_SORTING_PARAMS = ["title asc"]
+  ALLOWED_SORTING_PARAMS = [
+    "title asc", "title desc",
+    "createdAt asc", "createdAt desc",
+    "updatedAt asc", "updatedAt desc"
+  ]
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[title slug fleet_id archived_at category scenario cover_image_preset created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[fleet created_by mission_teams]
+  end
+
+  def archived?
+    archived_at.present?
+  end
+
+  def archive!
+    update!(archived_at: Time.current)
+  end
+
+  def unarchive!
+    update!(archived_at: nil)
+  end
+
+  private def update_slug
+    self.slug = generate_slug(title)
+  end
+end

--- a/app/models/mission_ship.rb
+++ b/app/models/mission_ship.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: mission_ships
+#
+#  id              :uuid             not null, primary key
+#  classification  :string
+#  description     :text
+#  focus           :string
+#  max_size        :string
+#  min_cargo       :decimal(, )
+#  min_crew        :integer
+#  min_size        :string
+#  position        :integer          default(0), not null
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  mission_team_id :uuid             not null
+#  model_id        :uuid
+#
+# Indexes
+#
+#  index_mission_ships_on_mission_team_id               (mission_team_id)
+#  index_mission_ships_on_mission_team_id_and_position  (mission_team_id,position)
+#  index_mission_ships_on_model_id                      (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (mission_team_id => mission_teams.id)
+#  fk_rails_...  (model_id => models.id)
+#
+class MissionShip < ApplicationRecord
+  belongs_to :mission_team, touch: true
+  belongs_to :model, optional: true
+  has_many :mission_slots, as: :slottable, dependent: :destroy
+
+  delegate :mission, to: :mission_team
+
+  default_scope -> { order(position: :asc) }
+
+  FILTER_ATTRIBUTES = %i[classification focus min_size max_size min_crew min_cargo].freeze
+
+  validate :model_or_filter_required
+  validate :model_must_be_in_game
+
+  def strict?
+    model_id.present?
+  end
+
+  def filtered?
+    FILTER_ATTRIBUTES.any? { |attr| self[attr].present? }
+  end
+
+  def display_title
+    title.presence || model&.name || I18n.t("labels.mission_ship.placeholder")
+  end
+
+  private def model_or_filter_required
+    return if strict? || filtered?
+
+    errors.add(:base, :model_or_filter_required)
+  end
+
+  private def model_must_be_in_game
+    return if model.blank?
+    return if model.in_game?
+
+    errors.add(:model_id, :must_be_in_game)
+  end
+end

--- a/app/models/mission_ship.rb
+++ b/app/models/mission_ship.rb
@@ -34,6 +34,8 @@ class MissionShip < ApplicationRecord
   belongs_to :mission_team, touch: true
   belongs_to :model, optional: true
   has_many :mission_slots, as: :slottable, dependent: :destroy
+  has_many :mission_ship_models, dependent: :destroy
+  has_many :allowed_models, through: :mission_ship_models, source: :model
 
   delegate :mission, to: :mission_team
 
@@ -43,9 +45,16 @@ class MissionShip < ApplicationRecord
 
   validate :model_or_filter_required
   validate :model_must_be_in_game
+  validate :allowed_models_must_be_in_game
 
   def strict?
     model_id.present?
+  end
+
+  # A hand-picked set of models rather than criteria: the spot takes any one of
+  # them, so a signup matches if its ship is in the list.
+  def listed?
+    mission_ship_models.any?
   end
 
   def filtered?
@@ -57,7 +66,7 @@ class MissionShip < ApplicationRecord
   end
 
   private def model_or_filter_required
-    return if strict? || filtered?
+    return if strict? || listed? || filtered?
 
     errors.add(:base, :model_or_filter_required)
   end
@@ -67,5 +76,17 @@ class MissionShip < ApplicationRecord
     return if model.in_game?
 
     errors.add(:model_id, :must_be_in_game)
+  end
+
+  # The same bar the single model has to clear: a spot cannot ask for a ship that
+  # is not in the game yet, however it names it.
+  #
+  # Read through the join rows rather than through allowed_models: a has_many
+  # :through on an unsaved parent queries the database and so comes back empty,
+  # which let a new spot list a concept ship unchecked.
+  private def allowed_models_must_be_in_game
+    return if mission_ship_models.map(&:model).compact.all?(&:in_game?)
+
+    errors.add(:allowed_model_ids, :must_be_in_game)
   end
 end

--- a/app/models/mission_ship_model.rb
+++ b/app/models/mission_ship_model.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# One model a mission ship will accept. A ship spot names either one exact model,
+# a list of models it will take, or the criteria a model has to meet — this is the
+# middle case, one row per allowed model.
+# == Schema Information
+#
+# Table name: mission_ship_models
+#
+#  id              :uuid             not null, primary key
+#  position        :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  mission_ship_id :uuid             not null
+#  model_id        :uuid             not null
+#
+# Indexes
+#
+#  index_mission_ship_models_on_mission_ship_id    (mission_ship_id)
+#  index_mission_ship_models_on_model_id           (model_id)
+#  index_mission_ship_models_on_ship_and_model     (mission_ship_id,model_id) UNIQUE
+#  index_mission_ship_models_on_ship_and_position  (mission_ship_id,position)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (mission_ship_id => mission_ships.id) ON DELETE => cascade
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class MissionShipModel < ApplicationRecord
+  belongs_to :mission_ship, touch: true
+  belongs_to :model
+
+  validates :model_id, uniqueness: {scope: :mission_ship_id}
+
+  default_scope -> { order(position: :asc) }
+
+  def mission
+    mission_ship&.mission
+  end
+end

--- a/app/models/mission_slot.rb
+++ b/app/models/mission_slot.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: mission_slots
+#
+#  id                :uuid             not null, primary key
+#  description       :text
+#  position          :integer          default(0), not null
+#  slottable_type    :string           not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  model_position_id :uuid
+#  slottable_id      :uuid             not null
+#
+# Indexes
+#
+#  index_mission_slots_on_model_position_id                (model_position_id)
+#  index_mission_slots_on_slottable_and_position           (slottable_type,slottable_id,position)
+#  index_mission_slots_on_slottable_type_and_slottable_id  (slottable_type,slottable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_position_id => model_positions.id)
+#
+class MissionSlot < ApplicationRecord
+  belongs_to :slottable, polymorphic: true, touch: true
+  belongs_to :model_position, optional: true
+
+  validates :title, presence: true
+  validates :slottable_type, inclusion: {in: %w[MissionTeam MissionShip]}
+
+  default_scope -> { order(position: :asc) }
+
+  def mission
+    slottable&.mission
+  end
+
+  def derived?
+    model_position_id.present?
+  end
+
+  def position_type
+    model_position&.position_type
+  end
+end

--- a/app/models/mission_team.rb
+++ b/app/models/mission_team.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: mission_teams
+#
+#  id          :uuid             not null, primary key
+#  description :text
+#  position    :integer          default(0), not null
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  mission_id  :uuid             not null
+#
+# Indexes
+#
+#  index_mission_teams_on_mission_id               (mission_id)
+#  index_mission_teams_on_mission_id_and_position  (mission_id,position)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (mission_id => missions.id)
+#
+class MissionTeam < ApplicationRecord
+  belongs_to :mission, touch: true
+  has_many :mission_ships, dependent: :destroy
+  has_many :mission_slots, as: :slottable, dependent: :destroy
+
+  validates :title, presence: true
+
+  default_scope -> { order(position: :asc) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@
 # Table name: users
 #
 #  id                        :uuid             not null, primary key
+#  calendar_feed_token       :string
 #  confirmation_sent_at      :datetime
 #  confirmation_token        :string(255)
 #  confirmed_at              :datetime
@@ -13,6 +14,7 @@
 #  current_sign_in_ip        :string(255)
 #  current_system            :string
 #  current_system_code       :string
+#  date_format               :string           default("dmy_dots"), not null
 #  discord                   :string
 #  email                     :string(255)      default(""), not null
 #  encrypted_otp_secret      :string
@@ -63,6 +65,7 @@
 #
 # Indexes
 #
+#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
 #  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_last_active_at        (last_active_at)

--- a/app/policies/mission_policy.rb
+++ b/app/policies/mission_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class MissionPolicy < FleetBasePolicy
+  def index?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:read"])
+  end
+
+  alias_rule :show?, to: :index?
+
+  def create?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:create"])
+  end
+
+  def update?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:update"])
+  end
+
+  def destroy?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:delete"])
+  end
+
+  params_filter do |params|
+    params.permit(:title, :description, :archived_at, :category, :scenario, :cover_image, :cover_image_preset)
+  end
+end

--- a/app/policies/mission_policy.rb
+++ b/app/policies/mission_policy.rb
@@ -19,7 +19,12 @@ class MissionPolicy < FleetBasePolicy
     accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:delete"])
   end
 
+  # Archiving happens through destroy, so restoring has to cost the same
+  # privilege. Left on update? it would let someone with only
+  # fleet:missions:update pull a mission back into the active list.
+  alias_rule :unarchive?, to: :destroy?
+
   params_filter do |params|
-    params.permit(:title, :description, :archived_at, :category, :scenario, :cover_image, :cover_image_preset)
+    params.permit(:title, :description, :category, :scenario, :cover_image, :cover_image_preset)
   end
 end

--- a/app/policies/mission_ship_policy.rb
+++ b/app/policies/mission_ship_policy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class MissionShipPolicy < FleetBasePolicy
+  authorize :mission, optional: true
+
+  def create?
+    can_update_mission?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(
+      :title, :description, :model_id,
+      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
+    )
+  end
+
+  private def can_update_mission?
+    membership = user&.fleet_memberships&.find_by(fleet_id: mission_fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:update"])
+  end
+
+  private def mission_fleet_id
+    record_mission&.fleet_id || mission&.fleet_id
+  end
+
+  private def record_mission
+    record.try(:mission) || (record.is_a?(Mission) ? record : nil)
+  end
+end

--- a/app/policies/mission_ship_policy.rb
+++ b/app/policies/mission_ship_policy.rb
@@ -12,7 +12,8 @@ class MissionShipPolicy < FleetBasePolicy
   params_filter do |params|
     params.permit(
       :title, :description, :model_id,
-      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
+      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo,
+      allowed_model_ids: []
     )
   end
 

--- a/app/policies/mission_ship_policy.rb
+++ b/app/policies/mission_ship_policy.rb
@@ -7,7 +7,7 @@ class MissionShipPolicy < FleetBasePolicy
     can_update_mission?
   end
 
-  alias_rule :update?, :destroy?, :sort?, to: :create?
+  alias_rule :update?, :destroy?, :sort?, :duplicate?, to: :create?
 
   params_filter do |params|
     params.permit(

--- a/app/policies/mission_slot_policy.rb
+++ b/app/policies/mission_slot_policy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class MissionSlotPolicy < FleetBasePolicy
+  authorize :mission, optional: true
+
+  def create?
+    can_update_mission?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(:title, :description, :slottable_type, :slottable_id)
+  end
+
+  private def can_update_mission?
+    membership = user&.fleet_memberships&.find_by(fleet_id: mission_fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:update"])
+  end
+
+  private def mission_fleet_id
+    record_mission&.fleet_id || mission&.fleet_id
+  end
+
+  private def record_mission
+    record.try(:mission) || (record.is_a?(Mission) ? record : nil)
+  end
+end

--- a/app/policies/mission_team_policy.rb
+++ b/app/policies/mission_team_policy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class MissionTeamPolicy < FleetBasePolicy
+  authorize :mission, optional: true
+
+  def create?
+    can_update_mission?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(:title, :description)
+  end
+
+  private def can_update_mission?
+    membership = user&.fleet_memberships&.find_by(fleet_id: mission_fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:missions:manage", "fleet:missions:update"])
+  end
+
+  private def mission_fleet_id
+    record_mission&.fleet_id || mission&.fleet_id
+  end
+
+  private def record_mission
+    record.try(:mission) || (record.is_a?(Mission) ? record : nil)
+  end
+end

--- a/app/views/api/v1/mission_ships/_base.jbuilder
+++ b/app/views/api/v1/mission_ships/_base.jbuilder
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+json.id mission_ship.id
+json.mission_team_id mission_ship.mission_team_id
+json.title mission_ship.title
+json.display_title mission_ship.display_title
+json.description mission_ship.description
+json.position mission_ship.position
+json.strict mission_ship.strict?
+
+if mission_ship.model.present?
+  json.model do
+    json.id mission_ship.model.id
+    json.name mission_ship.model.name
+    json.slug mission_ship.model.slug
+    json.min_crew mission_ship.model.min_crew
+    json.max_crew mission_ship.model.max_crew
+
+    image_attr = if mission_ship.model.store_image.attached?
+      :store_image
+    elsif mission_ship.model.angled_view.attached?
+      :angled_view
+    elsif mission_ship.model.fleetchart_image.attached?
+      :fleetchart_image
+    end
+
+    if image_attr
+      json.image do
+        json.partial! "api/v1/shared/file", record: mission_ship.model, attr: image_attr
+      end
+    else
+      json.image nil
+    end
+  end
+else
+  json.model nil
+end
+
+json.filters do
+  json.classification mission_ship.classification
+  json.focus mission_ship.focus
+  json.min_size mission_ship.min_size
+  json.max_size mission_ship.max_size
+  json.min_crew mission_ship.min_crew
+  json.min_cargo mission_ship.min_cargo&.to_f
+end
+
+json.slots do
+  json.array! mission_ship.mission_slots,
+    partial: "api/v1/mission_slots/mission_slot",
+    as: :mission_slot
+end

--- a/app/views/api/v1/mission_ships/_base.jbuilder
+++ b/app/views/api/v1/mission_ships/_base.jbuilder
@@ -10,30 +10,18 @@ json.strict mission_ship.strict?
 
 if mission_ship.model.present?
   json.model do
-    json.id mission_ship.model.id
-    json.name mission_ship.model.name
-    json.slug mission_ship.model.slug
-    json.min_crew mission_ship.model.min_crew
-    json.max_crew mission_ship.model.max_crew
-
-    image_attr = if mission_ship.model.store_image.attached?
-      :store_image
-    elsif mission_ship.model.angled_view.attached?
-      :angled_view
-    elsif mission_ship.model.fleetchart_image.attached?
-      :fleetchart_image
-    end
-
-    if image_attr
-      json.image do
-        json.partial! "api/v1/shared/file", record: mission_ship.model, attr: image_attr
-      end
-    else
-      json.image nil
-    end
+    json.partial! "api/v1/shared/ship_model", model: mission_ship.model
   end
 else
   json.model nil
+end
+
+# The models this spot will take when it names several rather than one. Empty for
+# the other two kinds of spot, so the client can tell them apart by shape.
+json.allowed_models do
+  json.array!(mission_ship.allowed_models) do |model|
+    json.partial! "api/v1/shared/ship_model", model: model
+  end
 end
 
 json.filters do

--- a/app/views/api/v1/mission_ships/_mission_ship.jbuilder
+++ b/app/views/api/v1/mission_ships/_mission_ship.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_ships/base", mission_ship: mission_ship

--- a/app/views/api/v1/mission_ships/show.jbuilder
+++ b/app/views/api/v1/mission_ships/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_ships/mission_ship", mission_ship: @ship

--- a/app/views/api/v1/mission_slots/_base.jbuilder
+++ b/app/views/api/v1/mission_slots/_base.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.id mission_slot.id
+json.slottable_type mission_slot.slottable_type
+json.slottable_id mission_slot.slottable_id
+json.title mission_slot.title
+json.description mission_slot.description
+json.position mission_slot.position
+json.derived mission_slot.derived?
+json.position_type mission_slot.position_type

--- a/app/views/api/v1/mission_slots/_mission_slot.jbuilder
+++ b/app/views/api/v1/mission_slots/_mission_slot.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_slots/base", mission_slot: mission_slot

--- a/app/views/api/v1/mission_slots/show.jbuilder
+++ b/app/views/api/v1/mission_slots/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_slots/mission_slot", mission_slot: @slot

--- a/app/views/api/v1/mission_teams/_base.jbuilder
+++ b/app/views/api/v1/mission_teams/_base.jbuilder
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+json.id mission_team.id
+json.mission_id mission_team.mission_id
+json.title mission_team.title
+json.description mission_team.description
+json.position mission_team.position
+
+json.slots do
+  json.array! mission_team.mission_slots,
+    partial: "api/v1/mission_slots/mission_slot",
+    as: :mission_slot
+end
+
+json.ships do
+  json.array! mission_team.mission_ships,
+    partial: "api/v1/mission_ships/mission_ship",
+    as: :mission_ship
+end

--- a/app/views/api/v1/mission_teams/_mission_team.jbuilder
+++ b/app/views/api/v1/mission_teams/_mission_team.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_teams/base", mission_team: mission_team

--- a/app/views/api/v1/mission_teams/show.jbuilder
+++ b/app/views/api/v1/mission_teams/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/mission_teams/mission_team", mission_team: @team

--- a/app/views/api/v1/missions/_base.jbuilder
+++ b/app/views/api/v1/missions/_base.jbuilder
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+json.id mission.id
+json.title mission.title
+json.slug mission.slug
+json.description mission.description
+json.category mission.category
+json.scenario mission.scenario
+json.cover_image_preset mission.cover_image_preset
+json.archived mission.archived?
+json.archived_at mission.archived_at
+
+if mission.cover_image.attached?
+  json.cover_image do
+    json.partial! "api/v1/shared/file", record: mission, attr: :cover_image
+  end
+else
+  json.cover_image nil
+end
+
+if mission.created_by.present?
+  json.created_by do
+    json.id mission.created_by.id
+    json.username mission.created_by.username
+  end
+else
+  json.created_by nil
+end
+
+json.team_count mission.mission_teams.size
+json.ship_count mission.mission_ships.count
+
+json.partial! "api/shared/dates", record: mission

--- a/app/views/api/v1/missions/_mission.jbuilder
+++ b/app/views/api/v1/missions/_mission.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", mission] do
+  json.partial!("api/v1/missions/base", mission:)
+end

--- a/app/views/api/v1/missions/index.jbuilder
+++ b/app/views/api/v1/missions/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @missions, partial: "api/v1/missions/mission", as: :mission
+end
+json.partial! "api/shared/meta", result: @missions

--- a/app/views/api/v1/missions/show.jbuilder
+++ b/app/views/api/v1/missions/show.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/missions/base", mission: @mission
+
+json.teams do
+  json.array! @mission.mission_teams.includes(:mission_slots, mission_ships: [:model, :mission_slots]),
+    partial: "api/v1/mission_teams/mission_team",
+    as: :mission_team
+end

--- a/app/views/api/v1/shared/_ship_model.jbuilder
+++ b/app/views/api/v1/shared/_ship_model.jbuilder
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# The trimmed model a ship spot points at: enough to name the ship, show its
+# cover and read its crew, without the rest of a model payload. Shared because a
+# spot can name one model or list several, on a mission and on an event alike —
+# four copies of this block before it lived here.
+json.id model.id
+json.name model.name
+json.slug model.slug
+json.min_crew model.min_crew
+json.max_crew model.max_crew
+
+image_attr = if model.store_image.attached?
+  :store_image
+elsif model.angled_view.attached?
+  :angled_view
+elsif model.fleetchart_image.attached?
+  :fleetchart_image
+end
+
+if image_attr
+  json.image do
+    json.partial! "api/v1/shared/file", record: model, attr: image_attr
+  end
+else
+  json.image nil
+end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -31,6 +31,9 @@ fleet_logistics:
   description: "Fleet logistics — fleet inventories with a deposit/withdrawal ledger"
   self_service: fleet
 
+fleet_mission_builder:
+  description: "Mission builder — fleet missions, events, the calendar and Discord sync"
+
 fleet_starmap:
   description: "Starmap on the fleet page"
 

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -244,6 +244,14 @@ en:
         record_invalid: Bad Data
         svg_not_supported: must not be an SVG image
       models:
+        mission_ship:
+          attributes:
+            base:
+              model_or_filter_required: needs a ship, a list of ships, or filters
+            model_id:
+              must_be_in_game: is not in the game yet
+            allowed_model_ids:
+              must_be_in_game: name a ship that is not in the game yet
         fleet_role:
           attributes:
             resource_access:

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -58,6 +58,7 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
       put :sort, on: :collection
       resources :mission_ships, path: "ships", only: %i[create update destroy] do
         put :sort, on: :collection
+        post :duplicate, on: :member
       end
     end
   end

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -53,6 +53,7 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
   end
 
   resources :missions, param: :slug, only: %i[index show create update destroy] do
+    put :unarchive, on: :member
     resources :mission_teams, path: "teams", only: %i[create update destroy] do
       put :sort, on: :collection
       resources :mission_ships, path: "ships", only: %i[create update destroy] do

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -52,6 +52,15 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
     delete "stock/:slug", to: "fleet_inventory_stock#destroy"
   end
 
+  resources :missions, param: :slug, only: %i[index show create update destroy] do
+    resources :mission_teams, path: "teams", only: %i[create update destroy] do
+      put :sort, on: :collection
+      resources :mission_ships, path: "ships", only: %i[create update destroy] do
+        put :sort, on: :collection
+      end
+    end
+  end
+
   resource :fleet_stats, path: "stats", only: %i[] do
     get "model-counts", to: "fleet_stats#model_counts"
     get "vehicles", to: "fleet_stats#vehicles"

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -70,6 +70,10 @@ v1_api_routes = lambda do
     get :random, on: :collection
   end
 
+  resources :mission_slots, path: "mission-slots", only: %i[create update destroy] do
+    put :sort, on: :collection
+  end
+
   namespace :stats do
     get "quick-stats", to: "base#quick_stats"
     get "models-per-month", to: "base#models_per_month"

--- a/db/data/20260504100000_grant_mission_privileges_to_existing_roles.rb
+++ b/db/data/20260504100000_grant_mission_privileges_to_existing_roles.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class GrantMissionPrivilegesToExistingRoles < ActiveRecord::Migration[8.1]
+  def up
+    FleetRole.find_each do |role|
+      access = Array(role.resource_access)
+      added = []
+
+      # All members get read
+      added << "fleet:missions:read" unless access.include?("fleet:missions:read")
+
+      # Officer-equivalents (anyone with manage on something else) get manage
+      if access.include?("fleet:manage") || access.include?("fleet:memberships:manage")
+        added << "fleet:missions:manage" unless access.include?("fleet:missions:manage")
+      end
+
+      next if added.empty?
+
+      role.update_columns(resource_access: (access + added).uniq)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260503120000_create_missions.rb
+++ b/db/migrate/20260503120000_create_missions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateMissions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :missions, id: :uuid do |t|
+      t.references :fleet, type: :uuid, null: false, foreign_key: true, index: false
+      t.uuid :created_by_id, null: false
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.datetime :archived_at
+      t.timestamps
+    end
+
+    add_index :missions, [:fleet_id, :slug], unique: true
+    add_index :missions, [:fleet_id, :archived_at]
+    add_foreign_key :missions, :users, column: :created_by_id
+  end
+end

--- a/db/migrate/20260503120001_create_mission_teams.rb
+++ b/db/migrate/20260503120001_create_mission_teams.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateMissionTeams < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mission_teams, id: :uuid do |t|
+      t.references :mission, type: :uuid, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :mission_teams, [:mission_id, :position]
+  end
+end

--- a/db/migrate/20260503120002_create_mission_ships.rb
+++ b/db/migrate/20260503120002_create_mission_ships.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateMissionShips < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mission_ships, id: :uuid do |t|
+      t.references :mission, type: :uuid, null: false, foreign_key: true
+      t.references :model, type: :uuid, null: true, foreign_key: true
+      t.string :title
+      t.text :description
+      t.string :classification
+      t.string :focus
+      t.string :min_size
+      t.string :max_size
+      t.integer :min_crew
+      t.decimal :min_cargo
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :mission_ships, [:mission_id, :position]
+  end
+end

--- a/db/migrate/20260503120003_create_mission_slots.rb
+++ b/db/migrate/20260503120003_create_mission_slots.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateMissionSlots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mission_slots, id: :uuid do |t|
+      t.string :slottable_type, null: false
+      t.uuid :slottable_id, null: false
+      t.string :title, null: false
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :mission_slots, [:slottable_type, :slottable_id]
+    add_index :mission_slots, [:slottable_type, :slottable_id, :position],
+      name: "index_mission_slots_on_slottable_and_position"
+  end
+end

--- a/db/migrate/20260503130000_restructure_mission_ships_under_teams.rb
+++ b/db/migrate/20260503130000_restructure_mission_ships_under_teams.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RestructureMissionShipsUnderTeams < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :mission_ships, :missions
+    remove_index :mission_ships, [:mission_id, :position] if index_exists?(:mission_ships, [:mission_id, :position])
+    remove_index :mission_ships, :mission_id if index_exists?(:mission_ships, :mission_id)
+    remove_column :mission_ships, :mission_id, :uuid
+
+    add_reference :mission_ships, :mission_team, type: :uuid, null: false, foreign_key: true
+    add_index :mission_ships, [:mission_team_id, :position]
+
+    add_reference :mission_slots, :model_position, type: :uuid, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20260504200000_add_category_to_missions.rb
+++ b/db/migrate/20260504200000_add_category_to_missions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCategoryToMissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :missions, :category, :integer, null: false, default: 0
+    add_index :missions, [:fleet_id, :category]
+  end
+end

--- a/db/migrate/20260504210000_add_scenario_to_missions.rb
+++ b/db/migrate/20260504210000_add_scenario_to_missions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddScenarioToMissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :missions, :scenario, :string
+    add_index :missions, [:fleet_id, :scenario]
+  end
+end

--- a/db/migrate/20260505100000_add_cover_image_preset_to_missions.rb
+++ b/db/migrate/20260505100000_add_cover_image_preset_to_missions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCoverImagePresetToMissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :missions, :cover_image_preset, :string
+  end
+end

--- a/db/migrate/20260819100000_create_mission_ship_models.rb
+++ b/db/migrate/20260819100000_create_mission_ship_models.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateMissionShipModels < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mission_ship_models, id: :uuid do |t|
+      t.references :mission_ship, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+      # Cascade rather than nullify: the row exists to name one allowed model, so
+      # an sc_data import retiring that model should drop it from the list
+      # instead of leaving an entry that matches nothing.
+      t.references :model, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :mission_ship_models, [:mission_ship_id, :model_id], unique: true,
+      name: "index_mission_ship_models_on_ship_and_model"
+    add_index :mission_ship_models, [:mission_ship_id, :position],
+      name: "index_mission_ship_models_on_ship_and_position"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -323,6 +323,151 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.index ["feature_name"], name: "index_feature_settings_on_feature_name", unique: true
   end
 
+  create_table "fleet_event_admins", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "fleet_event_id", null: false
+    t.uuid "granted_by_id"
+    t.string "role", default: "admin", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["fleet_event_id", "user_id"], name: "index_fleet_event_admins_on_fleet_event_id_and_user_id", unique: true
+    t.index ["fleet_event_id"], name: "index_fleet_event_admins_on_fleet_event_id"
+    t.index ["user_id"], name: "index_fleet_event_admins_on_user_id"
+  end
+
+  create_table "fleet_event_occurrence_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "briefing"
+    t.datetime "cancelled_at"
+    t.text "cancelled_reason"
+    t.string "cover_image_preset"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "discord_event_id"
+    t.datetime "discord_synced_at"
+    t.uuid "fleet_event_id", null: false
+    t.string "location"
+    t.datetime "locked_at"
+    t.string "meetup_location"
+    t.date "occurrence_date", null: false
+    t.string "scenario"
+    t.datetime "starting_soon_notified_at"
+    t.string "status"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["fleet_event_id", "occurrence_date"], name: "idx_fleet_event_occurrence_states_on_event_and_date", unique: true
+  end
+
+  create_table "fleet_event_ships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "classification"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.uuid "fleet_event_team_id", null: false
+    t.string "focus"
+    t.string "max_size"
+    t.decimal "min_cargo"
+    t.integer "min_crew"
+    t.string "min_size"
+    t.uuid "model_id"
+    t.integer "position", default: 0, null: false
+    t.uuid "source_ship_id"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["fleet_event_team_id", "position"], name: "index_fleet_event_ships_on_fleet_event_team_id_and_position"
+    t.index ["fleet_event_team_id"], name: "index_fleet_event_ships_on_fleet_event_team_id"
+    t.index ["model_id"], name: "index_fleet_event_ships_on_model_id"
+  end
+
+  create_table "fleet_event_signups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.uuid "fleet_event_id", null: false
+    t.uuid "fleet_event_slot_id"
+    t.uuid "fleet_membership_id", null: false
+    t.text "notes"
+    t.date "occurrence_date"
+    t.string "status", default: "confirmed", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "vehicle_id"
+    t.datetime "withdrawn_at"
+    t.index ["fleet_event_id", "occurrence_date", "fleet_membership_id"], name: "idx_fleet_event_signups_on_event_and_occurrence_and_member"
+    t.index ["fleet_event_id", "occurrence_date", "fleet_membership_id"], name: "index_fleet_event_signups_unique_active_per_event", unique: true, where: "((status)::text <> 'withdrawn'::text)"
+    t.index ["fleet_event_id"], name: "index_fleet_event_signups_on_fleet_event_id"
+    t.index ["fleet_event_slot_id"], name: "index_fleet_event_signups_on_fleet_event_slot_id"
+    t.index ["fleet_membership_id"], name: "index_fleet_event_signups_on_fleet_membership_id"
+  end
+
+  create_table "fleet_event_slots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.uuid "model_position_id"
+    t.integer "position", default: 0, null: false
+    t.string "signup_approval"
+    t.uuid "slottable_id", null: false
+    t.string "slottable_type", null: false
+    t.uuid "source_slot_id"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["model_position_id"], name: "index_fleet_event_slots_on_model_position_id"
+    t.index ["slottable_type", "slottable_id", "position"], name: "index_fleet_event_slots_on_slottable_and_position"
+    t.index ["slottable_type", "slottable_id"], name: "index_fleet_event_slots_on_slottable_type_and_slottable_id"
+  end
+
+  create_table "fleet_event_teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.uuid "fleet_event_id", null: false
+    t.integer "position", default: 0, null: false
+    t.uuid "source_team_id"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fleet_event_id", "position"], name: "index_fleet_event_teams_on_fleet_event_id_and_position"
+    t.index ["fleet_event_id"], name: "index_fleet_event_teams_on_fleet_event_id"
+  end
+
+  create_table "fleet_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "archived_at"
+    t.boolean "auto_lock_enabled", default: true, null: false
+    t.integer "auto_lock_minutes_before", default: 60, null: false
+    t.text "briefing"
+    t.text "cancelled_reason"
+    t.integer "category", default: 0, null: false
+    t.string "cover_image_preset"
+    t.datetime "created_at", null: false
+    t.uuid "created_by_id", null: false
+    t.text "description"
+    t.string "discord_event_id"
+    t.string "discord_message_id"
+    t.datetime "discord_synced_at"
+    t.datetime "ends_at"
+    t.date "excluded_dates", default: [], null: false, array: true
+    t.uuid "external_uid", null: false
+    t.uuid "fleet_id", null: false
+    t.string "location"
+    t.integer "max_attendees"
+    t.string "meetup_location"
+    t.uuid "mission_id"
+    t.integer "recurrence_count"
+    t.string "recurrence_interval"
+    t.date "recurrence_until"
+    t.boolean "recurring", default: false, null: false
+    t.string "scenario"
+    t.string "signup_approval", default: "direct", null: false
+    t.string "slug", null: false
+    t.datetime "starting_soon_notified_at"
+    t.datetime "starts_at", null: false
+    t.string "status", default: "draft", null: false
+    t.string "timezone", default: "UTC", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.string "visibility", default: "members", null: false
+    t.index ["external_uid"], name: "index_fleet_events_on_external_uid", unique: true
+    t.index ["fleet_id", "recurring"], name: "index_fleet_events_on_fleet_id_and_recurring"
+    t.index ["fleet_id", "slug"], name: "index_fleet_events_on_fleet_id_and_slug", unique: true
+    t.index ["fleet_id", "starts_at"], name: "index_fleet_events_on_fleet_id_and_starts_at"
+    t.index ["fleet_id", "status"], name: "index_fleet_events_on_fleet_id_and_status"
+    t.index ["mission_id"], name: "index_fleet_events_on_mission_id"
+  end
+
   create_table "fleet_inventories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
@@ -393,6 +538,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.index ["user_id", "fleet_id"], name: "index_fleet_memberships_on_user_id_and_fleet_id", unique: true, where: "(discarded_at IS NULL)"
   end
 
+  create_table "fleet_notification_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "discord_channel_id"
+    t.string "discord_guild_id"
+    t.text "discord_webhook_url"
+    t.text "enabled_in_app_events", default: "---\n- fleet_event.published\n- fleet_event.locked\n- fleet_event.starting_soon\n- fleet_event.cancelled\n- fleet_event_signup.created\n- fleet_event_signup.withdrawn"
+    t.uuid "fleet_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fleet_id"], name: "index_fleet_notification_settings_on_fleet_id", unique: true
+  end
+
   create_table "fleet_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "fleet_id", null: false
@@ -415,8 +571,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   end
 
   create_table "fleets", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+    t.string "calendar_feed_token"
     t.datetime "created_at", precision: nil, null: false
     t.uuid "created_by"
+    t.string "default_timezone", default: "UTC", null: false
     t.text "description"
     t.datetime "discarded_at"
     t.string "discord"
@@ -434,6 +592,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.string "twitch"
     t.datetime "updated_at", precision: nil, null: false
     t.string "youtube"
+    t.index ["calendar_feed_token"], name: "index_fleets_on_calendar_feed_token", unique: true
     t.index ["discarded_at"], name: "index_fleets_on_discarded_at"
     t.index ["fid"], name: "index_fleets_on_fid", unique: true, where: "(discarded_at IS NULL)"
   end
@@ -642,6 +801,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.text "to"
     t.datetime "updated_at", null: false
     t.uuid "user_id"
+  end
+
+  create_table "mission_ship_models", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "mission_ship_id", null: false
+    t.uuid "model_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["mission_ship_id", "model_id"], name: "index_mission_ship_models_on_ship_and_model", unique: true
+    t.index ["mission_ship_id", "position"], name: "index_mission_ship_models_on_ship_and_position"
+    t.index ["mission_ship_id"], name: "index_mission_ship_models_on_mission_ship_id"
+    t.index ["model_id"], name: "index_mission_ship_models_on_model_id"
   end
 
   create_table "mission_ships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1126,6 +1297,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   end
 
   create_table "users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+    t.string "calendar_feed_token"
     t.datetime "confirmation_sent_at", precision: nil
     t.string "confirmation_token", limit: 255
     t.datetime "confirmed_at", precision: nil
@@ -1135,6 +1307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.string "current_sign_in_ip", limit: 255
     t.string "current_system"
     t.string "current_system_code"
+    t.string "date_format", default: "dmy_dots", null: false
     t.string "discord"
     t.string "email", limit: 255, default: "", null: false
     t.string "encrypted_otp_secret"
@@ -1181,6 +1354,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.string "username", limit: 255, default: "", null: false
     t.integer "wanted_vehicles_count", default: 0, null: false
     t.string "youtube"
+    t.index ["calendar_feed_token"], name: "index_users_on_calendar_feed_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["last_active_at"], name: "index_users_on_last_active_at"
@@ -1295,17 +1469,37 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_notifications", "admin_users", on_delete: :cascade
   add_foreign_key "cargo_hold_container_capacities", "cargo_holds"
+  add_foreign_key "fleet_event_admins", "fleet_events"
+  add_foreign_key "fleet_event_admins", "users"
+  add_foreign_key "fleet_event_occurrence_states", "fleet_events"
+  add_foreign_key "fleet_event_ships", "fleet_event_teams"
+  add_foreign_key "fleet_event_ships", "mission_ships", column: "source_ship_id", on_delete: :nullify
+  add_foreign_key "fleet_event_ships", "models"
+  add_foreign_key "fleet_event_signups", "fleet_event_slots"
+  add_foreign_key "fleet_event_signups", "fleet_events"
+  add_foreign_key "fleet_event_signups", "fleet_memberships"
+  add_foreign_key "fleet_event_signups", "vehicles", on_delete: :nullify
+  add_foreign_key "fleet_event_slots", "mission_slots", column: "source_slot_id", on_delete: :nullify
+  add_foreign_key "fleet_event_slots", "model_positions"
+  add_foreign_key "fleet_event_teams", "fleet_events"
+  add_foreign_key "fleet_event_teams", "mission_teams", column: "source_team_id", on_delete: :nullify
+  add_foreign_key "fleet_events", "fleets"
+  add_foreign_key "fleet_events", "missions"
+  add_foreign_key "fleet_events", "users", column: "created_by_id"
   add_foreign_key "fleet_inventories", "fleets"
   add_foreign_key "fleet_inventories", "users", column: "managed_by"
   add_foreign_key "fleet_inventory_items", "fleet_inventories"
   add_foreign_key "fleet_inventory_items", "users", column: "added_by"
   add_foreign_key "fleet_inventory_items", "users", column: "member_id"
   add_foreign_key "fleet_memberships", "fleet_roles"
+  add_foreign_key "fleet_notification_settings", "fleets"
   add_foreign_key "fleet_roles", "fleets"
   add_foreign_key "hardpoints", "components"
   add_foreign_key "imports", "admin_users"
   add_foreign_key "inventories", "vehicles", on_delete: :nullify
   add_foreign_key "inventory_items", "inventories"
+  add_foreign_key "mission_ship_models", "mission_ships", on_delete: :cascade
+  add_foreign_key "mission_ship_models", "models", on_delete: :cascade
   add_foreign_key "mission_ships", "mission_teams"
   add_foreign_key "mission_ships", "models"
   add_foreign_key "mission_slots", "model_positions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -644,6 +644,68 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.uuid "user_id"
   end
 
+  create_table "mission_ships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "classification"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "focus"
+    t.string "max_size"
+    t.decimal "min_cargo"
+    t.integer "min_crew"
+    t.string "min_size"
+    t.uuid "mission_team_id", null: false
+    t.uuid "model_id"
+    t.integer "position", default: 0, null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["mission_team_id", "position"], name: "index_mission_ships_on_mission_team_id_and_position"
+    t.index ["mission_team_id"], name: "index_mission_ships_on_mission_team_id"
+    t.index ["model_id"], name: "index_mission_ships_on_model_id"
+  end
+
+  create_table "mission_slots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.uuid "model_position_id"
+    t.integer "position", default: 0, null: false
+    t.uuid "slottable_id", null: false
+    t.string "slottable_type", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["model_position_id"], name: "index_mission_slots_on_model_position_id"
+    t.index ["slottable_type", "slottable_id", "position"], name: "index_mission_slots_on_slottable_and_position"
+    t.index ["slottable_type", "slottable_id"], name: "index_mission_slots_on_slottable_type_and_slottable_id"
+  end
+
+  create_table "mission_teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.uuid "mission_id", null: false
+    t.integer "position", default: 0, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mission_id", "position"], name: "index_mission_teams_on_mission_id_and_position"
+    t.index ["mission_id"], name: "index_mission_teams_on_mission_id"
+  end
+
+  create_table "missions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "archived_at"
+    t.integer "category", default: 0, null: false
+    t.string "cover_image_preset"
+    t.datetime "created_at", null: false
+    t.uuid "created_by_id", null: false
+    t.text "description"
+    t.uuid "fleet_id", null: false
+    t.string "scenario"
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fleet_id", "archived_at"], name: "index_missions_on_fleet_id_and_archived_at"
+    t.index ["fleet_id", "category"], name: "index_missions_on_fleet_id_and_category"
+    t.index ["fleet_id", "scenario"], name: "index_missions_on_fleet_id_and_scenario"
+    t.index ["fleet_id", "slug"], name: "index_missions_on_fleet_id_and_slug", unique: true
+  end
+
   create_table "model_hardpoint_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "component_id"
     t.datetime "created_at", null: false
@@ -1244,6 +1306,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   add_foreign_key "imports", "admin_users"
   add_foreign_key "inventories", "vehicles", on_delete: :nullify
   add_foreign_key "inventory_items", "inventories"
+  add_foreign_key "mission_ships", "mission_teams"
+  add_foreign_key "mission_ships", "models"
+  add_foreign_key "mission_slots", "model_positions"
+  add_foreign_key "mission_teams", "missions"
+  add_foreign_key "missions", "fleets"
+  add_foreign_key "missions", "users", column: "created_by_id"
   add_foreign_key "model_paints", "components", on_delete: :nullify
   add_foreign_key "model_positions", "hardpoints", on_delete: :nullify
   add_foreign_key "model_positions", "models"

--- a/lib/tasks/missions.rake
+++ b/lib/tasks/missions.rake
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+module MissionBuilderExamples
+  EXAMPLES = [
+    {
+      title: "Fighter Sweep",
+      category: "ship_combat",
+      description: "Light fighter patrol clearing pirate activity from a contested system. Pure ship combat, fast in/out.",
+      teams: [
+        {
+          title: "Strike Element",
+          description: "Forward air-to-air engagement.",
+          slots: ["Wing Lead", "Wing 2", "Wing 3", "Wing 4"],
+          ships: [
+            {model: "Gladius"},
+            {model: "Arrow"},
+            {model: "Sabre"}
+          ]
+        },
+        {
+          title: "Heavy Support",
+          description: "Anti-fighter platform providing fire support.",
+          slots: ["Mission Commander"],
+          ships: [{model: "Hammerhead"}]
+        }
+      ]
+    },
+    {
+      title: "Ground Assault",
+      category: "ground_combat",
+      description: "Surface objective takedown. Ground troops assault a fortified outpost while air cover suppresses defenders.",
+      teams: [
+        {
+          title: "Boots on the Ground",
+          description: "Marine team driving the assault.",
+          slots: ["Squad Leader", "Marine 1", "Marine 2", "Marine 3"],
+          ships: [{model: "Cyclone"}]
+        },
+        {
+          title: "Air Cover",
+          description: "Suppression and overwatch.",
+          slots: ["Flight Lead"],
+          ships: [
+            {model: "Hurricane"},
+            {model: "Vanguard Sentinel"}
+          ]
+        }
+      ]
+    },
+    {
+      title: "Combined Combat Operation",
+      category: "combined_combat",
+      description: "Coordinated naval + ground op. Capital-class strike package with ground insertion.",
+      teams: [
+        {
+          title: "Naval Strike Group",
+          description: "Capital, escort, and CAP elements.",
+          slots: ["Group Commander", "Naval Liaison"],
+          ships: [
+            {model: "Hammerhead"},
+            {model: "Vanguard Sentinel"},
+            {model: "Gladius"}
+          ]
+        },
+        {
+          title: "Marine Element",
+          description: "Surface objective team.",
+          slots: ["Marine Commander", "Boarding Lead"],
+          ships: [
+            {model: "Cutlass Black"},
+            {model: "Cyclone"}
+          ]
+        },
+        {
+          title: "Logistics",
+          description: "Supply, refuel, repair.",
+          slots: ["Logistics Lead"],
+          ships: [
+            {classification: "transport", min_size: "large"}
+          ]
+        }
+      ]
+    },
+    {
+      title: "Mining Operation",
+      category: "mining",
+      description: "Ore extraction run with refining and hauling. Includes light escort against pirate interest.",
+      teams: [
+        {
+          title: "Mining Crew",
+          description: "Primary extraction.",
+          slots: ["Operation Lead"],
+          ships: [
+            {model: "MOLE"},
+            {model: "Prospector"},
+            {model: "Prospector"}
+          ]
+        },
+        {
+          title: "Hauling",
+          description: "Move refined ore to market.",
+          slots: ["Logistics Lead"],
+          ships: [
+            {model: "Hull C"},
+            {model: "Caterpillar"}
+          ]
+        },
+        {
+          title: "Escort",
+          description: "Pirate response.",
+          slots: ["Escort Lead"],
+          ships: [
+            {classification: "combat", min_size: "medium"}
+          ]
+        }
+      ]
+    },
+    {
+      title: "Salvage Operation",
+      category: "salvage",
+      description: "Recover wreckage from a recent fleet engagement. Strip hulls, haul materials, defend the site.",
+      teams: [
+        {
+          title: "Salvage Crew",
+          description: "Hull stripping and material processing.",
+          slots: ["Salvage Director"],
+          ships: [
+            {model: "Reclaimer"},
+            {model: "Vulture"},
+            {model: "Vulture"}
+          ]
+        },
+        {
+          title: "Site Security",
+          description: "Defensive posture against scavengers.",
+          slots: ["Security Lead"],
+          ships: [
+            {model: "Vanguard Sentinel"},
+            {model: "Hammerhead"}
+          ]
+        }
+      ]
+    },
+    {
+      title: "Cargo Hauling",
+      category: "cargo_hauling",
+      description: "Bulk freight run between trade hubs. Convoy formation with escort element.",
+      teams: [
+        {
+          title: "Convoy",
+          description: "Primary haulage.",
+          slots: ["Convoy Lead"],
+          ships: [
+            {model: "Hull C"},
+            {model: "Caterpillar"},
+            {model: "Hull A"}
+          ]
+        },
+        {
+          title: "Escort",
+          description: "Pirate intercept response.",
+          slots: ["Escort Lead", "Escort Wing"],
+          ships: [
+            {model: "Vanguard Sentinel"},
+            {classification: "combat", min_size: "medium"}
+          ]
+        }
+      ]
+    }
+  ].freeze
+
+  module_function
+
+  def call(fleet, creator)
+    EXAMPLES.each { |spec| build_mission(fleet, creator, spec) }
+  end
+
+  def build_mission(fleet, creator, spec)
+    if fleet.missions.exists?(["LOWER(title) = ?", spec[:title].downcase])
+      puts "  - skipping (exists): #{spec[:title]}"
+      return
+    end
+
+    Mission.transaction do
+      mission = fleet.missions.create!(
+        title: spec[:title],
+        description: spec[:description],
+        category: spec[:category] || "other",
+        created_by: creator
+      )
+
+      spec[:teams].each_with_index do |team_spec, team_idx|
+        team = mission.mission_teams.create!(
+          title: team_spec[:title],
+          description: team_spec[:description],
+          position: team_idx
+        )
+
+        team_spec[:slots].each_with_index do |slot_title, slot_idx|
+          team.mission_slots.create!(title: slot_title, position: slot_idx)
+        end
+
+        team_spec[:ships].each_with_index do |ship_spec, ship_idx|
+          ship = build_ship(team, ship_spec, ship_idx)
+          next unless ship
+
+          materialize_seats(ship)
+        end
+      end
+
+      puts "  + #{spec[:title]} — #{mission.mission_teams.count} teams"
+    end
+  end
+
+  def build_ship(team, spec, position)
+    if spec[:model]
+      model = Model.where("LOWER(name) = ?", spec[:model].downcase).where(in_game: true).first
+      unless model
+        puts "    ! ship skipped (model not in_game or missing): #{spec[:model]}"
+        return nil
+      end
+      team.mission_ships.create!(model_id: model.id, position: position)
+    else
+      team.mission_ships.create!(
+        classification: spec[:classification],
+        focus: spec[:focus],
+        min_size: spec[:min_size],
+        max_size: spec[:max_size],
+        min_crew: spec[:min_crew],
+        min_cargo: spec[:min_cargo],
+        position: position
+      )
+    end
+  end
+
+  def materialize_seats(ship)
+    return unless ship.model_id
+
+    ship.model.model_positions.order(:position).each_with_index do |mp, idx|
+      ship.mission_slots.create!(
+        title: mp.name,
+        model_position_id: mp.id,
+        position: idx
+      )
+    end
+  end
+end
+
+namespace :missions do
+  desc "Seed example mission templates for a fleet (FLEET_FID env var, defaults to first fleet)"
+  task seed_examples: :environment do
+    fleet = ENV["FLEET_FID"] ? Fleet.find_by!(fid: ENV["FLEET_FID"]) : Fleet.first
+    abort "No fleet found. Pass FLEET_FID=... to target a specific fleet." unless fleet
+
+    creator = fleet.fleet_memberships.where(aasm_state: "accepted").first&.user || User.first
+    abort "No user found." unless creator
+
+    puts "Seeding example missions in fleet #{fleet.fid} (created by @#{creator.username})..."
+    MissionBuilderExamples.call(fleet, creator)
+    puts "Done."
+  end
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2820,6 +2820,46 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{slug}/unarchive":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Unarchive Mission
+      tags:
+      - Missions
+      operationId: unarchiveFleetMission
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/roles":
     parameters:
     - name: fleetSlug
@@ -14476,11 +14516,6 @@ components:
           type:
           - string
           - 'null'
-        archivedAt:
-          type:
-          - string
-          - 'null'
-          format: date-time
       additionalProperties: false
       title: MissionUpdateInput
     MissionsList:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10183,6 +10183,7 @@ components:
       type: string
       enum:
       - fleet_logistics
+      - fleet_mission_builder
       - fleet_starmap
       - fleet_worldmap
       - hangar_inventories
@@ -10198,6 +10199,7 @@ components:
       - tools_travel_times
       x-enumNames:
       - FLEET_LOGISTICS
+      - FLEET_MISSION_BUILDER
       - FLEET_STARMAP
       - FLEET_WORLDMAP
       - HANGAR_INVENTORIES

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -14252,25 +14252,11 @@ components:
         strict:
           type: boolean
         model:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-            minCrew:
-              type: integer
-            maxCrew:
-              type: integer
-            image:
-              "$ref": "#/components/schemas/MediaFile"
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ShipModel"
+        allowedModels:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ShipModel"
         filters:
           type: object
           properties:
@@ -14295,6 +14281,7 @@ components:
       - missionTeamId
       - position
       - strict
+      - allowedModels
       - slots
       additionalProperties: false
       title: MissionShip
@@ -14338,6 +14325,13 @@ components:
           type:
           - number
           - 'null'
+        allowedModelIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Models this spot will accept, when it names several rather
+            than one
         positionIds:
           type: array
           items:
@@ -14387,6 +14381,13 @@ components:
           type:
           - number
           - 'null'
+        allowedModelIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Models this spot will accept, when it names several rather
+            than one
       additionalProperties: false
       title: MissionShipUpdateInput
     MissionSlot:
@@ -16707,6 +16708,27 @@ components:
           type: string
       additionalProperties: false
       title: SetupOtpInput
+    ShipModel:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        minCrew:
+          type: integer
+        maxCrew:
+          type: integer
+        image:
+          "$ref": "#/components/schemas/MediaFile"
+      required:
+      - id
+      - name
+      - slug
+      title: ShipModel
     SortInput:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2269,6 +2269,557 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/missions":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      description: Fleet slug
+      required: true
+    post:
+      summary: Create Mission
+      tags:
+      - Missions
+      operationId: createFleetMission
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden - member cannot create
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: List Missions
+      tags:
+      - Missions
+      operationId: fleetMissions
+      parameters:
+      - name: archived
+        in: query
+        schema:
+          type: boolean
+        required: false
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionsList"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Create Mission Team
+      tags:
+      - Missions
+      operationId: createMissionTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionTeamCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionTeam"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/sort":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Sort Mission Teams
+      tags:
+      - Missions
+      operationId: sortMissionTeams
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SortInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{id}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Destroy Mission Team
+      tags:
+      - Missions
+      operationId: destroyMissionTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Mission Team
+      tags:
+      - Missions
+      operationId: updateMissionTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionTeamUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionTeam"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Create Mission Ship
+      tags:
+      - Missions
+      operationId: createMissionShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionShipCreateInput"
+      responses:
+        '201':
+          description: successful - range filter
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionShip"
+        '400':
+          description: bad request - non-in-game model
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/sort":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Sort Mission Ships
+      tags:
+      - Missions
+      operationId: sortMissionShips
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SortInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/{id}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Destroy Mission Ship
+      tags:
+      - Missions
+      operationId: destroyMissionShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Mission Ship
+      tags:
+      - Missions
+      operationId: updateMissionShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionShipUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionShip"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{slug}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Archive Mission
+      tags:
+      - Missions
+      operationId: destroyFleetMission
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful - archived
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionExtended"
+        '204':
+          description: successful - permanent delete on already-archived mission
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Show Mission
+      tags:
+      - Missions
+      operationId: fleetMission
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Mission
+      tags:
+      - Missions
+      operationId: updateFleetMission
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/roles":
     parameters:
     - name: fleetSlug
@@ -4381,6 +4932,144 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Manufacturers"
+  "/mission-slots":
+    post:
+      summary: Create Mission Slot
+      tags:
+      - Missions
+      operationId: createMissionSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionSlotCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionSlot"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/mission-slots/sort":
+    put:
+      summary: Sort Mission Slots
+      tags:
+      - Missions
+      operationId: sortMissionSlots
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionSlotSortInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/mission-slots/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Destroy Mission Slot
+      tags:
+      - Missions
+      operationId: destroyMissionSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Mission Slot
+      tags:
+      - Missions
+      operationId: updateMissionSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/MissionSlotUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionSlot"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/model-paints":
     get:
       summary: Model Paints List
@@ -13342,6 +14031,471 @@ components:
           "$ref": "#/components/schemas/Pagination"
       additionalProperties: false
       title: Meta
+    Mission:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type: string
+        coverImagePreset:
+          type: string
+        coverImage:
+          "$ref": "#/components/schemas/MediaFile"
+        archived:
+          type: boolean
+        archivedAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            username:
+              type: string
+        teamCount:
+          type: integer
+        shipCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+      - id
+      - title
+      - slug
+      - category
+      - archived
+      - teamCount
+      - shipCount
+      - createdAt
+      - updatedAt
+      title: Mission
+    MissionCreateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type:
+          - string
+          - 'null'
+        coverImagePreset:
+          type:
+          - string
+          - 'null'
+        coverImage:
+          type:
+          - string
+          - 'null'
+      required:
+      - title
+      additionalProperties: false
+      title: MissionCreateInput
+    MissionExtended:
+      allOf:
+      - "$ref": "#/components/schemas/Mission"
+      - type: object
+        properties:
+          teams:
+            type: array
+            items:
+              "$ref": "#/components/schemas/MissionTeam"
+        required:
+        - teams
+      title: MissionExtended
+    MissionShip:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        missionTeamId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        displayTitle:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        strict:
+          type: boolean
+        model:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            slug:
+              type: string
+            minCrew:
+              type: integer
+            maxCrew:
+              type: integer
+            image:
+              "$ref": "#/components/schemas/MediaFile"
+          required:
+          - id
+          - name
+          - slug
+        filters:
+          type: object
+          properties:
+            classification:
+              type: string
+            focus:
+              type: string
+            minSize:
+              type: string
+            maxSize:
+              type: string
+            minCrew:
+              type: integer
+            minCargo:
+              type: number
+        slots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/MissionSlot"
+      required:
+      - id
+      - missionTeamId
+      - position
+      - strict
+      - slots
+      additionalProperties: false
+      title: MissionShip
+    MissionShipCreateInput:
+      type: object
+      properties:
+        title:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        modelId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        classification:
+          type:
+          - string
+          - 'null'
+        focus:
+          type:
+          - string
+          - 'null'
+        minSize:
+          type:
+          - string
+          - 'null'
+        maxSize:
+          type:
+          - string
+          - 'null'
+        minCrew:
+          type:
+          - integer
+          - 'null'
+        minCargo:
+          type:
+          - number
+          - 'null'
+        positionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Optional list of ModelPosition IDs to materialize as slots
+            when modelId is set
+      additionalProperties: false
+      title: MissionShipCreateInput
+    MissionShipUpdateInput:
+      type: object
+      properties:
+        title:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        modelId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        classification:
+          type:
+          - string
+          - 'null'
+        focus:
+          type:
+          - string
+          - 'null'
+        minSize:
+          type:
+          - string
+          - 'null'
+        maxSize:
+          type:
+          - string
+          - 'null'
+        minCrew:
+          type:
+          - integer
+          - 'null'
+        minCargo:
+          type:
+          - number
+          - 'null'
+      additionalProperties: false
+      title: MissionShipUpdateInput
+    MissionSlot:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        slottableType:
+          type: string
+          enum:
+          - MissionTeam
+          - MissionShip
+        slottableId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        derived:
+          type: boolean
+        positionType:
+          type: string
+      required:
+      - id
+      - slottableType
+      - slottableId
+      - title
+      - position
+      - derived
+      additionalProperties: false
+      title: MissionSlot
+    MissionSlotCreateInput:
+      type: object
+      properties:
+        slottableType:
+          type: string
+          enum:
+          - MissionTeam
+          - MissionShip
+        slottableId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      required:
+      - slottableType
+      - slottableId
+      - title
+      additionalProperties: false
+      title: MissionSlotCreateInput
+    MissionSlotSortInput:
+      type: object
+      properties:
+        slottableType:
+          type: string
+          enum:
+          - MissionTeam
+          - MissionShip
+        slottableId:
+          type: string
+          format: uuid
+        sorting:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+      - slottableType
+      - slottableId
+      - sorting
+      additionalProperties: false
+      title: MissionSlotSortInput
+    MissionSlotUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: MissionSlotUpdateInput
+    MissionTeam:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        missionId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        slots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/MissionSlot"
+        ships:
+          type: array
+          items:
+            "$ref": "#/components/schemas/MissionShip"
+      required:
+      - id
+      - missionId
+      - title
+      - position
+      - slots
+      - ships
+      additionalProperties: false
+      title: MissionTeam
+    MissionTeamCreateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      required:
+      - title
+      additionalProperties: false
+      title: MissionTeamCreateInput
+    MissionTeamUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: MissionTeamUpdateInput
+    MissionUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type:
+          - string
+          - 'null'
+        coverImagePreset:
+          type:
+          - string
+          - 'null'
+        coverImage:
+          type:
+          - string
+          - 'null'
+        archivedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+      additionalProperties: false
+      title: MissionUpdateInput
+    MissionsList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Mission"
+        meta:
+          "$ref": "#/components/schemas/Meta"
+      required:
+      - items
+      - meta
+      title: MissionsList
     Model:
       type: object
       properties:
@@ -15468,6 +16622,18 @@ components:
           type: string
       additionalProperties: false
       title: SetupOtpInput
+    SortInput:
+      type: object
+      properties:
+        sorting:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+      - sorting
+      additionalProperties: false
+      title: SortInput
     StandardError:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2710,6 +2710,56 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/{id}/duplicate":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: missionTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Duplicate Mission Ship
+      tags:
+      - Missions
+      operationId: duplicateMissionShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MissionShip"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/missions/{slug}":
     parameters:
     - name: fleetSlug

--- a/test/factories/fleets.rb
+++ b/test/factories/fleets.rb
@@ -2,31 +2,34 @@
 #
 # Table name: fleets
 #
-#  id                 :uuid             not null, primary key
-#  created_by         :uuid
-#  description        :text
-#  discarded_at       :datetime
-#  discord            :string
-#  fid                :string
-#  guilded            :string
-#  homepage           :string
-#  name               :string
-#  normalized_fid     :string
-#  public_fleet       :boolean          default(FALSE)
-#  public_fleet_stats :boolean          default(FALSE)
-#  rsi_sid            :string
-#  sid                :string
-#  slug               :string
-#  ts                 :string
-#  twitch             :string
-#  youtube            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                  :uuid             not null, primary key
+#  calendar_feed_token :string
+#  created_by          :uuid
+#  default_timezone    :string           default("UTC"), not null
+#  description         :text
+#  discarded_at        :datetime
+#  discord             :string
+#  fid                 :string
+#  guilded             :string
+#  homepage            :string
+#  name                :string
+#  normalized_fid      :string
+#  public_fleet        :boolean          default(FALSE)
+#  public_fleet_stats  :boolean          default(FALSE)
+#  rsi_sid             :string
+#  sid                 :string
+#  slug                :string
+#  ts                  :string
+#  twitch              :string
+#  youtube             :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 # Indexes
 #
-#  index_fleets_on_discarded_at  (discarded_at)
-#  index_fleets_on_fid           (fid) UNIQUE WHERE (discarded_at IS NULL)
+#  index_fleets_on_calendar_feed_token  (calendar_feed_token) UNIQUE
+#  index_fleets_on_discarded_at         (discarded_at)
+#  index_fleets_on_fid                  (fid) UNIQUE WHERE (discarded_at IS NULL)
 #
 FactoryBot.define do
   factory :fleet do

--- a/test/factories/missions.rb
+++ b/test/factories/missions.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: missions
+#
+#  id                 :uuid             not null, primary key
+#  archived_at        :datetime
+#  category           :integer          default(0), not null
+#  cover_image_preset :string
+#  description        :text
+#  scenario           :string
+#  slug               :string           not null
+#  title              :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_id      :uuid             not null
+#  fleet_id           :uuid             not null
+#
+# Indexes
+#
+#  index_missions_on_fleet_id_and_archived_at  (fleet_id,archived_at)
+#  index_missions_on_fleet_id_and_category     (fleet_id,category)
+#  index_missions_on_fleet_id_and_scenario     (fleet_id,scenario)
+#  index_missions_on_fleet_id_and_slug         (fleet_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (fleet_id => fleets.id)
+#
+FactoryBot.define do
+  factory :mission do
+    fleet
+    association :created_by, factory: :user
+    sequence(:title) { |n| "Mission #{n}" }
+    description { Faker::Lorem.sentence }
+
+    trait :archived do
+      archived_at { Time.current }
+    end
+  end
+
+  factory :mission_team do
+    mission
+    sequence(:title) { |n| "Team #{n}" }
+    description { Faker::Lorem.sentence }
+    sequence(:position) { |n| n }
+  end
+
+  factory :mission_ship do
+    mission_team
+    sequence(:position) { |n| n }
+    classification { "Combat" }
+
+    trait :strict do
+      classification { nil }
+      association :model, in_game: true
+    end
+
+    trait :ranged do
+      classification { "Combat" }
+      min_size { "medium" }
+    end
+  end
+
+  factory :mission_slot do
+    title { "Pilot" }
+    description { Faker::Lorem.sentence }
+    sequence(:position) { |n| n }
+    association :slottable, factory: :mission_team
+
+    trait :for_team do
+      association :slottable, factory: :mission_team
+    end
+
+    trait :for_ship do
+      association :slottable, factory: :mission_ship
+    end
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                        :uuid             not null, primary key
+#  calendar_feed_token       :string
 #  confirmation_sent_at      :datetime
 #  confirmation_token        :string(255)
 #  confirmed_at              :datetime
@@ -11,6 +12,7 @@
 #  current_sign_in_ip        :string(255)
 #  current_system            :string
 #  current_system_code       :string
+#  date_format               :string           default("dmy_dots"), not null
 #  discord                   :string
 #  email                     :string(255)      default(""), not null
 #  encrypted_otp_secret      :string
@@ -61,6 +63,7 @@
 #
 # Indexes
 #
+#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
 #  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_last_active_at        (last_active_at)

--- a/test/integration/api/v1/fleets_mission_teams_create_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_create_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+
+    post("Create Mission Team") do
+      operationId "createMissionTeam"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionTeamCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/MissionTeam"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams creates a team" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      body: {title: "Strike Team", description: "Main combat group"} do
+      assert_equal "Strike Team", parsed_body["title"]
+      assert_equal 0, parsed_body["position"]
+    end
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Strike Team", description: "Main combat group"}
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Strike Team", description: "Main combat group"}
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      body: {title: "Strike Team", description: "Main combat group"}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_destroy_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_destroy_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    delete("Destroy Mission Team") do
+      operationId "destroyMissionTeam"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id destroys the team" do
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @team.reload }
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_ships_create_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_create_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsShipsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "missionTeamId", in: :path, schema: {type: :string}
+
+    post("Create Mission Ship") do
+      operationId "createMissionShip"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionShipCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful - range filter") do
+        schema "$ref": "#/components/schemas/MissionShip"
+      end
+
+      response(400, "bad request - non-in-game model") do
+        schema "$ref": "#/components/schemas/ValidationError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships creates a ranged ship" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {classification: "Combat", minSize: "medium"} do
+      assert_equal false, parsed_body["strict"]
+      assert_equal "Combat", parsed_body["filters"]["classification"]
+    end
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships creates a specific model with materialized seats" do
+    model = create(:model, in_game: true)
+    positions = [
+      create(:model_position, model: model, name: "Pilot", position_type: :pilot, position: 0),
+      create(:model_position, model: model, name: "Co-Pilot", position_type: :copilot, position: 1)
+    ]
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {modelId: model.id, positionIds: positions.map(&:id)} do
+      assert_equal true, parsed_body["strict"]
+      assert_equal model.id, parsed_body["model"]["id"]
+      assert_equal 2, parsed_body["slots"].size
+      assert_equal ["Pilot", "Co-Pilot"].sort, parsed_body["slots"].map { |s| s["title"] }.sort
+      assert parsed_body["slots"].all? { |s| s["derived"] }
+    end
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships returns 400 for non-in-game model" do
+    model = create(:model, in_game: false)
+    sign_in @admin
+
+    assert_api_response :post, 400,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {modelId: model.id}
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {classification: "Combat", minSize: "medium"}
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {classification: "Combat", minSize: "medium"}
+  end
+
+  test "POST /fleets/:slug/missions/:slug/teams/:id/ships returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {classification: "Combat", minSize: "medium"}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_ships_destroy_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_destroy_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsShipsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "missionTeamId", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    delete("Destroy Mission Ship") do
+      operationId "destroyMissionShip"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @ship = create(:mission_ship, :ranged, mission_team: @team)
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id/ships/:id destroys the ship" do
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @ship.reload }
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id/ships/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id/ships/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug/teams/:id/ships/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_ships_duplicate_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_duplicate_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsShipsDuplicateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/{id}/duplicate" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "missionTeamId", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    post("Duplicate Mission Ship") do
+      operationId "duplicateMissionShip"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/MissionShip"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @ship = create(:mission_ship, mission_team: @team, title: "Escort",
+      description: "Runs point", classification: "combat", min_crew: 2)
+  end
+
+  def path_params
+    {
+      fleetSlug: @fleet.slug,
+      missionSlug: @mission.slug,
+      missionTeamId: @team.id,
+      id: @ship.id
+    }
+  end
+
+  test "POST .../ships/:id/duplicate copies the ship to the end of the team" do
+    sign_in @admin
+
+    assert_api_response :post, 201, path_params: path_params do
+      assert_equal 2, @team.mission_ships.count
+      assert_equal "Escort", parsed_body["title"]
+      assert_equal "Runs point", parsed_body["description"]
+      assert_equal 2, parsed_body["filters"]["minCrew"]
+      assert_not_equal @ship.id, parsed_body["id"]
+      assert_equal @team.mission_ships.maximum(:position), parsed_body["position"]
+    end
+  end
+
+  test "POST .../ships/:id/duplicate copies the slots as they stand" do
+    @ship.mission_slots.create!(title: "Pilot", position: 0)
+    @ship.mission_slots.create!(title: "Renamed gunner", description: "Top turret", position: 1)
+    sign_in @admin
+
+    assert_api_response :post, 201, path_params: path_params do
+      copy = @team.mission_ships.order(:position).last
+
+      assert_equal ["Pilot", "Renamed gunner"], copy.mission_slots.order(:position).pluck(:title)
+      assert_equal "Top turret", copy.mission_slots.order(:position).last.description
+    end
+  end
+
+  test "POST .../ships/:id/duplicate returns 401 without a session" do
+    assert_api_response :post, 401, path_params: path_params
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_ships_sort_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_sort_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsShipsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/sort" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "missionTeamId", in: :path, schema: {type: :string}
+
+    put("Sort Mission Ships") do
+      operationId "sortMissionShips"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/SortInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :object, properties: {success: {type: :boolean}}
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @ships = create_list(:mission_ship, 3, :ranged, mission_team: @team)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/sort updates positions" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {sorting: @ships.reverse.map(&:id)}
+
+    @ships.reverse.each_with_index do |ship, index|
+      assert_equal index, ship.reload.position
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id},
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_ships_update_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_update_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsShipsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{missionTeamId}/ships/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "missionTeamId", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update Mission Ship") do
+      operationId "updateMissionShip"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionShipUpdateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionShip"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @ship = create(:mission_ship, :ranged, mission_team: @team)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/:id updates the ship" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      body: {description: "Updated description"} do
+      assert_equal "Updated description", parsed_body["description"]
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {description: "Updated description"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {description: "Updated description"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id/ships/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, missionTeamId: @team.id, id: @ship.id},
+      body: {description: "Updated description"}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_sort_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_sort_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/sort" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+
+    put("Sort Mission Teams") do
+      operationId "sortMissionTeams"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/SortInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :object, properties: {success: {type: :boolean}}
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @teams = create_list(:mission_team, 3, mission: @mission)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/sort updates positions" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      body: {sorting: @teams.reverse.map(&:id)}
+
+    @teams.reverse.each_with_index do |team, index|
+      assert_equal index, team.reload.position
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug},
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+end

--- a/test/integration/api/v1/fleets_mission_teams_update_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_update_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionTeamsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{missionSlug}/teams/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "missionSlug", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update Mission Team") do
+      operationId "updateMissionTeam"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionTeamUpdateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionTeam"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id updates the team" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      body: {title: "Renamed Team"} do
+      assert_equal "Renamed Team", parsed_body["title"]
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Renamed Team"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Renamed Team"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/teams/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, missionSlug: @mission.slug, id: @team.id},
+      body: {title: "Renamed Team"}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_create_test.rb
+++ b/test/integration/api/v1/fleets_missions_create_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    post("Create Mission") do
+      operationId "createFleetMission"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/MissionCreateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/MissionExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden - member cannot create") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+  end
+
+  test "POST /fleets/:slug/missions creates a mission" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug},
+      body: {title: "Operation Bluebird", description: "Cargo run"} do
+      assert_equal "Operation Bluebird", parsed_body["title"]
+      assert_equal "operation-bluebird", parsed_body["slug"]
+    end
+  end
+
+  test "POST /fleets/:slug/missions returns 403 when caller is a member" do
+    sign_in @member
+
+    assert_api_response :post, 403,
+      path_params: {fleetSlug: @fleet.slug},
+      body: {title: "Operation Bluebird", description: "Cargo run"}
+  end
+
+  test "POST /fleets/:slug/missions with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Operation Bluebird", description: "Cargo run"}
+  end
+
+  test "POST /fleets/:slug/missions returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Operation Bluebird", description: "Cargo run"}
+  end
+
+  test "POST /fleets/:slug/missions returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      body: {title: "Operation Bluebird", description: "Cargo run"}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_destroy_test.rb
+++ b/test/integration/api/v1/fleets_missions_destroy_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    delete("Archive Mission") do
+      operationId "destroyFleetMission"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful - archived") do
+        schema "$ref": "#/components/schemas/MissionExtended"
+      end
+
+      response(204, "successful - permanent delete on already-archived mission") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug archives an active mission" do
+    sign_in @admin
+
+    assert_api_response :delete, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug} do
+      assert_equal true, parsed_body["archived"]
+    end
+    assert @mission.reload.archived?
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug permanently deletes an already-archived mission" do
+    archived = create(:mission, :archived, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, slug: archived.slug}
+
+    assert_raises(ActiveRecord::RecordNotFound) { archived.reload }
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug with OAuth bearer token" do
+    assert_api_response :delete, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/missions/:slug returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_index_test.rb
+++ b/test/integration/api/v1/fleets_missions_index_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsIndexTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+
+    get("List Missions") do
+      operationId "fleetMissions"
+      tags "Missions"
+      produces "application/json"
+
+      parameter name: :archived, in: :query, schema: {type: :boolean}, required: false
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionsList"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "GET /fleets/:slug/missions returns the list" do
+    create_list(:mission, 2, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal 2, parsed_body["items"].size
+    end
+  end
+
+  test "GET /fleets/:slug/missions with OAuth bearer token" do
+    create_list(:mission, 1, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/missions returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/missions returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_show_test.rb
+++ b/test/integration/api/v1/fleets_missions_show_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    get("Show Mission") do
+      operationId "fleetMission"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+  end
+
+  test "GET /fleets/:slug/missions/:slug returns the mission" do
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug} do
+      assert_equal @mission.title, parsed_body["title"]
+      assert_kind_of Array, parsed_body["teams"]
+    end
+  end
+
+  test "GET /fleets/:slug/missions/:slug returns 404 for an unknown mission" do
+    sign_in @admin
+
+    assert_api_response :get, 404,
+      path_params: {fleetSlug: @fleet.slug, slug: "missing-mission"}
+  end
+
+  test "GET /fleets/:slug/missions/:slug with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/missions/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/missions/:slug returns 401 when not signed in" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_unarchive_test.rb
+++ b/test/integration/api/v1/fleets_missions_unarchive_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsUnarchiveTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{slug}/unarchive" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Unarchive Mission") do
+      operationId "unarchiveFleetMission"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin,
+      archived_at: 1.day.ago)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/unarchive restores the mission" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug} do
+      assert_nil @mission.reload.archived_at
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug/unarchive returns 401 without a session" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_missions_update_test.rb
+++ b/test/integration/api/v1/fleets_missions_update_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMissionsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/missions/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Update Mission") do
+      operationId "updateFleetMission"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/MissionUpdateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+  end
+
+  test "PUT /fleets/:slug/missions/:slug updates the mission" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      body: {title: "Updated Mission"} do
+      assert_equal "Updated Mission", parsed_body["title"]
+    end
+  end
+
+  test "PUT /fleets/:slug/missions/:slug with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Updated Mission"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Updated Mission"}
+  end
+
+  test "PUT /fleets/:slug/missions/:slug returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @mission.slug},
+      body: {title: "Updated Mission"}
+  end
+end

--- a/test/integration/api/v1/mission_slots_create_test.rb
+++ b/test/integration/api/v1/mission_slots_create_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MissionSlotsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/mission-slots" do
+    post("Create Mission Slot") do
+      operationId "createMissionSlot"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionSlotCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/MissionSlot"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+  end
+
+  test "POST /mission-slots creates a slot" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      body: {slottableType: "MissionTeam", slottableId: @team.id, title: "Pilot"} do
+      assert_equal "Pilot", parsed_body["title"]
+      assert_equal "MissionTeam", parsed_body["slottableType"]
+    end
+  end
+
+  test "POST /mission-slots with OAuth bearer token" do
+    assert_api_response :post, 201,
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {slottableType: "MissionTeam", slottableId: @team.id, title: "Pilot"}
+  end
+
+  test "POST /mission-slots returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {slottableType: "MissionTeam", slottableId: @team.id, title: "Pilot"}
+  end
+
+  test "POST /mission-slots returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      body: {slottableType: "MissionTeam", slottableId: @team.id, title: "Pilot"}
+  end
+end

--- a/test/integration/api/v1/mission_slots_destroy_test.rb
+++ b/test/integration/api/v1/mission_slots_destroy_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MissionSlotsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/mission-slots/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    delete("Destroy Mission Slot") do
+      operationId "destroyMissionSlot"
+      tags "Missions"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @slot = create(:mission_slot, slottable: @team)
+  end
+
+  test "DELETE /mission-slots/:id destroys the slot" do
+    sign_in @admin
+
+    assert_api_response :delete, 204, path_params: {id: @slot.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @slot.reload }
+  end
+
+  test "DELETE /mission-slots/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /mission-slots/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /mission-slots/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401, path_params: {id: @slot.id}
+  end
+end

--- a/test/integration/api/v1/mission_slots_sort_test.rb
+++ b/test/integration/api/v1/mission_slots_sort_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MissionSlotsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/mission-slots/sort" do
+    put("Sort Mission Slots") do
+      operationId "sortMissionSlots"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionSlotSortInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :object, properties: {success: {type: :boolean}}
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @slots = create_list(:mission_slot, 3, slottable: @team)
+  end
+
+  test "PUT /mission-slots/sort updates positions" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      body: {slottableType: "MissionTeam", slottableId: @team.id, sorting: @slots.reverse.map(&:id)}
+
+    @slots.reverse.each_with_index do |slot, index|
+      assert_equal index, slot.reload.position
+    end
+  end
+
+  test "PUT /mission-slots/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {slottableType: "MissionTeam", slottableId: @team.id, sorting: @slots.reverse.map(&:id)}
+  end
+
+  test "PUT /mission-slots/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {slottableType: "MissionTeam", slottableId: @team.id, sorting: @slots.reverse.map(&:id)}
+  end
+
+  test "PUT /mission-slots/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      body: {slottableType: "MissionTeam", slottableId: @team.id, sorting: @slots.reverse.map(&:id)}
+  end
+end

--- a/test/integration/api/v1/mission_slots_update_test.rb
+++ b/test/integration/api/v1/mission_slots_update_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MissionSlotsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/mission-slots/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update Mission Slot") do
+      operationId "updateMissionSlot"
+      tags "Missions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/MissionSlotUpdateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/MissionSlot"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @slot = create(:mission_slot, slottable: @team)
+  end
+
+  test "PUT /mission-slots/:id updates the slot" do
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {id: @slot.id}, body: {title: "Co-Pilot"} do
+      assert_equal "Co-Pilot", parsed_body["title"]
+    end
+  end
+
+  test "PUT /mission-slots/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Co-Pilot"}
+  end
+
+  test "PUT /mission-slots/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Co-Pilot"}
+  end
+
+  test "PUT /mission-slots/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {id: @slot.id},
+      body: {title: "Co-Pilot"}
+  end
+end

--- a/test/integration/fleet_mission_builder_gate_test.rb
+++ b/test/integration/fleet_mission_builder_gate_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Lives outside test/integration/api/v1 on purpose: it asserts gate behaviour
+# rather than a documented response, so it must not contribute to the generated
+# OpenAPI schema.
+class FleetMissionBuilderGateTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    sign_in @admin
+  end
+
+  test "the missions list is forbidden while the flag is off" do
+    get "/api/v1/fleets/#{@fleet.slug}/missions"
+
+    assert_response :forbidden
+  end
+
+  test "enabling the flag for the fleet opens the missions list" do
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+
+    get "/api/v1/fleets/#{@fleet.slug}/missions"
+
+    assert_response :success
+  end
+
+  test "a flag enabled for one fleet does not open another" do
+    other = create(:fleet, admins: [@admin])
+    Flipper.enable_actor("fleet_mission_builder", other)
+
+    get "/api/v1/fleets/#{@fleet.slug}/missions"
+
+    assert_response :forbidden
+  end
+
+  test "enabling the flag for the member alone still opens the list" do
+    Flipper.enable_actor("fleet_mission_builder", @admin)
+
+    get "/api/v1/fleets/#{@fleet.slug}/missions"
+
+    assert_response :success
+  end
+end

--- a/test/integration/fleet_mission_builder_gate_test.rb
+++ b/test/integration/fleet_mission_builder_gate_test.rb
@@ -42,4 +42,34 @@ class FleetMissionBuilderGateTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+  test "restoring an archived mission needs delete access, not just update" do
+    updater = create(:user)
+    role = @fleet.fleet_roles.create!(
+      name: "Mission editor", rank: 90,
+      resource_access: ["fleet:missions:read", "fleet:missions:update"]
+    )
+    create(:fleet_membership, fleet: @fleet, user: updater,
+      fleet_role: role, aasm_state: :accepted)
+    mission = create(:mission, fleet: @fleet, created_by: @admin,
+      archived_at: 1.day.ago)
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+
+    sign_in updater
+    put "/api/v1/fleets/#{@fleet.slug}/missions/#{mission.slug}/unarchive"
+
+    assert_response :forbidden
+    assert_not_nil mission.reload.archived_at
+  end
+
+  test "an update cannot clear archived_at on its own" do
+    mission = create(:mission, fleet: @fleet, created_by: @admin,
+      archived_at: 1.day.ago)
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+
+    patch "/api/v1/fleets/#{@fleet.slug}/missions/#{mission.slug}",
+      params: {archivedAt: nil}, as: :json
+
+    assert_response :success
+    assert_not_nil mission.reload.archived_at
+  end
 end

--- a/test/integration/fleet_mission_ship_allowed_models_test.rb
+++ b/test/integration/fleet_mission_ship_allowed_models_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A ship spot names one exact model, a list of models it will take, or the
+# criteria a model has to meet. This covers the middle one, which is the only
+# kind whose answer lives in rows rather than columns.
+class FleetMissionShipAllowedModelsTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+    @mission = create(:mission, fleet: @fleet, created_by: @admin)
+    @team = create(:mission_team, mission: @mission)
+    @connie = create(:model, name: "Constellation Andromeda", in_game: true)
+    @freelancer = create(:model, name: "Freelancer MAX", in_game: true)
+    sign_in @admin
+  end
+
+  def ships_path
+    "/api/v1/fleets/#{@fleet.slug}/missions/#{@mission.slug}/teams/#{@team.id}/ships"
+  end
+
+  test "a list of models is enough on its own to describe a spot" do
+    post ships_path,
+      params: {title: "Escort", allowedModelIds: [@connie.id, @freelancer.id]},
+      as: :json
+
+    assert_response :created
+    ship = @team.mission_ships.order(:position).last
+    assert_equal [@connie.id, @freelancer.id], ship.allowed_models.map(&:id)
+    assert ship.listed?
+    assert_not ship.strict?
+    assert_not ship.filtered?
+  end
+
+  test "the order the models were picked in is the order they come back" do
+    post ships_path,
+      params: {title: "Escort", allowedModelIds: [@freelancer.id, @connie.id]},
+      as: :json
+
+    assert_response :created
+    ship = @team.mission_ships.order(:position).last
+    assert_equal ["Freelancer MAX", "Constellation Andromeda"], ship.allowed_models.map(&:name)
+  end
+
+  test "a spot with neither a model, a list nor a filter is rejected" do
+    post ships_path, params: {title: "Escort"}, as: :json
+
+    assert_response :bad_request
+  end
+
+  test "a list cannot name a ship that is not in the game" do
+    concept = create(:model, in_game: false)
+
+    post ships_path,
+      params: {title: "Escort", allowedModelIds: [concept.id]},
+      as: :json
+
+    assert_response :bad_request
+  end
+
+  test "updating with a list replaces it rather than adding to it" do
+    ship = create(:mission_ship, mission_team: @team, classification: "combat")
+    ship.mission_ship_models.create!(model_id: @connie.id, position: 0)
+
+    patch "#{ships_path}/#{ship.id}",
+      params: {allowedModelIds: [@freelancer.id]},
+      as: :json
+
+    assert_response :success
+    assert_equal [@freelancer.id], ship.reload.allowed_models.map(&:id)
+  end
+
+  test "an update that does not mention the list leaves it alone" do
+    ship = create(:mission_ship, mission_team: @team)
+    ship.mission_ship_models.create!(model_id: @connie.id, position: 0)
+
+    patch "#{ships_path}/#{ship.id}", params: {title: "Renamed"}, as: :json
+
+    assert_response :success
+    assert_equal "Renamed", ship.reload.title
+    assert_equal [@connie.id], ship.allowed_models.map(&:id)
+  end
+
+  test "duplicating a spot carries its list" do
+    ship = create(:mission_ship, mission_team: @team)
+    ship.mission_ship_models.create!(model_id: @connie.id, position: 0)
+    ship.mission_ship_models.create!(model_id: @freelancer.id, position: 1)
+
+    post "#{ships_path}/#{ship.id}/duplicate"
+
+    assert_response :created
+    copy = @team.mission_ships.order(:position).last
+    assert_not_equal ship.id, copy.id
+    assert_equal [@connie.id, @freelancer.id], copy.allowed_models.map(&:id)
+  end
+
+  test "retiring a model drops it from the lists that named it" do
+    ship = create(:mission_ship, mission_team: @team)
+    ship.mission_ship_models.create!(model_id: @connie.id, position: 0)
+    ship.mission_ship_models.create!(model_id: @freelancer.id, position: 1)
+
+    @connie.destroy
+
+    assert_equal [@freelancer.id], ship.reload.allowed_models.map(&:id)
+  end
+end

--- a/test/integration/fleet_mission_ship_allowed_models_test.rb
+++ b/test/integration/fleet_mission_ship_allowed_models_test.rb
@@ -83,6 +83,37 @@ class FleetMissionShipAllowedModelsTest < ActionDispatch::IntegrationTest
     assert_equal [@connie.id], ship.allowed_models.map(&:id)
   end
 
+  # The factory gives a ship filters, which satisfied model_or_filter_required on
+  # its own and so hid an ordering bug: a spot whose whole spec is a list has
+  # nothing in its columns.
+  def listed_ship(*model_ids)
+    ship = MissionShip.new(mission_team: @team, title: "Listed", position: 0)
+    model_ids.each_with_index do |id, index|
+      ship.mission_ship_models.build(model_id: id, position: index)
+    end
+    ship.save!
+    ship
+  end
+
+  test "duplicating a spot whose whole spec is a list" do
+    ship = listed_ship(@connie.id, @freelancer.id)
+
+    post "#{ships_path}/#{ship.id}/duplicate"
+
+    assert_response :created
+    copy = @team.mission_ships.order(:position).last
+    assert_not_equal ship.id, copy.id
+    assert_equal [@connie.id, @freelancer.id], copy.allowed_models.map(&:id)
+    assert_nil copy.classification
+  end
+
+  test "a spot that says nothing at all reports it rather than raising" do
+    post ships_path, params: {title: "Empty"}, as: :json
+
+    assert_response :bad_request
+    assert_includes response.body.downcase, "ship"
+  end
+
   test "duplicating a spot carries its list" do
     ship = create(:mission_ship, mission_team: @team)
     ship.mission_ship_models.create!(model_id: @connie.id, position: 0)

--- a/test/models/fleet_test.rb
+++ b/test/models/fleet_test.rb
@@ -4,31 +4,34 @@
 #
 # Table name: fleets
 #
-#  id                 :uuid             not null, primary key
-#  created_by         :uuid
-#  description        :text
-#  discarded_at       :datetime
-#  discord            :string
-#  fid                :string
-#  guilded            :string
-#  homepage           :string
-#  name               :string
-#  normalized_fid     :string
-#  public_fleet       :boolean          default(FALSE)
-#  public_fleet_stats :boolean          default(FALSE)
-#  rsi_sid            :string
-#  sid                :string
-#  slug               :string
-#  ts                 :string
-#  twitch             :string
-#  youtube            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                  :uuid             not null, primary key
+#  calendar_feed_token :string
+#  created_by          :uuid
+#  default_timezone    :string           default("UTC"), not null
+#  description         :text
+#  discarded_at        :datetime
+#  discord             :string
+#  fid                 :string
+#  guilded             :string
+#  homepage            :string
+#  name                :string
+#  normalized_fid      :string
+#  public_fleet        :boolean          default(FALSE)
+#  public_fleet_stats  :boolean          default(FALSE)
+#  rsi_sid             :string
+#  sid                 :string
+#  slug                :string
+#  ts                  :string
+#  twitch              :string
+#  youtube             :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 # Indexes
 #
-#  index_fleets_on_discarded_at  (discarded_at)
-#  index_fleets_on_fid           (fid) UNIQUE WHERE (discarded_at IS NULL)
+#  index_fleets_on_calendar_feed_token  (calendar_feed_token) UNIQUE
+#  index_fleets_on_discarded_at         (discarded_at)
+#  index_fleets_on_fid                  (fid) UNIQUE WHERE (discarded_at IS NULL)
 #
 require "test_helper"
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,7 @@
 # Table name: users
 #
 #  id                        :uuid             not null, primary key
+#  calendar_feed_token       :string
 #  confirmation_sent_at      :datetime
 #  confirmation_token        :string(255)
 #  confirmed_at              :datetime
@@ -13,6 +14,7 @@
 #  current_sign_in_ip        :string(255)
 #  current_system            :string
 #  current_system_code       :string
+#  date_format               :string           default("dmy_dots"), not null
 #  discord                   :string
 #  email                     :string(255)      default(""), not null
 #  encrypted_otp_secret      :string
@@ -63,6 +65,7 @@
 #
 # Indexes
 #
+#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
 #  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_last_active_at        (last_active_at)


### PR DESCRIPTION
Second of the stack splitting #3893. Stacked on #4443 — **review that one first**; this PR's diff against `main` will shrink once it lands.

Missions are a fleet's reusable roster template: teams, the ships each team brings, and the slots members can be assigned to. Scheduling a mission onto the calendar (fleet events) follows in the next PRs.

### What's here

- Tables: `missions`, `mission_teams`, `mission_ships`, `mission_slots`
- CRUD plus sorting for teams, ships and slots
- Privileges: `fleet:missions:read` for every member, `fleet:missions:manage` for anyone who already manages the fleet or its memberships. A data migration grants both to existing roles.
- `lib/tasks/missions.rake`

All of it sits behind the `fleet_mission_builder` flag from #4443, so nothing is reachable until the flag is enabled for an actor.

### Reviewing the diff

- **`swagger/v1/schema.yaml` is generated — skip it.** The churn is path *ordering*: openapi-ruby emits paths in test-contribution order, so adding tests reshuffles the file. The path set is exactly `main`'s 190 plus the 11 new mission paths, nothing removed.
- The migrations are timestamped `20260503*`, older than main's current schema version. That's fine for production (which migrates incrementally) and `db/schema.rb` carries the tables for `schema:load` setups, but it's why the schema version line is unchanged.

### Verification

- `test/integration/api/v1/`, `test/models`, `test/lib` — 1386 tests, 3322 assertions, 0 failures
- `vue-tsc` + `tsc` clean, `standardrb` clean on every touched Ruby file
- `bin/generate-schema` regenerated clean, Orval generates all three clients

🤖