### PR TITLE
fix(tooltip): stop tooltips getting stranded on screen

### DIFF
--- a/app/frontend/shared/plugins/Tooltip.spec.ts
+++ b/app/frontend/shared/plugins/Tooltip.spec.ts
@@ -1,0 +1,168 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import TooltipPlugin from "./Tooltip";
+
+const tooltips = () =>
+  Array.from(document.querySelectorAll<HTMLElement>("[data-tooltip]"));
+
+const visibleTooltips = () =>
+  tooltips().filter(
+    (el) => el.style.display !== "none" && el.style.opacity !== "0",
+  );
+
+// jsdom has no layout, so every element measures 0×0 and the anchor watcher
+// would treat any tooltip as orphaned. Give anchors a box the tests can move
+// or collapse on demand.
+let anchorRect = { top: 10, left: 10, width: 100, height: 20 };
+
+const Anchor = defineComponent({
+  props: {
+    content: { type: [String, Boolean], default: "Delete" },
+  },
+  template: `<button v-tooltip="content">x</button>`,
+});
+
+const mountAnchor = (props: Record<string, unknown> = {}) => {
+  const wrapper = mount(Anchor, {
+    props,
+    global: { plugins: [TooltipPlugin] },
+    attachTo: document.body,
+  });
+
+  const el = wrapper.element as HTMLElement;
+  el.getBoundingClientRect = () =>
+    ({ ...anchorRect, bottom: 0, right: 0 }) as DOMRect;
+
+  return { wrapper, el };
+};
+
+const nextFrame = () => vi.advanceTimersByTimeAsync(20);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  anchorRect = { top: 10, left: 10, width: 100, height: 20 };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  tooltips().forEach((el) => el.remove());
+  document.body.innerHTML = "";
+});
+
+describe("v-tooltip", () => {
+  it("shows on mouseenter and hides on mouseleave", async () => {
+    const { el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    expect(visibleTooltips()).toHaveLength(1);
+
+    el.dispatchEvent(new Event("mouseleave"));
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("stays hidden when the pointer leaves within the same frame", async () => {
+    const { el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseleave"));
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("follows the anchor when it moves", async () => {
+    const { el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    const [tip] = visibleTooltips();
+    expect(tip).toBeDefined();
+    const before = tip.style.top;
+
+    anchorRect = { ...anchorRect, top: 400 };
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(1);
+    expect(tip.style.top).not.toBe(before);
+  });
+
+  it("hides once the anchor is collapsed", async () => {
+    const { el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    expect(visibleTooltips()).toHaveLength(1);
+
+    anchorRect = { top: 0, left: 0, width: 0, height: 0 };
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("hides when the pointer moves onto an unrelated element", async () => {
+    const { el } = mountAnchor();
+    const other = document.createElement("div");
+    document.body.appendChild(other);
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    expect(visibleTooltips()).toHaveLength(1);
+
+    other.dispatchEvent(new Event("pointerover", { bubbles: true }));
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("hides on Escape", async () => {
+    const { el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("does not show on focus that is not keyboard driven", async () => {
+    const { el } = mountAnchor();
+    vi.spyOn(el, "matches").mockReturnValue(false);
+
+    el.dispatchEvent(new Event("focus"));
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+
+  it("removes its element when the anchor unmounts", async () => {
+    const { wrapper, el } = mountAnchor();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    expect(tooltips()).toHaveLength(1);
+
+    wrapper.unmount();
+    expect(tooltips()).toHaveLength(0);
+  });
+
+  it("keeps at most one tooltip on screen", async () => {
+    const first = mountAnchor();
+    const second = mountAnchor({ content: "Edit" });
+
+    first.el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+    second.el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(1);
+  });
+
+  it("never shows without content", async () => {
+    const { el } = mountAnchor({ content: false });
+
+    el.dispatchEvent(new Event("mouseenter"));
+    await nextFrame();
+
+    expect(visibleTooltips()).toHaveLength(0);
+  });
+});

--- a/app/frontend/shared/plugins/Tooltip.ts
+++ b/app/frontend/shared/plugins/Tooltip.ts
@@ -39,6 +39,7 @@ function setContent(el: HTMLElement, options: TooltipOptions) {
 }
 
 const ARROW_SIZE = 6;
+const FADE_DURATION = 150;
 
 function createTooltipEl(options: TooltipOptions): HTMLElement {
   const el = document.createElement("div");
@@ -55,7 +56,8 @@ function createTooltipEl(options: TooltipOptions): HTMLElement {
     "line-height:1.4",
     "white-space:nowrap",
     "opacity:0",
-    "transition:opacity .15s ease",
+    "display:none",
+    `transition:opacity ${FADE_DURATION}ms ease`,
   ].join(";");
   setContent(el, options);
 
@@ -161,6 +163,8 @@ function positionTooltip(
   tooltip.style.left = `${left}px`;
 
   positionArrow(tooltip, placement);
+
+  return rect;
 }
 
 interface TooltipState {
@@ -168,30 +172,107 @@ interface TooltipState {
   options: TooltipOptions;
   showHandler: () => void;
   hideHandler: () => void;
-  scrollHandler: () => void;
-  scrollParents: EventTarget[];
+  focusHandler: () => void;
+  fadeFrame: number;
+  hideTimer: number;
+  anchorRect: DOMRect | null;
 }
 
 const stateMap = new WeakMap<HTMLElement, TooltipState>();
 
-function getScrollParents(el: HTMLElement): EventTarget[] {
-  const parents: EventTarget[] = [window];
-  let current: HTMLElement | null = el.parentElement;
+// Only one tooltip is ever on screen, so a single anchor watcher and one set of
+// global listeners cover whichever is currently up.
+let activeEl: HTMLElement | null = null;
+let watchFrame = 0;
 
-  while (current) {
-    const { overflow, overflowX, overflowY } = getComputedStyle(current);
-    if (/(auto|scroll|overlay)/.test(overflow + overflowX + overflowY)) {
-      parents.push(current);
+function anchorMoved(previous: DOMRect, next: DOMRect) {
+  return (
+    Math.abs(next.top - previous.top) > 0.5 ||
+    Math.abs(next.left - previous.left) > 0.5 ||
+    Math.abs(next.width - previous.width) > 0.5 ||
+    Math.abs(next.height - previous.height) > 0.5
+  );
+}
+
+// A tooltip is only ever correct for the anchor's current box. Scrolling and
+// reflow move that box, and an anchor can be hidden or torn down outside Vue
+// without ever firing a leave event — in which case the tooltip would be left
+// hanging in mid-air.
+function watchAnchor() {
+  watchFrame = requestAnimationFrame(() => {
+    watchFrame = 0;
+
+    const el = activeEl;
+    if (!el) return;
+
+    const state = stateMap.get(el);
+    if (!state?.tooltipEl || !state.anchorRect) return;
+
+    const rect = el.getBoundingClientRect();
+    if (!el.isConnected || (!rect.width && !rect.height)) {
+      hide(el);
+      return;
     }
-    current = current.parentElement;
+
+    if (anchorMoved(state.anchorRect, rect)) {
+      state.anchorRect = positionTooltip(
+        el,
+        state.tooltipEl,
+        state.options.placement,
+      );
+    }
+
+    watchAnchor();
+  });
+}
+
+function onPointerOver(event: Event) {
+  const el = activeEl;
+  if (!el) return;
+
+  const target = event.target as Node | null;
+  if (target && (el === target || el.contains(target))) return;
+
+  hide(el);
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape" && activeEl) hide(activeEl);
+}
+
+function onWindowHide() {
+  if (activeEl) hide(activeEl);
+}
+
+function addGlobalListeners() {
+  document.addEventListener("pointerover", onPointerOver, true);
+  document.addEventListener("keydown", onKeydown, true);
+  document.addEventListener("visibilitychange", onWindowHide);
+  window.addEventListener("blur", onWindowHide);
+}
+
+function removeGlobalListeners() {
+  document.removeEventListener("pointerover", onPointerOver, true);
+  document.removeEventListener("keydown", onKeydown, true);
+  document.removeEventListener("visibilitychange", onWindowHide);
+  window.removeEventListener("blur", onWindowHide);
+}
+
+function deactivate() {
+  if (watchFrame) {
+    cancelAnimationFrame(watchFrame);
+    watchFrame = 0;
   }
 
-  return parents;
+  activeEl = null;
+  removeGlobalListeners();
 }
 
 function show(el: HTMLElement) {
   const state = stateMap.get(el);
-  if (!state || !state.options.content) return;
+  if (!state || !state.options.content || !el.isConnected) return;
+
+  if (activeEl && activeEl !== el) hide(activeEl);
 
   if (!state.tooltipEl) {
     state.tooltipEl = createTooltipEl(state.options);
@@ -204,56 +285,86 @@ function show(el: HTMLElement) {
   setContent(tip, state.options);
   if (arrow) tip.appendChild(arrow);
 
+  window.clearTimeout(state.hideTimer);
+
   // Measure at 0 opacity
   tip.style.opacity = "0";
   tip.style.display = "block";
 
-  positionTooltip(el, tip, state.options.placement);
+  state.anchorRect = positionTooltip(el, tip, state.options.placement);
+
+  activeEl = el;
+  addGlobalListeners();
 
   // Fade in
-  requestAnimationFrame(() => {
+  if (state.fadeFrame) cancelAnimationFrame(state.fadeFrame);
+  state.fadeFrame = requestAnimationFrame(() => {
+    state.fadeFrame = 0;
+    // A hide within the same frame must win, otherwise the tooltip fades back
+    // in with nothing left to dismiss it.
+    if (activeEl !== el) return;
     tip.style.opacity = "1";
   });
 
-  state.scrollParents = getScrollParents(el);
-  for (const parent of state.scrollParents) {
-    parent.addEventListener("scroll", state.scrollHandler, { passive: true });
-  }
+  if (!watchFrame) watchAnchor();
 }
 
 function hide(el: HTMLElement) {
+  if (activeEl === el) deactivate();
+
   const state = stateMap.get(el);
   if (!state?.tooltipEl) return;
 
-  state.tooltipEl.style.opacity = "0";
-
-  for (const parent of state.scrollParents) {
-    parent.removeEventListener("scroll", state.scrollHandler);
+  if (state.fadeFrame) {
+    cancelAnimationFrame(state.fadeFrame);
+    state.fadeFrame = 0;
   }
-  state.scrollParents = [];
+
+  const tip = state.tooltipEl;
+  tip.style.opacity = "0";
+  state.anchorRect = null;
+
+  window.clearTimeout(state.hideTimer);
+  state.hideTimer = window.setTimeout(() => {
+    tip.style.display = "none";
+  }, FADE_DURATION);
 }
 
 function cleanup(el: HTMLElement) {
   const state = stateMap.get(el);
   if (!state) return;
 
+  if (activeEl === el) deactivate();
+
   el.removeEventListener("mouseenter", state.showHandler);
   el.removeEventListener("mouseleave", state.hideHandler);
   el.removeEventListener("pointerleave", state.hideHandler);
   el.removeEventListener("click", state.hideHandler);
-  el.removeEventListener("focus", state.showHandler);
+  el.removeEventListener("focus", state.focusHandler);
   el.removeEventListener("blur", state.hideHandler);
 
-  for (const parent of state.scrollParents) {
-    parent.removeEventListener("scroll", state.scrollHandler);
-  }
+  if (state.fadeFrame) cancelAnimationFrame(state.fadeFrame);
+  window.clearTimeout(state.hideTimer);
 
   state.tooltipEl?.remove();
   stateMap.delete(el);
 }
 
+// Pointer focus already gets the tooltip from `mouseenter`; showing it on every
+// focus also pops one up when focus is restored after a modal closes, far away
+// from the cursor.
+function isKeyboardFocus(el: HTMLElement) {
+  try {
+    return el.matches(":focus-visible");
+  } catch {
+    return true;
+  }
+}
+
 const vTooltip: Directive = {
   mounted(el: HTMLElement, binding: DirectiveBinding) {
+    cleanup(el);
+
     const options = parseBinding(binding);
 
     const state: TooltipState = {
@@ -261,8 +372,12 @@ const vTooltip: Directive = {
       options,
       showHandler: () => show(el),
       hideHandler: () => hide(el),
-      scrollHandler: () => hide(el),
-      scrollParents: [],
+      focusHandler: () => {
+        if (isKeyboardFocus(el)) show(el);
+      },
+      fadeFrame: 0,
+      hideTimer: 0,
+      anchorRect: null,
     };
 
     stateMap.set(el, state);
@@ -271,7 +386,7 @@ const vTooltip: Directive = {
     el.addEventListener("mouseleave", state.hideHandler);
     el.addEventListener("pointerleave", state.hideHandler);
     el.addEventListener("click", state.hideHandler);
-    el.addEventListener("focus", state.showHandler);
+    el.addEventListener("focus", state.focusHandler);
     el.addEventListener("blur", state.hideHandler);
   },
 


### PR DESCRIPTION
Tooltips could stay on screen with nothing left to dismiss them — hanging in mid-air after the element they belonged to had moved or gone away.

## Causes

Four separate paths in `v-tooltip` could strand one:

1. **rAF race** — the fade-in set `opacity: 1` inside a `requestAnimationFrame`. A `mouseleave` or `click` in the same frame set opacity 0 first, then the frame fired and turned it back on.
2. **Focus restore** — `focus` unconditionally showed the tooltip, so when a modal closed and the browser returned focus to the button that opened it, a tooltip appeared with the cursor nowhere near it.
3. **Anchor moving or vanishing** — dismissal relied on `mouseleave` plus scroll listeners on the ancestors measured at show time. A grid reflow after a delete, a `v-show`, or a teardown outside Vue never fires a leave event, so the tooltip stayed at the anchor's old fixed position.
4. **`hide` never fully hid** — it only set `opacity: 0`, leaving a stale-positioned element in the DOM that any later opacity write brought back.

## Changes

- The fade-in frame is guarded by the active-tooltip identity and cancelled on hide, so a same-frame hide wins.
- `focus` only shows on `:focus-visible` — pointer clicks no longer re-show, keyboard navigation still does.
- `getScrollParents` and the per-parent scroll listeners are replaced by a single rAF anchor watcher that repositions the tooltip while the anchor moves (scroll, reflow, hover transforms) and hides it as soon as the anchor is disconnected or measures 0×0.
- Global dismissal while visible: capture-phase `pointerover` outside the anchor, `Escape`, window `blur`, `visibilitychange`.
- Only one tooltip is ever on screen; `hide` sets `display: none` after the fade; `mounted` cleans up any prior state on the same element.

## Tests

New `Tooltip.spec.ts` with 10 cases — 7 of them fail against the previous implementation. Full frontend suite passes (232 tests), typecheck and Prettier clean.

🤖
