### PR TITLE
feat(fleets): fleet events

### DIFF
--- a/app/api_components/v1/schemas/fleets/events/fleet_event.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEvent
+          include OpenapiRuby::Components::Base
+
+          STATUSES = %w[draft open locked active completed cancelled].freeze
+          VISIBILITIES = %w[members officers fleet].freeze
+          SIGNUP_APPROVALS = %w[direct confirmation_required].freeze
+          VIEWER_EVENT_ROLES = %w[creator admin moderator].freeze
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetId: {type: :string, format: :uuid},
+              missionId: {type: :string, format: :uuid},
+              title: {type: :string},
+              slug: {type: :string},
+              description: {type: :string},
+              briefing: {type: :string},
+              status: {type: :string, enum: STATUSES},
+              startsAt: {type: :string, format: "date-time"},
+              endsAt: {type: :string, format: "date-time"},
+              timezone: {type: :string},
+              location: {type: :string},
+              meetupLocation: {type: :string},
+              visibility: {type: :string, enum: VISIBILITIES},
+              category: {
+                type: :string,
+                enum: V1::Schemas::Fleets::Missions::Mission::CATEGORIES
+              },
+              scenario: {type: :string},
+              coverImagePreset: {type: :string},
+              coverImage: {"$ref": "#/components/schemas/MediaFile"},
+              maxAttendees: {type: :integer},
+              autoLockEnabled: {type: :boolean},
+              autoLockMinutesBefore: {type: :integer},
+              cancelledReason: {type: :string},
+              signupApproval: {type: :string, enum: SIGNUP_APPROVALS},
+              viewerEventRole: {
+                type: :string,
+                enum: VIEWER_EVENT_ROLES
+              },
+              archived: {type: :boolean},
+              archivedAt: {type: :string, format: "date-time"},
+              externalUid: {type: :string, format: :uuid},
+              createdBy: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  username: {type: :string}
+                }
+              },
+              signupsCount: {type: :integer},
+              teamCount: {type: :integer},
+              past: {type: :boolean},
+              signupsOpen: {type: :boolean},
+              recurring: {type: :boolean},
+              recurrenceInterval: {
+                type: :string,
+                enum: ::FleetEvent::RECURRENCE_INTERVALS
+
+              },
+              recurrenceUntil: {type: :string, format: :date},
+              recurrenceCount: {type: :integer},
+              excludedDates: {
+                type: :array,
+                items: {type: :string, format: :date}
+              },
+              occurrenceDate: {type: :string, format: :date},
+              parentEventSlug: {type: :string},
+              createdAt: {type: :string, format: "date-time"},
+              updatedAt: {type: :string, format: "date-time"}
+            },
+            required: %w[
+              id fleetId title slug status startsAt timezone visibility category
+              autoLockEnabled archived externalUid signupApproval signupsCount teamCount past signupsOpen createdAt updatedAt
+            ]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_admin.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_admin.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventAdmin
+          include OpenapiRuby::Components::Base
+
+          ROLES = %w[admin moderator].freeze
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetEventId: {type: :string, format: :uuid},
+              role: {type: :string, enum: ROLES},
+              createdAt: {type: :string, format: "date-time"},
+              user: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  username: {type: :string}
+                },
+                required: %w[id username]
+              },
+              grantedBy: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  username: {type: :string}
+                }
+              }
+            },
+            required: %w[id fleetEventId role user createdAt],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_admins_list.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_admins_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventAdminsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/FleetEventAdmin"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_extended.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_extended.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventExtended
+          include OpenapiRuby::Components::Base
+
+          schema({
+            allOf: [
+              {"$ref": "#/components/schemas/FleetEvent"},
+              {
+                type: :object,
+                properties: {
+                  teams: {
+                    type: :array,
+                    items: {"$ref": "#/components/schemas/FleetEventTeam"}
+                  },
+                  unassignedSignups: {
+                    type: :array,
+                    items: {"$ref": "#/components/schemas/FleetEventSignup"}
+                  }
+                },
+                required: %w[teams unassignedSignups]
+              }
+            ]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_occurrence_state.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_occurrence_state.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventOccurrenceState
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetEventId: {type: :string, format: :uuid},
+              occurrenceDate: {type: :string, format: :date},
+              status: {type: :string},
+              lockedAt: {type: :string, format: "date-time"},
+              startingSoonNotifiedAt: {type: :string, format: "date-time"},
+              cancelledAt: {type: :string, format: "date-time"},
+              cancelledReason: {type: :string},
+              discordEventId: {type: :string},
+              discordSyncedAt: {type: :string, format: "date-time"},
+              title: {type: :string},
+              description: {type: :string},
+              briefing: {type: :string},
+              location: {type: :string},
+              meetupLocation: {type: :string},
+              scenario: {type: :string},
+              coverImagePreset: {type: :string}
+            },
+            required: %w[id fleetEventId occurrenceDate]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventShip
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetEventTeamId: {type: :string, format: :uuid},
+              title: {type: :string},
+              displayTitle: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              strict: {type: :boolean},
+              model: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  name: {type: :string},
+                  slug: {type: :string},
+                  minCrew: {type: :integer},
+                  maxCrew: {type: :integer},
+                  image: {"$ref": "#/components/schemas/MediaFile"}
+                },
+                required: %w[id name slug]
+              },
+              filters: {
+                type: :object,
+                properties: {
+                  classification: {type: :string},
+                  focus: {type: :string},
+                  minSize: {type: :string},
+                  maxSize: {type: :string},
+                  minCrew: {type: :integer},
+                  minCargo: {type: :number}
+                }
+              },
+              slots: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEventSlot"}
+              }
+            },
+            required: %w[id fleetEventTeamId position strict slots],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
@@ -17,17 +17,12 @@ module V1
               description: {type: :string},
               position: {type: :integer},
               strict: {type: :boolean},
-              model: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  name: {type: :string},
-                  slug: {type: :string},
-                  minCrew: {type: :integer},
-                  maxCrew: {type: :integer},
-                  image: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                required: %w[id name slug]
+              model: {"$ref": "#/components/schemas/ShipModel"},
+              # The models a spot will take when it names several rather than
+              # one; empty for the other two kinds of spot.
+              allowedModels: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/ShipModel"}
               },
               filters: {
                 type: :object,
@@ -45,7 +40,7 @@ module V1
                 items: {"$ref": "#/components/schemas/FleetEventSlot"}
               }
             },
-            required: %w[id fleetEventTeamId position strict slots],
+            required: %w[id fleetEventTeamId position strict allowedModels slots],
             additionalProperties: false
           })
         end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_signup.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_signup.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventSignup
+          include OpenapiRuby::Components::Base
+
+          STATUSES = %w[confirmed tentative interested pending withdrawn].freeze
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetEventId: {type: :string, format: :uuid},
+              fleetEventSlotId: {type: :string, format: :uuid},
+              occurrenceDate: {type: :string, format: :date},
+              status: {type: :string, enum: STATUSES},
+              notes: {type: :string},
+              confirmedAt: {type: :string, format: "date-time"},
+              withdrawnAt: {type: :string, format: "date-time"},
+              user: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  username: {type: :string}
+                }
+              },
+              vehicle: {
+                type: :object,
+                properties: {
+                  id: {type: :string, format: :uuid},
+                  name: {type: :string},
+                  model: {
+                    type: :object,
+                    properties: {
+                      id: {type: :string, format: :uuid},
+                      name: {type: :string},
+                      slug: {type: :string},
+                      classification: {type: :string},
+                      focus: {type: :string},
+                      size: {type: :string},
+                      minCrew: {type: :integer},
+                      maxCrew: {type: :integer},
+                      cargo: {type: :integer},
+                      positionCount: {type: :integer}
+                    }
+                  }
+                }
+              }
+            },
+            required: %w[id fleetEventId status],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_slot.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_slot.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventSlot
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              slottableType: {type: :string, enum: %w[FleetEventTeam FleetEventShip]},
+              slottableId: {type: :string, format: :uuid},
+              title: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              derived: {type: :boolean},
+              positionType: {type: :string},
+              modelPositionId: {type: :string, format: :uuid},
+              signupApproval: {
+                type: :string,
+                enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS
+              },
+              effectiveSignupApproval: {
+                type: :string,
+                enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS
+              },
+              signups: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEventSignup"}
+              }
+            },
+            required: %w[id slottableType slottableId title position derived effectiveSignupApproval signups],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_team.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_team.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventTeam
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              fleetEventId: {type: :string, format: :uuid},
+              title: {type: :string},
+              description: {type: :string},
+              position: {type: :integer},
+              slots: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEventSlot"}
+              },
+              ships: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEventShip"}
+              }
+            },
+            required: %w[id fleetEventId title position slots ships],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_events_list.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_events_list.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              items: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEvent"}
+              },
+              meta: {"$ref": "#/components/schemas/Meta"}
+            },
+            required: %w[items meta]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_admin_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_admin_create_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventAdminCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            userId: {type: :string, format: :uuid},
+            role: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEventAdmin::ROLES
+            }
+          },
+          required: %w[userId],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_create_input.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            missionSlug: {type: [:string, :null]},
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            briefing: {type: [:string, :null]},
+            startsAt: {type: :string, format: "date-time"},
+            endsAt: {type: [:string, :null], format: "date-time"},
+            timezone: {type: :string},
+            location: {type: [:string, :null]},
+            meetupLocation: {type: [:string, :null]},
+            visibility: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEvent::VISIBILITIES
+            },
+            category: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Missions::Mission::CATEGORIES
+            },
+            scenario: {type: [:string, :null]},
+            coverImagePreset: {type: [:string, :null]},
+            coverImage: {type: [:string, :null]},
+            maxAttendees: {type: [:integer, :null]},
+            autoLockEnabled: {type: :boolean},
+            autoLockMinutesBefore: {type: [:integer, :null]},
+            signupApproval: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS
+            },
+            recurring: {type: :boolean},
+            recurrenceInterval: {
+              type: [:string, :null],
+              enum: ::FleetEvent::RECURRENCE_INTERVALS
+            },
+            recurrenceUntil: {type: [:string, :null], format: :date},
+            recurrenceCount: {type: [:integer, :null]}
+          },
+          required: %w[title startsAt timezone visibility],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_create_input.rb
@@ -39,7 +39,11 @@ module V1
             recurring: {type: :boolean},
             recurrenceInterval: {
               type: [:string, :null],
-              enum: ::FleetEvent::RECURRENCE_INTERVALS
+              # An enum constrains the value alongside the type rather than
+              # instead of it, so a nullable enum has to list null too. Without
+              # it a one-off event could not be created at all: the model
+              # requires the interval to be absent unless the event recurs.
+              enum: ::FleetEvent::RECURRENCE_INTERVALS + [nil]
             },
             recurrenceUntil: {type: [:string, :null], format: :date},
             recurrenceCount: {type: [:integer, :null]}

--- a/app/api_components/v1/schemas/inputs/fleet_event_ship_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_ship_create_input.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventShipCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: [:string, :null]},
+            description: {type: [:string, :null]},
+            modelId: {type: [:string, :null], format: :uuid},
+            classification: {type: [:string, :null]},
+            focus: {type: [:string, :null]},
+            minSize: {type: [:string, :null]},
+            maxSize: {type: [:string, :null]},
+            minCrew: {type: [:integer, :null]},
+            minCargo: {type: [:number, :null]},
+            positionIds: {
+              type: :array,
+              items: {type: :string, format: :uuid}
+            }
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_ship_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_ship_create_input.rb
@@ -18,6 +18,11 @@ module V1
             maxSize: {type: [:string, :null]},
             minCrew: {type: [:integer, :null]},
             minCargo: {type: [:number, :null]},
+            allowedModelIds: {
+              type: :array,
+              items: {type: :string, format: :uuid},
+              description: "Models this spot will accept, when it names several rather than one"
+            },
             positionIds: {
               type: :array,
               items: {type: :string, format: :uuid}

--- a/app/api_components/v1/schemas/inputs/fleet_event_ship_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_ship_update_input.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventShipUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: [:string, :null]},
+            description: {type: [:string, :null]},
+            modelId: {type: [:string, :null], format: :uuid},
+            classification: {type: [:string, :null]},
+            focus: {type: [:string, :null]},
+            minSize: {type: [:string, :null]},
+            maxSize: {type: [:string, :null]},
+            minCrew: {type: [:integer, :null]},
+            minCargo: {type: [:number, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_ship_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_ship_update_input.rb
@@ -17,7 +17,12 @@ module V1
             minSize: {type: [:string, :null]},
             maxSize: {type: [:string, :null]},
             minCrew: {type: [:integer, :null]},
-            minCargo: {type: [:number, :null]}
+            minCargo: {type: [:number, :null]},
+            allowedModelIds: {
+              type: :array,
+              items: {type: :string, format: :uuid},
+              description: "Models this spot will accept, when it names several rather than one"
+            }
           },
           additionalProperties: false
         })

--- a/app/api_components/v1/schemas/inputs/fleet_event_signup_assign_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_signup_assign_input.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSignupAssignInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            fleetEventSlotId: {type: [:string, :null], format: :uuid},
+            status: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEventSignup::STATUSES
+            },
+            vehicleId: {type: [:string, :null], format: :uuid},
+            notes: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_signup_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_signup_create_input.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSignupCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            status: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEventSignup::STATUSES
+            },
+            vehicleId: {type: [:string, :null], format: :uuid},
+            notes: {type: [:string, :null]},
+            occurrenceDate: {type: [:string, :null], format: :date}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_signup_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_signup_update_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSignupUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            status: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEventSignup::STATUSES
+            },
+            vehicleId: {type: [:string, :null], format: :uuid},
+            notes: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_slot_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_slot_create_input.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSlotCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slottableType: {type: :string, enum: %w[FleetEventTeam FleetEventShip]},
+            slottableId: {type: :string, format: :uuid},
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            signupApproval: {
+              type: [:string, :null],
+              enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS + [nil]
+            }
+          },
+          required: %w[slottableType slottableId title],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_slot_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_slot_update_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSlotUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            signupApproval: {
+              type: [:string, :null],
+              enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS + [nil]
+            }
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_team_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_team_create_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventTeamCreateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          required: %w[title],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_team_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_team_update_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventTeamUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_update_input.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            title: {type: :string},
+            description: {type: [:string, :null]},
+            briefing: {type: [:string, :null]},
+            startsAt: {type: :string, format: "date-time"},
+            endsAt: {type: [:string, :null], format: "date-time"},
+            timezone: {type: :string},
+            location: {type: [:string, :null]},
+            meetupLocation: {type: [:string, :null]},
+            visibility: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEvent::VISIBILITIES
+            },
+            category: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Missions::Mission::CATEGORIES
+            },
+            scenario: {type: [:string, :null]},
+            coverImagePreset: {type: [:string, :null]},
+            coverImage: {type: [:string, :null]},
+            maxAttendees: {type: [:integer, :null]},
+            autoLockEnabled: {type: :boolean},
+            autoLockMinutesBefore: {type: [:integer, :null]},
+            cancelledReason: {type: [:string, :null]},
+            signupApproval: {
+              type: :string,
+              enum: V1::Schemas::Fleets::Events::FleetEvent::SIGNUP_APPROVALS
+            },
+            recurring: {type: :boolean},
+            recurrenceInterval: {
+              type: [:string, :null],
+              enum: ::FleetEvent::RECURRENCE_INTERVALS
+            },
+            recurrenceUntil: {type: [:string, :null], format: :date},
+            recurrenceCount: {type: [:integer, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_update_input.rb
@@ -39,7 +39,11 @@ module V1
             recurring: {type: :boolean},
             recurrenceInterval: {
               type: [:string, :null],
-              enum: ::FleetEvent::RECURRENCE_INTERVALS
+              # An enum constrains the value alongside the type rather than
+              # instead of it, so a nullable enum has to list null too. Without
+              # it a one-off event could not be created at all: the model
+              # requires the interval to be absent unless the event recurs.
+              enum: ::FleetEvent::RECURRENCE_INTERVALS + [nil]
             },
             recurrenceUntil: {type: [:string, :null], format: :date},
             recurrenceCount: {type: [:integer, :null]}

--- a/app/controllers/api/v1/fleet_event_admins_controller.rb
+++ b/app/controllers/api/v1/fleet_event_admins_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventAdminsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[index]
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?,
+        only: %i[create destroy]
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_event
+      before_action :set_admin, only: %i[destroy]
+
+      def index
+        authorize! @event, with: FleetEventAdminPolicy
+
+        @admins = @event.fleet_event_admins.includes(:user, :granted_by)
+      end
+
+      def create
+        authorize! @event, with: FleetEventAdminPolicy, to: :create?
+
+        target_user = User.find_by!(id: params[:user_id])
+        @admin = @event.fleet_event_admins.new(
+          user: target_user,
+          role: params[:role].presence || "admin",
+          granted_by: current_resource_owner
+        )
+
+        if @admin.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_event_admins.create", errors: @admin.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @admin, with: FleetEventAdminPolicy, context: {fleet_event: @event}
+
+        @admin.destroy
+        head :no_content
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+      end
+
+      private def set_event
+        @event = @fleet.fleet_events.find_by!(slug: params[:fleet_event_slug])
+      end
+
+      private def set_admin
+        @admin = @event.fleet_event_admins.find(params[:id])
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_event_ships_controller.rb
+++ b/app/controllers/api/v1/fleet_event_ships_controller.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventShipsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_event
+      before_action :set_team
+      before_action :set_ship, only: %i[update destroy expand_from_model]
+
+      def create
+        @ship = @team.fleet_event_ships.new(ship_params)
+        @ship.position = next_position
+
+        authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :create?
+
+        ActiveRecord::Base.transaction do
+          @ship.save!
+          materialize_position_slots(@ship, position_ids_param)
+        end
+
+        render :show, status: :created
+      rescue ActiveRecord::RecordInvalid
+        render json: ValidationError.new("fleet_event_ships.create", errors: @ship.errors), status: :bad_request
+      end
+
+      def update
+        authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :update?
+
+        if @ship.update(ship_params)
+          render :show
+        else
+          render json: ValidationError.new("fleet_event_ships.update", errors: @ship.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :destroy?
+
+        unless @ship.destroy
+          render json: ValidationError.new("fleet_event_ships.destroy", errors: @ship.errors), status: :bad_request
+        end
+      end
+
+      # Adds extra slots to this ship for any model_positions of the given
+      # model that aren't already represented as slots — useful when a member
+      # signs up with a specific vehicle and we want to materialize the
+      # remaining seats (gunner, copilot, …) so other members can join.
+      def expand_from_model
+        authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :update?
+
+        model = Model.find(params[:model_id])
+
+        existing_position_ids = @ship.fleet_event_slots.where.not(model_position_id: nil).pluck(:model_position_id)
+        positions = model.model_positions.where.not(id: existing_position_ids)
+
+        if (requested = position_ids_param).present?
+          positions = positions.where(id: requested)
+        end
+
+        positions = positions.order(:position)
+
+        if positions.empty?
+          render json: {code: "no_new_positions", message: "No additional positions to add"}, status: :unprocessable_entity
+          return
+        end
+
+        next_slot_position = @ship.fleet_event_slots.maximum(:position) || -1
+
+        ActiveRecord::Base.transaction do
+          positions.each do |mp|
+            next_slot_position += 1
+            @ship.fleet_event_slots.create!(
+              title: mp.name,
+              model_position_id: mp.id,
+              position: next_slot_position
+            )
+          end
+        end
+
+        render :show
+      end
+
+      def sort
+        authorize! @event, with: FleetEventShipPolicy, to: :sort?, context: {fleet_event: @event}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        FleetEventShip.transaction do
+          sorting.each_with_index do |id, index|
+            @team.fleet_event_ships.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def ship_params
+        authorized(params, with: FleetEventShipPolicy)
+      end
+
+      private def position_ids_param
+        Array(params[:position_ids]).map(&:to_s)
+      end
+
+      private def materialize_position_slots(ship, position_ids)
+        return if position_ids.blank?
+        return if ship.model_id.blank?
+
+        positions = ship.model.model_positions.where(id: position_ids).order(:position)
+        next_slot_position = -1
+        positions.each do |mp|
+          next_slot_position += 1
+          ship.fleet_event_slots.create!(
+            title: mp.name,
+            model_position_id: mp.id,
+            position: next_slot_position
+          )
+        end
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_event
+        @event = @fleet.fleet_events.find_by!(slug: params[:fleet_event_slug])
+      end
+
+      private def set_team
+        @team = @event.fleet_event_teams.find(params[:fleet_event_team_id])
+      end
+
+      private def set_ship
+        @ship = @team.fleet_event_ships.find(params[:id])
+      end
+
+      private def next_position
+        (@team.fleet_event_ships.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_event_ships_controller.rb
+++ b/app/controllers/api/v1/fleet_event_ships_controller.rb
@@ -16,6 +16,10 @@ module Api
       def create
         @ship = @team.fleet_event_ships.new(ship_params)
         @ship.position = next_position
+        # Built rather than written: model_or_filter_required runs on save and a
+        # spot that names only a list has nothing else to satisfy it, so the rows
+        # have to exist in memory by then.
+        build_allowed_models(@ship, allowed_model_ids_param)
 
         authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :create?
 
@@ -23,6 +27,10 @@ module Api
           @ship.save!
           materialize_position_slots(@ship, position_ids_param)
         end
+
+        # The associations were read during validation, when the rows were still
+        # in memory, so the response would otherwise serialise that stale view.
+        @ship.reload
 
         render :show, status: :created
       rescue ActiveRecord::RecordInvalid
@@ -32,11 +40,14 @@ module Api
       def update
         authorize! @ship, with: FleetEventShipPolicy, context: {fleet_event: @event}, to: :update?
 
-        if @ship.update(ship_params)
-          render :show
-        else
-          render json: ValidationError.new("fleet_event_ships.update", errors: @ship.errors), status: :bad_request
+        ActiveRecord::Base.transaction do
+          sync_allowed_models!(@ship, allowed_model_ids_param)
+          @ship.update!(ship_params)
         end
+
+        render :show
+      rescue ActiveRecord::RecordInvalid
+        render json: ValidationError.new("fleet_event_ships.update", errors: @ship.errors), status: :bad_request
       end
 
       def destroy
@@ -101,7 +112,39 @@ module Api
       end
 
       private def ship_params
-        authorized(params, with: FleetEventShipPolicy)
+        authorized(params, with: FleetEventShipPolicy).except(:allowed_model_ids)
+      end
+
+      # nil when the client did not mention the list at all, which leaves it
+      # alone; [] is a client clearing it.
+      private def allowed_model_ids_param
+        permitted = authorized(params, with: FleetEventShipPolicy)
+        return unless permitted.key?(:allowed_model_ids)
+
+        Array(permitted[:allowed_model_ids]).map(&:to_s).compact_blank.uniq
+      end
+
+      private def build_allowed_models(ship, ids)
+        return if ids.blank?
+
+        ids.each_with_index do |model_id, index|
+          ship.fleet_event_ship_models.build(model_id: model_id, position: index)
+        end
+      end
+
+      # A supplied list is the whole answer to "which ships fit here", so rows
+      # that are not in it go. Reset afterwards so the validation on update reads
+      # the list as it now stands rather than as it was loaded.
+      private def sync_allowed_models!(ship, ids)
+        return if ids.nil?
+
+        ship.fleet_event_ship_models.where.not(model_id: ids).destroy_all
+        ids.each_with_index do |model_id, index|
+          record = ship.fleet_event_ship_models.find_or_initialize_by(model_id: model_id)
+          record.position = index
+          record.save! if record.changed?
+        end
+        ship.fleet_event_ship_models.reset
       end
 
       private def position_ids_param

--- a/app/controllers/api/v1/fleet_event_signups_controller.rb
+++ b/app/controllers/api/v1/fleet_event_signups_controller.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventSignupsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_slot, only: %i[create update destroy_self]
+      before_action :set_event_for_event_signup, only: %i[event_signup]
+      before_action :set_membership_for_slot, only: %i[create update destroy_self]
+      before_action :set_membership_for_event, only: %i[event_signup]
+      before_action :set_signup_for_self, only: %i[update destroy_self]
+      before_action :set_signup_admin, only: %i[destroy update_admin]
+      before_action :check_fleet_mission_builder_feature
+
+      def create
+        if @membership.nil?
+          render json: {code: "forbidden", message: "Not a fleet member"}, status: :forbidden
+          return
+        end
+
+        target_status = requested_status_for(@slot.fleet_event, @slot, params[:status])
+
+        occurrence_date = parsed_occurrence_date(params[:occurrence_date])
+        if @slot.fleet_event.recurring? && occurrence_date.blank?
+          authorize! @slot.fleet_event, with: FleetEventPolicy, to: :show?
+          render json: {code: "missing_occurrence_date", message: "occurrence_date is required for recurring events"}, status: :unprocessable_entity
+          return
+        end
+
+        # If the member already has an unassigned (interested/tentative) signup
+        # for this event/occurrence, promote it onto this slot rather than
+        # creating a new one (which would fail unique-active-signup validation).
+        existing = @slot.fleet_event.fleet_event_signups
+          .where(fleet_membership_id: @membership.id, occurrence_date: occurrence_date)
+          .where.not(status: "withdrawn")
+          .first
+
+        if existing && existing.fleet_event_slot_id.present? && existing.fleet_event_slot_id != @slot.id
+          authorize! existing, with: FleetEventSignupPolicy, context: {fleet_event: @slot.fleet_event}, to: :create?
+          render json: {code: "already_signed_up", message: "Already signed up to a different slot"}, status: :conflict
+          return
+        end
+
+        if existing
+          @signup = existing
+          attrs = {
+            fleet_event_slot_id: @slot.id,
+            status: target_status,
+            notes: params[:notes].presence || @signup.notes
+          }
+          attrs[:vehicle_id] = params[:vehicle_id] if params.key?(:vehicle_id)
+
+          authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @slot.fleet_event}, to: :update?
+
+          previous_status = @signup.status
+          if @signup.update(attrs)
+            event_name = (previous_status != @signup.status) ? "fleet_event_signup.status_changed" : "fleet_event_signup.created"
+            ActiveSupport::Notifications.instrument(event_name, signup: @signup, previous_status: previous_status)
+            render :show
+          else
+            render json: ValidationError.new("fleet_event_signups.create", errors: @signup.errors), status: :bad_request
+          end
+          return
+        end
+
+        @signup = @slot.fleet_event_signups.new(
+          fleet_event: @slot.fleet_event,
+          fleet_membership_id: @membership.id,
+          status: target_status,
+          vehicle_id: params[:vehicle_id],
+          notes: params[:notes],
+          occurrence_date: occurrence_date
+        )
+
+        authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @slot.fleet_event}
+
+        if @signup.save
+          ActiveSupport::Notifications.instrument("fleet_event_signup.created", signup: @signup)
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_event_signups.create", errors: @signup.errors), status: :bad_request
+        end
+      end
+
+      # Sign up to the event without picking a slot. Acts as upsert: if the
+      # member already has an unassigned signup, updates it (so they can switch
+      # interested ↔ tentative ↔ confirmed without withdrawing first). If they
+      # are already in a slot, returns 409 — they need to withdraw first.
+      def event_signup
+        if @membership.nil?
+          render json: {code: "forbidden", message: "Not a fleet member"}, status: :forbidden
+          return
+        end
+
+        requested_status =
+          params[:status].presence&.then { |s| FleetEventSignup::MEMBER_REQUESTABLE_STATUSES.include?(s) ? s : "interested" } ||
+          "interested"
+
+        occurrence_date = parsed_occurrence_date(params[:occurrence_date])
+        if @event.recurring? && occurrence_date.blank?
+          authorize! @event, with: FleetEventPolicy, to: :show?
+          render json: {code: "missing_occurrence_date", message: "occurrence_date is required for recurring events"}, status: :unprocessable_entity
+          return
+        end
+
+        existing = @event.fleet_event_signups
+          .where(fleet_membership_id: @membership.id, occurrence_date: occurrence_date)
+          .where.not(status: "withdrawn")
+          .first
+
+        if existing && existing.fleet_event_slot_id.present?
+          authorize! existing, with: FleetEventSignupPolicy, context: {fleet_event: @event}, to: :create?
+          render json: {code: "already_signed_up", message: "Already signed up to a slot in this event"}, status: :conflict
+          return
+        end
+
+        if existing
+          @signup = existing
+          authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @event}, to: :update?
+
+          attrs = {status: requested_status}
+          attrs[:notes] = params[:notes] if params.key?(:notes)
+          attrs[:vehicle_id] = params[:vehicle_id] if params.key?(:vehicle_id)
+
+          previous_status = @signup.status
+          if @signup.update(attrs)
+            if previous_status != @signup.status
+              ActiveSupport::Notifications.instrument(
+                "fleet_event_signup.status_changed",
+                signup: @signup,
+                previous_status: previous_status
+              )
+            end
+            render :show
+          else
+            render json: ValidationError.new("fleet_event_signups.update", errors: @signup.errors), status: :bad_request
+          end
+          return
+        end
+
+        @signup = @event.fleet_event_signups.new(
+          fleet_membership_id: @membership.id,
+          fleet_event_slot_id: nil,
+          status: requested_status,
+          vehicle_id: params[:vehicle_id],
+          notes: params[:notes],
+          occurrence_date: occurrence_date
+        )
+
+        authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @event}, to: :create?
+
+        if @signup.save
+          ActiveSupport::Notifications.instrument("fleet_event_signup.created", signup: @signup)
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_event_signups.create", errors: @signup.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @slot.fleet_event}
+
+        previous_status = @signup.status
+        if @signup.update(self_signup_attrs)
+          if previous_status != @signup.status
+            ActiveSupport::Notifications.instrument("fleet_event_signup.status_changed", signup: @signup, previous_status: previous_status)
+          end
+          render :show
+        else
+          render json: ValidationError.new("fleet_event_signups.update", errors: @signup.errors), status: :bad_request
+        end
+      end
+
+      # Admin endpoint — can reassign slot, change status (including approving
+      # `pending` to `confirmed`), or update notes/vehicle.
+      def update_admin
+        authorize! @signup, with: FleetEventSignupPolicy,
+          context: {fleet_event: @signup.fleet_event}, to: :manage?
+
+        previous_status = @signup.status
+        previous_slot_id = @signup.fleet_event_slot_id
+        if @signup.update(admin_signup_attrs)
+          if previous_slot_id != @signup.fleet_event_slot_id
+            ActiveSupport::Notifications.instrument(
+              "fleet_event_signup.assigned",
+              signup: @signup,
+              previous_slot_id: previous_slot_id
+            )
+          end
+          if previous_status != @signup.status
+            ActiveSupport::Notifications.instrument(
+              "fleet_event_signup.status_changed",
+              signup: @signup,
+              previous_status: previous_status,
+              by_admin: true
+            )
+          end
+          render :show
+        else
+          render json: ValidationError.new("fleet_event_signups.update", errors: @signup.errors), status: :bad_request
+        end
+      end
+
+      def destroy_self
+        authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @slot.fleet_event}, to: :destroy?
+
+        @signup.withdraw!
+        ActiveSupport::Notifications.instrument("fleet_event_signup.withdrawn", signup: @signup)
+        head :no_content
+      end
+
+      def destroy
+        authorize! @signup, with: FleetEventSignupPolicy, context: {fleet_event: @signup.fleet_event}, to: :destroy?
+
+        @signup.withdraw!
+        ActiveSupport::Notifications.instrument("fleet_event_signup.withdrawn", signup: @signup, kicked: true)
+        head :no_content
+      end
+
+      # Member-side update params — never allow direct status promotion past
+      # what their slot's approval mode allows.
+      private def self_signup_attrs
+        attrs = params.permit(:status, :vehicle_id, :notes).to_h.symbolize_keys
+        if attrs[:status].present?
+          attrs[:status] = requested_status_for(@signup.fleet_event, @signup.fleet_event_slot, attrs[:status])
+        end
+        attrs
+      end
+
+      private def admin_signup_attrs
+        attrs = params.permit(:status, :vehicle_id, :notes, :fleet_event_slot_id).to_h.symbolize_keys
+        # Slot-bound signups must be confirmed (or pending awaiting approval).
+        # If an admin assigns a slot but doesn't override status, promote any
+        # tentative/interested status to confirmed automatically.
+        if attrs.key?(:fleet_event_slot_id) && attrs[:fleet_event_slot_id].present?
+          current_status = attrs[:status].presence || @signup.status
+          unless FleetEventSignup::SLOT_BOUND_STATUSES.include?(current_status)
+            attrs[:status] = "confirmed"
+          end
+        end
+        attrs
+      end
+
+      private def requested_status_for(event, slot, requested)
+        requested = requested.presence || "confirmed"
+        unless FleetEventSignup::MEMBER_REQUESTABLE_STATUSES.include?(requested)
+          requested = "confirmed"
+        end
+
+        # Tentative/interested are event-level only — picking a slot is a
+        # commitment, so coerce to confirmed.
+        requested = "confirmed" if slot.present? && requested != "confirmed"
+
+        approval = slot&.signup_approval.presence || event&.signup_approval || "direct"
+        if approval == "confirmation_required" && requested == "confirmed"
+          "pending"
+        else
+          requested
+        end
+      end
+
+      private def set_slot
+        @slot = FleetEventSlot.find(params[:id])
+      end
+
+      private def set_event_for_event_signup
+        @fleet = Fleet.find_by!(slug: params[:fleet_slug])
+        @event = @fleet.fleet_events.find_by!(slug: params[:slug])
+      end
+
+      private def set_membership_for_slot
+        return if @slot.nil?
+
+        @membership = current_resource_owner&.fleet_memberships&.find_by(
+          fleet_id: @slot.fleet_event.fleet_id,
+          aasm_state: "accepted"
+        )
+      end
+
+      private def set_membership_for_event
+        return if @event.nil?
+
+        @membership = current_resource_owner&.fleet_memberships&.find_by(
+          fleet_id: @event.fleet_id,
+          aasm_state: "accepted"
+        )
+      end
+
+      private def set_signup_for_self
+        return if @membership.nil?
+
+        @signup = @slot.fleet_event_signups
+          .where(fleet_membership_id: @membership.id)
+          .where.not(status: "withdrawn")
+          .first
+
+        if @signup.nil?
+          render json: {code: "not_found", message: "Signup not found"}, status: :not_found
+          nil
+        end
+      end
+
+      private def set_signup_admin
+        @signup = FleetEventSignup.find(params[:id])
+      end
+
+      private def check_fleet_mission_builder_feature
+        # Reached four ways — via a slot, an event, or a signup — so the actor
+        # comes off whichever record this action loaded.
+        fleet = @fleet || @slot&.fleet_event&.fleet || @signup&.fleet_event&.fleet
+        return if feature_enabled?("fleet_mission_builder", fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+
+      private def parsed_occurrence_date(value)
+        return nil if value.blank?
+        Date.parse(value.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_event_slots_controller.rb
+++ b/app/controllers/api/v1/fleet_event_slots_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventSlotsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_slottable, only: %i[create]
+      before_action :set_slot, only: %i[update destroy]
+      before_action :check_fleet_mission_builder_feature
+
+      def create
+        @slot = @slottable.fleet_event_slots.new(slot_attrs)
+        @slot.position = next_position
+
+        authorize! @slot, with: FleetEventSlotPolicy, context: {fleet_event: @slottable.fleet_event}, to: :create?
+
+        if @slot.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_event_slots.create", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @slot, with: FleetEventSlotPolicy, context: {fleet_event: @slot.fleet_event}, to: :update?
+
+        if @slot.update(slot_attrs)
+          render :show
+        else
+          render json: ValidationError.new("fleet_event_slots.update", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @slot, with: FleetEventSlotPolicy, context: {fleet_event: @slot.fleet_event}, to: :destroy?
+
+        unless @slot.destroy
+          render json: ValidationError.new("fleet_event_slots.destroy", errors: @slot.errors), status: :bad_request
+        end
+      end
+
+      def sort
+        slottable = find_slottable(params[:slottable_type], params[:slottable_id])
+        return render json: {code: "not_found"}, status: :not_found unless slottable
+
+        authorize! slottable, with: FleetEventSlotPolicy, to: :sort?, context: {fleet_event: slottable.fleet_event}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        FleetEventSlot.transaction do
+          sorting.each_with_index do |id, index|
+            slottable.fleet_event_slots.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def slot_attrs
+        authorized(params, with: FleetEventSlotPolicy)
+          .except(:slottable_type, :slottable_id)
+      end
+
+      private def set_slottable
+        @slottable = find_slottable(params[:slottable_type], params[:slottable_id])
+        raise ActiveRecord::RecordNotFound, "slottable not found" unless @slottable
+      end
+
+      private def set_slot
+        @slot = FleetEventSlot.find(params[:id])
+      end
+
+      private def find_slottable(type, id)
+        case type
+        when "FleetEventTeam" then FleetEventTeam.find_by(id: id)
+        when "FleetEventShip" then FleetEventShip.find_by(id: id)
+        end
+      end
+
+      private def next_position
+        (@slottable.fleet_event_slots.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        # Slots are addressed directly, without a fleet in the path, so the
+        # actor comes off whichever record this action loaded.
+        fleet = (@slottable || @slot)&.fleet_event&.fleet
+        return if feature_enabled?("fleet_mission_builder", fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_event_teams_controller.rb
+++ b/app/controllers/api/v1/fleet_event_teams_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventTeamsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_event
+      before_action :set_team, only: %i[update destroy]
+
+      def create
+        @team = @event.fleet_event_teams.new(team_params)
+        @team.position = next_position
+
+        authorize! @team, with: FleetEventTeamPolicy, context: {fleet_event: @event}, to: :create?
+
+        if @team.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_event_teams.create", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def update
+        authorize! @team, with: FleetEventTeamPolicy, context: {fleet_event: @event}, to: :update?
+
+        if @team.update(team_params)
+          render :show
+        else
+          render json: ValidationError.new("fleet_event_teams.update", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @team, with: FleetEventTeamPolicy, context: {fleet_event: @event}, to: :destroy?
+
+        unless @team.destroy
+          render json: ValidationError.new("fleet_event_teams.destroy", errors: @team.errors), status: :bad_request
+        end
+      end
+
+      def sort
+        authorize! @event, with: FleetEventTeamPolicy, to: :sort?, context: {fleet_event: @event}
+
+        sorting = params.permit(sorting: [])[:sorting] || []
+
+        FleetEventTeam.transaction do
+          sorting.each_with_index do |id, index|
+            @event.fleet_event_teams.where(id: id).update_all(position: index)
+          end
+        end
+
+        render json: {success: true}
+      end
+
+      private def team_params
+        authorized(params, with: FleetEventTeamPolicy)
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_event
+        @event = @fleet.fleet_events.find_by!(slug: params[:fleet_event_slug])
+      end
+
+      private def set_team
+        @team = @event.fleet_event_teams.find(params[:id])
+      end
+
+      private def next_position
+        (@event.fleet_event_teams.maximum(:position) || -1) + 1
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_events_controller.rb
+++ b/app/controllers/api/v1/fleet_events_controller.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetEventsController < ::Api::BaseController
+      after_action -> { pagination_header(:fleet_events) }, only: %i[index]
+
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[index show]
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?,
+        only: %i[create update destroy unarchive publish lock_signups unlock_signups start complete cancel skip_occurrence end_series update_occurrence]
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+      before_action :set_event, only: %i[show update destroy unarchive publish lock_signups unlock_signups start complete cancel skip_occurrence end_series update_occurrence]
+      before_action :set_mission, only: %i[create]
+
+      def index
+        authorize! with: FleetEventPolicy, context: {fleet: @fleet}
+
+        scope = if params[:archived] == "true"
+          @fleet.fleet_events.where.not(archived_at: nil)
+        else
+          @fleet.fleet_events.where(archived_at: nil)
+        end
+        scope = (params[:upcoming] == "true") ? scope.upcoming : scope
+        scope = scope.past if params[:past] == "true"
+
+        query_params = params.fetch(:q, {}).permit(:title_cont, :status_eq, :category_eq, :s)
+        normalize_sort_params(query_params)
+
+        @q = scope.ransack(query_params)
+        result = @q.result(distinct: true)
+
+        @fleet_events = result_with_pagination(result, 30)
+      end
+
+      def show
+        authorize! @fleet_event
+
+        @viewer_event_role = compute_viewer_event_role(@fleet_event)
+        @occurrence_date = parsed_show_occurrence_date
+        @occurrence_state =
+          if @occurrence_date
+            @fleet_event.occurrence_state_for(@occurrence_date)
+          end
+      end
+
+      private def parsed_show_occurrence_date
+        raw = params[:occurrence_date].presence || params[:occurrence].presence
+        return nil if raw.blank?
+        Date.parse(raw.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def create
+        @fleet_event = if @mission
+          FleetEvent.from_mission!(@mission, event_params.merge(created_by: current_resource_owner))
+        else
+          @fleet.fleet_events.new(event_params.merge(created_by: current_resource_owner))
+        end
+
+        authorize! @fleet_event
+
+        if @mission || @fleet_event.save
+          render :show, status: :created
+        else
+          render json: ValidationError.new("fleet_events.create", errors: @fleet_event.errors), status: :bad_request
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        render json: ValidationError.new("fleet_events.create", errors: e.record.errors), status: :bad_request
+      end
+
+      def update
+        authorize! @fleet_event
+
+        if @fleet_event.update(event_params)
+          render :show
+        else
+          render json: ValidationError.new("fleet_events.update", errors: @fleet_event.errors), status: :bad_request
+        end
+      end
+
+      def destroy
+        authorize! @fleet_event
+
+        if @fleet_event.archived?
+          if @fleet_event.destroy
+            ActiveSupport::Notifications.instrument("fleet_event.destroyed", event: @fleet_event)
+          else
+            render json: ValidationError.new("fleet_events.destroy", errors: @fleet_event.errors), status: :bad_request
+          end
+        elsif @fleet_event.archive!
+          ActiveSupport::Notifications.instrument("fleet_event.archived", event: @fleet_event)
+          render :show
+        else
+          render json: ValidationError.new("fleet_events.destroy", errors: @fleet_event.errors), status: :bad_request
+        end
+      end
+
+      def skip_occurrence
+        authorize! @fleet_event, to: :update?
+
+        unless @fleet_event.recurring?
+          render json: {code: "not_recurring", message: "Event is not recurring"}, status: :unprocessable_entity
+          return
+        end
+
+        date = params[:date].presence || params.dig(:occurrence_date)
+        if date.blank?
+          render json: {code: "missing_date", message: "date is required"}, status: :bad_request
+          return
+        end
+
+        parsed = Date.parse(date.to_s)
+        @fleet_event.skip_occurrence!(parsed)
+
+        render :show
+      end
+
+      # Update an individual occurrence of a recurring event. Override
+      # columns on the per-occurrence state row (title, description,
+      # location, etc) leave the parent event unchanged. Pass nil to clear
+      # a previously-set override and fall back to the event's value.
+      def update_occurrence
+        authorize! @fleet_event, to: :update?
+
+        unless @fleet_event.recurring?
+          render json: {code: "not_recurring", message: "Event is not recurring"}, status: :unprocessable_entity
+          return
+        end
+
+        date = params[:date].presence
+        if date.blank?
+          render json: {code: "missing_date", message: "date is required"}, status: :bad_request
+          return
+        end
+
+        parsed = Date.parse(date.to_s)
+        state = @fleet_event.occurrence_state_for(parsed, build: true)
+
+        attrs = params.permit(
+          :title, :description, :briefing,
+          :location, :meetup_location, :scenario, :cover_image_preset
+        ).to_h
+        state.assign_attributes(attrs)
+
+        if state.save
+          @occurrence_state = state
+          render :occurrence_state
+        else
+          render json: ValidationError.new("fleet_events.update_occurrence", errors: state.errors), status: :bad_request
+        end
+      end
+
+      def end_series
+        authorize! @fleet_event, to: :update?
+
+        unless @fleet_event.recurring?
+          render json: {code: "not_recurring", message: "Event is not recurring"}, status: :unprocessable_entity
+          return
+        end
+
+        date = params[:date].presence
+        if date.blank?
+          render json: {code: "missing_date", message: "date is required"}, status: :bad_request
+          return
+        end
+
+        @fleet_event.end_series_at!(date)
+        render :show
+      end
+
+      def unarchive
+        authorize! @fleet_event, to: :unarchive?
+
+        unless @fleet_event.archived?
+          render json: {code: "invalid_state", message: "Event is not archived"}, status: :bad_request
+          return
+        end
+
+        @fleet_event.unarchive!
+        ActiveSupport::Notifications.instrument("fleet_event.unarchived", event: @fleet_event)
+        render :show
+      end
+
+      %i[publish lock_signups unlock_signups start complete].each do |action|
+        define_method(action) do
+          authorize! @fleet_event, to: :"#{action}?"
+          if @fleet_event.send("may_#{action}?")
+            @fleet_event.send("#{action}!")
+            ActiveSupport::Notifications.instrument("fleet_event.#{transition_name(action)}", event: @fleet_event)
+            render :show
+          else
+            render json: {code: "invalid_state", message: "Cannot #{action} from #{@fleet_event.status}"}, status: :bad_request
+          end
+        end
+      end
+
+      def cancel
+        authorize! @fleet_event, to: :cancel?
+        if @fleet_event.may_cancel?
+          @fleet_event.update(cancelled_reason: params[:cancelled_reason]) if params[:cancelled_reason].present?
+          @fleet_event.cancel!
+          ActiveSupport::Notifications.instrument("fleet_event.cancelled", event: @fleet_event)
+          render :show
+        else
+          render json: {code: "invalid_state", message: "Cannot cancel from #{@fleet_event.status}"}, status: :bad_request
+        end
+      end
+
+      private def transition_name(action)
+        case action
+        when :publish then "published"
+        when :lock_signups then "locked"
+        when :unlock_signups then "unlocked"
+        when :start then "started"
+        when :complete then "completed"
+        else action.to_s
+        end
+      end
+
+      private def event_params
+        authorized(params, with: FleetEventPolicy)
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def set_event
+        @fleet_event = @fleet.fleet_events.find_by!(slug: params[:slug])
+      end
+
+      private def set_mission
+        return if params[:mission_slug].blank?
+
+        @mission = @fleet.missions.find_by!(slug: params[:mission_slug])
+      end
+
+      private def compute_viewer_event_role(event)
+        viewer = current_resource_owner
+        return nil unless viewer
+
+        return "creator" if event.created_by_id == viewer.id
+        event.event_admin_role_for(viewer)
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/jobs/fleet_events/auto_lock_job.rb
+++ b/app/jobs/fleet_events/auto_lock_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module FleetEvents
+  # Auto-lock events as their start time approaches.
+  # Honours per-event `auto_lock_enabled` and `auto_lock_minutes_before`.
+  # For one-off events this transitions the event itself via AASM; for
+  # recurring events it locks the next upcoming occurrence (persisted on
+  # the per-occurrence state row).
+  class AutoLockJob < ::ApplicationJob
+    sidekiq_options retry: true, queue: "default"
+
+    def perform
+      perform_for_one_off
+      perform_for_recurring
+    end
+
+    private def perform_for_one_off
+      events = FleetEvent
+        .where(status: "open", auto_lock_enabled: true, archived_at: nil, recurring: false)
+        .where("starts_at <= NOW() + (auto_lock_minutes_before || ' minutes')::interval")
+
+      events.find_each do |event|
+        next unless event.may_lock_signups?
+
+        event.lock_signups!
+        ActiveSupport::Notifications.instrument("fleet_event.locked", event: event)
+      end
+    end
+
+    private def perform_for_recurring
+      now = Time.current
+      events = FleetEvent
+        .where(auto_lock_enabled: true, archived_at: nil, recurring: true)
+        .where("status != ?", "cancelled")
+
+      events.find_each do |event|
+        window = (event.auto_lock_minutes_before || 60).minutes
+        # Look slightly past the lock window so we catch occurrences whose
+        # auto-lock moment is between now and now + window.
+        candidates = event.occurrences(from: now - window, to: now + window)
+        next if candidates.empty?
+
+        candidates.each do |occurrence|
+          lock_moment = occurrence - window
+          next if now < lock_moment
+
+          state = event.occurrence_state_for(occurrence.to_date, build: true)
+          next if state.locked_at.present?
+          next if state.cancelled?
+
+          state.locked_at = now
+          state.save!
+          ActiveSupport::Notifications.instrument(
+            "fleet_event.locked",
+            event: event, occurrence_date: occurrence.to_date
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -68,6 +68,7 @@ class Fleet < ApplicationRecord
     dependent: :destroy
   has_many :fleet_inventories, dependent: :destroy
   has_many :missions, dependent: :destroy
+  has_many :fleet_events, dependent: :destroy
   has_many :fleet_vehicles, dependent: :destroy
   has_many :vehicles, through: :fleet_vehicles, source: :vehicle
   has_many :models, through: :vehicles, source: :model

--- a/app/models/fleet_event.rb
+++ b/app/models/fleet_event.rb
@@ -229,7 +229,7 @@ class FleetEvent < ApplicationRecord
         )
       )
 
-      mission.mission_teams.includes(mission_ships: :model, mission_slots: :model_position).order(:position).each do |team|
+      mission.mission_teams.includes(mission_ships: [:model, :mission_ship_models], mission_slots: :model_position).order(:position).each do |team|
         event_team = event.fleet_event_teams.create!(
           source_team_id: team.id,
           title: team.title,
@@ -262,6 +262,15 @@ class FleetEvent < ApplicationRecord
             min_cargo: ship.min_cargo,
             position: ship.position
           )
+
+          # A spot that names a list of ships has to arrive with the list, or the
+          # event would spawn asking for nothing in particular.
+          ship.mission_ship_models.order(:position).each_with_index do |allowed, index|
+            event_ship.fleet_event_ship_models.create!(
+              model_id: allowed.model_id,
+              position: index
+            )
+          end
 
           ship.mission_slots.order(:position).each do |slot|
             FleetEventSlot.create!(

--- a/app/models/fleet_event.rb
+++ b/app/models/fleet_event.rb
@@ -1,0 +1,402 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_events
+#
+#  id                        :uuid             not null, primary key
+#  archived_at               :datetime
+#  auto_lock_enabled         :boolean          default(TRUE), not null
+#  auto_lock_minutes_before  :integer          default(60), not null
+#  briefing                  :text
+#  cancelled_reason          :text
+#  category                  :integer          default(0), not null
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  ends_at                   :datetime
+#  excluded_dates            :date             default([]), not null, is an Array
+#  external_uid              :uuid             not null
+#  location                  :string
+#  max_attendees             :integer
+#  meetup_location           :string
+#  recurrence_count          :integer
+#  recurrence_interval       :string
+#  recurrence_until          :date
+#  recurring                 :boolean          default(FALSE), not null
+#  scenario                  :string
+#  signup_approval           :string           default("direct"), not null
+#  slug                      :string           not null
+#  starting_soon_notified_at :datetime
+#  starts_at                 :datetime         not null
+#  status                    :string           default("draft"), not null
+#  timezone                  :string           default("UTC"), not null
+#  title                     :string           not null
+#  visibility                :string           default("members"), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid             not null
+#  discord_event_id          :string
+#  discord_message_id        :string
+#  fleet_id                  :uuid             not null
+#  mission_id                :uuid
+#
+# Indexes
+#
+#  index_fleet_events_on_external_uid            (external_uid) UNIQUE
+#  index_fleet_events_on_fleet_id_and_recurring  (fleet_id,recurring)
+#  index_fleet_events_on_fleet_id_and_slug       (fleet_id,slug) UNIQUE
+#  index_fleet_events_on_fleet_id_and_starts_at  (fleet_id,starts_at)
+#  index_fleet_events_on_fleet_id_and_status     (fleet_id,status)
+#  index_fleet_events_on_mission_id              (mission_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (fleet_id => fleets.id)
+#  fk_rails_...  (mission_id => missions.id)
+#
+class FleetEvent < ApplicationRecord
+  include AASM
+  include ActiveStorageVariants
+
+  paginates_per 30
+
+  belongs_to :fleet, touch: true
+  belongs_to :mission, optional: true
+  belongs_to :created_by, class_name: "User"
+
+  has_many :fleet_event_teams, dependent: :destroy
+  has_many :fleet_event_ships, through: :fleet_event_teams
+  has_many :fleet_event_signups, dependent: :destroy
+  has_many :fleet_event_admins, dependent: :destroy
+  has_many :event_admin_users, through: :fleet_event_admins, source: :user
+  has_many :fleet_event_occurrence_states, dependent: :destroy
+
+  has_one_attached :cover_image
+
+  enum :category, {
+    other: 0,
+    ship_combat: 1,
+    ground_combat: 2,
+    combined_combat: 3,
+    mining: 4,
+    salvage: 5,
+    cargo_hauling: 6,
+    exploration: 7
+  }
+
+  VISIBILITIES = %w[members officers fleet].freeze
+  SIGNUP_APPROVALS = %w[direct confirmation_required].freeze
+  RECURRENCE_INTERVALS = %w[daily weekly biweekly monthly].freeze
+
+  validates :title, presence: true
+  validates :starts_at, presence: true
+  validates :timezone, presence: true
+  validates :visibility, inclusion: {in: VISIBILITIES}
+  validates :signup_approval, inclusion: {in: SIGNUP_APPROVALS}
+  validates :recurrence_interval,
+    inclusion: {in: RECURRENCE_INTERVALS},
+    if: :recurring?
+  validates :recurrence_interval, absence: true, unless: :recurring?
+  validate :recurrence_count_or_until
+
+  before_validation :set_external_uid, on: :create
+  before_validation :ensure_id, on: :create
+  before_validation :default_cover_image_preset
+  before_save :update_slug
+
+  scope :upcoming, -> { where("starts_at >= ?", Time.current).order(:starts_at) }
+  scope :past, -> { where("starts_at < ?", Time.current).order(starts_at: :desc) }
+  scope :active_status, -> { where(archived_at: nil) }
+  scope :archived, -> { where.not(archived_at: nil) }
+
+  AVAILABLE_PRIVILEGES = [
+    "fleet:events:read",
+    "fleet:events:create",
+    "fleet:events:update",
+    "fleet:events:delete",
+    "fleet:events:manage"
+  ].freeze
+
+  DEFAULT_PRIVILEGES = {
+    admin: [],
+    officer: ["fleet:events:manage"],
+    member: ["fleet:events:read"]
+  }.freeze
+
+  aasm column: :status, timestamps: true, whiny_transitions: false do
+    state :draft, initial: true
+    state :open
+    state :locked
+    state :active
+    state :completed
+    state :cancelled
+
+    event :publish do
+      transitions from: :draft, to: :open
+    end
+
+    event :lock_signups do
+      transitions from: :open, to: :locked
+    end
+
+    event :unlock_signups do
+      transitions from: :locked, to: :open
+    end
+
+    event :start do
+      transitions from: [:open, :locked], to: :active
+    end
+
+    event :complete do
+      transitions from: :active, to: :completed
+    end
+
+    event :cancel do
+      transitions from: [:draft, :open, :locked, :active], to: :cancelled
+    end
+  end
+
+  def archived?
+    archived_at.present?
+  end
+
+  def event_admin_role_for(user)
+    return nil unless user
+    fleet_event_admins.find_by(user_id: user.id)&.role
+  end
+
+  def event_admin?(user)
+    event_admin_role_for(user) == "admin" || created_by_id == user&.id
+  end
+
+  def event_moderator_or_admin?(user)
+    %w[admin moderator].include?(event_admin_role_for(user)) ||
+      created_by_id == user&.id
+  end
+
+  def archive!
+    update!(archived_at: Time.current)
+  end
+
+  def unarchive!
+    update!(archived_at: nil)
+  end
+
+  # Returns all slots across event teams and ships (polymorphic).
+  def slots
+    team_ids = fleet_event_teams.pluck(:id)
+    ship_ids = fleet_event_ships.pluck(:id)
+
+    FleetEventSlot.where(slottable_type: "FleetEventTeam", slottable_id: team_ids)
+      .or(FleetEventSlot.where(slottable_type: "FleetEventShip", slottable_id: ship_ids))
+  end
+
+  def signups_count
+    fleet_event_signups.where.not(status: "withdrawn").count
+  end
+
+  def past?
+    reference = ends_at.presence || starts_at
+    reference.present? && reference < Time.current
+  end
+
+  def signups_open?
+    status == "open" && !past?
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[title slug fleet_id mission_id status starts_at ends_at category scenario archived_at created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[fleet mission created_by fleet_event_teams]
+  end
+
+  # Spawns a new event from a mission template, snapshotting the team/ship/slot tree.
+  def self.from_mission!(mission, attrs = {})
+    transaction do
+      event = mission.fleet.fleet_events.create!(
+        attrs.reverse_merge(
+          mission_id: mission.id,
+          title: default_title(mission, attrs[:starts_at]),
+          description: mission.description,
+          briefing: nil,
+          category: mission.category,
+          scenario: mission.scenario,
+          cover_image_preset: mission.cover_image_preset
+        )
+      )
+
+      mission.mission_teams.includes(mission_ships: :model, mission_slots: :model_position).order(:position).each do |team|
+        event_team = event.fleet_event_teams.create!(
+          source_team_id: team.id,
+          title: team.title,
+          description: team.description,
+          position: team.position
+        )
+
+        team.mission_slots.order(:position).each do |slot|
+          FleetEventSlot.create!(
+            slottable: event_team,
+            source_slot_id: slot.id,
+            model_position_id: slot.model_position_id,
+            title: slot.title,
+            description: slot.description,
+            position: slot.position
+          )
+        end
+
+        team.mission_ships.order(:position).each do |ship|
+          event_ship = event_team.fleet_event_ships.create!(
+            source_ship_id: ship.id,
+            model_id: ship.model_id,
+            title: ship.title,
+            description: ship.description,
+            classification: ship.classification,
+            focus: ship.focus,
+            min_size: ship.min_size,
+            max_size: ship.max_size,
+            min_crew: ship.min_crew,
+            min_cargo: ship.min_cargo,
+            position: ship.position
+          )
+
+          ship.mission_slots.order(:position).each do |slot|
+            FleetEventSlot.create!(
+              slottable: event_ship,
+              source_slot_id: slot.id,
+              model_position_id: slot.model_position_id,
+              title: slot.title,
+              description: slot.description,
+              position: slot.position
+            )
+          end
+        end
+      end
+
+      event
+    end
+  end
+
+  def self.default_title(mission, starts_at)
+    date_str = (starts_at.is_a?(Time) || starts_at.is_a?(DateTime)) ? starts_at.strftime("%b %-d, %Y") : "TBD"
+    "#{mission.title} — #{date_str}"
+  end
+
+  # Returns occurrence start times falling within [from, to]. For
+  # one-off events this is `[starts_at]` if it lies in the range.
+  # Recurring events are expanded forward from `starts_at` honouring
+  # `recurrence_until`, `recurrence_count`, and `excluded_dates`.
+  def occurrences(from:, to:)
+    from = from.to_time
+    to = to.to_time
+    return [] if starts_at.blank?
+
+    unless recurring?
+      return starts_at.between?(from, to) ? [starts_at] : []
+    end
+
+    interval_step = recurrence_step
+    return [] if interval_step.nil?
+
+    result = []
+    cursor = starts_at
+    limit = recurrence_count.presence
+    iterations = 0
+    until_time = recurrence_until&.end_of_day&.in_time_zone(timezone || "UTC")
+
+    while cursor <= to && (limit.nil? || iterations < limit)
+      break if until_time && cursor > until_time
+
+      excluded = excluded_dates.any? do |d|
+        date = d.is_a?(String) ? Date.parse(d) : d
+        date == cursor.to_date
+      end
+
+      result << cursor if cursor >= from && !excluded
+      cursor = advance_cursor(cursor, interval_step)
+      iterations += 1
+    end
+
+    result
+  end
+
+  # Returns the soonest occurrence at or after `after`, or nil if the
+  # series has ended.
+  def next_occurrence(after: Time.current)
+    occurrences(from: after, to: 1.year.from_now).first
+  end
+
+  def skip_occurrence!(date)
+    return if date.blank?
+    parsed = date.is_a?(Date) ? date : Date.parse(date.to_s)
+    return if excluded_dates.include?(parsed)
+
+    update!(excluded_dates: excluded_dates + [parsed])
+  end
+
+  def end_series_at!(date)
+    return if date.blank?
+    parsed = date.is_a?(Date) ? date : Date.parse(date.to_s)
+    update!(recurrence_until: parsed - 1.day)
+  end
+
+  # Find or build the per-occurrence state row for a given date. nil-safe.
+  def occurrence_state_for(date, build: false)
+    return nil if date.blank?
+    parsed = date.is_a?(Date) ? date : Date.parse(date.to_s)
+    state = fleet_event_occurrence_states.find_by(occurrence_date: parsed)
+    return state if state
+    build ? fleet_event_occurrence_states.build(occurrence_date: parsed) : nil
+  end
+
+  private def recurrence_step
+    case recurrence_interval
+    when "daily" then {value: 1, unit: :days}
+    when "weekly" then {value: 1, unit: :weeks}
+    when "biweekly" then {value: 2, unit: :weeks}
+    when "monthly" then {value: 1, unit: :months}
+    end
+  end
+
+  private def advance_cursor(cursor, step)
+    cursor + step[:value].public_send(step[:unit])
+  end
+
+  private def recurrence_count_or_until
+    return unless recurrence_count.present? && recurrence_until.present?
+    errors.add(:base, :recurrence_count_xor_until)
+  end
+
+  private def set_external_uid
+    self.external_uid ||= SecureRandom.uuid
+  end
+
+  private def ensure_id
+    self.id ||= SecureRandom.uuid
+  end
+
+  # Slugs are prefixed with the first segment of the event id. The prefix
+  # alone guarantees uniqueness within a fleet, so any title-based collisions
+  # disappear and URLs read as `<short-id>-<title>` (similar to GitHub issues).
+  private def update_slug
+    base = generate_slug(title)
+    prefix = id.to_s.split("-").first
+    candidate = prefix.present? ? "#{prefix}-#{base}" : base
+    return if slug == candidate
+
+    self.slug = candidate
+  end
+
+  # When the form doesn't pick a preset, default to the category's base
+  # asset. Mirrors the frontend useMissionCover fallback so the same cover
+  # appears in the UI, the OG image, and the Discord push.
+  private def default_cover_image_preset
+    return if cover_image_preset.present?
+    return if category.blank?
+
+    self.cover_image_preset = category.to_s
+  end
+end

--- a/app/models/fleet_event.rb
+++ b/app/models/fleet_event.rb
@@ -249,7 +249,7 @@ class FleetEvent < ApplicationRecord
         end
 
         team.mission_ships.order(:position).each do |ship|
-          event_ship = event_team.fleet_event_ships.create!(
+          event_ship = event_team.fleet_event_ships.new(
             source_ship_id: ship.id,
             model_id: ship.model_id,
             title: ship.title,
@@ -263,14 +263,17 @@ class FleetEvent < ApplicationRecord
             position: ship.position
           )
 
-          # A spot that names a list of ships has to arrive with the list, or the
-          # event would spawn asking for nothing in particular.
+          # Before the save, and not only so the event arrives with the list: a
+          # spot whose whole spec is a list has nothing in its columns, so saving
+          # first left model_or_filter_required with nothing to accept.
           ship.mission_ship_models.order(:position).each_with_index do |allowed, index|
-            event_ship.fleet_event_ship_models.create!(
+            event_ship.fleet_event_ship_models.build(
               model_id: allowed.model_id,
               position: index
             )
           end
+
+          event_ship.save!
 
           ship.mission_slots.order(:position).each do |slot|
             FleetEventSlot.create!(

--- a/app/models/fleet_event_admin.rb
+++ b/app/models/fleet_event_admin.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_admins
+#
+#  id             :uuid             not null, primary key
+#  role           :string           default("admin"), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  fleet_event_id :uuid             not null
+#  granted_by_id  :uuid
+#  user_id        :uuid             not null
+#
+# Indexes
+#
+#  index_fleet_event_admins_on_fleet_event_id              (fleet_event_id)
+#  index_fleet_event_admins_on_fleet_event_id_and_user_id  (fleet_event_id,user_id) UNIQUE
+#  index_fleet_event_admins_on_user_id                     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class FleetEventAdmin < ApplicationRecord
+  ROLES = %w[admin moderator].freeze
+
+  belongs_to :fleet_event, touch: true
+  belongs_to :user
+  belongs_to :granted_by, class_name: "User", optional: true
+
+  validates :role, inclusion: {in: ROLES}
+  validates :user_id, uniqueness: {scope: :fleet_event_id}
+
+  def admin?
+    role == "admin"
+  end
+
+  def moderator?
+    role == "moderator"
+  end
+end

--- a/app/models/fleet_event_occurrence_state.rb
+++ b/app/models/fleet_event_occurrence_state.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Per-occurrence overlay row for recurring FleetEvents. Each row tracks
+# state that differs per-occurrence: lifecycle timestamps, Discord scheduled
+# event linkage, and any per-occurrence override fields (title, location,
+# scenario, etc). nil columns mean "inherit from the parent FleetEvent".
+# == Schema Information
+#
+# Table name: fleet_event_occurrence_states
+#
+#  id                        :uuid             not null, primary key
+#  briefing                  :text
+#  cancelled_at              :datetime
+#  cancelled_reason          :text
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  location                  :string
+#  locked_at                 :datetime
+#  meetup_location           :string
+#  occurrence_date           :date             not null
+#  scenario                  :string
+#  starting_soon_notified_at :datetime
+#  status                    :string
+#  title                     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  discord_event_id          :string
+#  fleet_event_id            :uuid             not null
+#
+# Indexes
+#
+#  idx_fleet_event_occurrence_states_on_event_and_date  (fleet_event_id,occurrence_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#
+class FleetEventOccurrenceState < ApplicationRecord
+  belongs_to :fleet_event, touch: true
+
+  validates :occurrence_date, presence: true
+  validates :fleet_event_id, uniqueness: {scope: :occurrence_date}
+
+  STATUSES = FleetEvent::STATUSES if defined?(FleetEvent::STATUSES)
+
+  def cancelled?
+    cancelled_at.present? || status == "cancelled"
+  end
+
+  def locked?
+    locked_at.present?
+  end
+
+  def starting_soon_notified?
+    starting_soon_notified_at.present?
+  end
+
+  # Field accessor that prefers the override, falling back to the event's
+  # value. Used by serialisers and Discord/ICS builders.
+  def effective(attr)
+    public_send(attr).presence || fleet_event.public_send(attr)
+  end
+end

--- a/app/models/fleet_event_ship.rb
+++ b/app/models/fleet_event_ship.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_ships
+#
+#  id                  :uuid             not null, primary key
+#  classification      :string
+#  description         :text
+#  focus               :string
+#  max_size            :string
+#  min_cargo           :decimal(, )
+#  min_crew            :integer
+#  min_size            :string
+#  position            :integer          default(0), not null
+#  title               :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  fleet_event_team_id :uuid             not null
+#  model_id            :uuid
+#  source_ship_id      :uuid
+#
+# Indexes
+#
+#  index_fleet_event_ships_on_fleet_event_team_id               (fleet_event_team_id)
+#  index_fleet_event_ships_on_fleet_event_team_id_and_position  (fleet_event_team_id,position)
+#  index_fleet_event_ships_on_model_id                          (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_team_id => fleet_event_teams.id)
+#  fk_rails_...  (model_id => models.id)
+#  fk_rails_...  (source_ship_id => mission_ships.id) ON DELETE => nullify
+#
+class FleetEventShip < ApplicationRecord
+  belongs_to :fleet_event_team, touch: true
+  belongs_to :model, optional: true
+  belongs_to :source_ship, class_name: "MissionShip", optional: true
+  has_many :fleet_event_slots, as: :slottable, dependent: :destroy
+
+  delegate :fleet_event, to: :fleet_event_team
+
+  default_scope -> { order(position: :asc) }
+
+  FILTER_ATTRIBUTES = %i[classification focus min_size max_size min_crew min_cargo].freeze
+
+  validate :model_or_filter_required
+  validate :model_must_be_in_game
+
+  def strict?
+    model_id.present?
+  end
+
+  def filtered?
+    FILTER_ATTRIBUTES.any? { |attr| self[attr].present? }
+  end
+
+  def display_title
+    title.presence || model&.name || I18n.t("labels.fleet_event_ship.placeholder", default: "Unspecified Ship")
+  end
+
+  private def model_or_filter_required
+    return if strict? || filtered?
+
+    errors.add(:base, :model_or_filter_required)
+  end
+
+  private def model_must_be_in_game
+    return if model.blank?
+    return if model.in_game?
+
+    errors.add(:model_id, :must_be_in_game)
+  end
+end

--- a/app/models/fleet_event_ship.rb
+++ b/app/models/fleet_event_ship.rb
@@ -37,6 +37,8 @@ class FleetEventShip < ApplicationRecord
   belongs_to :model, optional: true
   belongs_to :source_ship, class_name: "MissionShip", optional: true
   has_many :fleet_event_slots, as: :slottable, dependent: :destroy
+  has_many :fleet_event_ship_models, dependent: :destroy
+  has_many :allowed_models, through: :fleet_event_ship_models, source: :model
 
   delegate :fleet_event, to: :fleet_event_team
 
@@ -46,9 +48,16 @@ class FleetEventShip < ApplicationRecord
 
   validate :model_or_filter_required
   validate :model_must_be_in_game
+  validate :allowed_models_must_be_in_game
 
   def strict?
     model_id.present?
+  end
+
+  # A hand-picked set of models rather than criteria: the spot takes any one of
+  # them, so a signup matches if its ship is in the list.
+  def listed?
+    fleet_event_ship_models.any?
   end
 
   def filtered?
@@ -60,7 +69,7 @@ class FleetEventShip < ApplicationRecord
   end
 
   private def model_or_filter_required
-    return if strict? || filtered?
+    return if strict? || listed? || filtered?
 
     errors.add(:base, :model_or_filter_required)
   end
@@ -70,5 +79,17 @@ class FleetEventShip < ApplicationRecord
     return if model.in_game?
 
     errors.add(:model_id, :must_be_in_game)
+  end
+
+  # The same bar the single model has to clear: a spot cannot ask for a ship that
+  # is not in the game yet, however it names it.
+  #
+  # Read through the join rows rather than through allowed_models: a has_many
+  # :through on an unsaved parent queries the database and so comes back empty,
+  # which let a new spot list a concept ship unchecked.
+  private def allowed_models_must_be_in_game
+    return if fleet_event_ship_models.map(&:model).compact.all?(&:in_game?)
+
+    errors.add(:allowed_model_ids, :must_be_in_game)
   end
 end

--- a/app/models/fleet_event_ship_model.rb
+++ b/app/models/fleet_event_ship_model.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# One model a fleet event ship will accept. A ship spot names either one exact
+# model, a list of models it will take, or the criteria a model has to meet —
+# this is the middle case, one row per allowed model.
+# == Schema Information
+#
+# Table name: fleet_event_ship_models
+#
+#  id                  :uuid             not null, primary key
+#  position            :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  fleet_event_ship_id :uuid             not null
+#  model_id            :uuid             not null
+#
+# Indexes
+#
+#  index_fleet_event_ship_models_on_model_id           (model_id)
+#  index_fleet_event_ship_models_on_ship               (fleet_event_ship_id)
+#  index_fleet_event_ship_models_on_ship_and_model     (fleet_event_ship_id,model_id) UNIQUE
+#  index_fleet_event_ship_models_on_ship_and_position  (fleet_event_ship_id,position)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_ship_id => fleet_event_ships.id) ON DELETE => cascade
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class FleetEventShipModel < ApplicationRecord
+  belongs_to :fleet_event_ship, touch: true
+  belongs_to :model
+
+  validates :model_id, uniqueness: {scope: :fleet_event_ship_id}
+
+  default_scope -> { order(position: :asc) }
+
+  def fleet_event
+    fleet_event_ship&.fleet_event
+  end
+end

--- a/app/models/fleet_event_signup.rb
+++ b/app/models/fleet_event_signup.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_signups
+#
+#  id                  :uuid             not null, primary key
+#  confirmed_at        :datetime
+#  notes               :text
+#  occurrence_date     :date
+#  status              :string           default("confirmed"), not null
+#  withdrawn_at        :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  fleet_event_id      :uuid             not null
+#  fleet_event_slot_id :uuid
+#  fleet_membership_id :uuid             not null
+#  vehicle_id          :uuid
+#
+# Indexes
+#
+#  idx_fleet_event_signups_on_event_and_occurrence_and_member  (fleet_event_id,occurrence_date,fleet_membership_id)
+#  index_fleet_event_signups_on_fleet_event_id                 (fleet_event_id)
+#  index_fleet_event_signups_on_fleet_event_slot_id            (fleet_event_slot_id)
+#  index_fleet_event_signups_on_fleet_membership_id            (fleet_membership_id)
+#  index_fleet_event_signups_unique_active_per_event           (fleet_event_id,occurrence_date,fleet_membership_id) UNIQUE WHERE ((status)::text <> 'withdrawn'::text)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#  fk_rails_...  (fleet_event_slot_id => fleet_event_slots.id)
+#  fk_rails_...  (fleet_membership_id => fleet_memberships.id)
+#  fk_rails_...  (vehicle_id => vehicles.id) ON DELETE => nullify
+#
+class FleetEventSignup < ApplicationRecord
+  STATUSES = %w[confirmed tentative interested pending withdrawn].freeze
+  MEMBER_REQUESTABLE_STATUSES = %w[confirmed tentative interested].freeze
+  # Slot-bound signups must commit to the slot — only fully confirmed
+  # signups (or those still awaiting admin approval) are allowed there.
+  SLOT_BOUND_STATUSES = %w[confirmed pending withdrawn].freeze
+
+  belongs_to :fleet_event, touch: true
+  belongs_to :fleet_event_slot, touch: true, optional: true
+  belongs_to :fleet_membership
+  belongs_to :vehicle, optional: true
+
+  validates :status, inclusion: {in: STATUSES}
+  validate :unique_active_signup_per_member, on: :create
+  validate :slot_not_already_taken, on: :create
+  validate :slot_belongs_to_event
+  validate :slot_bound_status_allowed
+
+  before_validation :assign_event_from_slot
+  before_save :stamp_status_timestamps
+
+  delegate :user, to: :fleet_membership
+
+  def withdrawn?
+    status == "withdrawn"
+  end
+
+  def confirmed?
+    status == "confirmed"
+  end
+
+  def tentative?
+    status == "tentative"
+  end
+
+  def interested?
+    status == "interested"
+  end
+
+  def pending?
+    status == "pending"
+  end
+
+  def withdraw!
+    update!(status: "withdrawn", withdrawn_at: Time.current)
+  end
+
+  # Effective approval mode (slot override, falling back to the event default).
+  def effective_signup_approval
+    fleet_event_slot&.signup_approval.presence ||
+      fleet_event&.signup_approval ||
+      "direct"
+  end
+
+  private def assign_event_from_slot
+    return if fleet_event_id.present?
+    return if fleet_event_slot.blank?
+
+    self.fleet_event = fleet_event_slot.fleet_event
+  end
+
+  private def slot_belongs_to_event
+    return if fleet_event_slot.blank? || fleet_event.blank?
+    return if fleet_event_slot.fleet_event&.id == fleet_event_id
+
+    errors.add(:fleet_event_slot_id, :wrong_event)
+  end
+
+  private def slot_bound_status_allowed
+    return if fleet_event_slot_id.blank?
+    return if SLOT_BOUND_STATUSES.include?(status)
+
+    errors.add(:status, :invalid_for_slot)
+  end
+
+  private def unique_active_signup_per_member
+    return if status == "withdrawn"
+    return if fleet_event_id.blank?
+
+    # For recurring events signups are scoped to a specific occurrence date,
+    # so the same member can sign up for "next Thursday" and "the Thursday
+    # after". For one-off events occurrence_date is nil on both sides.
+    existing = FleetEventSignup.where(
+      fleet_event_id: fleet_event_id,
+      fleet_membership_id: fleet_membership_id,
+      occurrence_date: occurrence_date
+    ).where.not(status: "withdrawn").where.not(id: id)
+
+    if existing.exists?
+      errors.add(:fleet_membership_id, :already_signed_up)
+    end
+  end
+
+  private def slot_not_already_taken
+    return if status == "withdrawn"
+    return if fleet_event_slot_id.blank?
+
+    # For recurring events a slot can host different members across
+    # different occurrences. A signup conflicts only if another active
+    # signup holds the same slot on the same occurrence (or, for one-off
+    # events, occurrence_date is nil on both sides).
+    taken = FleetEventSignup
+      .where(fleet_event_slot_id: fleet_event_slot_id, occurrence_date: occurrence_date)
+      .where.not(status: "withdrawn")
+      .where.not(id: id)
+      .where.not(fleet_membership_id: fleet_membership_id)
+
+    if taken.exists?
+      errors.add(:fleet_event_slot_id, :already_taken)
+    end
+  end
+
+  private def stamp_status_timestamps
+    if status_changed? && status == "confirmed" && confirmed_at.nil?
+      self.confirmed_at = Time.current
+    end
+    if status_changed? && status == "withdrawn" && withdrawn_at.nil?
+      self.withdrawn_at = Time.current
+    end
+  end
+end

--- a/app/models/fleet_event_slot.rb
+++ b/app/models/fleet_event_slot.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_slots
+#
+#  id                :uuid             not null, primary key
+#  description       :text
+#  position          :integer          default(0), not null
+#  signup_approval   :string
+#  slottable_type    :string           not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  model_position_id :uuid
+#  slottable_id      :uuid             not null
+#  source_slot_id    :uuid
+#
+# Indexes
+#
+#  index_fleet_event_slots_on_model_position_id                (model_position_id)
+#  index_fleet_event_slots_on_slottable_and_position           (slottable_type,slottable_id,position)
+#  index_fleet_event_slots_on_slottable_type_and_slottable_id  (slottable_type,slottable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_position_id => model_positions.id)
+#  fk_rails_...  (source_slot_id => mission_slots.id) ON DELETE => nullify
+#
+class FleetEventSlot < ApplicationRecord
+  belongs_to :slottable, polymorphic: true, touch: true
+  belongs_to :model_position, optional: true
+  belongs_to :source_slot, class_name: "MissionSlot", optional: true
+  has_many :fleet_event_signups, dependent: :destroy
+
+  validates :title, presence: true
+  validates :slottable_type, inclusion: {in: %w[FleetEventTeam FleetEventShip]}
+  validates :signup_approval,
+    inclusion: {in: FleetEvent::SIGNUP_APPROVALS},
+    allow_nil: true
+
+  default_scope -> { order(position: :asc) }
+
+  def fleet_event
+    case slottable
+    when FleetEventTeam
+      slottable.fleet_event
+    when FleetEventShip
+      slottable.fleet_event_team.fleet_event
+    end
+  end
+
+  def derived?
+    model_position_id.present?
+  end
+
+  def position_type
+    model_position&.position_type
+  end
+
+  def active_signups
+    fleet_event_signups.where.not(status: "withdrawn")
+  end
+end

--- a/app/models/fleet_event_team.rb
+++ b/app/models/fleet_event_team.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_teams
+#
+#  id             :uuid             not null, primary key
+#  description    :text
+#  position       :integer          default(0), not null
+#  title          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  fleet_event_id :uuid             not null
+#  source_team_id :uuid
+#
+# Indexes
+#
+#  index_fleet_event_teams_on_fleet_event_id               (fleet_event_id)
+#  index_fleet_event_teams_on_fleet_event_id_and_position  (fleet_event_id,position)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#  fk_rails_...  (source_team_id => mission_teams.id) ON DELETE => nullify
+#
+class FleetEventTeam < ApplicationRecord
+  belongs_to :fleet_event, touch: true
+  belongs_to :source_team, class_name: "MissionTeam", optional: true
+  has_many :fleet_event_ships, dependent: :destroy
+  has_many :fleet_event_slots, as: :slottable, dependent: :destroy
+
+  validates :title, presence: true
+
+  default_scope -> { order(position: :asc) }
+end

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -49,7 +49,8 @@ class FleetRole < ApplicationRecord
       FleetVehicle::AVAILABLE_PRIVILEGES,
       FleetRole::AVAILABLE_PRIVILEGES,
       FleetInventory::AVAILABLE_PRIVILEGES,
-      Mission::AVAILABLE_PRIVILEGES
+      Mission::AVAILABLE_PRIVILEGES,
+      FleetEvent::AVAILABLE_PRIVILEGES
     ].flatten.uniq
   end
 
@@ -75,7 +76,8 @@ class FleetRole < ApplicationRecord
         FleetVehicle::DEFAULT_PRIVILEGES[:admin],
         FleetRole::DEFAULT_PRIVILEGES[:admin],
         FleetInventory::DEFAULT_PRIVILEGES[:admin],
-        Mission::DEFAULT_PRIVILEGES[:admin]
+        Mission::DEFAULT_PRIVILEGES[:admin],
+        FleetEvent::DEFAULT_PRIVILEGES[:admin]
       ].flatten.uniq,
       officer: [
         Fleet::DEFAULT_PRIVILEGES[:officer],
@@ -84,7 +86,8 @@ class FleetRole < ApplicationRecord
         FleetVehicle::DEFAULT_PRIVILEGES[:officer],
         FleetRole::DEFAULT_PRIVILEGES[:officer],
         FleetInventory::DEFAULT_PRIVILEGES[:officer],
-        Mission::DEFAULT_PRIVILEGES[:officer]
+        Mission::DEFAULT_PRIVILEGES[:officer],
+        FleetEvent::DEFAULT_PRIVILEGES[:officer]
       ].flatten.uniq,
       member: [
         Fleet::DEFAULT_PRIVILEGES[:member],
@@ -93,7 +96,8 @@ class FleetRole < ApplicationRecord
         FleetVehicle::DEFAULT_PRIVILEGES[:member],
         FleetRole::DEFAULT_PRIVILEGES[:member],
         FleetInventory::DEFAULT_PRIVILEGES[:member],
-        Mission::DEFAULT_PRIVILEGES[:member]
+        Mission::DEFAULT_PRIVILEGES[:member],
+        FleetEvent::DEFAULT_PRIVILEGES[:member]
       ].flatten.uniq
     }
   end

--- a/app/policies/fleet_event_admin_policy.rb
+++ b/app/policies/fleet_event_admin_policy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class FleetEventAdminPolicy < FleetBasePolicy
+  authorize :fleet_event, optional: true
+
+  def index?
+    target = target_event
+    return false unless target
+
+    return true if target.created_by_id == user&.id
+    return true if target.event_admin?(user)
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
+  def create?
+    target = target_event
+    return false unless target
+
+    return true if target.created_by_id == user&.id
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
+  alias_rule :destroy?, :update?, to: :create?
+
+  params_filter do |params|
+    params.permit(:user_id, :role)
+  end
+
+  private def target_event
+    record.try(:fleet_event) || (record.is_a?(::FleetEvent) ? record : nil) || fleet_event
+  end
+
+  private def fleet_membership
+    target = target_event
+    return unless target
+
+    user&.fleet_memberships&.find_by(fleet_id: target.fleet_id)
+  end
+end

--- a/app/policies/fleet_event_policy.rb
+++ b/app/policies/fleet_event_policy.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class FleetEventPolicy < FleetBasePolicy
+  def index?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:read"])
+  end
+
+  alias_rule :show?, to: :index?
+
+  def create?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:create"])
+  end
+
+  def update?
+    return true if creator?
+    return true if event_admin?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:update"])
+  end
+
+  def destroy?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:delete"])
+  end
+
+  # Granting/revoking per-event admin roles is restricted to the original
+  # event creator and fleet-level managers.
+  def manage_admins?
+    return true if creator?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
+  alias_rule :publish?, :lock_signups?, :unlock_signups?, :start?, :complete?, :cancel?, to: :update?
+  alias_rule :unarchive?, to: :destroy?
+
+  params_filter do |params|
+    params.permit(
+      :title, :description, :briefing,
+      :starts_at, :ends_at, :timezone,
+      :location, :meetup_location,
+      :visibility, :category, :scenario,
+      :max_attendees, :auto_lock_enabled, :auto_lock_minutes_before,
+      :cover_image, :cover_image_preset, :signup_approval,
+      :recurring, :recurrence_interval, :recurrence_until, :recurrence_count,
+      excluded_dates: []
+    )
+  end
+
+  private def creator?
+    record.respond_to?(:created_by_id) && user && record.created_by_id == user.id
+  end
+
+  private def event_admin?
+    record.respond_to?(:event_admin?) && record.event_admin?(user)
+  end
+
+  private def draft?
+    record.respond_to?(:status) && record.status == "draft"
+  end
+end

--- a/app/policies/fleet_event_ship_policy.rb
+++ b/app/policies/fleet_event_ship_policy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class FleetEventShipPolicy < FleetBasePolicy
+  authorize :fleet_event, optional: true
+
+  def create?
+    can_manage_event?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(
+      :title, :description, :model_id, :strict,
+      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
+    )
+  end
+
+  private def can_manage_event?
+    target_event = record_event
+    return false unless target_event
+
+    return true if target_event.event_admin?(user)
+
+    membership = user&.fleet_memberships&.find_by(fleet_id: target_event.fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:update"])
+  end
+
+  private def record_event
+    if record.respond_to?(:fleet_event_team)
+      record.fleet_event_team&.fleet_event
+    end || record.try(:fleet_event) ||
+      (record.is_a?(FleetEvent) ? record : nil) ||
+      fleet_event
+  end
+end

--- a/app/policies/fleet_event_ship_policy.rb
+++ b/app/policies/fleet_event_ship_policy.rb
@@ -12,7 +12,8 @@ class FleetEventShipPolicy < FleetBasePolicy
   params_filter do |params|
     params.permit(
       :title, :description, :model_id, :strict,
-      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo
+      :classification, :focus, :min_size, :max_size, :min_crew, :min_cargo,
+      allowed_model_ids: []
     )
   end
 

--- a/app/policies/fleet_event_signup_policy.rb
+++ b/app/policies/fleet_event_signup_policy.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class FleetEventSignupPolicy < FleetBasePolicy
+  authorize :fleet_event, optional: true
+
+  def create?
+    return false unless signups_open_for_event?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:read"])
+  end
+
+  alias_rule :update?, to: :create?
+
+  # Admin-side management: reassigning slots, approving pending signups,
+  # kicking members. Allowed for fleet event-managers, the event creator,
+  # or per-event admins/moderators.
+  def manage?
+    return true if event_admin_or_moderator?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
+  def destroy?
+    return true if creator?
+    return true if event_admin_or_moderator?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
+  params_filter do |params|
+    params.permit(:status, :vehicle_id, :notes)
+  end
+
+  private def creator?
+    record.respond_to?(:fleet_membership_id) &&
+      accepted_fleet_membership &&
+      record.fleet_membership_id == accepted_fleet_membership.id
+  end
+
+  private def event_admin_or_moderator?
+    target_event = record.try(:fleet_event) || fleet_event
+    target_event&.event_moderator_or_admin?(user)
+  end
+
+  private def signups_open_for_event?
+    target_event = record.try(:fleet_event) || fleet_event
+    target_event.nil? || target_event.signups_open?
+  end
+
+  private def fleet_membership
+    record_fleet_id =
+      record.try(:fleet_event)&.fleet_id ||
+      record.try(:fleet_id) ||
+      fleet_event&.fleet_id ||
+      fleet&.id
+
+    return unless record_fleet_id
+
+    user&.fleet_memberships&.find_by(fleet_id: record_fleet_id)
+  end
+end

--- a/app/policies/fleet_event_slot_policy.rb
+++ b/app/policies/fleet_event_slot_policy.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class FleetEventSlotPolicy < FleetBasePolicy
+  authorize :fleet_event, optional: true
+
+  def create?
+    can_manage_event?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(:title, :description, :model_position_id, :signup_approval)
+  end
+
+  private def can_manage_event?
+    target_event = record_event
+    return false unless target_event
+
+    return true if target_event.event_admin?(user)
+
+    membership = user&.fleet_memberships&.find_by(fleet_id: target_event.fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:update"])
+  end
+
+  private def record_event
+    case record
+    when FleetEventSlot then record.fleet_event
+    when FleetEventShip then record.fleet_event_team&.fleet_event
+    when FleetEventTeam then record.fleet_event
+    when FleetEvent then record
+    else fleet_event
+    end
+  end
+end

--- a/app/policies/fleet_event_team_policy.rb
+++ b/app/policies/fleet_event_team_policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class FleetEventTeamPolicy < FleetBasePolicy
+  authorize :fleet_event, optional: true
+
+  def create?
+    can_manage_event?
+  end
+
+  alias_rule :update?, :destroy?, :sort?, to: :create?
+
+  params_filter do |params|
+    params.permit(:title, :description)
+  end
+
+  private def can_manage_event?
+    target_event = record_event
+    return false unless target_event
+
+    return true if target_event.event_admin?(user)
+
+    membership = user&.fleet_memberships&.find_by(fleet_id: target_event.fleet_id)
+    return false unless membership&.accepted?
+
+    membership.has_access?(["fleet:manage", "fleet:events:manage", "fleet:events:update"])
+  end
+
+  private def record_event
+    record.try(:fleet_event) || (record.is_a?(FleetEvent) ? record : nil) || fleet_event
+  end
+end

--- a/app/views/api/v1/fleet_event_admins/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_admins/_base.jbuilder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+json.id fleet_event_admin.id
+json.fleet_event_id fleet_event_admin.fleet_event_id
+json.role fleet_event_admin.role
+json.created_at fleet_event_admin.created_at
+json.user do
+  json.id fleet_event_admin.user.id
+  json.username fleet_event_admin.user.username
+end
+if fleet_event_admin.granted_by.present?
+  json.granted_by do
+    json.id fleet_event_admin.granted_by.id
+    json.username fleet_event_admin.granted_by.username
+  end
+else
+  json.granted_by nil
+end

--- a/app/views/api/v1/fleet_event_admins/_fleet_event_admin.jbuilder
+++ b/app/views/api/v1/fleet_event_admins/_fleet_event_admin.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_admins/base", fleet_event_admin: fleet_event_admin

--- a/app/views/api/v1/fleet_event_admins/index.jbuilder
+++ b/app/views/api/v1/fleet_event_admins/index.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.array! @admins,
+  partial: "api/v1/fleet_event_admins/fleet_event_admin",
+  as: :fleet_event_admin

--- a/app/views/api/v1/fleet_event_admins/show.jbuilder
+++ b/app/views/api/v1/fleet_event_admins/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_admins/base", fleet_event_admin: @admin

--- a/app/views/api/v1/fleet_event_ships/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_ships/_base.jbuilder
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+json.id fleet_event_ship.id
+json.fleet_event_team_id fleet_event_ship.fleet_event_team_id
+json.title fleet_event_ship.title
+json.display_title fleet_event_ship.display_title
+json.description fleet_event_ship.description
+json.position fleet_event_ship.position
+json.strict fleet_event_ship.strict?
+
+if fleet_event_ship.model.present?
+  json.model do
+    json.id fleet_event_ship.model.id
+    json.name fleet_event_ship.model.name
+    json.slug fleet_event_ship.model.slug
+    json.min_crew fleet_event_ship.model.min_crew
+    json.max_crew fleet_event_ship.model.max_crew
+
+    image_attr = if fleet_event_ship.model.store_image.attached?
+      :store_image
+    elsif fleet_event_ship.model.angled_view.attached?
+      :angled_view
+    elsif fleet_event_ship.model.fleetchart_image.attached?
+      :fleetchart_image
+    end
+
+    if image_attr
+      json.image do
+        json.partial! "api/v1/shared/file", record: fleet_event_ship.model, attr: image_attr
+      end
+    else
+      json.image nil
+    end
+  end
+else
+  json.model nil
+end
+
+json.filters do
+  json.classification fleet_event_ship.classification
+  json.focus fleet_event_ship.focus
+  json.min_size fleet_event_ship.min_size
+  json.max_size fleet_event_ship.max_size
+  json.min_crew fleet_event_ship.min_crew
+  json.min_cargo fleet_event_ship.min_cargo&.to_f
+end
+
+json.slots do
+  json.array! fleet_event_ship.fleet_event_slots,
+    partial: "api/v1/fleet_event_slots/fleet_event_slot",
+    as: :fleet_event_slot,
+    locals: {occurrence_date: local_assigns[:occurrence_date]}
+end

--- a/app/views/api/v1/fleet_event_ships/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_ships/_base.jbuilder
@@ -10,30 +10,18 @@ json.strict fleet_event_ship.strict?
 
 if fleet_event_ship.model.present?
   json.model do
-    json.id fleet_event_ship.model.id
-    json.name fleet_event_ship.model.name
-    json.slug fleet_event_ship.model.slug
-    json.min_crew fleet_event_ship.model.min_crew
-    json.max_crew fleet_event_ship.model.max_crew
-
-    image_attr = if fleet_event_ship.model.store_image.attached?
-      :store_image
-    elsif fleet_event_ship.model.angled_view.attached?
-      :angled_view
-    elsif fleet_event_ship.model.fleetchart_image.attached?
-      :fleetchart_image
-    end
-
-    if image_attr
-      json.image do
-        json.partial! "api/v1/shared/file", record: fleet_event_ship.model, attr: image_attr
-      end
-    else
-      json.image nil
-    end
+    json.partial! "api/v1/shared/ship_model", model: fleet_event_ship.model
   end
 else
   json.model nil
+end
+
+# The models this spot will take when it names several rather than one. Empty for
+# the other two kinds of spot, so the client can tell them apart by shape.
+json.allowed_models do
+  json.array!(fleet_event_ship.allowed_models) do |model|
+    json.partial! "api/v1/shared/ship_model", model: model
+  end
 end
 
 json.filters do

--- a/app/views/api/v1/fleet_event_ships/_fleet_event_ship.jbuilder
+++ b/app/views/api/v1/fleet_event_ships/_fleet_event_ship.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_ships/base",
+  fleet_event_ship: fleet_event_ship,
+  occurrence_date: local_assigns[:occurrence_date]

--- a/app/views/api/v1/fleet_event_ships/show.jbuilder
+++ b/app/views/api/v1/fleet_event_ships/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_ships/base", fleet_event_ship: @ship

--- a/app/views/api/v1/fleet_event_signups/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_signups/_base.jbuilder
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+json.id fleet_event_signup.id
+json.fleet_event_id fleet_event_signup.fleet_event_id
+json.fleet_event_slot_id fleet_event_signup.fleet_event_slot_id
+json.occurrence_date fleet_event_signup.occurrence_date
+json.status fleet_event_signup.status
+json.notes fleet_event_signup.notes
+json.confirmed_at fleet_event_signup.confirmed_at
+json.withdrawn_at fleet_event_signup.withdrawn_at
+
+if fleet_event_signup.user.present?
+  json.user do
+    json.id fleet_event_signup.user.id
+    json.username fleet_event_signup.user.username
+  end
+else
+  json.user nil
+end
+
+if fleet_event_signup.vehicle.present?
+  json.vehicle do
+    json.id fleet_event_signup.vehicle.id
+    json.name fleet_event_signup.vehicle.name
+    if fleet_event_signup.vehicle.model.present?
+      json.model do
+        json.id fleet_event_signup.vehicle.model.id
+        json.name fleet_event_signup.vehicle.model.name
+        json.slug fleet_event_signup.vehicle.model.slug
+        json.classification fleet_event_signup.vehicle.model.classification
+        json.focus fleet_event_signup.vehicle.model.focus
+        json.size fleet_event_signup.vehicle.model.size
+        json.min_crew fleet_event_signup.vehicle.model.min_crew
+        json.max_crew fleet_event_signup.vehicle.model.max_crew
+        json.cargo fleet_event_signup.vehicle.model.cargo
+        json.position_count fleet_event_signup.vehicle.model.model_positions.size
+      end
+    else
+      json.model nil
+    end
+  end
+else
+  json.vehicle nil
+end

--- a/app/views/api/v1/fleet_event_signups/_fleet_event_signup.jbuilder
+++ b/app/views/api/v1/fleet_event_signups/_fleet_event_signup.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_signups/base", fleet_event_signup: fleet_event_signup

--- a/app/views/api/v1/fleet_event_signups/show.jbuilder
+++ b/app/views/api/v1/fleet_event_signups/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_signups/fleet_event_signup", fleet_event_signup: @signup

--- a/app/views/api/v1/fleet_event_slots/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_slots/_base.jbuilder
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+json.id fleet_event_slot.id
+json.slottable_type fleet_event_slot.slottable_type
+json.slottable_id fleet_event_slot.slottable_id
+json.title fleet_event_slot.title
+json.description fleet_event_slot.description
+json.position fleet_event_slot.position
+json.derived fleet_event_slot.derived?
+json.position_type fleet_event_slot.position_type
+json.model_position_id fleet_event_slot.model_position_id
+json.signup_approval fleet_event_slot.signup_approval
+json.effective_signup_approval fleet_event_slot.signup_approval.presence ||
+  fleet_event_slot.fleet_event&.signup_approval ||
+  "direct"
+
+occurrence_date = local_assigns[:occurrence_date]
+signup_scope = fleet_event_slot.active_signups
+signup_scope = signup_scope.where(occurrence_date: occurrence_date) if occurrence_date
+
+json.signups do
+  json.array! signup_scope,
+    partial: "api/v1/fleet_event_signups/fleet_event_signup",
+    as: :fleet_event_signup
+end

--- a/app/views/api/v1/fleet_event_slots/_fleet_event_slot.jbuilder
+++ b/app/views/api/v1/fleet_event_slots/_fleet_event_slot.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_slots/base",
+  fleet_event_slot: fleet_event_slot,
+  occurrence_date: local_assigns[:occurrence_date]

--- a/app/views/api/v1/fleet_event_slots/show.jbuilder
+++ b/app/views/api/v1/fleet_event_slots/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_slots/base", fleet_event_slot: @slot

--- a/app/views/api/v1/fleet_event_teams/_base.jbuilder
+++ b/app/views/api/v1/fleet_event_teams/_base.jbuilder
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+occurrence_date = local_assigns[:occurrence_date]
+
+json.id fleet_event_team.id
+json.fleet_event_id fleet_event_team.fleet_event_id
+json.title fleet_event_team.title
+json.description fleet_event_team.description
+json.position fleet_event_team.position
+
+json.slots do
+  json.array! fleet_event_team.fleet_event_slots,
+    partial: "api/v1/fleet_event_slots/fleet_event_slot",
+    as: :fleet_event_slot,
+    locals: {occurrence_date: occurrence_date}
+end
+
+json.ships do
+  json.array! fleet_event_team.fleet_event_ships,
+    partial: "api/v1/fleet_event_ships/fleet_event_ship",
+    as: :fleet_event_ship,
+    locals: {occurrence_date: occurrence_date}
+end

--- a/app/views/api/v1/fleet_event_teams/_fleet_event_team.jbuilder
+++ b/app/views/api/v1/fleet_event_teams/_fleet_event_team.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_teams/base",
+  fleet_event_team: fleet_event_team,
+  occurrence_date: local_assigns[:occurrence_date]

--- a/app/views/api/v1/fleet_event_teams/show.jbuilder
+++ b/app/views/api/v1/fleet_event_teams/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_event_teams/base", fleet_event_team: @team

--- a/app/views/api/v1/fleet_events/_base.jbuilder
+++ b/app/views/api/v1/fleet_events/_base.jbuilder
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+json.id fleet_event.id
+json.fleet_id fleet_event.fleet_id
+json.mission_id fleet_event.mission_id
+json.title fleet_event.title
+json.slug fleet_event.slug
+json.description fleet_event.description
+json.briefing fleet_event.briefing
+json.status fleet_event.status
+json.starts_at fleet_event.starts_at
+json.ends_at fleet_event.ends_at
+json.timezone fleet_event.timezone
+json.location fleet_event.location
+json.meetup_location fleet_event.meetup_location
+json.visibility fleet_event.visibility
+json.category fleet_event.category
+json.scenario fleet_event.scenario
+json.cover_image_preset fleet_event.cover_image_preset
+json.max_attendees fleet_event.max_attendees
+json.auto_lock_enabled fleet_event.auto_lock_enabled
+json.auto_lock_minutes_before fleet_event.auto_lock_minutes_before
+json.cancelled_reason fleet_event.cancelled_reason
+json.signup_approval fleet_event.signup_approval
+json.archived fleet_event.archived?
+json.archived_at fleet_event.archived_at
+json.external_uid fleet_event.external_uid
+
+if fleet_event.cover_image.attached?
+  json.cover_image do
+    json.partial! "api/v1/shared/file", record: fleet_event, attr: :cover_image
+  end
+else
+  json.cover_image nil
+end
+
+if fleet_event.created_by.present?
+  json.created_by do
+    json.id fleet_event.created_by.id
+    json.username fleet_event.created_by.username
+  end
+else
+  json.created_by nil
+end
+
+json.signups_count fleet_event.signups_count
+json.team_count fleet_event.fleet_event_teams.size
+json.past fleet_event.past?
+json.signups_open fleet_event.signups_open?
+
+json.recurring fleet_event.recurring?
+json.recurrence_interval fleet_event.recurrence_interval
+json.recurrence_until fleet_event.recurrence_until
+json.recurrence_count fleet_event.recurrence_count
+json.excluded_dates(fleet_event.excluded_dates || [])
+json.occurrence_date local_assigns[:occurrence_date]
+json.parent_event_slug local_assigns[:parent_event_slug]
+
+json.viewer_event_role local_assigns[:viewer_event_role]
+
+json.partial! "api/shared/dates", record: fleet_event

--- a/app/views/api/v1/fleet_events/_fleet_event.jbuilder
+++ b/app/views/api/v1/fleet_events/_fleet_event.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_events/base", fleet_event: fleet_event

--- a/app/views/api/v1/fleet_events/index.jbuilder
+++ b/app/views/api/v1/fleet_events/index.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @fleet_events,
+    partial: "api/v1/fleet_events/fleet_event",
+    as: :fleet_event
+end
+json.partial! "api/shared/meta", result: @fleet_events

--- a/app/views/api/v1/fleet_events/occurrence_state.jbuilder
+++ b/app/views/api/v1/fleet_events/occurrence_state.jbuilder
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+json.id @occurrence_state.id
+json.fleet_event_id @occurrence_state.fleet_event_id
+json.occurrence_date @occurrence_state.occurrence_date
+json.status @occurrence_state.status
+json.locked_at @occurrence_state.locked_at
+json.starting_soon_notified_at @occurrence_state.starting_soon_notified_at
+json.cancelled_at @occurrence_state.cancelled_at
+json.cancelled_reason @occurrence_state.cancelled_reason
+json.discord_event_id @occurrence_state.discord_event_id
+json.discord_synced_at @occurrence_state.discord_synced_at
+json.title @occurrence_state.title
+json.description @occurrence_state.description
+json.briefing @occurrence_state.briefing
+json.location @occurrence_state.location
+json.meetup_location @occurrence_state.meetup_location
+json.scenario @occurrence_state.scenario
+json.cover_image_preset @occurrence_state.cover_image_preset

--- a/app/views/api/v1/fleet_events/show.jbuilder
+++ b/app/views/api/v1/fleet_events/show.jbuilder
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_events/base",
+  fleet_event: @fleet_event,
+  viewer_event_role: @viewer_event_role,
+  occurrence_date: @occurrence_date,
+  parent_event_slug: @occurrence_date ? @fleet_event.slug : nil
+
+# Per-occurrence override of fields when the request is scoped to a
+# specific date (?occurrence=YYYY-MM-DD). The starts_at/ends_at are
+# shifted to that day; titles, descriptions, location etc. prefer the
+# overlay row's values over the event defaults.
+if @occurrence_date
+  occurrence_start = @fleet_event.starts_at.in_time_zone(@fleet_event.timezone || "UTC").change(
+    year: @occurrence_date.year,
+    month: @occurrence_date.month,
+    day: @occurrence_date.day
+  )
+  duration = @fleet_event.ends_at ? (@fleet_event.ends_at - @fleet_event.starts_at) : 2.hours
+
+  json.starts_at occurrence_start
+  json.ends_at(occurrence_start + duration)
+
+  if @occurrence_state
+    json.title @occurrence_state.title.presence || @fleet_event.title
+    json.description @occurrence_state.description.presence || @fleet_event.description
+    json.briefing @occurrence_state.briefing.presence || @fleet_event.briefing
+    json.location @occurrence_state.location.presence || @fleet_event.location
+    json.meetup_location @occurrence_state.meetup_location.presence || @fleet_event.meetup_location
+    json.scenario @occurrence_state.scenario.presence || @fleet_event.scenario
+    json.cover_image_preset @occurrence_state.cover_image_preset.presence || @fleet_event.cover_image_preset
+    json.status @occurrence_state.status.presence || @fleet_event.status
+    json.discord_event_id @occurrence_state.discord_event_id
+    json.discord_synced_at @occurrence_state.discord_synced_at
+  end
+end
+
+json.teams do
+  teams = @fleet_event.fleet_event_teams
+    .includes(fleet_event_ships: [:model, fleet_event_slots: [:model_position]])
+    .includes(fleet_event_slots: [:model_position])
+  json.array! teams,
+    partial: "api/v1/fleet_event_teams/fleet_event_team",
+    as: :fleet_event_team,
+    locals: {occurrence_date: @occurrence_date}
+end
+
+# Signups attached directly to the event (no slot yet) — admins assign these
+# to slots later, and members see their own here. For recurring events the
+# list is scoped to the requested occurrence so members see signups for the
+# specific Thursday they're looking at.
+unassigned_scope = @fleet_event.fleet_event_signups
+  .where(fleet_event_slot_id: nil)
+  .where.not(status: "withdrawn")
+unassigned_scope = unassigned_scope.where(occurrence_date: @occurrence_date) if @occurrence_date
+
+json.unassigned_signups do
+  json.array! unassigned_scope,
+    partial: "api/v1/fleet_event_signups/fleet_event_signup",
+    as: :fleet_event_signup
+end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -252,6 +252,14 @@ en:
               must_be_in_game: is not in the game yet
             allowed_model_ids:
               must_be_in_game: name a ship that is not in the game yet
+        fleet_event_ship:
+          attributes:
+            base:
+              model_or_filter_required: needs a ship, a list of ships, or filters
+            model_id:
+              must_be_in_game: is not in the game yet
+            allowed_model_ids:
+              must_be_in_game: name a ship that is not in the game yet
         fleet_role:
           attributes:
             resource_access:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -284,3 +284,9 @@ en:
               invalid: Token is invalid
             username:
               taken: is already taken.
+        fleet_event_signup:
+          attributes:
+            fleet_membership_id:
+              already_signed_up: is already signed up to this slot
+            fleet_event_slot_id:
+              already_taken: is already taken by another member

--- a/config/locales/en/labels.yml
+++ b/config/locales/en/labels.yml
@@ -76,3 +76,5 @@ en:
       url: URL
     tax_excluded: excl. VAT
     unknown: Unknown
+    mission_ship:
+      placeholder: Unspecified Ship

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -27,6 +27,31 @@ en:
       accept: Fleet Invitation could not be accepted.
       decline: Fleet Invitation could not be declined.
       demote_not_permitted: You can't demote the last Member of a permanent Fleet Role.
+    fleet_events:
+      create: Event could not be created.
+      update: Event could not be updated.
+      destroy: Event could not be deleted.
+    fleet_event_teams:
+      create: Event team could not be created.
+      update: Event team could not be updated.
+      destroy: Event team could not be removed.
+    fleet_event_ships:
+      create: Event ship could not be created.
+      update: Event ship could not be updated.
+      destroy: Event ship could not be removed.
+    fleet_event_slots:
+      create: Event slot could not be created.
+      update: Event slot could not be updated.
+      destroy: Event slot could not be removed.
+    fleet_event_signups:
+      create: Sign-up failed.
+      update: Sign-up could not be updated.
+      destroy: Sign-up could not be withdrawn.
+    fleet_event_admins:
+      create: Event admin could not be granted.
+      destroy: Event admin could not be revoked.
+    fleet_notification_settings:
+      update: Notification settings could not be updated.
     hangar_group:
       create: Group could not be created
       destroy: Group could not be destroyed

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -61,6 +61,33 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
         post :duplicate, on: :member
       end
     end
+    resources :fleet_events, path: "events", only: %i[create]
+  end
+
+  resources :fleet_events, path: "events", param: :slug, only: %i[index show create update destroy], constraints: {slug: %r{[^/.]+}} do
+    member do
+      put :publish
+      put "lock-signups", action: :lock_signups
+      put "unlock-signups", action: :unlock_signups
+      put :start
+      put :complete
+      put :cancel
+      put :unarchive
+      post "skip-occurrence", action: :skip_occurrence
+      post "end-series", action: :end_series
+      patch "update-occurrence", action: :update_occurrence
+      post :signup, to: "fleet_event_signups#event_signup"
+    end
+
+    resources :fleet_event_admins, path: "admins", only: %i[index create destroy]
+
+    resources :fleet_event_teams, path: "teams", only: %i[create update destroy] do
+      put :sort, on: :collection
+      resources :fleet_event_ships, path: "ships", only: %i[create update destroy] do
+        put :sort, on: :collection
+        post "expand-from-model", action: :expand_from_model, on: :member
+      end
+    end
   end
 
   resource :fleet_stats, path: "stats", only: %i[] do

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -74,6 +74,21 @@ v1_api_routes = lambda do
     put :sort, on: :collection
   end
 
+  resources :fleet_event_slots, path: "fleet-event-slots", only: %i[create update destroy] do
+    put :sort, on: :collection
+    member do
+      post :signup, to: "fleet_event_signups#create"
+      patch :signup, to: "fleet_event_signups#update"
+      delete :signup, to: "fleet_event_signups#destroy_self"
+    end
+  end
+
+  resources :fleet_event_signups, path: "fleet-event-signups", only: %i[destroy] do
+    member do
+      patch :assign, to: "fleet_event_signups#update_admin"
+    end
+  end
+
   namespace :stats do
     get "quick-stats", to: "base#quick_stats"
     get "models-per-month", to: "base#models_per_month"

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -73,3 +73,8 @@ cleanup_visits_job:
   cron: '0 0 1 * *' # Monthly on the first day at 0:00
   class: 'Cleanup::VisitsJob'
   queue: 'cleanup'
+
+fleet_events_auto_lock_job:
+  cron: '*/5 * * * *' # Every 5 minutes
+  class: 'FleetEvents::AutoLockJob'
+  queue: 'default'

--- a/db/data/20260504100100_repair_double_encoded_role_access.rb
+++ b/db/data/20260504100100_repair_double_encoded_role_access.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RepairDoubleEncodedRoleAccess < ActiveRecord::Migration[8.1]
+  def up
+    FleetRole.find_each do |role|
+      raw = role.read_attribute_before_type_cast(:resource_access)
+      next if raw.blank?
+
+      first = YAML.safe_load(raw, permitted_classes: [Symbol], aliases: true)
+
+      if first.is_a?(String)
+        # Double-encoded — load again to get the real array
+        actual = YAML.safe_load(first, permitted_classes: [Symbol], aliases: true)
+        role.update_columns(resource_access: actual)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20260504100200_finally_repair_role_access.rb
+++ b/db/data/20260504100200_finally_repair_role_access.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class FinallyRepairRoleAccess < ActiveRecord::Migration[8.1]
+  def up
+    FleetRole.find_each do |role|
+      raw = role.read_attribute_before_type_cast(:resource_access)
+      next if raw.blank?
+
+      decoded = YAML.safe_load(raw, permitted_classes: [Symbol], aliases: true)
+
+      # Unwrap any level of double encoding until we have an Array
+      while decoded.is_a?(String)
+        decoded = YAML.safe_load(decoded, permitted_classes: [Symbol], aliases: true)
+      end
+
+      next unless decoded.is_a?(Array)
+
+      role.update_columns(resource_access: decoded)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260505200000_add_event_columns_to_fleets.rb
+++ b/db/migrate/20260505200000_add_event_columns_to_fleets.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddEventColumnsToFleets < ActiveRecord::Migration[7.2]
+  def change
+    add_column :fleets, :default_timezone, :string, null: false, default: "UTC"
+    add_column :fleets, :calendar_feed_token, :string
+    add_index :fleets, :calendar_feed_token, unique: true
+  end
+end

--- a/db/migrate/20260505200001_create_fleet_events.rb
+++ b/db/migrate/20260505200001_create_fleet_events.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class CreateFleetEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fleet_events, id: :uuid do |t|
+      t.references :fleet, type: :uuid, null: false, foreign_key: true, index: false
+      t.uuid :mission_id, null: true
+      t.uuid :created_by_id, null: false
+
+      t.string :title, null: false
+      t.text :description
+      t.text :briefing
+      t.string :slug, null: false
+
+      t.string :status, null: false, default: "draft"
+
+      t.datetime :starts_at, null: false
+      t.datetime :ends_at
+      t.string :timezone, null: false, default: "UTC"
+
+      t.string :location
+      t.string :meetup_location
+
+      t.string :visibility, null: false, default: "members"
+
+      t.integer :category, null: false, default: 0
+      t.string :scenario
+      t.string :cover_image_preset
+
+      t.integer :max_attendees
+      t.boolean :auto_lock_enabled, null: false, default: true
+      t.integer :auto_lock_minutes_before, null: false, default: 60
+      t.text :cancelled_reason
+      t.datetime :starting_soon_notified_at
+
+      t.uuid :external_uid, null: false
+
+      t.string :discord_event_id
+      t.string :discord_message_id
+      t.datetime :discord_synced_at
+
+      t.datetime :archived_at
+
+      t.timestamps
+    end
+
+    add_index :fleet_events, [:fleet_id, :slug], unique: true
+    add_index :fleet_events, [:fleet_id, :status]
+    add_index :fleet_events, [:fleet_id, :starts_at]
+    add_index :fleet_events, :mission_id
+    add_index :fleet_events, :external_uid, unique: true
+    add_foreign_key :fleet_events, :missions, column: :mission_id
+    add_foreign_key :fleet_events, :users, column: :created_by_id
+  end
+end

--- a/db/migrate/20260505200002_create_fleet_event_teams.rb
+++ b/db/migrate/20260505200002_create_fleet_event_teams.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateFleetEventTeams < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fleet_event_teams, id: :uuid do |t|
+      t.references :fleet_event, type: :uuid, null: false, foreign_key: true
+      t.uuid :source_team_id
+      t.string :title, null: false
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :fleet_event_teams, [:fleet_event_id, :position]
+    add_foreign_key :fleet_event_teams, :mission_teams, column: :source_team_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260505200003_create_fleet_event_ships.rb
+++ b/db/migrate/20260505200003_create_fleet_event_ships.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateFleetEventShips < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fleet_event_ships, id: :uuid do |t|
+      t.references :fleet_event_team, type: :uuid, null: false, foreign_key: true
+      t.uuid :source_ship_id
+      t.references :model, type: :uuid, null: true, foreign_key: true
+      t.string :title
+      t.text :description
+      t.string :classification
+      t.string :focus
+      t.string :min_size
+      t.string :max_size
+      t.integer :min_crew
+      t.decimal :min_cargo
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :fleet_event_ships, [:fleet_event_team_id, :position]
+    add_foreign_key :fleet_event_ships, :mission_ships, column: :source_ship_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260505200004_create_fleet_event_slots.rb
+++ b/db/migrate/20260505200004_create_fleet_event_slots.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateFleetEventSlots < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fleet_event_slots, id: :uuid do |t|
+      t.string :slottable_type, null: false
+      t.uuid :slottable_id, null: false
+      t.uuid :source_slot_id
+      t.references :model_position, type: :uuid, null: true, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :fleet_event_slots, [:slottable_type, :slottable_id]
+    add_index :fleet_event_slots, [:slottable_type, :slottable_id, :position],
+      name: "index_fleet_event_slots_on_slottable_and_position"
+    add_foreign_key :fleet_event_slots, :mission_slots, column: :source_slot_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260505200005_create_fleet_event_signups.rb
+++ b/db/migrate/20260505200005_create_fleet_event_signups.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateFleetEventSignups < ActiveRecord::Migration[7.2]
+  def change
+    create_table :fleet_event_signups, id: :uuid do |t|
+      t.references :fleet_event_slot, type: :uuid, null: false, foreign_key: true
+      t.references :fleet_membership, type: :uuid, null: false, foreign_key: true
+      t.uuid :vehicle_id
+      t.string :status, null: false, default: "confirmed"
+      t.text :notes
+      t.datetime :confirmed_at
+      t.datetime :withdrawn_at
+      t.timestamps
+    end
+
+    add_index :fleet_event_signups, [:fleet_event_slot_id, :fleet_membership_id],
+      unique: true,
+      where: "status != 'withdrawn'",
+      name: "index_fleet_event_signups_unique_active"
+    add_foreign_key :fleet_event_signups, :vehicles, column: :vehicle_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260505200007_backfill_fleet_event_privileges.rb
+++ b/db/migrate/20260505200007_backfill_fleet_event_privileges.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class BackfillFleetEventPrivileges < ActiveRecord::Migration[8.1]
+  # Default fleet roles are seeded with these names (see FleetRole.setup_default_roles!).
+  # Custom roles get nothing here — admins must grant the new event privileges manually.
+  DEFAULT_ROLE_PRIVILEGES = {
+    "Admin" => FleetEvent::DEFAULT_PRIVILEGES[:admin],
+    "Officer" => FleetEvent::DEFAULT_PRIVILEGES[:officer],
+    "Member" => FleetEvent::DEFAULT_PRIVILEGES[:member]
+  }.freeze
+
+  def up
+    FleetRole.find_each do |role|
+      defaults = DEFAULT_ROLE_PRIVILEGES[role.name]
+      next if defaults.blank?
+
+      current = Array(role.resource_access)
+      missing = defaults - current
+      next if missing.empty?
+
+      role.update_columns(resource_access: (current + missing).uniq)
+    end
+  end
+
+  def down
+    # No-op: removing privileges could break custom-tweaked roles
+  end
+end

--- a/db/migrate/20260505220000_extend_fleet_event_signups.rb
+++ b/db/migrate/20260505220000_extend_fleet_event_signups.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class ExtendFleetEventSignups < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :fleet_event_signups, :fleet_event, type: :uuid, foreign_key: true, null: true
+
+    execute <<~SQL
+      UPDATE fleet_event_signups s
+      SET fleet_event_id = sub.event_id
+      FROM (
+        SELECT slots.id AS slot_id,
+          CASE
+            WHEN slots.slottable_type = 'FleetEventTeam' THEN teams.fleet_event_id
+            WHEN slots.slottable_type = 'FleetEventShip' THEN team_for_ship.fleet_event_id
+          END AS event_id
+        FROM fleet_event_slots slots
+        LEFT JOIN fleet_event_teams teams
+          ON slots.slottable_type = 'FleetEventTeam' AND teams.id = slots.slottable_id
+        LEFT JOIN fleet_event_ships ships
+          ON slots.slottable_type = 'FleetEventShip' AND ships.id = slots.slottable_id
+        LEFT JOIN fleet_event_teams team_for_ship
+          ON slots.slottable_type = 'FleetEventShip' AND team_for_ship.id = ships.fleet_event_team_id
+      ) sub
+      WHERE s.fleet_event_slot_id = sub.slot_id;
+    SQL
+
+    change_column_null :fleet_event_signups, :fleet_event_id, false
+    change_column_null :fleet_event_signups, :fleet_event_slot_id, true
+
+    if index_exists?(:fleet_event_signups, [:fleet_event_slot_id, :fleet_membership_id], name: "index_fleet_event_signups_unique_active")
+      remove_index :fleet_event_signups, name: "index_fleet_event_signups_unique_active"
+    end
+
+    add_index :fleet_event_signups, [:fleet_event_id, :fleet_membership_id],
+      unique: true,
+      where: "status <> 'withdrawn'",
+      name: "index_fleet_event_signups_unique_active_per_event"
+
+    add_column :fleet_events, :signup_approval, :string, default: "direct", null: false
+    add_column :fleet_event_slots, :signup_approval, :string
+  end
+
+  def down
+    remove_column :fleet_event_slots, :signup_approval
+    remove_column :fleet_events, :signup_approval
+
+    if index_exists?(:fleet_event_signups, [:fleet_event_id, :fleet_membership_id], name: "index_fleet_event_signups_unique_active_per_event")
+      remove_index :fleet_event_signups, name: "index_fleet_event_signups_unique_active_per_event"
+    end
+
+    add_index :fleet_event_signups, [:fleet_event_slot_id, :fleet_membership_id],
+      unique: true,
+      where: "status <> 'withdrawn'",
+      name: "index_fleet_event_signups_unique_active"
+
+    change_column_null :fleet_event_signups, :fleet_event_slot_id, false
+    remove_reference :fleet_event_signups, :fleet_event, foreign_key: true
+  end
+end

--- a/db/migrate/20260505220001_create_fleet_event_admins.rb
+++ b/db/migrate/20260505220001_create_fleet_event_admins.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateFleetEventAdmins < ActiveRecord::Migration[8.1]
+  def change
+    create_table :fleet_event_admins, id: :uuid do |t|
+      t.references :fleet_event, type: :uuid, foreign_key: true, null: false
+      t.references :user, type: :uuid, foreign_key: true, null: false
+      t.string :role, null: false, default: "admin"
+      t.uuid :granted_by_id
+      t.timestamps
+    end
+
+    add_index :fleet_event_admins, [:fleet_event_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20260513110000_add_recurrence_to_fleet_events.rb
+++ b/db/migrate/20260513110000_add_recurrence_to_fleet_events.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddRecurrenceToFleetEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :fleet_events, :recurring, :boolean, null: false, default: false
+    add_column :fleet_events, :recurrence_interval, :string
+    add_column :fleet_events, :recurrence_until, :date
+    add_column :fleet_events, :recurrence_count, :integer
+    add_column :fleet_events, :excluded_dates, :date, array: true, null: false, default: []
+
+    add_index :fleet_events, [:fleet_id, :recurring]
+  end
+end

--- a/db/migrate/20260513110001_add_occurrence_date_to_fleet_event_signups.rb
+++ b/db/migrate/20260513110001_add_occurrence_date_to_fleet_event_signups.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddOccurrenceDateToFleetEventSignups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :fleet_event_signups, :occurrence_date, :date
+
+    add_index :fleet_event_signups,
+      [:fleet_event_id, :occurrence_date, :fleet_membership_id],
+      name: "idx_fleet_event_signups_on_event_and_occurrence_and_member"
+  end
+end

--- a/db/migrate/20260513110002_swap_fleet_event_signups_unique_index.rb
+++ b/db/migrate/20260513110002_swap_fleet_event_signups_unique_index.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SwapFleetEventSignupsUniqueIndex < ActiveRecord::Migration[8.1]
+  def up
+    remove_index :fleet_event_signups,
+      name: "index_fleet_event_signups_unique_active_per_event"
+    add_index :fleet_event_signups,
+      [:fleet_event_id, :occurrence_date, :fleet_membership_id],
+      unique: true,
+      where: "((status)::text <> 'withdrawn'::text)",
+      name: "index_fleet_event_signups_unique_active_per_event"
+  end
+
+  def down
+    remove_index :fleet_event_signups,
+      name: "index_fleet_event_signups_unique_active_per_event"
+    add_index :fleet_event_signups,
+      [:fleet_event_id, :fleet_membership_id],
+      unique: true,
+      where: "((status)::text <> 'withdrawn'::text)",
+      name: "index_fleet_event_signups_unique_active_per_event"
+  end
+end

--- a/db/migrate/20260513120000_create_fleet_event_occurrence_states.rb
+++ b/db/migrate/20260513120000_create_fleet_event_occurrence_states.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateFleetEventOccurrenceStates < ActiveRecord::Migration[8.1]
+  def change
+    create_table :fleet_event_occurrence_states, id: :uuid do |t|
+      t.references :fleet_event, type: :uuid, null: false, foreign_key: true,
+        index: false
+      t.date :occurrence_date, null: false
+
+      # Lifecycle state for this occurrence. nil means "inherit from event".
+      t.string :status
+      t.datetime :locked_at
+      t.datetime :starting_soon_notified_at
+      t.datetime :cancelled_at
+      t.text :cancelled_reason
+
+      # Discord per-occurrence tracking.
+      t.string :discord_event_id
+      t.datetime :discord_synced_at
+
+      # Per-occurrence override fields. nil means "inherit from event".
+      t.string :title
+      t.text :description
+      t.text :briefing
+      t.string :location
+      t.string :meetup_location
+      t.string :scenario
+      t.string :cover_image_preset
+
+      t.timestamps
+    end
+
+    add_index :fleet_event_occurrence_states,
+      [:fleet_event_id, :occurrence_date],
+      unique: true,
+      name: "idx_fleet_event_occurrence_states_on_event_and_date"
+  end
+end

--- a/db/migrate/20260819100100_create_fleet_event_ship_models.rb
+++ b/db/migrate/20260819100100_create_fleet_event_ship_models.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateFleetEventShipModels < ActiveRecord::Migration[8.1]
+  def change
+    create_table :fleet_event_ship_models, id: :uuid do |t|
+      t.references :fleet_event_ship, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade},
+        index: {name: "index_fleet_event_ship_models_on_ship"}
+      # Cascade rather than nullify: the row exists to name one allowed model, so
+      # an sc_data import retiring that model should drop it from the list
+      # instead of leaving an entry that matches nothing.
+      t.references :model, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :fleet_event_ship_models, [:fleet_event_ship_id, :model_id],
+      unique: true, name: "index_fleet_event_ship_models_on_ship_and_model"
+    add_index :fleet_event_ship_models, [:fleet_event_ship_id, :position],
+      name: "index_fleet_event_ship_models_on_ship_and_position"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -357,6 +357,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
     t.index ["fleet_event_id", "occurrence_date"], name: "idx_fleet_event_occurrence_states_on_event_and_date", unique: true
   end
 
+  create_table "fleet_event_ship_models", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "fleet_event_ship_id", null: false
+    t.uuid "model_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["fleet_event_ship_id", "model_id"], name: "index_fleet_event_ship_models_on_ship_and_model", unique: true
+    t.index ["fleet_event_ship_id", "position"], name: "index_fleet_event_ship_models_on_ship_and_position"
+    t.index ["fleet_event_ship_id"], name: "index_fleet_event_ship_models_on_ship"
+    t.index ["model_id"], name: "index_fleet_event_ship_models_on_model_id"
+  end
+
   create_table "fleet_event_ships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "classification"
     t.datetime "created_at", null: false
@@ -1472,6 +1484,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   add_foreign_key "fleet_event_admins", "fleet_events"
   add_foreign_key "fleet_event_admins", "users"
   add_foreign_key "fleet_event_occurrence_states", "fleet_events"
+  add_foreign_key "fleet_event_ship_models", "fleet_event_ships", on_delete: :cascade
+  add_foreign_key "fleet_event_ship_models", "models", on_delete: :cascade
   add_foreign_key "fleet_event_ships", "fleet_event_teams"
   add_foreign_key "fleet_event_ships", "mission_ships", column: "source_ship_id", on_delete: :nullify
   add_foreign_key "fleet_event_ships", "models"

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -13023,6 +13023,7 @@ components:
           - weekly
           - biweekly
           - monthly
+          -
         recurrenceUntil:
           type:
           - string
@@ -13661,6 +13662,7 @@ components:
           - weekly
           - biweekly
           - monthly
+          -
         recurrenceUntil:
           type:
           - string

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -13126,25 +13126,11 @@ components:
         strict:
           type: boolean
         model:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-            minCrew:
-              type: integer
-            maxCrew:
-              type: integer
-            image:
-              "$ref": "#/components/schemas/MediaFile"
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ShipModel"
+        allowedModels:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ShipModel"
         filters:
           type: object
           properties:
@@ -13169,6 +13155,7 @@ components:
       - fleetEventTeamId
       - position
       - strict
+      - allowedModels
       - slots
       additionalProperties: false
       title: FleetEventShip
@@ -13212,6 +13199,13 @@ components:
           type:
           - number
           - 'null'
+        allowedModelIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Models this spot will accept, when it names several rather
+            than one
         positionIds:
           type: array
           items:
@@ -13259,6 +13253,13 @@ components:
           type:
           - number
           - 'null'
+        allowedModelIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Models this spot will accept, when it names several rather
+            than one
       additionalProperties: false
       title: FleetEventShipUpdateInput
     FleetEventSignup:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -467,6 +467,326 @@ paths:
                 type: array
                 items:
                   "$ref": "#/components/schemas/FilterOption"
+  "/fleet-event-signups/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Withdraw a member's signup (admin)
+      tags:
+      - Fleet Event Signups
+      operationId: destroyFleetEventSignup
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleet-event-signups/{id}/assign":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    patch:
+      summary: 'Admin: assign or update a signup'
+      tags:
+      - Fleet Event Signups
+      operationId: assignFleetEventSignup
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSignupAssignInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSignup"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleet-event-slots":
+    post:
+      summary: Create event slot
+      tags:
+      - Fleet Event Slots
+      operationId: createFleetEventSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSlotCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSlot"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleet-event-slots/sort":
+    put:
+      summary: Sort event slots
+      tags:
+      - Fleet Event Slots
+      operationId: sortFleetEventSlots
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slottableType:
+                  type: string
+                  enum:
+                  - FleetEventTeam
+                  - FleetEventShip
+                slottableId:
+                  type: string
+                  format: uuid
+                sorting:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+              required:
+              - slottableType
+              - slottableId
+              - sorting
+      responses:
+        '200':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleet-event-slots/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Update event slot
+      tags:
+      - Fleet Event Slots
+      operationId: updateFleetEventSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSlotUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSlot"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Destroy event slot
+      tags:
+      - Fleet Event Slots
+      operationId: destroyFleetEventSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleet-event-slots/{id}/signup":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Sign up for slot
+      tags:
+      - Fleet Event Signups
+      operationId: signupFleetEventSlot
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSignupCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSignup"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    patch:
+      summary: Update own signup
+      tags:
+      - Fleet Event Signups
+      operationId: updateFleetEventSignup
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSignupUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSignup"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Withdraw own signup
+      tags:
+      - Fleet Event Signups
+      operationId: withdrawFleetEventSignup
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets":
     post:
       summary: Create Fleet
@@ -672,6 +992,1266 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/events":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Create Fleet Event
+      tags:
+      - Fleet Events
+      operationId: createFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: List Fleet Events
+      tags:
+      - Fleet Events
+      operationId: fleetEvents
+      parameters:
+      - name: upcoming
+        in: query
+        schema:
+          type: boolean
+        required: false
+      - name: past
+        in: query
+        schema:
+          type: boolean
+        required: false
+      - name: archived
+        in: query
+        schema:
+          type: boolean
+        required: false
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventsList"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Create event team
+      tags:
+      - Fleet Event Teams
+      operationId: createFleetEventTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventTeamCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventTeam"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/sort":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Sort event teams
+      tags:
+      - Fleet Event Teams
+      operationId: sortFleetEventTeams
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sorting:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+              required:
+              - sorting
+      responses:
+        '200':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Create event ship
+      tags:
+      - Fleet Event Ships
+      operationId: createFleetEventShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventShipCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventShip"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/sort":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Sort event ships
+      tags:
+      - Fleet Event Ships
+      operationId: sortFleetEventShips
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sorting:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+              required:
+              - sorting
+      responses:
+        '200':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/{id}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Update event ship
+      tags:
+      - Fleet Event Ships
+      operationId: updateFleetEventShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventShipUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventShip"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Destroy event ship
+      tags:
+      - Fleet Event Ships
+      operationId: destroyFleetEventShip
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/{id}/expand-from-model":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventTeamId
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Expand ship slots from model positions
+      tags:
+      - Fleet Event Ships
+      operationId: expandFleetEventShipFromModel
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+                  format: uuid
+                positionIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+              required:
+              - modelId
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventShip"
+        '422':
+          description: no new positions to add
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{id}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: fleetEventSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Update event team
+      tags:
+      - Fleet Event Teams
+      operationId: updateFleetEventTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventTeamUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventTeam"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Destroy event team
+      tags:
+      - Fleet Event Teams
+      operationId: destroyFleetEventTeam
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Archive Fleet Event
+      tags:
+      - Fleet Events
+      operationId: destroyFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful - archived
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '204':
+          description: successful - permanent delete on already-archived event
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Show Fleet Event
+      tags:
+      - Fleet Events
+      operationId: fleetEvent
+      parameters:
+      - name: occurrence
+        in: query
+        schema:
+          type: string
+        required: false
+        description: ISO-8601 date scoping the response to a single occurrence of
+          a recurring event
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Fleet Event
+      tags:
+      - Fleet Events
+      operationId: updateFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/admins":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Grant per-event admin/moderator role
+      tags:
+      - Fleet Event Admins
+      operationId: createFleetEventAdmin
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventAdminCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventAdmin"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: List event admins
+      tags:
+      - Fleet Event Admins
+      operationId: fleetEventAdmins
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventAdminsList"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/admins/{id}":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: id
+      in: path
+      schema:
+        type: string
+      required: true
+    delete:
+      summary: Revoke per-event admin/moderator role
+      tags:
+      - Fleet Event Admins
+      operationId: destroyFleetEventAdmin
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/cancel":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Cancel Fleet Event
+      tags:
+      - Fleet Events
+      operationId: cancelFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/complete":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Complete Fleet Event
+      tags:
+      - Fleet Events
+      operationId: completeFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/end-series":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: End a recurring event series from a given date
+      tags:
+      - Fleet Events
+      operationId: endFleetEventSeries
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                date:
+                  type: string
+                  format: date
+              required:
+              - date
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/lock-signups":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Lock Signups
+      tags:
+      - Fleet Events
+      operationId: lockFleetEventSignups
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/publish":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Publish Fleet Event
+      tags:
+      - Fleet Events
+      operationId: publishFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '400':
+          description: invalid state transition
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/events/{slug}/signup":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Sign up to event without picking a slot
+      tags:
+      - Fleet Event Signups
+      operationId: signupFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetEventSignupCreateInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventSignup"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/skip-occurrence":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Skip a specific occurrence of a recurring event
+      tags:
+      - Fleet Events
+      operationId: skipFleetEventOccurrence
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                date:
+                  type: string
+                  format: date
+              required:
+              - date
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '422':
+          description: not recurring
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/start":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Start Fleet Event
+      tags:
+      - Fleet Events
+      operationId: startFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/unarchive":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Unarchive Fleet Event
+      tags:
+      - Fleet Events
+      operationId: unarchiveFleetEvent
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '400':
+          description: not archived
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/events/{slug}/unlock-signups":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type: string
+      required: true
+    put:
+      summary: Unlock Signups
+      tags:
+      - Fleet Events
+      operationId: unlockFleetEventSignups
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventExtended"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/events/{slug}/update-occurrence":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type:
+        - string
+        - 'null'
+      required: true
+    - name: slug
+      in: path
+      schema:
+        type:
+        - string
+        - 'null'
+      required: true
+    patch:
+      summary: Override fields on a single occurrence
+      tags:
+      - Fleet Events
+      operationId: updateFleetEventOccurrence
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                date:
+                  type: string
+                  format: date
+                title:
+                  type:
+                  - string
+                  - 'null'
+                description:
+                  type:
+                  - string
+                  - 'null'
+                briefing:
+                  type:
+                  - string
+                  - 'null'
+                location:
+                  type:
+                  - string
+                  - 'null'
+                meetupLocation:
+                  type:
+                  - string
+                  - 'null'
+                scenario:
+                  type:
+                  - string
+                  - 'null'
+                coverImagePreset:
+                  type:
+                  - string
+                  - 'null'
+              required:
+              - date
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetEventOccurrenceState"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/features":
     parameters:
     - name: fleetSlug
@@ -11131,6 +12711,980 @@ components:
       - fid
       - name
       title: FleetCreateInput
+    FleetEvent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetId:
+          type: string
+          format: uuid
+        missionId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+        briefing:
+          type: string
+        status:
+          type: string
+          enum:
+          - draft
+          - open
+          - locked
+          - active
+          - completed
+          - cancelled
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        location:
+          type: string
+        meetupLocation:
+          type: string
+        visibility:
+          type: string
+          enum:
+          - members
+          - officers
+          - fleet
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type: string
+        coverImagePreset:
+          type: string
+        coverImage:
+          "$ref": "#/components/schemas/MediaFile"
+        maxAttendees:
+          type: integer
+        autoLockEnabled:
+          type: boolean
+        autoLockMinutesBefore:
+          type: integer
+        cancelledReason:
+          type: string
+        signupApproval:
+          type: string
+          enum:
+          - direct
+          - confirmation_required
+        viewerEventRole:
+          type: string
+          enum:
+          - creator
+          - admin
+          - moderator
+        archived:
+          type: boolean
+        archivedAt:
+          type: string
+          format: date-time
+        externalUid:
+          type: string
+          format: uuid
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            username:
+              type: string
+        signupsCount:
+          type: integer
+        teamCount:
+          type: integer
+        past:
+          type: boolean
+        signupsOpen:
+          type: boolean
+        recurring:
+          type: boolean
+        recurrenceInterval:
+          type: string
+          enum:
+          - daily
+          - weekly
+          - biweekly
+          - monthly
+        recurrenceUntil:
+          type: string
+          format: date
+        recurrenceCount:
+          type: integer
+        excludedDates:
+          type: array
+          items:
+            type: string
+            format: date
+        occurrenceDate:
+          type: string
+          format: date
+        parentEventSlug:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+      - id
+      - fleetId
+      - title
+      - slug
+      - status
+      - startsAt
+      - timezone
+      - visibility
+      - category
+      - autoLockEnabled
+      - archived
+      - externalUid
+      - signupApproval
+      - signupsCount
+      - teamCount
+      - past
+      - signupsOpen
+      - createdAt
+      - updatedAt
+      title: FleetEvent
+    FleetEventAdmin:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetEventId:
+          type: string
+          format: uuid
+        role:
+          type: string
+          enum:
+          - admin
+          - moderator
+        createdAt:
+          type: string
+          format: date-time
+        user:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            username:
+              type: string
+          required:
+          - id
+          - username
+        grantedBy:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            username:
+              type: string
+      required:
+      - id
+      - fleetEventId
+      - role
+      - user
+      - createdAt
+      additionalProperties: false
+      title: FleetEventAdmin
+    FleetEventAdminCreateInput:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        role:
+          type: string
+          enum:
+          - admin
+          - moderator
+      required:
+      - userId
+      additionalProperties: false
+      title: FleetEventAdminCreateInput
+    FleetEventAdminsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetEventAdmin"
+      title: FleetEventAdminsList
+    FleetEventCreateInput:
+      type: object
+      properties:
+        missionSlug:
+          type:
+          - string
+          - 'null'
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        briefing:
+          type:
+          - string
+          - 'null'
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        timezone:
+          type: string
+        location:
+          type:
+          - string
+          - 'null'
+        meetupLocation:
+          type:
+          - string
+          - 'null'
+        visibility:
+          type: string
+          enum:
+          - members
+          - officers
+          - fleet
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type:
+          - string
+          - 'null'
+        coverImagePreset:
+          type:
+          - string
+          - 'null'
+        coverImage:
+          type:
+          - string
+          - 'null'
+        maxAttendees:
+          type:
+          - integer
+          - 'null'
+        autoLockEnabled:
+          type: boolean
+        autoLockMinutesBefore:
+          type:
+          - integer
+          - 'null'
+        signupApproval:
+          type: string
+          enum:
+          - direct
+          - confirmation_required
+        recurring:
+          type: boolean
+        recurrenceInterval:
+          type:
+          - string
+          - 'null'
+          enum:
+          - daily
+          - weekly
+          - biweekly
+          - monthly
+        recurrenceUntil:
+          type:
+          - string
+          - 'null'
+          format: date
+        recurrenceCount:
+          type:
+          - integer
+          - 'null'
+      required:
+      - title
+      - startsAt
+      - timezone
+      - visibility
+      additionalProperties: false
+      title: FleetEventCreateInput
+    FleetEventExtended:
+      allOf:
+      - "$ref": "#/components/schemas/FleetEvent"
+      - type: object
+        properties:
+          teams:
+            type: array
+            items:
+              "$ref": "#/components/schemas/FleetEventTeam"
+          unassignedSignups:
+            type: array
+            items:
+              "$ref": "#/components/schemas/FleetEventSignup"
+        required:
+        - teams
+        - unassignedSignups
+      title: FleetEventExtended
+    FleetEventOccurrenceState:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetEventId:
+          type: string
+          format: uuid
+        occurrenceDate:
+          type: string
+          format: date
+        status:
+          type: string
+        lockedAt:
+          type: string
+          format: date-time
+        startingSoonNotifiedAt:
+          type: string
+          format: date-time
+        cancelledAt:
+          type: string
+          format: date-time
+        cancelledReason:
+          type: string
+        discordEventId:
+          type: string
+        discordSyncedAt:
+          type: string
+          format: date-time
+        title:
+          type: string
+        description:
+          type: string
+        briefing:
+          type: string
+        location:
+          type: string
+        meetupLocation:
+          type: string
+        scenario:
+          type: string
+        coverImagePreset:
+          type: string
+      required:
+      - id
+      - fleetEventId
+      - occurrenceDate
+      title: FleetEventOccurrenceState
+    FleetEventShip:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetEventTeamId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        displayTitle:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        strict:
+          type: boolean
+        model:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            slug:
+              type: string
+            minCrew:
+              type: integer
+            maxCrew:
+              type: integer
+            image:
+              "$ref": "#/components/schemas/MediaFile"
+          required:
+          - id
+          - name
+          - slug
+        filters:
+          type: object
+          properties:
+            classification:
+              type: string
+            focus:
+              type: string
+            minSize:
+              type: string
+            maxSize:
+              type: string
+            minCrew:
+              type: integer
+            minCargo:
+              type: number
+        slots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEventSlot"
+      required:
+      - id
+      - fleetEventTeamId
+      - position
+      - strict
+      - slots
+      additionalProperties: false
+      title: FleetEventShip
+    FleetEventShipCreateInput:
+      type: object
+      properties:
+        title:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        modelId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        classification:
+          type:
+          - string
+          - 'null'
+        focus:
+          type:
+          - string
+          - 'null'
+        minSize:
+          type:
+          - string
+          - 'null'
+        maxSize:
+          type:
+          - string
+          - 'null'
+        minCrew:
+          type:
+          - integer
+          - 'null'
+        minCargo:
+          type:
+          - number
+          - 'null'
+        positionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      additionalProperties: false
+      title: FleetEventShipCreateInput
+    FleetEventShipUpdateInput:
+      type: object
+      properties:
+        title:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        modelId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        classification:
+          type:
+          - string
+          - 'null'
+        focus:
+          type:
+          - string
+          - 'null'
+        minSize:
+          type:
+          - string
+          - 'null'
+        maxSize:
+          type:
+          - string
+          - 'null'
+        minCrew:
+          type:
+          - integer
+          - 'null'
+        minCargo:
+          type:
+          - number
+          - 'null'
+      additionalProperties: false
+      title: FleetEventShipUpdateInput
+    FleetEventSignup:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetEventId:
+          type: string
+          format: uuid
+        fleetEventSlotId:
+          type: string
+          format: uuid
+        occurrenceDate:
+          type: string
+          format: date
+        status:
+          type: string
+          enum:
+          - confirmed
+          - tentative
+          - interested
+          - pending
+          - withdrawn
+        notes:
+          type: string
+        confirmedAt:
+          type: string
+          format: date-time
+        withdrawnAt:
+          type: string
+          format: date-time
+        user:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            username:
+              type: string
+        vehicle:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            model:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                name:
+                  type: string
+                slug:
+                  type: string
+                classification:
+                  type: string
+                focus:
+                  type: string
+                size:
+                  type: string
+                minCrew:
+                  type: integer
+                maxCrew:
+                  type: integer
+                cargo:
+                  type: integer
+                positionCount:
+                  type: integer
+      required:
+      - id
+      - fleetEventId
+      - status
+      additionalProperties: false
+      title: FleetEventSignup
+    FleetEventSignupAssignInput:
+      type: object
+      properties:
+        fleetEventSlotId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        status:
+          type: string
+          enum:
+          - confirmed
+          - tentative
+          - interested
+          - pending
+          - withdrawn
+        vehicleId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        notes:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: FleetEventSignupAssignInput
+    FleetEventSignupCreateInput:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+          - confirmed
+          - tentative
+          - interested
+          - pending
+          - withdrawn
+        vehicleId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        notes:
+          type:
+          - string
+          - 'null'
+        occurrenceDate:
+          type:
+          - string
+          - 'null'
+          format: date
+      additionalProperties: false
+      title: FleetEventSignupCreateInput
+    FleetEventSignupUpdateInput:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+          - confirmed
+          - tentative
+          - interested
+          - pending
+          - withdrawn
+        vehicleId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        notes:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: FleetEventSignupUpdateInput
+    FleetEventSlot:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        slottableType:
+          type: string
+          enum:
+          - FleetEventTeam
+          - FleetEventShip
+        slottableId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        derived:
+          type: boolean
+        positionType:
+          type: string
+        modelPositionId:
+          type: string
+          format: uuid
+        signupApproval:
+          type: string
+          enum:
+          - direct
+          - confirmation_required
+        effectiveSignupApproval:
+          type: string
+          enum:
+          - direct
+          - confirmation_required
+        signups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEventSignup"
+      required:
+      - id
+      - slottableType
+      - slottableId
+      - title
+      - position
+      - derived
+      - effectiveSignupApproval
+      - signups
+      additionalProperties: false
+      title: FleetEventSlot
+    FleetEventSlotCreateInput:
+      type: object
+      properties:
+        slottableType:
+          type: string
+          enum:
+          - FleetEventTeam
+          - FleetEventShip
+        slottableId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        signupApproval:
+          type:
+          - string
+          - 'null'
+          enum:
+          - direct
+          - confirmation_required
+          -
+      required:
+      - slottableType
+      - slottableId
+      - title
+      additionalProperties: false
+      title: FleetEventSlotCreateInput
+    FleetEventSlotUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        signupApproval:
+          type:
+          - string
+          - 'null'
+          enum:
+          - direct
+          - confirmation_required
+          -
+      additionalProperties: false
+      title: FleetEventSlotUpdateInput
+    FleetEventTeam:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetEventId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        description:
+          type: string
+        position:
+          type: integer
+        slots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEventSlot"
+        ships:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEventShip"
+      required:
+      - id
+      - fleetEventId
+      - title
+      - position
+      - slots
+      - ships
+      additionalProperties: false
+      title: FleetEventTeam
+    FleetEventTeamCreateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      required:
+      - title
+      additionalProperties: false
+      title: FleetEventTeamCreateInput
+    FleetEventTeamUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: FleetEventTeamUpdateInput
+    FleetEventUpdateInput:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        briefing:
+          type:
+          - string
+          - 'null'
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        timezone:
+          type: string
+        location:
+          type:
+          - string
+          - 'null'
+        meetupLocation:
+          type:
+          - string
+          - 'null'
+        visibility:
+          type: string
+          enum:
+          - members
+          - officers
+          - fleet
+        category:
+          type: string
+          enum:
+          - other
+          - ship_combat
+          - ground_combat
+          - combined_combat
+          - mining
+          - salvage
+          - cargo_hauling
+          - exploration
+        scenario:
+          type:
+          - string
+          - 'null'
+        coverImagePreset:
+          type:
+          - string
+          - 'null'
+        coverImage:
+          type:
+          - string
+          - 'null'
+        maxAttendees:
+          type:
+          - integer
+          - 'null'
+        autoLockEnabled:
+          type: boolean
+        autoLockMinutesBefore:
+          type:
+          - integer
+          - 'null'
+        cancelledReason:
+          type:
+          - string
+          - 'null'
+        signupApproval:
+          type: string
+          enum:
+          - direct
+          - confirmation_required
+        recurring:
+          type: boolean
+        recurrenceInterval:
+          type:
+          - string
+          - 'null'
+          enum:
+          - daily
+          - weekly
+          - biweekly
+          - monthly
+        recurrenceUntil:
+          type:
+          - string
+          - 'null'
+          format: date
+        recurrenceCount:
+          type:
+          - integer
+          - 'null'
+      additionalProperties: false
+      title: FleetEventUpdateInput
+    FleetEventsList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEvent"
+        meta:
+          "$ref": "#/components/schemas/Meta"
+      required:
+      - items
+      - meta
+      title: FleetEventsList
     FleetFeature:
       type: object
       properties:

--- a/test/factories/fleet_event_occurrence_states.rb
+++ b/test/factories/fleet_event_occurrence_states.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_event_occurrence_states
+#
+#  id                        :uuid             not null, primary key
+#  briefing                  :text
+#  cancelled_at              :datetime
+#  cancelled_reason          :text
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  location                  :string
+#  locked_at                 :datetime
+#  meetup_location           :string
+#  occurrence_date           :date             not null
+#  scenario                  :string
+#  starting_soon_notified_at :datetime
+#  status                    :string
+#  title                     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  discord_event_id          :string
+#  fleet_event_id            :uuid             not null
+#
+# Indexes
+#
+#  idx_fleet_event_occurrence_states_on_event_and_date  (fleet_event_id,occurrence_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#
+FactoryBot.define do
+  factory :fleet_event_occurrence_state do
+    fleet_event
+    sequence(:occurrence_date) { |n| Date.today + n.days }
+  end
+end

--- a/test/factories/fleet_events.rb
+++ b/test/factories/fleet_events.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fleet_events
+#
+#  id                        :uuid             not null, primary key
+#  archived_at               :datetime
+#  auto_lock_enabled         :boolean          default(TRUE), not null
+#  auto_lock_minutes_before  :integer          default(60), not null
+#  briefing                  :text
+#  cancelled_reason          :text
+#  category                  :integer          default(0), not null
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  ends_at                   :datetime
+#  excluded_dates            :date             default([]), not null, is an Array
+#  external_uid              :uuid             not null
+#  location                  :string
+#  max_attendees             :integer
+#  meetup_location           :string
+#  recurrence_count          :integer
+#  recurrence_interval       :string
+#  recurrence_until          :date
+#  recurring                 :boolean          default(FALSE), not null
+#  scenario                  :string
+#  signup_approval           :string           default("direct"), not null
+#  slug                      :string           not null
+#  starting_soon_notified_at :datetime
+#  starts_at                 :datetime         not null
+#  status                    :string           default("draft"), not null
+#  timezone                  :string           default("UTC"), not null
+#  title                     :string           not null
+#  visibility                :string           default("members"), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid             not null
+#  discord_event_id          :string
+#  discord_message_id        :string
+#  fleet_id                  :uuid             not null
+#  mission_id                :uuid
+#
+# Indexes
+#
+#  index_fleet_events_on_external_uid            (external_uid) UNIQUE
+#  index_fleet_events_on_fleet_id_and_recurring  (fleet_id,recurring)
+#  index_fleet_events_on_fleet_id_and_slug       (fleet_id,slug) UNIQUE
+#  index_fleet_events_on_fleet_id_and_starts_at  (fleet_id,starts_at)
+#  index_fleet_events_on_fleet_id_and_status     (fleet_id,status)
+#  index_fleet_events_on_mission_id              (mission_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (fleet_id => fleets.id)
+#  fk_rails_...  (mission_id => missions.id)
+#
+FactoryBot.define do
+  factory :fleet_event do
+    fleet
+    association :created_by, factory: :user
+    sequence(:title) { |n| "Event #{n}" }
+    description { Faker::Lorem.sentence }
+    starts_at { 1.day.from_now }
+    timezone { "UTC" }
+    visibility { "members" }
+    category { "other" }
+
+    trait :open do
+      status { "open" }
+    end
+
+    trait :locked do
+      status { "locked" }
+    end
+
+    trait :active do
+      status { "active" }
+    end
+
+    trait :cancelled do
+      status { "cancelled" }
+    end
+  end
+
+  factory :fleet_event_team do
+    fleet_event
+    sequence(:title) { |n| "Team #{n}" }
+    sequence(:position) { |n| n }
+  end
+
+  factory :fleet_event_ship do
+    fleet_event_team
+    sequence(:position) { |n| n }
+    classification { "Combat" }
+
+    trait :strict do
+      classification { nil }
+      association :model, in_game: true
+    end
+  end
+
+  factory :fleet_event_slot do
+    title { "Pilot" }
+    sequence(:position) { |n| n }
+    association :slottable, factory: :fleet_event_team
+
+    trait :for_team do
+      association :slottable, factory: :fleet_event_team
+    end
+
+    trait :for_ship do
+      association :slottable, factory: :fleet_event_ship
+    end
+  end
+
+  factory :fleet_event_signup do
+    association :fleet_event_slot
+    fleet_membership
+    status { "confirmed" }
+  end
+end

--- a/test/integration/api/v1/fleet_event_ships_expand_from_model_behaviour_test.rb
+++ b/test/integration/api/v1/fleet_event_ships_expand_from_model_behaviour_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventShipsExpandFromModelBehaviourTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @event)
+    @ship = create(:fleet_event_ship, fleet_event_team: @team)
+    @model = create(:model)
+    @position1 = create(:model_position, model: @model, name: "Pilot", position: 0)
+    @position2 = create(:model_position, model: @model, name: "Gunner 1", position: 1)
+    @position3 = create(:model_position, model: @model, name: "Gunner 2", position: 2)
+    @url = "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/teams/#{@team.id}/ships/#{@ship.id}/expand-from-model"
+    sign_in @admin
+  end
+
+  test "creates slots for every position when no positionIds are given" do
+    post @url, params: {modelId: @model.id}, as: :json
+
+    assert_equal 200, response.status, "got #{response.status}: #{response.body}"
+    assert_equal 3, @ship.fleet_event_slots.count
+    assert_equal ["Pilot", "Gunner 1", "Gunner 2"].sort, @ship.fleet_event_slots.pluck(:title).sort
+  end
+
+  test "creates only the picked positions when positionIds is provided" do
+    post @url, params: {modelId: @model.id, positionIds: [@position2.id]}, as: :json
+
+    assert_equal 200, response.status, "got #{response.status}: #{response.body}"
+    assert_equal ["Gunner 1"], @ship.fleet_event_slots.pluck(:title)
+  end
+
+  test "skips positions that are already represented as slots" do
+    create(:fleet_event_slot, slottable: @ship, model_position_id: @position1.id, title: "Pilot")
+
+    post @url, params: {modelId: @model.id}, as: :json
+
+    assert_equal 200, response.status
+    assert_equal 2, @ship.fleet_event_slots.where(model_position_id: [@position2.id, @position3.id]).count
+    assert_equal 1, @ship.fleet_event_slots.where(model_position_id: @position1.id).count
+  end
+
+  test "returns 422 when there are no new positions to add" do
+    [@position1, @position2, @position3].each do |p|
+      create(:fleet_event_slot, slottable: @ship, model_position_id: p.id, title: p.name)
+    end
+
+    post @url, params: {modelId: @model.id}, as: :json
+
+    assert_equal 422, response.status
+  end
+end

--- a/test/integration/api/v1/fleet_event_signups_assign_test.rb
+++ b/test/integration/api/v1/fleet_event_signups_assign_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSignupsAssignTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-signups/{id}/assign" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    patch("Admin: assign or update a signup") do
+      operationId "assignFleetEventSignup"
+      tags "Fleet Event Signups"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSignupAssignInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSignup"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @fleet_event_team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @fleet_event_slot = create(:fleet_event_slot, slottable: @fleet_event_team)
+    @other_slot = create(:fleet_event_slot, slottable: @fleet_event_team)
+
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    @signup = create(:fleet_event_signup,
+      fleet_event: @fleet_event,
+      fleet_event_slot: nil,
+      fleet_membership: membership,
+      status: "interested")
+  end
+
+  test "PATCH /fleet-event-signups/:id/assign assigns slot and status" do
+    sign_in @admin
+
+    assert_api_response :patch, 200,
+      path_params: {id: @signup.id},
+      body: {fleetEventSlotId: @other_slot.id, status: "confirmed"} do
+      assert_equal "confirmed", parsed_body["status"]
+      assert_equal @other_slot.id, parsed_body["fleetEventSlotId"]
+    end
+  end
+
+  test "PATCH /fleet-event-signups/:id/assign with OAuth bearer token" do
+    assert_api_response :patch, 200,
+      path_params: {id: @signup.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {fleetEventSlotId: @other_slot.id, status: "confirmed"}
+  end
+
+  test "PATCH /fleet-event-signups/:id/assign returns 401 for OAuth token with wrong scope" do
+    assert_api_response :patch, 401,
+      path_params: {id: @signup.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {fleetEventSlotId: @other_slot.id, status: "confirmed"}
+  end
+
+  test "PATCH /fleet-event-signups/:id/assign returns 401 when not signed in" do
+    assert_api_response :patch, 401,
+      path_params: {id: @signup.id},
+      body: {fleetEventSlotId: @other_slot.id, status: "confirmed"}
+  end
+end

--- a/test/integration/api/v1/fleet_event_signups_destroy_test.rb
+++ b/test/integration/api/v1/fleet_event_signups_destroy_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSignupsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-signups/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    delete("Withdraw a member's signup (admin)") do
+      operationId "destroyFleetEventSignup"
+      tags "Fleet Event Signups"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @fleet_event_team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @fleet_event_slot = create(:fleet_event_slot, slottable: @fleet_event_team)
+  end
+
+  test "DELETE /fleet-event-signups/:id admin withdraws a member's signup" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    signup = create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership)
+    sign_in @admin
+
+    assert_api_response :delete, 204, path_params: {id: signup.id}
+    assert_equal "withdrawn", signup.reload.status
+  end
+
+  test "DELETE /fleet-event-signups/:id with OAuth bearer token" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    signup = create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership)
+
+    assert_api_response :delete, 204,
+      path_params: {id: signup.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleet-event-signups/:id returns 401 for OAuth token with wrong scope" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    signup = create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership)
+
+    assert_api_response :delete, 401,
+      path_params: {id: signup.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleet-event-signups/:id returns 401 when not signed in" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    signup = create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership)
+
+    assert_api_response :delete, 401, path_params: {id: signup.id}
+  end
+end

--- a/test/integration/api/v1/fleet_event_signups_signup_test.rb
+++ b/test/integration/api/v1/fleet_event_signups_signup_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSignupsSignupTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-slots/{id}/signup" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    post("Sign up for slot") do
+      operationId "signupFleetEventSlot"
+      tags "Fleet Event Signups"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSignupCreateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSignup"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    patch("Update own signup") do
+      operationId "updateFleetEventSignup"
+      tags "Fleet Event Signups"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSignupUpdateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSignup"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Withdraw own signup") do
+      operationId "withdrawFleetEventSignup"
+      tags "Fleet Event Signups"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @fleet_event_team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @fleet_event_slot = create(:fleet_event_slot, slottable: @fleet_event_team)
+  end
+
+  test "POST /fleet-event-slots/:id/signup creates a signup" do
+    sign_in @member
+
+    assert_api_response :post, 201,
+      path_params: {id: @fleet_event_slot.id},
+      body: {status: "confirmed", notes: "Ready"} do
+      assert_equal "confirmed", parsed_body["status"]
+      assert_equal "Ready", parsed_body["notes"]
+    end
+  end
+
+  test "POST /fleet-event-slots/:id/signup with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["fleet", "fleet:write"]),
+      body: {status: "confirmed", notes: "Ready"}
+  end
+
+  test "POST /fleet-event-slots/:id/signup returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["public"]),
+      body: {status: "confirmed", notes: "Ready"}
+  end
+
+  test "POST /fleet-event-slots/:id/signup returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {id: @fleet_event_slot.id},
+      body: {status: "confirmed", notes: "Ready"}
+  end
+
+  test "PATCH /fleet-event-slots/:id/signup updates own signup" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "pending")
+    sign_in @member
+
+    assert_api_response :patch, 200,
+      path_params: {id: @fleet_event_slot.id},
+      body: {status: "confirmed"} do
+      assert_equal "confirmed", parsed_body["status"]
+    end
+  end
+
+  test "PATCH /fleet-event-slots/:id/signup with OAuth bearer token" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "pending")
+
+    assert_api_response :patch, 200,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["fleet", "fleet:write"]),
+      body: {status: "confirmed"}
+  end
+
+  test "PATCH /fleet-event-slots/:id/signup returns 401 for OAuth token with wrong scope" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "pending")
+
+    assert_api_response :patch, 401,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["public"]),
+      body: {status: "confirmed"}
+  end
+
+  test "PATCH /fleet-event-slots/:id/signup returns 401 when not signed in" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "pending")
+
+    assert_api_response :patch, 401,
+      path_params: {id: @fleet_event_slot.id},
+      body: {status: "confirmed"}
+  end
+
+  test "DELETE /fleet-event-slots/:id/signup withdraws own signup" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "confirmed")
+    sign_in @member
+
+    assert_api_response :delete, 204, path_params: {id: @fleet_event_slot.id}
+  end
+
+  test "DELETE /fleet-event-slots/:id/signup with OAuth bearer token" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "confirmed")
+
+    assert_api_response :delete, 204,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleet-event-slots/:id/signup returns 401 for OAuth token with wrong scope" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "confirmed")
+
+    assert_api_response :delete, 401,
+      path_params: {id: @fleet_event_slot.id},
+      headers: oauth_headers_for(@member, scopes: ["public"])
+  end
+
+  test "DELETE /fleet-event-slots/:id/signup returns 401 when not signed in" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event_slot: @fleet_event_slot, fleet_membership: membership, status: "confirmed")
+
+    assert_api_response :delete, 401, path_params: {id: @fleet_event_slot.id}
+  end
+end

--- a/test/integration/api/v1/fleet_event_signups_upsert_test.rb
+++ b/test/integration/api/v1/fleet_event_signups_upsert_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSignupsUpsertTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @event)
+    @slot = create(:fleet_event_slot, slottable: @team)
+    sign_in @member
+  end
+
+  test "POST /fleets/:fleet/events/:slug/signup creates an interested signup by default" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup", params: {}, as: :json
+
+    assert_equal 201, response.status
+    assert_equal "interested", JSON.parse(response.body)["status"]
+  end
+
+  test "POST /fleets/:fleet/events/:slug/signup upserts existing event-level signup to a different status" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup", params: {status: "interested"}, as: :json
+    assert_equal 201, response.status
+
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup", params: {status: "tentative"}, as: :json
+    assert_equal 200, response.status
+    assert_equal "tentative", JSON.parse(response.body)["status"]
+
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    assert_equal 1, @event.fleet_event_signups.where(fleet_membership: membership).where.not(status: "withdrawn").count
+  end
+
+  test "POST /fleets/:fleet/events/:slug/signup returns 409 when the member is already in a slot" do
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: membership, status: "confirmed")
+
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup", params: {status: "interested"}, as: :json
+
+    assert_equal 409, response.status
+  end
+
+  test "POST /fleet-event-slots/:id/signup promotes an existing event-level signup onto the slot" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup", params: {status: "interested"}, as: :json
+    assert_equal 201, response.status
+
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup", params: {status: "confirmed"}, as: :json
+    assert_equal 200, response.status
+    data = JSON.parse(response.body)
+    assert_equal "confirmed", data["status"]
+    assert_equal @slot.id, data["fleetEventSlotId"]
+
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    assert_equal 1, @event.fleet_event_signups.where(fleet_membership: membership).where.not(status: "withdrawn").count
+  end
+
+  test "POST /fleet-event-slots/:id/signup coerces tentative requests to confirmed when binding to a slot" do
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup", params: {status: "tentative"}, as: :json
+
+    assert_equal 201, response.status
+    assert_equal "confirmed", JSON.parse(response.body)["status"]
+  end
+
+  test "POST /fleet-event-slots/:id/signup returns 409 when the member is already in a different slot" do
+    other_slot = create(:fleet_event_slot, slottable: @team)
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: other_slot, fleet_membership: membership, status: "confirmed")
+
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup", params: {status: "confirmed"}, as: :json
+
+    assert_equal 409, response.status
+  end
+
+  test "POST /fleet-event-slots/:id/signup rejects signups when the event is past" do
+    @event.update!(starts_at: 2.hours.ago, ends_at: 1.hour.ago)
+
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup", params: {status: "confirmed"}, as: :json
+
+    assert_includes [403, 400], response.status
+  end
+
+  test "PATCH /fleet-event-signups/:id/assign assigns an unassigned signup to a slot and promotes it to confirmed" do
+    other_member = create(:user)
+    other_membership = create(:fleet_membership, fleet: @fleet, user: other_member, aasm_state: "accepted")
+    signup = create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: nil, fleet_membership: other_membership, status: "interested")
+
+    sign_out @member
+    sign_in @admin
+
+    patch "/api/v1/fleet-event-signups/#{signup.id}/assign",
+      params: {fleetEventSlotId: @slot.id},
+      as: :json
+
+    assert_equal 200, response.status, "got #{response.status}: #{response.body}"
+    data = JSON.parse(response.body)
+    assert_equal @slot.id, data["fleetEventSlotId"]
+    assert_equal "confirmed", data["status"]
+  end
+end

--- a/test/integration/api/v1/fleet_event_slots_create_test.rb
+++ b/test/integration/api/v1/fleet_event_slots_create_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSlotsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-slots" do
+    post("Create event slot") do
+      operationId "createFleetEventSlot"
+      tags "Fleet Event Slots"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSlotCreateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSlot"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+  end
+
+  test "POST /fleet-event-slots creates a slot" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      body: {slottableType: "FleetEventTeam", slottableId: @team.id, title: "Pilot"}
+  end
+
+  test "POST /fleet-event-slots with OAuth bearer token" do
+    assert_api_response :post, 201,
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {slottableType: "FleetEventTeam", slottableId: @team.id, title: "Pilot"}
+  end
+
+  test "POST /fleet-event-slots returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {slottableType: "FleetEventTeam", slottableId: @team.id, title: "Pilot"}
+  end
+
+  test "POST /fleet-event-slots returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      body: {slottableType: "FleetEventTeam", slottableId: @team.id, title: "Pilot"}
+  end
+end

--- a/test/integration/api/v1/fleet_event_slots_recurring_signup_test.rb
+++ b/test/integration/api/v1/fleet_event_slots_recurring_signup_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSlotsRecurringSignupTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    travel_to Time.zone.parse("2026-05-13 20:00:00 UTC")
+    @admin = create(:user)
+    @alice = create(:user)
+    @bob = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@alice, @bob])
+    @event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+    @team = create(:fleet_event_team, fleet_event: @event)
+    @slot = create(:fleet_event_slot, slottable: @team, title: "Pilot")
+  end
+
+  teardown do
+    travel_back
+  end
+
+  test "allows two different members in the same slot on different occurrences" do
+    sign_in @alice
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup",
+      params: {status: "confirmed", occurrenceDate: "2026-05-21"},
+      as: :json
+    assert_equal 201, response.status, response.body
+
+    sign_out @alice
+    sign_in @bob
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup",
+      params: {status: "confirmed", occurrenceDate: "2026-05-28"},
+      as: :json
+    assert_equal 201, response.status, response.body
+
+    assert_equal 2, @slot.fleet_event_signups.count
+  end
+
+  test "still blocks two members claiming the same slot on the same occurrence" do
+    sign_in @alice
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup",
+      params: {status: "confirmed", occurrenceDate: "2026-05-21"},
+      as: :json
+    assert_equal 201, response.status
+
+    sign_out @alice
+    sign_in @bob
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup",
+      params: {status: "confirmed", occurrenceDate: "2026-05-21"},
+      as: :json
+
+    assert_includes [400, 422], response.status
+  end
+
+  test "requires occurrenceDate for recurring slot signups" do
+    sign_in @alice
+    post "/api/v1/fleet-event-slots/#{@slot.id}/signup",
+      params: {status: "confirmed"},
+      as: :json
+
+    assert_equal 422, response.status
+  end
+end

--- a/test/integration/api/v1/fleet_event_slots_sort_test.rb
+++ b/test/integration/api/v1/fleet_event_slots_sort_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSlotsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-slots/sort" do
+    put("Sort event slots") do
+      operationId "sortFleetEventSlots"
+      tags "Fleet Event Slots"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {
+        type: :object,
+        properties: {
+          slottableType: {type: :string, enum: %w[FleetEventTeam FleetEventShip]},
+          slottableId: {type: :string, format: :uuid},
+          sorting: {type: :array, items: {type: :string, format: :uuid}}
+        },
+        required: %w[slottableType slottableId sorting]
+      }, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @slots = create_list(:fleet_event_slot, 3, slottable: @team)
+  end
+
+  test "PUT /fleet-event-slots/sort sorts slots" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      body: {
+        slottableType: "FleetEventTeam",
+        slottableId: @team.id,
+        sorting: @slots.reverse.map(&:id)
+      }
+  end
+
+  test "PUT /fleet-event-slots/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {
+        slottableType: "FleetEventTeam",
+        slottableId: @team.id,
+        sorting: @slots.reverse.map(&:id)
+      }
+  end
+
+  test "PUT /fleet-event-slots/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {
+        slottableType: "FleetEventTeam",
+        slottableId: @team.id,
+        sorting: @slots.reverse.map(&:id)
+      }
+  end
+
+  test "PUT /fleet-event-slots/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      body: {
+        slottableType: "FleetEventTeam",
+        slottableId: @team.id,
+        sorting: @slots.reverse.map(&:id)
+      }
+  end
+end

--- a/test/integration/api/v1/fleet_event_slots_update_test.rb
+++ b/test/integration/api/v1/fleet_event_slots_update_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventSlotsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleet-event-slots/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update event slot") do
+      operationId "updateFleetEventSlot"
+      tags "Fleet Event Slots"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSlotUpdateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSlot"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Destroy event slot") do
+      operationId "destroyFleetEventSlot"
+      tags "Fleet Event Slots"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @slot = create(:fleet_event_slot, slottable: @team)
+  end
+
+  test "PUT /fleet-event-slots/:id updates the slot" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {id: @slot.id},
+      body: {title: "Wing Lead", description: "Squadron lead"}
+  end
+
+  test "PUT /fleet-event-slots/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Wing Lead", description: "Squadron lead"}
+  end
+
+  test "PUT /fleet-event-slots/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Wing Lead", description: "Squadron lead"}
+  end
+
+  test "PUT /fleet-event-slots/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {id: @slot.id},
+      body: {title: "Wing Lead", description: "Squadron lead"}
+  end
+
+  test "DELETE /fleet-event-slots/:id destroys the slot" do
+    sign_in @admin
+
+    assert_api_response :delete, 204, path_params: {id: @slot.id}
+    assert_raises(ActiveRecord::RecordNotFound) { @slot.reload }
+  end
+
+  test "DELETE /fleet-event-slots/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleet-event-slots/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {id: @slot.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleet-event-slots/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401, path_params: {id: @slot.id}
+  end
+end

--- a/test/integration/api/v1/fleet_events_archive_test.rb
+++ b/test/integration/api/v1/fleet_events_archive_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetEventsArchiveTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+  end
+
+  test "DELETE /fleets/:slug/events/:event archives a non-archived event instead of destroying it" do
+    delete "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}", as: :json
+
+    assert_equal 200, response.status
+    assert @event.reload.archived?
+  end
+
+  test "DELETE /fleets/:slug/events/:event destroys an already-archived event" do
+    @event.archive!
+
+    delete "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}", as: :json
+
+    assert_equal 204, response.status
+    refute FleetEvent.exists?(@event.id)
+  end
+
+  test "PUT /fleets/:slug/events/:event/unarchive restores an archived event" do
+    @event.archive!
+
+    put "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/unarchive", as: :json
+
+    assert_equal 200, response.status
+    refute @event.reload.archived?
+  end
+
+  test "PUT /fleets/:slug/events/:event/unarchive returns 400 when the event is not archived" do
+    put "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/unarchive", as: :json
+
+    assert_equal 400, response.status
+  end
+
+  test "GET /fleets/:slug/events hides archived events by default" do
+    @event.archive!
+    create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events", as: :json
+
+    assert_equal 200, response.status
+    ids = JSON.parse(response.body)["items"].map { |e| e["id"] }
+    refute_includes ids, @event.id
+  end
+
+  test "GET /fleets/:slug/events returns archived events with archived=true" do
+    @event.archive!
+
+    get "/api/v1/fleets/#{@fleet.slug}/events", params: {archived: "true"}, as: :json
+
+    assert_equal 200, response.status
+    ids = JSON.parse(response.body)["items"].map { |e| e["id"] }
+    assert_includes ids, @event.id
+  end
+end

--- a/test/integration/api/v1/fleets_events_admins_create_test.rb
+++ b/test/integration/api/v1/fleets_events_admins_create_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsAdminsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/admins" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    post("Grant per-event admin/moderator role") do
+      operationId "createFleetEventAdmin"
+      tags "Fleet Event Admins"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventAdminCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventAdmin"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @other = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@other])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "POST /fleets/:slug/events/:slug/admins grants the requested role" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {userId: @other.id, role: "admin"} do
+      assert_equal "admin", parsed_body["role"]
+    end
+  end
+
+  test "POST /fleets/:slug/events/:slug/admins with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {userId: @other.id, role: "admin"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/admins returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {userId: @other.id, role: "admin"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/admins returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {userId: @other.id, role: "admin"}
+  end
+end

--- a/test/integration/api/v1/fleets_events_admins_destroy_test.rb
+++ b/test/integration/api/v1/fleets_events_admins_destroy_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsAdminsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/admins/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    delete("Revoke per-event admin/moderator role") do
+      operationId "destroyFleetEventAdmin"
+      tags "Fleet Event Admins"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @other = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@other])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @granted = @fleet_event.fleet_event_admins.create!(user: @other, role: "admin", granted_by: @admin)
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/admins/:id revokes the role" do
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug, id: @granted.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @granted.reload }
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/admins/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug, id: @granted.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/admins/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug, id: @granted.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/admins/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug, id: @granted.id}
+  end
+end

--- a/test/integration/api/v1/fleets_events_admins_index_test.rb
+++ b/test/integration/api/v1/fleets_events_admins_index_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsAdminsIndexTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/admins" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    get("List event admins") do
+      operationId "fleetEventAdmins"
+      tags "Fleet Event Admins"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventAdminsList"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "GET /fleets/:slug/events/:slug/admins returns the list" do
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug}
+  end
+
+  test "GET /fleets/:slug/events/:slug/admins with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/events/:slug/admins returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/events/:slug/admins returns 401 when not signed in" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_cancel_test.rb
+++ b/test/integration/api/v1/fleets_events_cancel_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsCancelTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/cancel" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Cancel Fleet Event") do
+      operationId "cancelFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/cancel transitions to cancelled" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "cancelled", parsed_body["status"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/cancel with OAuth bearer token" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/cancel returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/cancel returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_complete_test.rb
+++ b/test/integration/api/v1/fleets_events_complete_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsCompleteTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/complete" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Complete Fleet Event") do
+      operationId "completeFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/complete transitions to completed" do
+    fleet_event = create(:fleet_event, :active, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "completed", parsed_body["status"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/complete with OAuth bearer token" do
+    fleet_event = create(:fleet_event, :active, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/complete returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, :active, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/complete returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, :active, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_create_test.rb
+++ b/test/integration/api/v1/fleets_events_create_test.rb
@@ -64,6 +64,24 @@ class Api::V1::FleetsEventsCreateTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # What the form sends for an event that does not repeat: the model requires the
+  # interval to be absent unless the event recurs, so null is the only value it
+  # can carry, and the schema has to accept it.
+  test "POST /fleets/:slug/events accepts a null recurrence interval" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug},
+      body: valid_body.merge(
+        recurring: false,
+        recurrenceInterval: nil,
+        recurrenceUntil: nil,
+        recurrenceCount: nil
+      ) do
+      assert_not parsed_body["recurring"]
+    end
+  end
+
   test "POST /fleets/:slug/events returns 403 when a member tries to create" do
     sign_in @member
 

--- a/test/integration/api/v1/fleets_events_create_test.rb
+++ b/test/integration/api/v1/fleets_events_create_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    post("Create Fleet Event") do
+      operationId "createFleetEvent"
+      tags "Fleet Events"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(403, "forbidden") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+  end
+
+  def valid_body
+    {
+      title: "Patrol Run",
+      startsAt: 2.days.from_now.iso8601,
+      timezone: "UTC",
+      visibility: "members",
+      autoLockEnabled: false
+    }
+  end
+
+  test "POST /fleets/:slug/events creates a draft event" do
+    sign_in @admin
+
+    assert_api_response :post, 201, path_params: {fleetSlug: @fleet.slug}, body: valid_body do
+      assert_equal "Patrol Run", parsed_body["title"]
+      assert_equal "draft", parsed_body["status"]
+    end
+  end
+
+  test "POST /fleets/:slug/events returns 403 when a member tries to create" do
+    sign_in @member
+
+    assert_api_response :post, 403, path_params: {fleetSlug: @fleet.slug}, body: valid_body
+  end
+
+  test "POST /fleets/:slug/events with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: valid_body
+  end
+
+  test "POST /fleets/:slug/events returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: valid_body
+  end
+
+  test "POST /fleets/:slug/events returns 401 when not signed in" do
+    assert_api_response :post, 401, path_params: {fleetSlug: @fleet.slug}, body: valid_body
+  end
+end

--- a/test/integration/api/v1/fleets_events_destroy_test.rb
+++ b/test/integration/api/v1/fleets_events_destroy_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsDestroyTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    delete("Archive Fleet Event") do
+      operationId "destroyFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful - archived") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(204, "successful - permanent delete on already-archived event") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "DELETE /fleets/:slug/events/:slug archives the event" do
+    sign_in @admin
+
+    assert_api_response :delete, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug} do
+      assert_equal true, parsed_body["archived"]
+    end
+
+    assert @fleet_event.reload.archived?
+  end
+
+  test "DELETE /fleets/:slug/events/:slug permanently deletes an already-archived event" do
+    archived = create(:fleet_event, fleet: @fleet, created_by: @admin, archived_at: Time.current)
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, slug: archived.slug}
+
+    assert_raises(ActiveRecord::RecordNotFound) { archived.reload }
+  end
+
+  test "DELETE /fleets/:slug/events/:slug with OAuth bearer token" do
+    assert_api_response :delete, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_end_series_test.rb
+++ b/test/integration/api/v1/fleets_events_end_series_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsEndSeriesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/end-series" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    post("End a recurring event series from a given date") do
+      operationId "endFleetEventSeries"
+      tags "Fleet Events"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {
+        type: :object,
+        properties: {date: {type: :string, format: :date}},
+        required: %w[date]
+      }, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+  end
+
+  test "POST /fleets/:slug/events/:slug/end-series sets recurrence_until to the day before" do
+    sign_in @admin
+
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {date: "2026-06-04"}
+
+    assert_equal Date.parse("2026-06-03"), @fleet_event.reload.recurrence_until
+  end
+end

--- a/test/integration/api/v1/fleets_events_index_test.rb
+++ b/test/integration/api/v1/fleets_events_index_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsIndexTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    get("List Fleet Events") do
+      operationId "fleetEvents"
+      tags "Fleet Events"
+      produces "application/json"
+
+      parameter name: :upcoming, in: :query, schema: {type: :boolean}, required: false
+      parameter name: :past, in: :query, schema: {type: :boolean}, required: false
+      parameter name: :archived, in: :query, schema: {type: :boolean}, required: false
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventsList"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "GET /fleets/:slug/events returns the list" do
+    create_list(:fleet_event, 2, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal 2, parsed_body["items"].size
+    end
+  end
+
+  test "GET /fleets/:slug/events with OAuth bearer token" do
+    create_list(:fleet_event, 1, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/events returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/events returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_lock_signups_test.rb
+++ b/test/integration/api/v1/fleets_events_lock_signups_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsLockSignupsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/lock-signups" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Lock Signups") do
+      operationId "lockFleetEventSignups"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/lock-signups transitions to locked" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "locked", parsed_body["status"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/lock-signups with OAuth bearer token" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/lock-signups returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/lock-signups returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_publish_test.rb
+++ b/test/integration/api/v1/fleets_events_publish_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsPublishTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/publish" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Publish Fleet Event") do
+      operationId "publishFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(400, "invalid state transition") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/publish transitions to open" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "open", parsed_body["status"]
+    end
+    assert_equal "open", fleet_event.reload.status
+  end
+
+  test "PUT /fleets/:slug/events/:slug/publish returns 400 for invalid transition" do
+    fleet_event = create(:fleet_event, :active, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 400, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/publish with OAuth bearer token" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/publish returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/publish returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_recurrence_test.rb
+++ b/test/integration/api/v1/fleets_events_recurrence_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsRecurrenceTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/skip-occurrence" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    post("Skip a specific occurrence of a recurring event") do
+      operationId "skipFleetEventOccurrence"
+      tags "Fleet Events"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {
+        type: :object,
+        properties: {date: {type: :string, format: :date}},
+        required: %w[date]
+      }, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(422, "not recurring") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+  end
+
+  test "POST /fleets/:slug/events/:slug/skip-occurrence adds the date to excluded_dates" do
+    sign_in @admin
+
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {date: "2026-05-21"}
+
+    assert_includes @fleet_event.reload.excluded_dates.map(&:to_s), "2026-05-21"
+  end
+
+  test "POST /fleets/:slug/events/:slug/skip-occurrence returns 422 when event is not recurring" do
+    non_recurring = create(:fleet_event, :open, fleet: @fleet, created_by: @admin, recurring: false)
+    sign_in @admin
+
+    assert_api_response :post, 422,
+      path_params: {fleetSlug: @fleet.slug, slug: non_recurring.slug},
+      body: {date: "2026-05-21"}
+  end
+end

--- a/test/integration/api/v1/fleets_events_recurring_signup_test.rb
+++ b/test/integration/api/v1/fleets_events_recurring_signup_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsRecurringSignupTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    travel_to Time.zone.parse("2026-05-13 20:00:00 UTC")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+    sign_in @member
+  end
+
+  teardown do
+    travel_back
+  end
+
+  test "requires an occurrence_date for recurring events" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup",
+      params: {status: "interested"}, as: :json
+
+    assert_equal 422, response.status
+    assert_equal "missing_occurrence_date", JSON.parse(response.body)["code"]
+  end
+
+  test "stores the occurrence_date on the signup" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup",
+      params: {status: "interested", occurrenceDate: "2026-05-21"},
+      as: :json
+
+    assert_equal 201, response.status, response.body
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    signup = FleetEventSignup.find_by(
+      fleet_event_id: @event.id, fleet_membership_id: membership.id
+    )
+    assert_equal Date.parse("2026-05-21"), signup.occurrence_date
+  end
+
+  test "allows the same member to sign up for two different occurrences" do
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup",
+      params: {status: "interested", occurrenceDate: "2026-05-21"},
+      as: :json
+    assert_equal 201, response.status
+
+    post "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/signup",
+      params: {status: "interested", occurrenceDate: "2026-05-28"},
+      as: :json
+    assert_equal 201, response.status
+
+    membership = @fleet.fleet_memberships.find_by(user: @member)
+    assert_equal 2, FleetEventSignup.where(
+      fleet_event_id: @event.id, fleet_membership_id: membership.id
+    ).count
+  end
+end

--- a/test/integration/api/v1/fleets_events_show_test.rb
+++ b/test/integration/api/v1/fleets_events_show_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    get("Show Fleet Event") do
+      operationId "fleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      parameter name: :occurrence, in: :query, schema: {type: :string}, required: false,
+        description: "ISO-8601 date scoping the response to a single occurrence of a recurring event"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "GET /fleets/:slug/events/:slug returns the event" do
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug} do
+      assert_equal @fleet_event.title, parsed_body["title"]
+      assert_kind_of Array, parsed_body["teams"]
+    end
+  end
+
+  test "GET /fleets/:slug/events/:slug with occurrence scopes the response" do
+    recurring = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: recurring.slug},
+      params: {occurrence: "2026-05-21"} do
+      assert_equal "2026-05-21", parsed_body["occurrenceDate"]
+      assert_includes parsed_body["startsAt"], "2026-05-21"
+    end
+  end
+
+  test "GET /fleets/:slug/events/:slug returns 404 when event missing" do
+    sign_in @admin
+
+    assert_api_response :get, 404, path_params: {fleetSlug: @fleet.slug, slug: "missing-event"}
+  end
+
+  test "GET /fleets/:slug/events/:slug with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/events/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/events/:slug returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_signup_test.rb
+++ b/test/integration/api/v1/fleets_events_signup_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsSignupTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/signup" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    post("Sign up to event without picking a slot") do
+      operationId "signupFleetEvent"
+      tags "Fleet Event Signups"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventSignupCreateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventSignup"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @member = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+  end
+
+  test "POST /fleets/:slug/events/:slug/signup creates a signup" do
+    sign_in @member
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {status: "interested"} do
+      assert_equal "interested", parsed_body["status"]
+      assert_nil parsed_body["fleetEventSlotId"]
+    end
+  end
+
+  test "POST /fleets/:slug/events/:slug/signup with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@member, scopes: ["fleet", "fleet:write"]),
+      body: {status: "interested"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/signup returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@member, scopes: ["public"]),
+      body: {status: "interested"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/signup returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {status: "interested"}
+  end
+end

--- a/test/integration/api/v1/fleets_events_start_test.rb
+++ b/test/integration/api/v1/fleets_events_start_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsStartTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/start" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Start Fleet Event") do
+      operationId "startFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/start transitions to active" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "active", parsed_body["status"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/start with OAuth bearer token" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/start returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/start returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_create_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_create_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+
+    post("Create event team") do
+      operationId "createFleetEventTeam"
+      tags "Fleet Event Teams"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventTeamCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventTeam"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams creates a team" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      body: {title: "Strike Team", description: "Heavy fighters"} do
+      assert_equal "Strike Team", parsed_body["title"]
+    end
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Strike Team", description: "Heavy fighters"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Strike Team", description: "Heavy fighters"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      body: {title: "Strike Team", description: "Heavy fighters"}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_ships_create_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_create_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsShipsCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventTeamId", in: :path, schema: {type: :string}
+
+    post("Create event ship") do
+      operationId "createFleetEventShip"
+      tags "Fleet Event Ships"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventShipCreateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(201, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventShip"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships creates a ship" do
+    sign_in @admin
+
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      body: {classification: "Combat", minSize: "small"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships with OAuth bearer token" do
+    assert_api_response :post, 201,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {classification: "Combat", minSize: "small"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {classification: "Combat", minSize: "small"}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      body: {classification: "Combat", minSize: "small"}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_ships_expand_from_model_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_expand_from_model_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsShipsExpandFromModelTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/{id}/expand-from-model" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventTeamId", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    post("Expand ship slots from model positions") do
+      operationId "expandFleetEventShipFromModel"
+      tags "Fleet Event Ships"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {
+        type: :object,
+        properties: {
+          modelId: {type: :string, format: :uuid},
+          positionIds: {type: :array, items: {type: :string, format: :uuid}}
+        },
+        required: %w[modelId]
+      }
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventShip"
+      end
+
+      response(422, "no new positions to add") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @model = create(:model)
+    @ship = create(:fleet_event_ship, fleet_event_team: @team)
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships/:id/expand-from-model expands slots" do
+    create(:model_position, model: @model)
+    sign_in @admin
+
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      body: {modelId: @model.id}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships/:id/expand-from-model returns 422 with no new positions" do
+    sign_in @admin
+
+    assert_api_response :post, 422,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      body: {modelId: @model.id}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships/:id/expand-from-model with OAuth bearer token" do
+    create(:model_position, model: @model)
+
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {modelId: @model.id}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships/:id/expand-from-model returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {modelId: @model.id}
+  end
+
+  test "POST /fleets/:slug/events/:slug/teams/:id/ships/:id/expand-from-model returns 401 when not signed in" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      body: {modelId: @model.id}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_ships_sort_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_sort_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsShipsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/sort" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventTeamId", in: :path, schema: {type: :string}
+
+    put("Sort event ships") do
+      operationId "sortFleetEventShips"
+      tags "Fleet Event Ships"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {
+        type: :object,
+        properties: {sorting: {type: :array, items: {type: :string, format: :uuid}}},
+        required: %w[sorting]
+      }
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @ships = create_list(:fleet_event_ship, 3, fleet_event_team: @team)
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/sort sorts ships" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id},
+      body: {sorting: @ships.reverse.map(&:id)}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_ships_update_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_update_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsShipsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{fleetEventTeamId}/ships/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventTeamId", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update event ship") do
+      operationId "updateFleetEventShip"
+      tags "Fleet Event Ships"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventShipUpdateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventShip"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Destroy event ship") do
+      operationId "destroyFleetEventShip"
+      tags "Fleet Event Ships"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+    @ship = create(:fleet_event_ship, fleet_event_team: @team)
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/:id updates the ship" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      body: {classification: "Industrial", description: "Hauling"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {classification: "Industrial", description: "Hauling"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {classification: "Industrial", description: "Hauling"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id/ships/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      body: {classification: "Industrial", description: "Hauling"}
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id/ships/:id destroys the ship" do
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @ship.reload }
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id/ships/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id/ships/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id/ships/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, fleetEventTeamId: @team.id, id: @ship.id}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_sort_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_sort_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsSortTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/sort" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+
+    put("Sort event teams") do
+      operationId "sortFleetEventTeams"
+      tags "Fleet Event Teams"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {
+        type: :object,
+        properties: {sorting: {type: :array, items: {type: :string, format: :uuid}}},
+        required: %w[sorting]
+      }
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @teams = create_list(:fleet_event_team, 3, fleet_event: @fleet_event)
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/sort sorts teams" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/sort with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/sort returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/sort returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug},
+      body: {sorting: @teams.reverse.map(&:id)}
+  end
+end

--- a/test/integration/api/v1/fleets_events_teams_update_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_update_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsTeamsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{fleetEventSlug}/teams/{id}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "fleetEventSlug", in: :path, schema: {type: :string}
+    parameter name: "id", in: :path, schema: {type: :string}
+
+    put("Update event team") do
+      operationId "updateFleetEventTeam"
+      tags "Fleet Event Teams"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventTeamUpdateInput"}
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventTeam"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Destroy event team") do
+      operationId "destroyFleetEventTeam"
+      tags "Fleet Event Teams"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @fleet_event)
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id updates the team" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      body: {title: "Renamed", description: "Updated"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Renamed", description: "Updated"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Renamed", description: "Updated"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/teams/:id returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      body: {title: "Renamed", description: "Updated"}
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id destroys the team" do
+    sign_in @admin
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id}
+
+    assert_raises(ActiveRecord::RecordNotFound) { @team.reload }
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id with OAuth bearer token" do
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id returns 401 for OAuth token with wrong scope" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/events/:slug/teams/:id returns 401 when not signed in" do
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug, fleetEventSlug: @fleet_event.slug, id: @team.id}
+  end
+end

--- a/test/integration/api/v1/fleets_events_unarchive_test.rb
+++ b/test/integration/api/v1/fleets_events_unarchive_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsUnarchiveTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/unarchive" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Unarchive Fleet Event") do
+      operationId "unarchiveFleetEvent"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(400, "not archived") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unarchive unarchives the event" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    fleet_event.archive!
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal false, parsed_body["archived"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unarchive returns 400 when event is not archived" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 400, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unarchive with OAuth bearer token" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    fleet_event.archive!
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unarchive returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    fleet_event.archive!
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unarchive returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+    fleet_event.archive!
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_unlock_signups_test.rb
+++ b/test/integration/api/v1/fleets_events_unlock_signups_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsUnlockSignupsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/unlock-signups" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Unlock Signups") do
+      operationId "unlockFleetEventSignups"
+      tags "Fleet Events"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unlock-signups transitions back to open" do
+    fleet_event = create(:fleet_event, :locked, fleet: @fleet, created_by: @admin)
+    sign_in @admin
+
+    assert_api_response :put, 200, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug} do
+      assert_equal "open", parsed_body["status"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unlock-signups with OAuth bearer token" do
+    fleet_event = create(:fleet_event, :locked, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unlock-signups returns 401 for OAuth token with wrong scope" do
+    fleet_event = create(:fleet_event, :locked, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "PUT /fleets/:slug/events/:slug/unlock-signups returns 401 when not signed in" do
+    fleet_event = create(:fleet_event, :locked, fleet: @fleet, created_by: @admin)
+
+    assert_api_response :put, 401, path_params: {fleetSlug: @fleet.slug, slug: fleet_event.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_update_occurrence_swagger_test.rb
+++ b/test/integration/api/v1/fleets_events_update_occurrence_swagger_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsUpdateOccurrenceSwaggerTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}/update-occurrence" do
+    parameter name: "fleetSlug", in: :path, schema: {type: [:string, :null]}
+    parameter name: "slug", in: :path, schema: {type: [:string, :null]}
+
+    patch("Override fields on a single occurrence") do
+      operationId "updateFleetEventOccurrence"
+      tags "Fleet Events"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {
+        type: :object,
+        properties: {
+          date: {type: :string, format: :date},
+          title: {type: [:string, :null]},
+          description: {type: [:string, :null]},
+          briefing: {type: [:string, :null]},
+          location: {type: [:string, :null]},
+          meetupLocation: {type: [:string, :null]},
+          scenario: {type: [:string, :null]},
+          coverImagePreset: {type: [:string, :null]}
+        },
+        required: %w[date]
+      }, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventOccurrenceState"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC",
+      recurring: true, recurrence_interval: "weekly")
+  end
+
+  test "PATCH /fleets/:slug/events/:slug/update-occurrence overrides occurrence fields" do
+    sign_in @admin
+
+    assert_api_response :patch, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {date: "2026-05-21", location: "Levski", scenario: "Bunker raid"} do
+      assert_equal "Levski", parsed_body["location"]
+      assert_equal "Bunker raid", parsed_body["scenario"]
+    end
+  end
+end

--- a/test/integration/api/v1/fleets_events_update_occurrence_test.rb
+++ b/test/integration/api/v1/fleets_events_update_occurrence_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsUpdateOccurrenceTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @event = create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin,
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      timezone: "UTC", location: "Stanton",
+      recurring: true, recurrence_interval: "weekly")
+    sign_in @admin
+  end
+
+  test "creates a per-occurrence state row with the override fields" do
+    patch "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/update-occurrence",
+      params: {date: "2026-05-21", location: "Levski", scenario: "Bunker raid"},
+      as: :json
+
+    assert_equal 200, response.status, response.body
+    state = @event.reload.fleet_event_occurrence_states.find_by(
+      occurrence_date: Date.parse("2026-05-21")
+    )
+    assert_equal "Levski", state.location
+    assert_equal "Bunker raid", state.scenario
+  end
+
+  test "updates an existing state row" do
+    create(:fleet_event_occurrence_state,
+      fleet_event: @event, occurrence_date: Date.parse("2026-05-21"),
+      location: "Levski")
+
+    patch "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/update-occurrence",
+      params: {date: "2026-05-21", location: "Yela"},
+      as: :json
+
+    assert_equal 200, response.status, response.body
+    assert_equal "Yela", @event.fleet_event_occurrence_states.first.reload.location
+  end
+
+  test "rejects when the event is not recurring" do
+    one_off = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+
+    patch "/api/v1/fleets/#{@fleet.slug}/events/#{one_off.slug}/update-occurrence",
+      params: {date: "2026-05-21", location: "Levski"},
+      as: :json
+
+    assert_equal 422, response.status
+  end
+
+  test "rejects when date is missing" do
+    patch "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/update-occurrence",
+      params: {location: "Levski"},
+      as: :json
+
+    assert_equal 400, response.status
+  end
+end

--- a/test/integration/api/v1/fleets_events_update_test.rb
+++ b/test/integration/api/v1/fleets_events_update_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/events/{slug}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+    parameter name: "slug", in: :path, schema: {type: :string}
+
+    put("Update Fleet Event") do
+      operationId "updateFleetEvent"
+      tags "Fleet Events"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body schema: {"$ref": "#/components/schemas/FleetEventUpdateInput"}, required: true
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/FleetEventExtended"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, fleet: @fleet, created_by: @admin)
+  end
+
+  test "PUT /fleets/:slug/events/:slug updates the event" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {title: "Renamed Event"} do
+      assert_equal "Renamed Event", parsed_body["title"]
+    end
+  end
+
+  test "PUT /fleets/:slug/events/:slug with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {title: "Renamed Event"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug returns 401 for OAuth token with wrong scope" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"]),
+      body: {title: "Renamed Event"}
+  end
+
+  test "PUT /fleets/:slug/events/:slug returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, slug: @fleet_event.slug},
+      body: {title: "Renamed Event"}
+  end
+end

--- a/test/integration/fleet_event_ship_allowed_models_test.rb
+++ b/test/integration/fleet_event_ship_allowed_models_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The event side of a hand-picked ship list, and the part that only exists here:
+# a spot spawned from a mission has to arrive with the list it was given.
+class FleetEventShipAllowedModelsTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+    @event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
+    @team = create(:fleet_event_team, fleet_event: @event)
+    @connie = create(:model, name: "Constellation Andromeda", in_game: true)
+    @freelancer = create(:model, name: "Freelancer MAX", in_game: true)
+    sign_in @admin
+  end
+
+  def ships_path
+    "/api/v1/fleets/#{@fleet.slug}/events/#{@event.slug}/teams/#{@team.id}/ships"
+  end
+
+  test "a list of models is enough on its own to describe a spot" do
+    post ships_path,
+      params: {title: "Escort", allowedModelIds: [@connie.id, @freelancer.id]},
+      as: :json
+
+    assert_response :created
+    ship = @team.fleet_event_ships.order(:position).last
+    assert_equal [@connie.id, @freelancer.id], ship.allowed_models.map(&:id)
+    assert ship.listed?
+  end
+
+  test "a list cannot name a ship that is not in the game" do
+    concept = create(:model, in_game: false)
+
+    post ships_path,
+      params: {title: "Escort", allowedModelIds: [concept.id]},
+      as: :json
+
+    assert_response :bad_request
+  end
+
+  test "updating with a list replaces it rather than adding to it" do
+    ship = create(:fleet_event_ship, fleet_event_team: @team, classification: "combat")
+    ship.fleet_event_ship_models.create!(model_id: @connie.id, position: 0)
+
+    patch "#{ships_path}/#{ship.id}",
+      params: {allowedModelIds: [@freelancer.id]},
+      as: :json
+
+    assert_response :success
+    assert_equal [@freelancer.id], ship.reload.allowed_models.map(&:id)
+  end
+
+  test "an event spawned from a mission carries each spot's list" do
+    mission = create(:mission, fleet: @fleet, created_by: @admin)
+    mission_team = create(:mission_team, mission: mission)
+    mission_ship = create(:mission_ship, mission_team: mission_team)
+    mission_ship.mission_ship_models.create!(model_id: @connie.id, position: 0)
+    mission_ship.mission_ship_models.create!(model_id: @freelancer.id, position: 1)
+
+    event = FleetEvent.from_mission!(
+      mission,
+      created_by: @admin,
+      starts_at: 2.days.from_now,
+      timezone: "UTC"
+    )
+
+    spawned = event.fleet_event_teams.first.fleet_event_ships.first
+    assert_equal [@connie.id, @freelancer.id], spawned.allowed_models.map(&:id)
+  end
+
+  test "retiring a model drops it from the lists that named it" do
+    ship = create(:fleet_event_ship, fleet_event_team: @team)
+    ship.fleet_event_ship_models.create!(model_id: @connie.id, position: 0)
+    ship.fleet_event_ship_models.create!(model_id: @freelancer.id, position: 1)
+
+    @connie.destroy
+
+    assert_equal [@freelancer.id], ship.reload.allowed_models.map(&:id)
+  end
+end

--- a/test/integration/fleet_event_ship_allowed_models_test.rb
+++ b/test/integration/fleet_event_ship_allowed_models_test.rb
@@ -53,6 +53,28 @@ class FleetEventShipAllowedModelsTest < ActionDispatch::IntegrationTest
     assert_equal [@freelancer.id], ship.reload.allowed_models.map(&:id)
   end
 
+  # The factory gives a ship filters, which satisfied model_or_filter_required on
+  # its own and so hid an ordering bug: a spot whose whole spec is a list has
+  # nothing in its columns.
+  test "an event spawns from a mission spot whose whole spec is a list" do
+    mission = create(:mission, fleet: @fleet, created_by: @admin)
+    mission_team = create(:mission_team, mission: mission)
+    listed = MissionShip.new(mission_team: mission_team, title: "Listed", position: 0)
+    listed.mission_ship_models.build(model_id: @connie.id, position: 0)
+    listed.save!
+
+    event = FleetEvent.from_mission!(
+      mission,
+      created_by: @admin,
+      starts_at: 2.days.from_now,
+      timezone: "UTC"
+    )
+
+    spawned = event.fleet_event_teams.first.fleet_event_ships.first
+    assert_equal [@connie.id], spawned.allowed_models.map(&:id)
+    assert_nil spawned.classification
+  end
+
   test "an event spawned from a mission carries each spot's list" do
     mission = create(:mission, fleet: @fleet, created_by: @admin)
     mission_team = create(:mission_team, mission: mission)

--- a/test/integration/fleet_mission_builder_gate_test.rb
+++ b/test/integration/fleet_mission_builder_gate_test.rb
@@ -42,6 +42,21 @@ class FleetMissionBuilderGateTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "the events list is forbidden while the flag is off" do
+    get "/api/v1/fleets/#{@fleet.slug}/events"
+
+    assert_response :forbidden
+  end
+
+  test "enabling the flag for the fleet opens the events list" do
+    Flipper.enable_actor("fleet_mission_builder", @fleet)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events"
+
+    assert_response :success
+  end
+
   test "restoring an archived mission needs delete access, not just update" do
     updater = create(:user)
     role = @fleet.fleet_roles.create!(

--- a/test/jobs/fleet_events/auto_lock_job_test.rb
+++ b/test/jobs/fleet_events/auto_lock_job_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module FleetEvents
+  class AutoLockJobTest < ActiveJob::TestCase
+    setup do
+      @fleet = create(:fleet)
+    end
+
+    test "locks open events whose auto-lock window has begun" do
+      event = create(:fleet_event, :open,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        auto_lock_minutes_before: 60,
+        starts_at: 30.minutes.from_now)
+
+      ::FleetEvents::AutoLockJob.new.perform
+
+      assert_equal "locked", event.reload.status
+    end
+
+    test "leaves open events whose window hasn't started yet" do
+      event = create(:fleet_event, :open,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        auto_lock_minutes_before: 60,
+        starts_at: 3.hours.from_now)
+
+      ::FleetEvents::AutoLockJob.new.perform
+
+      assert_equal "open", event.reload.status
+    end
+
+    test "skips events with auto-lock disabled" do
+      event = create(:fleet_event, :open,
+        fleet: @fleet,
+        auto_lock_enabled: false,
+        auto_lock_minutes_before: 60,
+        starts_at: 10.minutes.from_now)
+
+      ::FleetEvents::AutoLockJob.new.perform
+
+      assert_equal "open", event.reload.status
+    end
+
+    test "skips events not in the open state" do
+      locked = create(:fleet_event, :locked,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        starts_at: 5.minutes.from_now)
+      active = create(:fleet_event, :active,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        starts_at: 5.minutes.ago)
+
+      before = [locked.reload.status, active.reload.status]
+      ::FleetEvents::AutoLockJob.new.perform
+      after = [locked.reload.status, active.reload.status]
+      assert_equal before, after
+    end
+
+    test "still locks events whose start time has already passed" do
+      event = create(:fleet_event, :open,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        auto_lock_minutes_before: 60,
+        starts_at: 10.minutes.ago)
+
+      ::FleetEvents::AutoLockJob.new.perform
+
+      assert_equal "locked", event.reload.status
+    end
+
+    test "fires the fleet_event.locked notification for each locked event" do
+      event = create(:fleet_event, :open,
+        fleet: @fleet,
+        auto_lock_enabled: true,
+        auto_lock_minutes_before: 60,
+        starts_at: 5.minutes.from_now)
+
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe("fleet_event.locked") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      begin
+        ::FleetEvents::AutoLockJob.new.perform
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      assert_equal 1, events.size
+      assert_equal event, events.first.payload[:event]
+    end
+
+    class RecurringEventsTest < AutoLockJobTest
+      test "locks the next occurrence within the auto-lock window" do
+        event = create(:fleet_event, :open,
+          fleet: @fleet,
+          recurring: true, recurrence_interval: "weekly",
+          auto_lock_enabled: true, auto_lock_minutes_before: 60,
+          starts_at: 30.minutes.from_now)
+
+        ::FleetEvents::AutoLockJob.new.perform
+
+        state = event.fleet_event_occurrence_states.first
+        assert state.present?
+        assert_equal event.starts_at.to_date, state.occurrence_date
+        assert state.locked_at.present?
+      end
+
+      test "is idempotent — re-running doesn't re-lock the same occurrence" do
+        event = create(:fleet_event, :open,
+          fleet: @fleet,
+          recurring: true, recurrence_interval: "weekly",
+          auto_lock_enabled: true, auto_lock_minutes_before: 60,
+          starts_at: 30.minutes.from_now)
+
+        ::FleetEvents::AutoLockJob.new.perform
+        first_locked_at = event.fleet_event_occurrence_states.first.locked_at
+
+        ::FleetEvents::AutoLockJob.new.perform
+
+        assert_equal first_locked_at, event.fleet_event_occurrence_states.first.reload.locked_at
+      end
+
+      test "doesn't lock occurrences whose window hasn't begun" do
+        event = create(:fleet_event, :open,
+          fleet: @fleet,
+          recurring: true, recurrence_interval: "weekly",
+          auto_lock_enabled: true, auto_lock_minutes_before: 60,
+          starts_at: 3.hours.from_now)
+
+        ::FleetEvents::AutoLockJob.new.perform
+
+        assert_empty event.fleet_event_occurrence_states
+      end
+
+      test "skips cancelled occurrences" do
+        event = create(:fleet_event, :open,
+          fleet: @fleet,
+          recurring: true, recurrence_interval: "weekly",
+          auto_lock_enabled: true, auto_lock_minutes_before: 60,
+          starts_at: 30.minutes.from_now)
+        create(:fleet_event_occurrence_state,
+          fleet_event: event, occurrence_date: event.starts_at.to_date,
+          cancelled_at: Time.current)
+
+        ::FleetEvents::AutoLockJob.new.perform
+
+        assert_nil event.fleet_event_occurrence_states.first.locked_at
+      end
+    end
+  end
+end

--- a/test/models/fleet_event_occurrence_state_test.rb
+++ b/test/models/fleet_event_occurrence_state_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: fleet_event_occurrence_states
+#
+#  id                        :uuid             not null, primary key
+#  briefing                  :text
+#  cancelled_at              :datetime
+#  cancelled_reason          :text
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  location                  :string
+#  locked_at                 :datetime
+#  meetup_location           :string
+#  occurrence_date           :date             not null
+#  scenario                  :string
+#  starting_soon_notified_at :datetime
+#  status                    :string
+#  title                     :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  discord_event_id          :string
+#  fleet_event_id            :uuid             not null
+#
+# Indexes
+#
+#  idx_fleet_event_occurrence_states_on_event_and_date  (fleet_event_id,occurrence_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#
+class FleetEventOccurrenceStateTest < ActiveSupport::TestCase
+  setup do
+    @event = create(:fleet_event, :open,
+      title: "Thursday Play Evening",
+      location: "Stanton",
+      starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+      recurring: true, recurrence_interval: "weekly")
+  end
+
+  class UniquenessTest < FleetEventOccurrenceStateTest
+    test "enforces one row per (event, occurrence_date)" do
+      create(:fleet_event_occurrence_state,
+        fleet_event: @event, occurrence_date: Date.parse("2026-05-14"))
+
+      dup = build(:fleet_event_occurrence_state,
+        fleet_event: @event, occurrence_date: Date.parse("2026-05-14"))
+
+      refute dup.valid?
+    end
+  end
+
+  class EffectiveTest < FleetEventOccurrenceStateTest
+    test "returns the override when set" do
+      state = create(:fleet_event_occurrence_state,
+        fleet_event: @event, occurrence_date: Date.parse("2026-05-21"),
+        location: "Levski")
+
+      assert_equal "Levski", state.effective(:location)
+    end
+
+    test "falls back to the event's value when nil" do
+      state = create(:fleet_event_occurrence_state,
+        fleet_event: @event, occurrence_date: Date.parse("2026-05-21"))
+
+      assert_equal "Stanton", state.effective(:location)
+      assert_equal "Thursday Play Evening", state.effective(:title)
+    end
+  end
+
+  class FleetEventOccurrenceStateForTest < FleetEventOccurrenceStateTest
+    test "returns nil for an unknown date by default" do
+      assert_nil @event.occurrence_state_for(Date.parse("2026-05-21"))
+    end
+
+    test "builds a new state when build: true" do
+      state = @event.occurrence_state_for(Date.parse("2026-05-21"), build: true)
+
+      assert state.present?
+      assert state.new_record?
+      assert_equal Date.parse("2026-05-21"), state.occurrence_date
+    end
+
+    test "returns the existing state if present" do
+      existing = create(:fleet_event_occurrence_state,
+        fleet_event: @event, occurrence_date: Date.parse("2026-05-21"),
+        location: "Levski")
+
+      result = @event.occurrence_state_for(Date.parse("2026-05-21"))
+
+      assert_equal existing, result
+    end
+  end
+end

--- a/test/models/fleet_event_signup_test.rb
+++ b/test/models/fleet_event_signup_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: fleet_event_signups
+#
+#  id                  :uuid             not null, primary key
+#  confirmed_at        :datetime
+#  notes               :text
+#  occurrence_date     :date
+#  status              :string           default("confirmed"), not null
+#  withdrawn_at        :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  fleet_event_id      :uuid             not null
+#  fleet_event_slot_id :uuid
+#  fleet_membership_id :uuid             not null
+#  vehicle_id          :uuid
+#
+# Indexes
+#
+#  idx_fleet_event_signups_on_event_and_occurrence_and_member  (fleet_event_id,occurrence_date,fleet_membership_id)
+#  index_fleet_event_signups_on_fleet_event_id                 (fleet_event_id)
+#  index_fleet_event_signups_on_fleet_event_slot_id            (fleet_event_slot_id)
+#  index_fleet_event_signups_on_fleet_membership_id            (fleet_membership_id)
+#  index_fleet_event_signups_unique_active_per_event           (fleet_event_id,occurrence_date,fleet_membership_id) UNIQUE WHERE ((status)::text <> 'withdrawn'::text)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fleet_event_id => fleet_events.id)
+#  fk_rails_...  (fleet_event_slot_id => fleet_event_slots.id)
+#  fk_rails_...  (fleet_membership_id => fleet_memberships.id)
+#  fk_rails_...  (vehicle_id => vehicles.id) ON DELETE => nullify
+#
+class FleetEventSignupTest < ActiveSupport::TestCase
+  setup do
+    @event = create(:fleet_event, :open)
+    @team = create(:fleet_event_team, fleet_event: @event)
+    @slot = create(:fleet_event_slot, slottable: @team)
+    @fleet_membership = create(:fleet_membership, fleet: @event.fleet)
+  end
+
+  class SlotBoundStatusAllowedTest < FleetEventSignupTest
+    test "accepts confirmed signups bound to a slot" do
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "confirmed")
+      assert signup.valid?
+    end
+
+    test "accepts pending signups bound to a slot" do
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "pending")
+      assert signup.valid?
+    end
+
+    test "rejects tentative signups bound to a slot" do
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "tentative")
+      refute signup.valid?
+      assert_includes signup.errors.details[:status], {error: :invalid_for_slot}
+    end
+
+    test "rejects interested signups bound to a slot" do
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "interested")
+      refute signup.valid?
+    end
+
+    test "allows tentative signups when there is no slot" do
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: nil, fleet_membership: @fleet_membership, status: "tentative")
+      assert signup.valid?
+    end
+  end
+
+  class UniqueActiveSignupPerMemberTest < FleetEventSignupTest
+    test "rejects a second active signup for the same member on the same event" do
+      create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "confirmed")
+      other_slot = create(:fleet_event_slot, slottable: @team)
+      duplicate = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: other_slot, fleet_membership: @fleet_membership, status: "confirmed")
+      refute duplicate.valid?
+    end
+
+    test "allows another signup once the first is withdrawn" do
+      first = create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "confirmed")
+      first.withdraw!
+      other_slot = create(:fleet_event_slot, slottable: @team)
+      duplicate = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: other_slot, fleet_membership: @fleet_membership, status: "confirmed")
+      assert duplicate.valid?
+    end
+  end
+
+  class SlotNotAlreadyTakenTest < FleetEventSignupTest
+    test "rejects a second signup on a slot that already has someone" do
+      first_member = create(:fleet_membership, fleet: @event.fleet)
+      create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: first_member, status: "confirmed")
+
+      other = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership, status: "confirmed")
+      refute other.valid?
+    end
+  end
+
+  class EffectiveSignupApprovalTest < FleetEventSignupTest
+    test "uses the slot override when present" do
+      @slot.update!(signup_approval: "confirmation_required")
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership)
+      assert_equal "confirmation_required", signup.effective_signup_approval
+    end
+
+    test "falls back to the event default when the slot has none" do
+      @event.update!(signup_approval: "confirmation_required")
+      signup = build(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership)
+      assert_equal "confirmation_required", signup.effective_signup_approval
+    end
+  end
+end

--- a/test/models/fleet_event_test.rb
+++ b/test/models/fleet_event_test.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: fleet_events
+#
+#  id                        :uuid             not null, primary key
+#  archived_at               :datetime
+#  auto_lock_enabled         :boolean          default(TRUE), not null
+#  auto_lock_minutes_before  :integer          default(60), not null
+#  briefing                  :text
+#  cancelled_reason          :text
+#  category                  :integer          default(0), not null
+#  cover_image_preset        :string
+#  description               :text
+#  discord_synced_at         :datetime
+#  ends_at                   :datetime
+#  excluded_dates            :date             default([]), not null, is an Array
+#  external_uid              :uuid             not null
+#  location                  :string
+#  max_attendees             :integer
+#  meetup_location           :string
+#  recurrence_count          :integer
+#  recurrence_interval       :string
+#  recurrence_until          :date
+#  recurring                 :boolean          default(FALSE), not null
+#  scenario                  :string
+#  signup_approval           :string           default("direct"), not null
+#  slug                      :string           not null
+#  starting_soon_notified_at :datetime
+#  starts_at                 :datetime         not null
+#  status                    :string           default("draft"), not null
+#  timezone                  :string           default("UTC"), not null
+#  title                     :string           not null
+#  visibility                :string           default("members"), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid             not null
+#  discord_event_id          :string
+#  discord_message_id        :string
+#  fleet_id                  :uuid             not null
+#  mission_id                :uuid
+#
+# Indexes
+#
+#  index_fleet_events_on_external_uid            (external_uid) UNIQUE
+#  index_fleet_events_on_fleet_id_and_recurring  (fleet_id,recurring)
+#  index_fleet_events_on_fleet_id_and_slug       (fleet_id,slug) UNIQUE
+#  index_fleet_events_on_fleet_id_and_starts_at  (fleet_id,starts_at)
+#  index_fleet_events_on_fleet_id_and_status     (fleet_id,status)
+#  index_fleet_events_on_mission_id              (mission_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (fleet_id => fleets.id)
+#  fk_rails_...  (mission_id => missions.id)
+#
+class FleetEventTest < ActiveSupport::TestCase
+  class SignupsCountTest < FleetEventTest
+    setup do
+      @event = create(:fleet_event, :open)
+      @team = create(:fleet_event_team, fleet_event: @event)
+      @slot = create(:fleet_event_slot, slottable: @team)
+      @fleet_membership = create(:fleet_membership, fleet: @event.fleet)
+      @other_membership = create(:fleet_membership, fleet: @event.fleet)
+    end
+
+    test "counts slot-bound and unassigned signups together, ignoring withdrawn" do
+      create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: @slot, fleet_membership: @fleet_membership)
+      create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: nil, fleet_membership: @other_membership, status: "interested")
+      withdrawn_member = create(:fleet_membership, fleet: @event.fleet)
+      create(:fleet_event_signup, fleet_event: @event, fleet_event_slot: nil, fleet_membership: withdrawn_member, status: "withdrawn")
+
+      assert_equal 2, @event.signups_count
+    end
+  end
+
+  class PastTest < FleetEventTest
+    test "is true when ends_at is in the past" do
+      event = build(:fleet_event, starts_at: 2.hours.ago, ends_at: 1.hour.ago)
+      assert event.past?
+    end
+
+    test "falls back to starts_at when ends_at is nil" do
+      event = build(:fleet_event, starts_at: 1.hour.ago, ends_at: nil)
+      assert event.past?
+    end
+
+    test "is false for upcoming events" do
+      event = build(:fleet_event, starts_at: 1.day.from_now)
+      refute event.past?
+    end
+  end
+
+  class SignupsOpenTest < FleetEventTest
+    test "is true when status is open and event is not past" do
+      event = build(:fleet_event, :open, starts_at: 1.day.from_now)
+      assert event.signups_open?
+    end
+
+    test "is false when status is open but the event already happened" do
+      event = build(:fleet_event, :open, starts_at: 2.hours.ago, ends_at: 1.hour.ago)
+      refute event.signups_open?
+    end
+
+    test "is false for non-open statuses" do
+      %i[locked active cancelled].each do |trait|
+        event = build(:fleet_event, trait, starts_at: 1.day.from_now)
+        refute event.signups_open?, "expected #{trait} event to be closed"
+      end
+    end
+  end
+
+  class ArchiveTest < FleetEventTest
+    test "round-trips archived_at" do
+      event = create(:fleet_event)
+      refute event.archived?
+      event.archive!
+      assert event.reload.archived?
+      event.unarchive!
+      refute event.reload.archived?
+    end
+  end
+
+  class OccurrencesTest < FleetEventTest
+    setup do
+      @fleet = create(:fleet)
+      @thursday = Time.zone.parse("2026-05-14 20:00:00 UTC")
+    end
+
+    test "returns just starts_at for a one-off event within the range" do
+      event = create(:fleet_event, fleet: @fleet, starts_at: @thursday)
+
+      assert_equal [@thursday],
+        event.occurrences(from: @thursday - 1.day, to: @thursday + 1.day)
+    end
+
+    test "returns nothing for a one-off event outside the range" do
+      event = create(:fleet_event, fleet: @fleet, starts_at: @thursday)
+
+      assert_empty event.occurrences(from: @thursday + 1.day, to: @thursday + 7.days)
+    end
+
+    test "expands a weekly recurring event into successive occurrences" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "weekly")
+
+      result = event.occurrences(from: @thursday, to: @thursday + 4.weeks)
+
+      assert_equal 5, result.size
+      assert_equal [4], result.map { |t| t.wday }.uniq
+    end
+
+    test "honours biweekly interval" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "biweekly")
+
+      result = event.occurrences(from: @thursday, to: @thursday + 6.weeks)
+
+      assert_equal 4, result.size
+    end
+
+    test "honours daily interval" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "daily")
+
+      result = event.occurrences(from: @thursday, to: @thursday + 3.days)
+
+      assert_equal 4, result.size
+    end
+
+    test "honours recurrence_until" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "weekly",
+        recurrence_until: Date.parse("2026-05-28"))
+
+      result = event.occurrences(from: @thursday, to: @thursday + 8.weeks)
+
+      assert_equal 3, result.size
+    end
+
+    test "honours recurrence_count" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "weekly",
+        recurrence_count: 4)
+
+      result = event.occurrences(from: @thursday, to: @thursday + 8.weeks)
+
+      assert_equal 4, result.size
+    end
+
+    test "honours excluded_dates" do
+      event = create(:fleet_event,
+        fleet: @fleet, starts_at: @thursday,
+        recurring: true, recurrence_interval: "weekly",
+        excluded_dates: [Date.parse("2026-05-21")])
+
+      result = event.occurrences(from: @thursday, to: @thursday + 4.weeks)
+
+      refute_includes result.map(&:to_date), Date.parse("2026-05-21")
+      assert_equal 4, result.size
+    end
+  end
+
+  class SkipOccurrenceTest < FleetEventTest
+    test "appends the date to excluded_dates" do
+      event = create(:fleet_event,
+        starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+        recurring: true, recurrence_interval: "weekly")
+
+      event.skip_occurrence!(Date.parse("2026-05-21"))
+
+      assert_includes event.reload.excluded_dates, Date.parse("2026-05-21")
+    end
+
+    test "is idempotent for already-excluded dates" do
+      event = create(:fleet_event,
+        starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+        recurring: true, recurrence_interval: "weekly",
+        excluded_dates: [Date.parse("2026-05-21")])
+
+      before_size = event.excluded_dates.size
+      event.skip_occurrence!(Date.parse("2026-05-21"))
+      assert_equal before_size, event.reload.excluded_dates.size
+    end
+  end
+
+  class EndSeriesAtTest < FleetEventTest
+    test "sets recurrence_until to the day before the given date" do
+      event = create(:fleet_event,
+        starts_at: Time.zone.parse("2026-05-14 20:00:00 UTC"),
+        recurring: true, recurrence_interval: "weekly")
+
+      event.end_series_at!(Date.parse("2026-06-04"))
+
+      assert_equal Date.parse("2026-06-03"), event.reload.recurrence_until
+    end
+  end
+
+  class RecurringValidationTest < FleetEventTest
+    test "requires recurrence_interval when recurring" do
+      event = build(:fleet_event,
+        recurring: true, recurrence_interval: nil)
+
+      refute event.valid?
+      assert event.errors[:recurrence_interval].present?
+    end
+
+    test "rejects recurrence_interval on non-recurring events" do
+      event = build(:fleet_event,
+        recurring: false, recurrence_interval: "weekly")
+
+      refute event.valid?
+      assert event.errors[:recurrence_interval].present?
+    end
+
+    test "rejects both recurrence_count and recurrence_until" do
+      event = build(:fleet_event,
+        recurring: true, recurrence_interval: "weekly",
+        recurrence_count: 4, recurrence_until: Date.tomorrow)
+
+      refute event.valid?
+    end
+  end
+end


### PR DESCRIPTION
Third of the stack splitting #3893. Stacked on #4445 → #4443 — **review those first.**

Schedules a mission onto a fleet's calendar. An event carries its own copy of the mission's teams, ships and slots, so editing the event never touches the template it came from.

### What's here

- `fleet_events` with a publish / lock-signups / start / complete / cancel state machine
- Teams, ships and slots, expandable from a model
- Sign-ups with direct or approval flows, per-slot assignment, and event admins who can manage them
- Recurring events as RRULE-on-event: occurrences are derived rather than materialised, with per-occurrence override rows (`fleet_event_occurrence_states`) for the ones that differ
- `FleetEvents::AutoLockJob` closes sign-ups as the start window approaches (5-minute cron)
- Privileges follow missions: `fleet:events:read` for members, `fleet:events:manage` for anyone already managing the fleet, backfilled onto existing roles

### Why this one is bigger than planned

I'd intended to split events core from sign-ups and recurrence, but they aren't separable: the state machine, the sign-up counters and the occurrence generation all live inside `fleet_event.rb`. Cutting them apart would have meant authoring intermediate versions of that model that never existed on the original branch. Feeds and the Discord push *are* separable — they're wired through subscribers and their own files — so those follow in the next two PRs.

Consequently **`ics` and `sync_to_discord` are deliberately absent** from `fleet_events_controller`, along with the Discord fields on the event payload. PR 4 adds the first back, PR 5 the other two.

### Two things to know

- `20260505200000_add_event_columns_to_fleets` adds `calendar_feed_token` alongside `default_timezone`. The column is unused until PR 4 — I kept the migration whole rather than splitting one migration file across two PRs.
- **`swagger/v1/schema.yaml` is generated — skip it.** The path set is PR 2's 201 plus exactly 28 new event paths, nothing removed; the rest of the diff is openapi-ruby reordering.

### Verification

- `test/integration`, `test/models`, `test/lib`, `test/jobs`, `test/mailers` — 2541 tests, 5940 assertions, 0 failures
- `standardrb` clean on every touched Ruby file, `vue-tsc` + `tsc` clean
- `db/schema.rb` regenerated by migrating a scratch database, not dumped from a dev DB, so it contains only this PR's tables

🤖