### PR TITLE
fix(setup): isolate worktree Redis databases and stop slots drifting

### DIFF
--- a/app/lib/api_usage_tracker.rb
+++ b/app/lib/api_usage_tracker.rb
@@ -76,7 +76,7 @@ class ApiUsageTracker
     private def store
       @store ||= ActiveSupport::Cache::RedisCacheStore.new(
         url: Rails.configuration.redis.url,
-        db: 1,
+        db: Rails.configuration.redis.api_usage_db,
         namespace:
       )
     end

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require "fileutils"
 require "json"
-require "zlib"
 require "open3"
 
 APP_ROOT = File.expand_path("..", __dir__)
@@ -107,30 +106,71 @@ def link_shared_paths(main_root)
   end
 end
 
-# A worktree owns one slot, and a slot owns the adjacent port pair
-# (base + 2N, base + 2N + 1). Deriving both ports from a single slot is what
-# keeps one worktree's Vite port from landing on another's Rails port. The base
-# clears the shared Postgres/Redis containers and the main checkout's own ports,
-# so only worktrees ever compete for this range.
+# A worktree owns one slot, and that slot owns the adjacent port pair
+# (base + 2N, base + 2N + 1) and the Redis database (base + N). Deriving all
+# three from a single number is what keeps one worktree's Vite port off another's
+# Rails port, and what stops two worktrees from sharing a Redis database. The
+# port base clears the shared Postgres/Redis containers and the main checkout's
+# own ports, so only worktrees ever compete for this range.
 PORT_SLOT_BASE = 8300
-PORT_SLOTS = 200
+PORT_SLOTS = 32
 
-# Redis 0 belongs to the main checkout, and the shared container runs the
-# default `databases 16`, so worktrees have 1..15 to share.
-REDIS_DATABASES = 15
+# Each checkout owns a band of consecutive Redis databases, one per subsystem —
+# config/redis.yml maps the offsets. The main checkout leaves REDIS_DB unset and
+# takes the first band, so worktrees start after it. The top of the range
+# (REDIS_DB_BASE + PORT_SLOTS * REDIS_DBS_PER_CHECKOUT) has to stay under the
+# `--databases` docker-compose.yml starts the shared Redis with, or a high slot
+# gets an index Redis rejects at runtime with `ERR DB index is out of range`.
+REDIS_DBS_PER_CHECKOUT = 6
+REDIS_DB_BASE = REDIS_DBS_PER_CHECKOUT
 
 def slot_ports(slot)
   first = PORT_SLOT_BASE + (slot * 2)
   [first, first + 1]
 end
 
-# Every other worktree's assignment, whichever scheme wrote it. Values are read
-# rather than recomputed so a sibling holding a legacy (pre-slot) pair still
-# blocks the slot that overlaps it.
-def claims_by_siblings
-  out, status = Open3.capture2("git", "-C", APP_ROOT, "worktree", "list", "--porcelain")
-  return {ports: [], redis_dbs: []} unless status.success?
+def slot_redis_db(slot)
+  REDIS_DB_BASE + (slot * REDIS_DBS_PER_CHECKOUT)
+end
 
+def slot_redis_dbs(slot)
+  base = slot_redis_db(slot)
+  base...(base + REDIS_DBS_PER_CHECKOUT)
+end
+
+def slot_in_range(slot)
+  slot if slot && (0...PORT_SLOTS).cover?(slot)
+end
+
+# The slot a worktree currently holds, read from its `.env.local`. Worktrees set
+# up before the slot was recorded have no WORKTREE_SLOT line, so fall back to
+# deriving it from the port they are still serving on. A pair that maps to no
+# slot at all — one below the base, or one left over from a wider range — yields
+# nothing here, and only its raw ports get reserved.
+def recorded_slot(body)
+  explicit = slot_in_range(body[/^WORKTREE_SLOT=(\d+)/, 1]&.to_i)
+  return explicit if explicit
+
+  port = body[/^PORT=(\d+)/, 1]&.to_i
+  return nil unless port
+
+  offset = port - PORT_SLOT_BASE
+  slot_in_range(offset / 2) if offset >= 0 && offset.even?
+end
+
+# Every worktree's recorded assignment, ours included. Slots are read rather than
+# recomputed so we can keep the one we already hold. Raw ports and Redis database
+# indexes are collected alongside them because the two used to be allocated by
+# separate hashes: a worktree set up that way sits on a port implying one slot
+# and a database implying another, so reserving only the slot its port maps to
+# would leave the database its Sidekiq is still draining free for the taker of
+# the overlapping band.
+def worktree_claims
+  out, status = Open3.capture2("git", "-C", APP_ROOT, "worktree", "list", "--porcelain")
+  return {own_slot: nil, slots: [], ports: [], redis_dbs: []} unless status.success?
+
+  own_slot = nil
+  slots = []
   ports = []
   redis_dbs = []
 
@@ -138,33 +178,46 @@ def claims_by_siblings
     next unless line.start_with?("worktree ")
 
     root = line.split(" ", 2).last.strip
-    next if root == APP_ROOT
-
     env_path = File.join(root, ".env.local")
     next unless File.file?(env_path)
 
     body = File.read(env_path)
+
+    # Compared by inode rather than string: `git worktree list` may report a
+    # path that resolves to APP_ROOT without matching it character for
+    # character, and mistaking our own claim for a sibling's would move us off
+    # the slot we are trying to keep.
+    if File.identical?(root, APP_ROOT)
+      own_slot = recorded_slot(body)
+      next
+    end
+
+    slot = recorded_slot(body)
+    slots << slot if slot
     ports.concat([body[/^PORT=(\d+)/, 1], body[/^VITE_RUBY_PORT=(\d+)/, 1]].compact.map(&:to_i))
     redis_db = body[/^REDIS_DB=(\d+)/, 1]
     redis_dbs << redis_db.to_i if redis_db
   end
 
-  {ports:, redis_dbs:}
+  {own_slot:, slots:, ports:, redis_dbs:}
 end
 
-# crc32 alone hands identical ports to any two names that share a residue, and
-# whichever worktree booted second then failed to bind. The hash now only picks
-# where to start looking, so a name keeps a stable slot while taken ones get
-# skipped.
-def allocate_port_slot(name, claimed)
-  start = Zlib.crc32(name) % PORT_SLOTS
-
-  PORT_SLOTS.times do |offset|
-    slot = (start + offset) % PORT_SLOTS
-    return slot if (slot_ports(slot) & claimed).empty?
+# Keep the slot we already hold, so ports and the Redis database never move under
+# a running server — a re-run only gives it up if a sibling turns out to hold it
+# too. New worktrees take the lowest free slot, which reuses whatever a removed
+# worktree left behind and keeps the Redis database index small.
+def allocate_slot(claims)
+  free = lambda do |slot|
+    !claims[:slots].include?(slot) &&
+      (slot_ports(slot) & claims[:ports]).empty? &&
+      claims[:redis_dbs].none? { |db| slot_redis_dbs(slot).cover?(db) }
   end
 
-  abort "All #{PORT_SLOTS} worktree port slots are taken. Free one, or pass --port and --vite-port."
+  own = claims[:own_slot]
+  return own if own && free.call(own)
+
+  PORT_SLOTS.times.find(&free) ||
+    abort("All #{PORT_SLOTS} worktree slots are taken. Free one, or pass --port and --vite-port.")
 end
 
 def sanitize_worktree_name(name)
@@ -181,25 +234,6 @@ end
 
 def worktree_db_suffix(name)
   "_wt_#{sanitize_worktree_name(name)}"
-end
-
-# Every worktree points at the one shared Redis container, so the database index
-# is what keeps their Sidekiq queues, cache entries and sessions apart. Folding
-# the 200 port slots onto 15 indexes collided immediately — four of the six
-# worktrees here shared a database while nine sat unused. As with the port slot
-# the hash now only picks where to start looking, so indexes a sibling already
-# holds get skipped and two worktrees share one only once all 15 are spoken for.
-def allocate_redis_db(name, claimed)
-  start = Zlib.crc32(name) % REDIS_DATABASES
-
-  REDIS_DATABASES.times do |offset|
-    db = 1 + ((start + offset) % REDIS_DATABASES)
-    return db unless claimed.include?(db)
-  end
-
-  fallback = 1 + start
-  puts "   All #{REDIS_DATABASES} Redis databases are claimed — sharing DB #{fallback} with another worktree."
-  fallback
 end
 
 def write_superset_ports(port, vite_port)
@@ -232,8 +266,9 @@ def write_managed_env(filename, managed_body)
   File.write(path, user_content + "#{WORKTREE_MARKER}\n" + managed_body)
 end
 
-def write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix: nil)
+def write_env_local(slot, port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix: nil)
   write_managed_env(".env.local", <<~ENV)
+    WORKTREE_SLOT=#{slot}
     PORT=#{port}
     DB_PORT=#{db_port}
     REDIS_URL=redis://localhost:#{redis_port}
@@ -271,9 +306,9 @@ if ARGV.include?("--help") || ARGV.include?("-h")
     Options:
       --fresh         Wipe application state (Docker volumes) before setup
                       WARNING: affects all worktrees (shared Docker services)
-      --name=NAME     Override the worktree name used for DB suffix, ports, etc.
-      --port=N        Override the Rails port (default: derived from name)
-      --vite-port=N   Override the Vite dev server port (default: derived from name)
+      --name=NAME     Override the worktree name used for the DB suffix, cookies, etc.
+      --port=N        Override the Rails port (default: derived from the slot)
+      --vite-port=N   Override the Vite dev server port (default: derived from the slot)
       --dev           Start the development server after setup
       --dev-<flag>    Forward --<flag> to bin/dev (e.g. --dev-docker, --dev-open)
       --verbose       Show full command output (default: concise status lines)
@@ -297,18 +332,18 @@ FileUtils.chdir APP_ROOT do
     # Scanning the siblings and writing our own claim have to happen under one
     # lock, or a concurrent setup reads the range before we appear in it.
     with_allocation_lock do
-      claims = claims_by_siblings
-      slot = allocate_port_slot(effective_name, claims[:ports])
+      slot = allocate_slot(worktree_claims)
       slot_port, slot_vite_port = slot_ports(slot)
       port = PORT_OVERRIDE || slot_port
       db_port = worktree_db_port(effective_name)
       redis_port = worktree_redis_port(effective_name)
       vite_port = VITE_PORT_OVERRIDE || slot_vite_port
       db_suffix = worktree_db_suffix(effective_name)
-      redis_db = allocate_redis_db(effective_name, claims[:redis_dbs])
+      redis_db = slot_redis_db(slot)
 
       if VERBOSE
         puts "== Worktree detected: #{wt_name}#{" (as #{effective_name})" if NAME_OVERRIDE} =="
+        puts "   Slot:        #{slot}"
         puts "   Rails port:  #{port}#{" (override)" if PORT_OVERRIDE}"
         puts "   Vite port:   #{vite_port}#{" (override)" if VITE_PORT_OVERRIDE}"
         puts "   DB port:     #{db_port}"
@@ -316,11 +351,11 @@ FileUtils.chdir APP_ROOT do
         puts "   Redis DB:    #{redis_db}"
         puts "   DB suffix:   #{db_suffix}"
       else
-        puts "  Worktree: #{effective_name} (port #{port})"
+        puts "  Worktree: #{effective_name} (slot #{slot}, port #{port})"
       end
 
       cookie_prefix = "FLTYRD_WT_#{sanitize_worktree_name(effective_name)}"
-      write_env_local(port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix:)
+      write_env_local(slot, port, db_port, redis_port, vite_port, db_suffix, redis_db, cookie_prefix:)
       write_env_test_local(db_port, db_suffix)
       puts "   Wrote .env.local and .env.test.local" if VERBOSE
     end

--- a/bin/setup
+++ b/bin/setup
@@ -107,21 +107,21 @@ def link_shared_paths(main_root)
 end
 
 # A worktree owns one slot, and that slot owns the adjacent port pair
-# (base + 2N, base + 2N + 1) and the Redis database (base + N). Deriving all
-# three from a single number is what keeps one worktree's Vite port off another's
-# Rails port, and what stops two worktrees from sharing a Redis database. The
-# port base clears the shared Postgres/Redis containers and the main checkout's
-# own ports, so only worktrees ever compete for this range.
+# (base + 2N, base + 2N + 1) and a band of Redis databases. Deriving all of them
+# from a single number is what keeps one worktree's Vite port off another's Rails
+# port, and what stops two worktrees from sharing a Redis database. The port base
+# clears the shared Postgres/Redis containers and the main checkout's own ports,
+# so only worktrees ever compete for this range.
 PORT_SLOT_BASE = 8300
-PORT_SLOTS = 32
+PORT_SLOTS = 200
 
-# Each checkout owns a band of consecutive Redis databases, one per subsystem —
-# config/redis.yml maps the offsets. The main checkout leaves REDIS_DB unset and
-# takes the first band, so worktrees start after it. The top of the range
+# Each checkout owns a band of consecutive Redis databases; config/redis.yml maps
+# each subsystem to an offset within it. The main checkout leaves REDIS_DB unset
+# and takes the first band, so worktrees start after it. The top of the range
 # (REDIS_DB_BASE + PORT_SLOTS * REDIS_DBS_PER_CHECKOUT) has to stay under the
 # `--databases` docker-compose.yml starts the shared Redis with, or a high slot
 # gets an index Redis rejects at runtime with `ERR DB index is out of range`.
-REDIS_DBS_PER_CHECKOUT = 6
+REDIS_DBS_PER_CHECKOUT = 4
 REDIS_DB_BASE = REDIS_DBS_PER_CHECKOUT
 
 def slot_ports(slot)

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,12 @@
 production: &default
   adapter: redis
   url: <%= Rails.configuration.redis.url %>
-  channel_prefix: fleetyards_<%= Rails.env %>
+  # Scopes keyed data written over this connection, such as presence sets.
+  db: <%= Rails.configuration.redis.cable_db %>
+  # Broadcasts need the prefix as well: PUBLISH/SUBSCRIBE are server-wide rather
+  # than per-database, so `db` alone would still let worktrees receive each
+  # other's messages.
+  channel_prefix: fleetyards_<%= Rails.env %><%= ENV["WORKTREE_SUFFIX"] %>
 
 staging:
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,13 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :redis_cache_store, {url: Rails.configuration.redis.url, db: Rails.configuration.redis.db}
+    # Namespaced so `Rails.cache.clear` deletes by prefix; an un-namespaced
+    # RedisCacheStore clears with FLUSHDB, which takes the whole database.
+    config.cache_store = :redis_cache_store, {
+      url: Rails.configuration.redis.url,
+      db: Rails.configuration.redis.cache_db,
+      namespace: "fleetyards-#{Rails.env}"
+    }
 
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"

--- a/config/environments/devenv.rb
+++ b/config/environments/devenv.rb
@@ -28,7 +28,13 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :redis_cache_store, {url: Rails.configuration.redis.url, db: Rails.configuration.redis.db}
+    # Namespaced so `Rails.cache.clear` deletes by prefix; an un-namespaced
+    # RedisCacheStore clears with FLUSHDB, which takes the whole database.
+    config.cache_store = :redis_cache_store, {
+      url: Rails.configuration.redis.url,
+      db: Rails.configuration.redis.cache_db,
+      namespace: "fleetyards-#{Rails.env}"
+    }
 
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,10 +92,11 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use Redis for caching (DB 1 to isolate from sessions/Sidekiq/Action Cable on DB 0)
+  # Use Redis for caching on its own database, isolated from sessions, Sidekiq
+  # and Action Cable — see config/redis.yml for the full band layout.
   config.cache_store = :redis_cache_store, {
     url: Rails.configuration.redis.url,
-    db: 1,
+    db: Rails.configuration.redis.cache_db,
     namespace: "fleetyards-#{Rails.env}",
     expires_in: 1.day
   }

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,7 +6,7 @@ Rack::Attack.cache.store =
   else
     ActiveSupport::Cache::RedisCacheStore.new(
       url: Rails.configuration.redis.url,
-      db: 1,
+      db: Rails.configuration.redis.rack_attack_db,
       namespace: "rack-attack"
     )
   end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -8,7 +8,7 @@ cookie_domain = Rails.configuration.app.cookie_domain
 cookie_domain = :all if cookie_domain.to_s == "all"
 
 session_store_options = {
-  servers: "#{Rails.configuration.redis.url}/#{Rails.configuration.redis.db}/fleetyards-#{Rails.env}-session",
+  servers: "#{Rails.configuration.redis.url}/#{Rails.configuration.redis.session_db}/fleetyards-#{Rails.env}-session",
   key: Rails.configuration.cookie_prefix,
   domain: cookie_domain,
   secure: Rails.env.production? || Rails.env.staging?,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,7 +4,7 @@ require "sidekiq/web"
 require "sidekiq-scheduler/web"
 require "sidekiq-failures"
 
-sidekiq_config = {url: Rails.configuration.redis.url, db: Rails.configuration.redis.db}
+sidekiq_config = {url: Rails.configuration.redis.url, db: Rails.configuration.redis.sidekiq_db}
 
 Sidekiq.configure_server do |config|
   config.redis = sidekiq_config

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,19 +1,27 @@
 <% base = (ENV["REDIS_DB"] || 0).to_i %>
 # Each checkout owns a contiguous band of Redis databases starting at REDIS_DB,
-# and every subsystem takes a fixed offset within it. One index per subsystem
-# rather than one shared index, so a keyspace-wide operation on one — a cache
-# clear, a flush — cannot reach another's data. bin/setup hands each worktree a
-# band of its own (see PORT_SLOTS / REDIS_DBS_PER_CHECKOUT there); the main
-# checkout leaves REDIS_DB unset and takes the first band.
+# and every subsystem takes a fixed offset within it. bin/setup hands each
+# worktree a band of its own (see PORT_SLOTS / REDIS_DBS_PER_CHECKOUT there), so
+# their queues, sessions and cache entries cannot mix; the main checkout leaves
+# REDIS_DB unset and takes the first band.
 #
-# Offsets are append-only: renumbering one migrates live data, and moving the
-# session index logs every user out.
+# Sidekiq gets an offset to itself: its queues are the one keyspace another
+# subsystem's bulk operation must never be able to touch, and its keys are not
+# namespaced. It holds offset +0 so that its absolute index in production does
+# not move — renumbering it would strand whatever sits in `queue:*`, `retry` and
+# `schedule` at cutover, and dropped jobs fail silently and permanently, where a
+# reassigned session index merely costs everyone one login.
+#
+# The subsystems sharing offset +1 are each namespaced, and Rails clears a
+# namespaced cache with a prefix scan rather than FLUSHDB, so none of them can
+# reach another's keys. +1 keeps the index production already uses too, so the
+# rate-limit and usage counters survive a deploy.
 shared:
   url: <%= ENV["REDIS_URL"] || "redis://localhost:8272" %>
   db: <%= base %>
   sidekiq_db: <%= base %>
   cache_db: <%= base + 1 %>
+  rack_attack_db: <%= base + 1 %>
+  api_usage_db: <%= base + 1 %>
   session_db: <%= base + 2 %>
-  rack_attack_db: <%= base + 3 %>
-  cable_db: <%= base + 4 %>
-  api_usage_db: <%= base + 5 %>
+  cable_db: <%= base + 3 %>

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,19 @@
+<% base = (ENV["REDIS_DB"] || 0).to_i %>
+# Each checkout owns a contiguous band of Redis databases starting at REDIS_DB,
+# and every subsystem takes a fixed offset within it. One index per subsystem
+# rather than one shared index, so a keyspace-wide operation on one — a cache
+# clear, a flush — cannot reach another's data. bin/setup hands each worktree a
+# band of its own (see PORT_SLOTS / REDIS_DBS_PER_CHECKOUT there); the main
+# checkout leaves REDIS_DB unset and takes the first band.
+#
+# Offsets are append-only: renumbering one migrates live data, and moving the
+# session index logs every user out.
 shared:
-  url: <%= ENV["REDIS_URL"] || 'redis://localhost:8272' %>
-  db: <%= ENV["REDIS_DB"] || 0 %>
+  url: <%= ENV["REDIS_URL"] || "redis://localhost:8272" %>
+  db: <%= base %>
+  sidekiq_db: <%= base %>
+  cache_db: <%= base + 1 %>
+  session_db: <%= base + 2 %>
+  rack_attack_db: <%= base + 3 %>
+  cable_db: <%= base + 4 %>
+  api_usage_db: <%= base + 5 %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       - postgres:/var/lib/postgresql/data
   redis:
     image: redis:7.2.15-alpine
+    # Every worktree shares this container and keeps its Sidekiq queues, cache,
+    # sessions and counters apart by database index — bin/setup gives each one a
+    # band and config/redis.yml maps the offsets within it. Redis defaults to 16
+    # databases, far fewer than that range needs, and an index above the count
+    # fails with `ERR DB index is out of range`. Must stay above bin/setup's
+    # REDIS_DB_BASE + PORT_SLOTS * REDIS_DBS_PER_CHECKOUT.
+    command: redis-server --databases 1024
     ports:
       - 8272:6379
     volumes:


### PR DESCRIPTION
Worktrees picked their port slot and their Redis database from two independent `crc32(name)` probes, and recomputed the slot on every run instead of reading back what they already held. Separately, Sidekiq, the cache and the session store all read the single `db` from `config/redis.yml`, so they shared one index — and two other consumers hardcoded `db: 1` on top of it.

### Slot allocation

- **A re-run could move a running worktree.** The probe walked forward from `crc32(name)` past taken slots but never read the worktree's own `.env.local`, so one that had been pushed to `start+1` walked back to `start` once the sibling holding it went away — moving its ports and Redis databases out from under a running server. `WORKTREE_SLOT` is now recorded and kept, given up only when a sibling turns out to hold it too.
- **Redis databases were handed out twice over.** Folding the port slots onto the 15 available databases collided immediately, and the fallback knowingly gave out one another worktree already held, printing a line and carrying on. Two worktrees' Sidekiq processes then consumed each other's jobs, which nothing announces. Ports and the Redis band now derive from the one slot number.
- **A legacy worktree occupies two slots at once.** Because the port and the database were probed separately, one slot comes from its port and another from the band holding the database it is still using. Reserving only the former leaves that database free for whoever takes the overlapping band, so a sibling's recorded `REDIS_DB` now reserves the band containing it regardless of what its port maps to.

New worktrees take the lowest free slot, so a removed worktree's slot is reused with no cleanup step, and no worktree with a slot already in range is renumbered by this change.

### Database layout

Each checkout owns a band starting at `REDIS_DB`, and each subsystem takes a fixed offset in it:

| Offset | Subsystem | Main checkout | Was |
|---|---|---|---|
| +0 | Sidekiq | 0 | 0 — unchanged |
| +1 | Rails cache | 1 | 1 — unchanged |
| +1 | Rack::Attack | 1 | 1 (hardcoded) — unchanged |
| +1 | ApiUsageTracker | 1 | 1 (hardcoded) — unchanged |
| +2 | Sessions | 2 | 0 |
| +3 | Action Cable | 3 | 0 |

**Sidekiq gets an offset to itself** — its queues are the keyspace no other subsystem's bulk operation may touch, and its keys carry no namespace. The stores sharing +1 are each namespaced (`fleetyards-<env>`, `rack-attack`, and ApiUsageTracker's own), and `RedisCacheStore#clear` deletes by prefix scan when a namespace is set rather than issuing `FLUSHDB` — so sharing that index cannot let one reach another's keys.

The dev and devenv cache stores gained the `namespace` they were missing, which is what made the shared index dangerous rather than merely untidy: without one, `Rails.cache.clear` was a `FLUSHDB` that took that checkout's queued jobs and sessions with it.

Offsets are chosen so the absolute indexes that matter in production don't move. Sidekiq keeps 0 because renumbering it would strand whatever sits in `queue:*`, `retry` and `schedule` at cutover — dropped jobs fail silently and permanently, and only manual key migration recovers them. The counters keep 1 so they survive a deploy. Sessions absorb the one move, because a reassigned session index costs everyone a single login and strands nothing.

Action Cable additionally takes `WORKTREE_SUFFIX` in its `channel_prefix`. Its `db` scopes keyed data such as presence sets, but `PUBLISH`/`SUBSCRIBE` are server-wide rather than per-database, so without the prefix one worktree's broadcasts reach another's browsers.

### ✅ Verification

`ruby -c` and `bin/rubocop` clean across all nine Ruby files. App boots resolving `sidekiq=0 cache=1 rack_attack=1 api_usage=1 session=2 cable=3`. 20 tests pass across `api_usage_tracker`, `rate_limit` and both `sessions` suites.

A 14-check layout harness asserts the production indexes that must not move, that nothing shares Sidekiq's index, that no index appears in two worktree bands, and that the top index (803) fits `--databases 1024`.

Allocation exercised against real git worktrees (34 checks): sequential fill, gap reuse after removal, slot stability across re-runs, no downward drift when a sibling is freed, slot inferred from a legacy `PORT`, out-of-range slots dropped, a legacy worktree occupying two slots at once with the claimant skipping the band that holds its live database, sibling conflict resolution, and exhaustion aborting cleanly.

Concurrency proven with 8 real git worktrees claiming at once, with a negative control confirming the test is live:

```
with the lock:     claimed slots [0, 1, 2, 3, 4, 5, 6, 7]
without the lock:  claimed slots [0, 0, 0, 0, 0, 0, 0, 0]
```

### ⚠️ Deploy note

Sessions move from database 0 to 2, so this logs every user out once. That is the deliberate trade: the alternative layouts either leave sessions sharing Sidekiq's keyspace, or move Sidekiq and silently drop whatever is queued at cutover.

🤖
