### PR TITLE
feat(supporters): link a contribution to a user account

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/supporter_contribution_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/supporter_contribution_input.rb
@@ -17,7 +17,8 @@ module Admin
               recurring: {type: :boolean},
               startedAt: {type: :string, format: :date},
               endedAt: {type: :string, format: :date},
-              note: {type: :string}
+              note: {type: :string},
+              userId: {type: [:string, :null], format: :uuid}
             },
             additionalProperties: false,
             required: %w[amountCents startedAt]

--- a/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
@@ -19,6 +19,9 @@ module Admin
               startedAtLteq: {type: :string, format: :date},
               endedAtGteq: {type: :string, format: :date},
               endedAtLteq: {type: :string, format: :date},
+              userIdEq: {type: :string, format: :uuid},
+              userIdNull: {type: :boolean},
+              userUsernameCont: {type: :string},
               sorts: {anyOf: [{
                 type: :array, items: {"$ref": "#/components/schemas/SupporterContributionSortEnum"}
               }, {

--- a/app/api_components/admin/v1/schemas/queries/user_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/user_query.rb
@@ -11,6 +11,7 @@ module Admin
             type: :object,
             properties: {
               searchCont: {type: :string},
+              idEq: {type: :string, format: :uuid},
               usernameCont: {type: :string},
               usernameEq: {type: :string},
               emailCont: {type: :string},

--- a/app/api_components/admin/v1/schemas/supporter_contribution.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution.rb
@@ -20,6 +20,8 @@ module Admin
             startedAt: {type: :string, format: :date},
             endedAt: {type: :string, format: :date},
             note: {type: :string},
+            userId: {type: :string, format: :uuid},
+            user: {"$ref": "#/components/schemas/UserOption"},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },

--- a/app/api_components/v1/schemas/support_progress.rb
+++ b/app/api_components/v1/schemas/support_progress.rb
@@ -46,6 +46,7 @@ module V1
               type: :object,
               properties: {
                 displayName: {type: :string},
+                username: {type: :string},
                 amountCents: {type: :integer},
                 currency: {type: :string},
                 recurring: {type: :boolean}

--- a/app/api_components/v1/schemas/user_public.rb
+++ b/app/api_components/v1/schemas/user_public.rb
@@ -20,10 +20,11 @@ module V1
           homepage: {type: :string},
           publicHangarLoaners: {type: :boolean},
           publicHangarStats: {type: :boolean},
-          publicWishlist: {type: :boolean}
+          publicWishlist: {type: :boolean},
+          supporter: {type: :boolean}
         },
         additionalProperties: false,
-        required: %w[username publicHangarLoaners publicHangarStats publicWishlist]
+        required: %w[username publicHangarLoaners publicHangarStats publicWishlist supporter]
       })
     end
   end

--- a/app/controllers/admin/api/v1/supporter_contributions_controller.rb
+++ b/app/controllers/admin/api/v1/supporter_contributions_controller.rb
@@ -18,6 +18,7 @@ module Admin
           q = SupporterContribution.ransack(supporter_contribution_query_params)
 
           @supporter_contributions = q.result(distinct: true)
+            .includes(:user)
             .page(params[:page])
             .per(per_page(SupporterContribution))
         end
@@ -84,7 +85,7 @@ module Admin
         private def supporter_contribution_params
           @supporter_contribution_params ||= params.permit(
             :name, :amount_cents, :currency, :anonymous, :recurring,
-            :started_at, :ended_at, :note
+            :started_at, :ended_at, :note, :user_id
           )
         end
 
@@ -92,6 +93,7 @@ module Admin
           @supporter_contribution_query_params ||= params.permit(q: [
             :name_cont, :name_eq, :recurring_eq, :anonymous_eq, :source_eq,
             :started_at_gteq, :started_at_lteq, :ended_at_gteq, :ended_at_lteq,
+            :user_id_eq, :user_id_null, :user_username_cont,
             :sorts, sorts: []
           ]).fetch(:q, {})
         end

--- a/app/controllers/admin/api/v1/users_controller.rb
+++ b/app/controllers/admin/api/v1/users_controller.rb
@@ -83,7 +83,7 @@ module Admin
 
         private def user_query_params
           @user_query_params ||= params.permit(q: [
-            :search_cont, :username_cont, :username_eq, :email_cont, :rsi_handle_cont, :sorts,
+            :id_eq, :search_cont, :username_cont, :username_eq, :email_cont, :rsi_handle_cont, :sorts,
             id_in: [], username_in: [], email_in: [], rsi_handle_in: [], sorts: []
           ]).fetch(:q, {})
         end

--- a/app/controllers/api/v1/supporters_controller.rb
+++ b/app/controllers/api/v1/supporters_controller.rb
@@ -11,7 +11,8 @@ module Api
         today = Date.current
         @goals = FundingGoal.active_for_month(today)
         @monthly_total = SupporterContribution.monthly_total(today)
-        @contributions = SupporterContribution.active_in(today.beginning_of_month, today.end_of_month)
+        @contributions = SupporterContribution.active_now(today)
+          .includes(:user)
           .order(started_at: :desc, created_at: :desc)
       end
     end

--- a/app/frontend/admin/components/SupporterContributions/FilterForm/index.vue
+++ b/app/frontend/admin/components/SupporterContributions/FilterForm/index.vue
@@ -10,6 +10,7 @@ import RadioList from "@/shared/components/base/RadioList/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
+import UserFilterGroup from "@/admin/components/base/UserFilterGroup/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type SupporterContributionQuery } from "@/services/fyAdminApi";
 import { useSupporterContributionFilters } from "@/admin/composables/useSupporterContributionFilters";
@@ -19,6 +20,19 @@ const { booleanOptions } = useFilterOptions();
 
 const { t } = useI18n();
 
+// userIdNull is inverted from the reader's point of view: "linked" means the
+// column is *not* null.
+const linkedOptions = [
+  {
+    label: t("labels.filters.supporterContributions.linkedOnly"),
+    value: "false",
+  },
+  {
+    label: t("labels.filters.supporterContributions.unlinkedOnly"),
+    value: "true",
+  },
+];
+
 const prefillFormValues = () => {
   return {
     nameCont: filters.value.nameCont,
@@ -26,6 +40,8 @@ const prefillFormValues = () => {
     anonymousEq: filters.value.anonymousEq,
     startedAtGteq: filters.value.startedAtGteq,
     startedAtLteq: filters.value.startedAtLteq,
+    userIdEq: filters.value.userIdEq,
+    userIdNull: filters.value.userIdNull,
   };
 };
 
@@ -79,6 +95,23 @@ watch(
       :reset-label="t('labels.all')"
       :options="booleanOptions"
       name="anonymousEq"
+    />
+
+    <UserFilterGroup
+      v-model="form.userIdEq"
+      :label="t('labels.filters.supporterContributions.user')"
+      :no-label="false"
+      :multiple="false"
+      value-attr="id"
+      name="userIdEq"
+    />
+
+    <RadioList
+      v-model="form.userIdNull"
+      :label="t('labels.filters.supporterContributions.linked')"
+      :reset-label="t('labels.all')"
+      :options="linkedOptions"
+      name="userIdNull"
     />
 
     <FormDatePicker

--- a/app/frontend/admin/components/base/UserFilterGroup/index.vue
+++ b/app/frontend/admin/components/base/UserFilterGroup/index.vue
@@ -21,12 +21,16 @@ type Props = {
   modelValue?: string | string[];
   multiple?: boolean;
   noLabel?: boolean;
+  label?: string;
+  valueAttr?: "username" | "id";
 };
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: undefined,
   multiple: false,
   noLabel: true,
+  label: undefined,
+  valueAttr: "username",
 });
 
 const { t } = useI18n();
@@ -57,7 +61,7 @@ const formatter = (response: UserOptions) => {
   return response.items.map((user) => {
     return {
       label: user.username,
-      value: user.username,
+      value: user[props.valueAttr],
     };
   });
 };
@@ -70,7 +74,13 @@ const fetch = async (params: FilterGroupParams<UserOption>) => {
   }
 
   if (params.missing) {
-    if (props.multiple) {
+    if (props.valueAttr === "id") {
+      if (props.multiple) {
+        q.idIn = params.missing as string[];
+      } else {
+        q.idEq = params.missing as string;
+      }
+    } else if (props.multiple) {
       q.usernameIn = params.missing as string[];
     } else {
       q.usernameEq = params.missing as string;
@@ -87,7 +97,7 @@ const fetch = async (params: FilterGroupParams<UserOption>) => {
 <template>
   <FilterGroup
     v-model="internalValue"
-    :label="t('labels.selectUser')"
+    :label="label || t('labels.selectUser')"
     :search-label="t('labels.findUser')"
     :query-fn="fetch"
     :query-response-formatter="formatter"

--- a/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
+++ b/app/frontend/admin/pages/supporter-contributions/[id]/edit.vue
@@ -21,6 +21,7 @@ import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormToggle from "@/shared/components/base/FormToggle/index.vue";
 import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
+import UserFilterGroup from "@/admin/components/base/UserFilterGroup/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { toCents } from "@/shared/utils/currencyHelpers";
@@ -47,6 +48,7 @@ type FormValues = {
   anonymous: boolean;
   note?: string;
   currency?: string;
+  userId?: string;
 };
 
 const initialValues = ref<FormValues>({
@@ -58,6 +60,7 @@ const initialValues = ref<FormValues>({
   anonymous: props.supporterContribution.anonymous,
   note: props.supporterContribution.note,
   currency: props.supporterContribution.currency,
+  userId: props.supporterContribution.userId,
 });
 
 const validationSchema = {
@@ -77,6 +80,7 @@ const [endedAt, endedAtProps] = defineField("endedAt");
 const [recurring, recurringProps] = defineField("recurring");
 const [anonymous, anonymousProps] = defineField("anonymous");
 const [note, noteProps] = defineField("note");
+const [userId, userIdProps] = defineField("userId");
 
 const submitting = ref(false);
 
@@ -109,6 +113,7 @@ const onSubmit = handleSubmit(async (values) => {
     anonymous: values.anonymous,
     note: values.note || undefined,
     currency: values.currency,
+    userId: values.userId || null,
   };
 
   await updateMutation
@@ -186,6 +191,15 @@ const handleCancel = async () => {
           v-bind="anonymousProps"
           translation-key="supporterContribution.anonymous"
           name="anonymous"
+        />
+        <UserFilterGroup
+          v-model="userId"
+          v-bind="userIdProps"
+          :label="t('labels.supporterContribution.user')"
+          :no-label="false"
+          :multiple="false"
+          value-attr="id"
+          name="userId"
         />
         <FormTextarea
           v-model="note"

--- a/app/frontend/admin/pages/supporter-contributions/create.vue
+++ b/app/frontend/admin/pages/supporter-contributions/create.vue
@@ -19,6 +19,7 @@ import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormToggle from "@/shared/components/base/FormToggle/index.vue";
 import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
+import UserFilterGroup from "@/admin/components/base/UserFilterGroup/index.vue";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { todayIsoDateLocal } from "@/shared/utils/dateHelpers";
@@ -39,6 +40,7 @@ type FormValues = {
   recurring: boolean;
   anonymous: boolean;
   note?: string;
+  userId?: string;
 };
 
 const validationSchema = {
@@ -66,6 +68,7 @@ const [endedAt, endedAtProps] = defineField("endedAt");
 const [recurring, recurringProps] = defineField("recurring");
 const [anonymous, anonymousProps] = defineField("anonymous");
 const [note, noteProps] = defineField("note");
+const [userId, userIdProps] = defineField("userId");
 
 const submitting = ref(false);
 
@@ -90,6 +93,7 @@ const onSubmit = handleSubmit(async (values) => {
     recurring: values.recurring,
     anonymous: values.anonymous,
     note: values.note || undefined,
+    userId: values.userId || undefined,
   };
 
   await createMutation
@@ -163,6 +167,15 @@ const handleCancel = async () => {
           v-bind="anonymousProps"
           translation-key="supporterContribution.anonymous"
           name="anonymous"
+        />
+        <UserFilterGroup
+          v-model="userId"
+          v-bind="userIdProps"
+          :label="t('labels.supporterContribution.user')"
+          :no-label="false"
+          :multiple="false"
+          value-attr="id"
+          name="userId"
         />
         <FormTextarea
           v-model="note"

--- a/app/frontend/admin/pages/supporter-contributions/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/index.vue
@@ -102,6 +102,11 @@ const columns: BaseTableCol<SupporterContribution>[] = [
     sortable: false,
   },
   {
+    name: "user",
+    label: "Account",
+    mobile: false,
+  },
+  {
     name: "startedAt",
     label: "Started at",
     sortable: true,
@@ -238,6 +243,15 @@ const syncFromPatreon = () => {
         </template>
         <template #col-amount="{ record }">
           {{ formatCents(record.amountCents, record.currency) }}
+        </template>
+        <template #col-user="{ record }">
+          <router-link
+            v-if="record.user"
+            :to="{ name: 'admin-user-edit', params: { id: record.user.id } }"
+          >
+            {{ record.user.username }}
+          </router-link>
+          <span v-else>—</span>
         </template>
         <template #col-startedAt="{ record }">
           {{ l(record.startedAt, "datetime.formats.short") }}

--- a/app/frontend/frontend/components/Hangar/PublicHeading/index.scss
+++ b/app/frontend/frontend/components/Hangar/PublicHeading/index.scss
@@ -9,3 +9,9 @@
 .justify-center {
   justify-content: center;
 }
+
+.hangar-public-heading__supporter {
+  margin-left: 12px;
+  font-size: 0.6em;
+  vertical-align: middle;
+}

--- a/app/frontend/frontend/components/Hangar/PublicHeading/index.spec.ts
+++ b/app/frontend/frontend/components/Hangar/PublicHeading/index.spec.ts
@@ -1,0 +1,43 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { UserPublic } from "@/services/fyApi";
+import Component from "./index.vue";
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const user = (attributes: Partial<UserPublic>) =>
+  ({
+    username: "alice",
+    publicHangarLoaners: true,
+    publicHangarStats: true,
+    publicWishlist: true,
+    supporter: false,
+    ...attributes,
+  }) as UserPublic;
+
+const mountWith = (attributes: Partial<UserPublic>) =>
+  mount(Component, {
+    props: { user: user(attributes) },
+    global: {
+      stubs: { Avatar: true, Heading: { template: "<div><slot /></div>" } },
+      directives: { tooltip: () => {} },
+    },
+  });
+
+describe("HangarPublicHeading", () => {
+  it("badges a supporter", () => {
+    const wrapper = mountWith({ supporter: true });
+
+    expect(wrapper.get('[data-test="pill"]').text()).toContain(
+      "labels.supporter.badge",
+    );
+  });
+
+  it("leaves a non-supporter unbadged", () => {
+    const wrapper = mountWith({ supporter: false });
+
+    expect(wrapper.find('[data-test="pill"]').exists()).toBe(false);
+  });
+});

--- a/app/frontend/frontend/components/Hangar/PublicHeading/index.vue
+++ b/app/frontend/frontend/components/Hangar/PublicHeading/index.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import Avatar from "@/shared/components/Avatar/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import Pill from "@/shared/components/base/Pill/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type UserPublic } from "@/services/fyApi";
 
@@ -45,6 +46,16 @@ const props = withDefaults(defineProps<Props>(), {
       <span>
         {{ t(props.headlineKey, { user: usernamePlural }) }}
       </span>
+      <Pill
+        v-if="props.user.supporter"
+        v-tooltip="t('labels.supporter.tooltip')"
+        class="hangar-public-heading__supporter"
+        variant="success"
+        uppercase
+      >
+        <i class="fa-duotone fa-heart" />
+        {{ t("labels.supporter.badge") }}
+      </Pill>
     </div>
   </Heading>
 </template>

--- a/app/frontend/frontend/components/SupportProgress/index.scss
+++ b/app/frontend/frontend/components/SupportProgress/index.scss
@@ -24,6 +24,39 @@
     opacity: 0.7;
   }
 
+  &__thanks {
+    margin-top: 12px;
+
+    &__headline {
+      margin: 0 0 6px;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      opacity: 0.7;
+    }
+
+    &__list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px 12px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    &__item {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 0.9rem;
+    }
+
+    &__recurring {
+      font-size: 0.75rem;
+      opacity: 0.6;
+    }
+  }
+
   &--compact {
     .support-progress__header {
       font-size: 1rem;

--- a/app/frontend/frontend/components/SupportProgress/index.spec.ts
+++ b/app/frontend/frontend/components/SupportProgress/index.spec.ts
@@ -1,0 +1,102 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { SupportProgress } from "@/services/fyApi";
+
+const progress = vi.hoisted(() => ({ value: undefined as unknown }));
+
+vi.mock("@/services/fyApi", () => ({
+  useSupportersProgress: () => ({ data: progress }),
+}));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/shared/composables/useCurrencyFormat", () => ({
+  useCurrencyFormat: () => ({
+    formatCents: (cents: number, currency: string) => `${cents} ${currency}`,
+  }),
+}));
+
+import Component from "./index.vue";
+
+const RouterLinkStub = {
+  props: ["to"],
+  template: '<a :href="to.params.username"><slot /></a>',
+};
+
+const mountWith = (
+  contributions: SupportProgress["contributions"],
+  props: { compact?: boolean } = {},
+) => {
+  progress.value = {
+    monthlyTotal: { amountCents: 1000, currency: "EUR" },
+    contributions,
+  } satisfies SupportProgress;
+
+  return mount(Component, {
+    props,
+    global: {
+      stubs: { "router-link": RouterLinkStub, ProgressBar: true },
+      directives: { tooltip: () => {} },
+    },
+  });
+};
+
+const supporter = (
+  attributes: Partial<SupportProgress["contributions"][number]>,
+) => ({
+  displayName: "Alice",
+  amountCents: 500,
+  currency: "EUR",
+  recurring: false,
+  ...attributes,
+});
+
+describe("SupportProgress", () => {
+  it("links a supporter that carries a username to their hangar", () => {
+    const wrapper = mountWith([
+      supporter({ displayName: "linked", username: "linked" }),
+    ]);
+
+    const link = wrapper.get(".support-progress__thanks__item a");
+
+    expect(link.text()).toBe("linked");
+    expect(link.attributes("href")).toBe("linked");
+  });
+
+  it("renders an unlinked supporter as plain text", () => {
+    const wrapper = mountWith([supporter({ displayName: "Dora" })]);
+
+    expect(wrapper.find(".support-progress__thanks__item a").exists()).toBe(
+      false,
+    );
+    expect(wrapper.get(".support-progress__thanks__item").text()).toContain(
+      "Dora",
+    );
+  });
+
+  it("never links an anonymous supporter", () => {
+    // The payload withholds `username` for anonymous rows, so there is nothing
+    // to point at even though the entry is listed.
+    const wrapper = mountWith([supporter({ displayName: "Anonymous" })]);
+
+    expect(wrapper.find(".support-progress__thanks__item a").exists()).toBe(
+      false,
+    );
+  });
+
+  it("omits the supporter list in compact mode", () => {
+    const wrapper = mountWith([supporter({ username: "linked" })], {
+      compact: true,
+    });
+
+    expect(wrapper.find(".support-progress__thanks").exists()).toBe(false);
+  });
+
+  it("omits the supporter list when nobody contributed", () => {
+    const wrapper = mountWith([]);
+
+    expect(wrapper.find(".support-progress__thanks").exists()).toBe(false);
+  });
+});

--- a/app/frontend/frontend/components/SupportProgress/index.vue
+++ b/app/frontend/frontend/components/SupportProgress/index.vue
@@ -49,6 +49,8 @@ const formattedTotal = computed(() =>
 const formattedGoal = computed(() =>
   formatCents(goalAmount.value, currency.value),
 );
+
+const supporters = computed(() => progress.value?.contributions ?? []);
 </script>
 
 <template>
@@ -66,6 +68,34 @@ const formattedGoal = computed(() =>
     <p v-if="!compact && progress?.goal" class="support-progress__caption">
       {{ t("texts.support.thisMonth") }}
     </p>
+    <div v-if="!compact && supporters.length" class="support-progress__thanks">
+      <h4 class="support-progress__thanks__headline">
+        {{ t("headlines.supporters") }}
+      </h4>
+      <ul class="support-progress__thanks__list">
+        <li
+          v-for="(supporter, index) in supporters"
+          :key="`${supporter.displayName}-${index}`"
+          class="support-progress__thanks__item"
+        >
+          <router-link
+            v-if="supporter.username"
+            :to="{
+              name: 'hangar-public',
+              params: { username: supporter.username },
+            }"
+          >
+            {{ supporter.displayName }}
+          </router-link>
+          <span v-else>{{ supporter.displayName }}</span>
+          <i
+            v-if="supporter.recurring"
+            v-tooltip="t('labels.supporterContribution.recurring')"
+            class="fa-duotone fa-arrows-rotate support-progress__thanks__recurring"
+          />
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -263,6 +263,7 @@
       "hangarGuideEmpty": "Not much to see here?",
       "hangarGuide": "Hangar Guide",
       "support": "Support FleetYards.net",
+      "supporters": "Danke an unsere Unterstützer",
       "supportHint": {
         "hangarSync": "Schön, dass dir der Sync hilft",
         "vehicleAdded": "Dein Hangar wächst",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -4,6 +4,10 @@
       "true": "Ja",
       "false": "Nein",
       "null": "-",
+      "supporter": {
+        "badge": "Unterstützer",
+        "tooltip": "Unterstützt FleetYards.net diesen Monat"
+      },
       "and": "und",
       "hide": "Verbergen",
       "show": "Anzeigen",
@@ -558,6 +562,7 @@
       },
       "supporterContribution": {
         "name": "Unterstützer-Name",
+        "user": "Verknüpftes Konto",
         "amount": "Betrag",
         "currency": "Währung",
         "anonymous": "Anonym",
@@ -995,7 +1000,11 @@
           "recurring": "Wiederkehrend",
           "anonymous": "Anonym",
           "startedAtGteq": "Beginnt ab",
-          "startedAtLteq": "Beginnt bis"
+          "startedAtLteq": "Beginnt bis",
+          "user": "Verknüpftes Konto",
+          "linked": "Konto-Verknüpfung",
+          "linkedOnly": "Verknüpft",
+          "unlinkedOnly": "Nicht verknüpft"
         },
         "images": {
           "station": "Station",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -270,6 +270,7 @@
       "hangarGuideEmpty": "Not much to see here?",
       "hangarGuide": "Hangar Guide",
       "support": "Support FleetYards.net",
+      "supporters": "Thanks to our supporters",
       "supportHint": {
         "hangarSync": "Glad we could help with your sync",
         "vehicleAdded": "Your hangar is growing",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -4,6 +4,10 @@
       "true": "Yes",
       "false": "No",
       "null": "-",
+      "supporter": {
+        "badge": "Supporter",
+        "tooltip": "Supports FleetYards.net this month"
+      },
       "destroyedFleets": {
         "discarded": "Discarded",
         "purged": "Purged"
@@ -827,6 +831,7 @@
       },
       "supporterContribution": {
         "name": "Supporter Name",
+        "user": "Linked Account",
         "amount": "Amount",
         "currency": "Currency",
         "anonymous": "Anonymous",
@@ -1394,7 +1399,11 @@
           "recurring": "Recurring",
           "anonymous": "Anonymous",
           "startedAtGteq": "Started from",
-          "startedAtLteq": "Started until"
+          "startedAtLteq": "Started until",
+          "user": "Linked account",
+          "linked": "Account link",
+          "linkedOnly": "Linked",
+          "unlinkedOnly": "Not linked"
         },
         "adminNotifications": {
           "search": "Search"

--- a/app/models/supporter_contribution.rb
+++ b/app/models/supporter_contribution.rb
@@ -19,15 +19,24 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  patreon_member_id   :string
+#  user_id             :uuid
 #
 # Indexes
 #
 #  index_supporter_contributions_on_patreon_member_id       (patreon_member_id) UNIQUE WHERE (patreon_member_id IS NOT NULL)
 #  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
 #  index_supporter_contributions_on_started_at              (started_at)
+#  index_supporter_contributions_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class SupporterContribution < ApplicationRecord
   paginates_per 30
+
+  # Touch so a linked account's cached public profile picks the badge up.
+  belongs_to :user, optional: true, touch: true
 
   DEFAULT_SORTING_PARAMS = "started_at desc"
   ALLOWED_SORTING_PARAMS = [
@@ -43,9 +52,12 @@ class SupporterContribution < ApplicationRecord
   validates :amount_cents, presence: true, numericality: {greater_than: 0, only_integer: true}
   validates :currency, presence: true
   validates :started_at, presence: true
+  validates :user, presence: true, if: :user_id?
   validate :ended_at_after_started_at
 
   before_validation :force_anonymous_when_name_blank
+
+  scope :active_now, ->(date = Date.current) { active_in(date.beginning_of_month, date.end_of_month) }
 
   scope :active_in, ->(month_start, month_end) {
     where(
@@ -60,18 +72,16 @@ class SupporterContribution < ApplicationRecord
     [
       "name", "amount_cents", "currency", "anonymous", "recurring",
       "started_at", "ended_at", "note", "source", "patreon_member_id",
-      "created_at", "updated_at", "id"
+      "created_at", "updated_at", "id", "user_id"
     ]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    []
+    ["user"]
   end
 
   def self.monthly_total(date = Date.current)
-    month_start = date.beginning_of_month
-    month_end = date.end_of_month
-    active_in(month_start, month_end).sum(:amount_cents)
+    active_now(date).sum(:amount_cents)
   end
 
   def formatted_amount
@@ -79,7 +89,23 @@ class SupporterContribution < ApplicationRecord
   end
 
   def display_name
-    name.presence || I18n.t("messages.supporter_contributions.anonymous_name")
+    name.presence || user&.username || I18n.t("messages.supporter_contributions.anonymous_name")
+  end
+
+  # Nil whenever the contribution must not be attributed publicly, so callers
+  # can fall back to their own anonymous wording.
+  def public_name
+    return if anonymous?
+
+    name.presence || user&.username
+  end
+
+  # Only usernames with a reachable public hangar, otherwise the profile link
+  # we render would land on a 404.
+  def public_profile_username
+    return if anonymous?
+
+    user&.username if user&.public_hangar?
   end
 
   private def ended_at_after_started_at
@@ -90,6 +116,6 @@ class SupporterContribution < ApplicationRecord
   end
 
   private def force_anonymous_when_name_blank
-    self.anonymous = true if name.blank?
+    self.anonymous = true if name.blank? && user_id.blank?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,10 @@ class User < ApplicationRecord
   has_many :oauth_applications, class_name: "Oauth::Application", as: :owner
   has_many :omniauth_connections, dependent: :destroy
 
+  # Nullify, never destroy: a deleted account must not erase the bookkeeping for
+  # money that was actually received.
+  has_many :supporter_contributions, dependent: :nullify
+
   has_many :access_grants,
     class_name: "Oauth::AccessGrant",
     foreign_key: :resource_owner_id,
@@ -194,14 +198,16 @@ class User < ApplicationRecord
     [
       "confirmed_at", "created_at", "current_sign_in_at", "discord", "email",
       "guilded", "hangar_updated_at", "homepage", "last_active_at", "last_sign_in_at", "locale",
-      "rsi_handle", "twitch", "updated_at", "username", "wanted_vehicles_count", "youtube", "search"
+      "id", "rsi_handle", "twitch", "updated_at", "username", "wanted_vehicles_count", "youtube",
+      "search"
     ]
   end
 
   def self.ransackable_associations(auth_object = nil)
     [
       "fleet_memberships", "fleets", "manufacturers", "models", "public_models", "public_vehicles",
-      "purchased_vehicles", "vehicle_modules", "vehicle_upgrades", "vehicles", "wanted_vehicles"
+      "purchased_vehicles", "supporter_contributions", "vehicle_modules", "vehicle_upgrades",
+      "vehicles", "wanted_vehicles"
     ]
   end
 
@@ -304,6 +310,18 @@ class User < ApplicationRecord
 
   def placeholder_email?
     email.ends_with?("@users.noreply.fleetyards.net")
+  end
+
+  # Gate perks on this one: it ignores anonymity, so an anonymous supporter keeps
+  # whatever their contribution earns them.
+  def supporter?
+    supporter_contributions.active_now.exists?
+  end
+
+  # Safe to expose: an anonymous contribution must not out its supporter, so the
+  # public badge only reflects the ones cleared for attribution.
+  def public_supporter?
+    supporter_contributions.active_now.where(anonymous: false).exists?
   end
 
   def reset_password(new_password, new_password_confirmation)

--- a/app/views/admin/api/v1/supporter_contributions/_base.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/_base.jbuilder
@@ -12,4 +12,11 @@ json.started_at supporter_contribution.started_at.iso8601
 json.ended_at supporter_contribution.ended_at&.iso8601 if supporter_contribution.ended_at.present?
 json.note supporter_contribution.note if supporter_contribution.note.present?
 
+if supporter_contribution.user.present?
+  json.user_id supporter_contribution.user_id
+  json.user do
+    json.partial! "admin/api/v1/users/option", user: supporter_contribution.user
+  end
+end
+
 json.partial! "api/shared/dates", record: supporter_contribution

--- a/app/views/admin/api/v1/supporter_contributions/_supporter_contribution.jbuilder
+++ b/app/views/admin/api/v1/supporter_contributions/_supporter_contribution.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", supporter_contribution] do
+json.cache! ["v1", supporter_contribution, supporter_contribution.user] do
   json.partial!("admin/api/v1/supporter_contributions/base", supporter_contribution:)
 end

--- a/app/views/api/v1/public/users/_base.jbuilder
+++ b/app/views/api/v1/public/users/_base.jbuilder
@@ -15,3 +15,4 @@ json.homepage user.homepage
 json.public_hangar_loaners user.public_hangar_loaners
 json.public_hangar_stats user.public_hangar_stats
 json.public_wishlist user.public_wishlist
+json.supporter user.public_supporter?

--- a/app/views/api/v1/public/users/_user.jbuilder
+++ b/app/views/api/v1/public/users/_user.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", user] do
+json.cache! ["v1", user, Date.current.beginning_of_month] do
   json.partial!("api/v1/public/users/base", user:)
 end

--- a/app/views/api/v1/supporters/progress.jbuilder
+++ b/app/views/api/v1/supporters/progress.jbuilder
@@ -22,7 +22,10 @@ json.monthly_total do
 end
 
 json.contributions @contributions do |contribution|
-  json.display_name contribution.anonymous? ? "Anonymous" : contribution.name
+  profile_username = contribution.public_profile_username
+
+  json.display_name contribution.public_name || "Anonymous"
+  json.username profile_username if profile_username.present?
   json.amount_cents contribution.amount_cents
   json.currency contribution.currency
   json.recurring contribution.recurring

--- a/db/migrate/20260820120000_add_user_to_supporter_contributions.rb
+++ b/db/migrate/20260820120000_add_user_to_supporter_contributions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserToSupporterContributions < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :supporter_contributions, :user, type: :uuid, foreign_key: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1040,9 +1040,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
     t.string "source_currency"
     t.date "started_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id"
     t.index ["patreon_member_id"], name: "index_supporter_contributions_on_patreon_member_id", unique: true, where: "(patreon_member_id IS NOT NULL)"
     t.index ["recurring", "ended_at"], name: "index_supporter_contributions_on_recurring_and_ended_at"
     t.index ["started_at"], name: "index_supporter_contributions_on_started_at"
+    t.index ["user_id"], name: "index_supporter_contributions_on_user_id"
   end
 
   create_table "task_forces", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -1253,6 +1255,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "omniauth_connections", "users"
+  add_foreign_key "supporter_contributions", "users"
   add_foreign_key "vehicle_loadout_hardpoints", "components"
   add_foreign_key "vehicle_loadout_hardpoints", "model_hardpoints"
   add_foreign_key "vehicle_loadout_hardpoints", "vehicle_loadouts"

--- a/swagger/admin/v1/oasdiff-ignore.txt
+++ b/swagger/admin/v1/oasdiff-ignore.txt
@@ -5,3 +5,5 @@ POST /images the 'size' response's property type/format changed from 'integer'/'
 PUT /images/{id} the 'size' response's property type/format changed from 'integer'/'' to 'number'/'' for status '200'
 POST /features api removed without deprecation
 DELETE /features/{id} api removed without deprecation
+POST /supporter-contributions removed the required property `details` from the response with the `400` status
+POST /supporter-contributions removed the required property `error` from the response with the `400` status

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6147,6 +6147,12 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SupporterContribution"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
         '403':
           description: forbidden
           content:
@@ -6159,8 +6165,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
-        '400':
-          "$ref": "#/components/responses/SchemaValidationError"
     get:
       summary: Supporter Contributions list
       tags:
@@ -14493,6 +14497,11 @@ components:
           format: date
         note:
           type: string
+        userId:
+          type: string
+          format: uuid
+        user:
+          "$ref": "#/components/schemas/UserOption"
         createdAt:
           type: string
           format: date-time
@@ -14532,6 +14541,11 @@ components:
           format: date
         note:
           type: string
+        userId:
+          type:
+          - string
+          - 'null'
+          format: uuid
       additionalProperties: false
       required:
       - amountCents
@@ -14594,6 +14608,13 @@ components:
         endedAtLteq:
           type: string
           format: date
+        userIdEq:
+          type: string
+          format: uuid
+        userIdNull:
+          type: boolean
+        userUsernameCont:
+          type: string
         sorts:
           anyOf:
           - type: array
@@ -14823,6 +14844,9 @@ components:
       properties:
         searchCont:
           type: string
+        idEq:
+          type: string
+          format: uuid
         usernameCont:
           type: string
         usernameEq:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -15577,6 +15577,8 @@ components:
             properties:
               displayName:
                 type: string
+              username:
+                type: string
               amountCents:
                 type: integer
               currency:
@@ -15834,12 +15836,15 @@ components:
           type: boolean
         publicWishlist:
           type: boolean
+        supporter:
+          type: boolean
       additionalProperties: false
       required:
       - username
       - publicHangarLoaners
       - publicHangarStats
       - publicWishlist
+      - supporter
       title: UserPublic
     UserSortEnum:
       type: string

--- a/test/factories/supporter_contributions.rb
+++ b/test/factories/supporter_contributions.rb
@@ -19,12 +19,18 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  patreon_member_id   :string
+#  user_id             :uuid
 #
 # Indexes
 #
 #  index_supporter_contributions_on_patreon_member_id       (patreon_member_id) UNIQUE WHERE (patreon_member_id IS NOT NULL)
 #  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
 #  index_supporter_contributions_on_started_at              (started_at)
+#  index_supporter_contributions_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :supporter_contribution do

--- a/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
@@ -66,6 +66,18 @@ class Admin::Api::V1::SupporterContributionsStatsTest < ActionDispatch::Integrat
     end
   end
 
+  test "GET /supporter-contributions/stats narrows to one linked account" do
+    supporter = create(:user)
+    create(:supporter_contribution, user: supporter, amount_cents: 500)
+    create(:supporter_contribution, amount_cents: 1_000)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"userIdEq" => supporter.id}} do
+      assert_equal 500, parsed_body["totalAmountCents"]
+      assert_equal 1, parsed_body["totalCount"]
+    end
+  end
+
   test "GET /supporter-contributions/stats returns 401 when not signed in" do
     assert_api_response :get, 401
   end

--- a/test/integration/admin/api/v1/supporter_contributions_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_test.rb
@@ -20,6 +20,10 @@ class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTe
         schema "$ref": "#/components/schemas/SupporterContribution"
       end
 
+      response(400, "bad request") do
+        schema "$ref": "#/components/schemas/ValidationError"
+      end
+
       response(403, "forbidden") do
         schema "$ref": "#/components/schemas/StandardError"
       end
@@ -150,6 +154,27 @@ class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTe
     end
   end
 
+  test "POST /supporter-contributions links the contribution to a user" do
+    user = create(:user)
+    sign_in @user
+
+    body = {amountCents: 500, startedAt: Date.current.iso8601, userId: user.id}
+
+    assert_api_response :post, 200, body: body do
+      assert_equal user.id, parsed_body["userId"]
+      assert_equal user.username, parsed_body["user"]["username"]
+      assert_equal false, parsed_body["anonymous"]
+    end
+  end
+
+  test "POST /supporter-contributions rejects a userId with no account" do
+    sign_in @user
+
+    body = {amountCents: 500, startedAt: Date.current.iso8601, userId: SecureRandom.uuid}
+
+    assert_api_response :post, 400, body: body
+  end
+
   test "POST /supporter-contributions returns 401 when not signed in" do
     assert_api_response :post, 401, body: {amountCents: 100, startedAt: Date.current.iso8601}
   end
@@ -176,6 +201,39 @@ class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTe
 
     assert_api_response :get, 200, params: {q: {"recurringEq" => true}} do
       assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /supporter-contributions filters by userIdEq" do
+    user = create(:user)
+    create(:supporter_contribution, user:)
+    create_list(:supporter_contribution, 2)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"userIdEq" => user.id}} do
+      assert_equal 1, parsed_body["items"].count
+      assert_equal user.username, parsed_body["items"].first["user"]["username"]
+    end
+  end
+
+  test "GET /supporter-contributions filters by userUsernameCont" do
+    user = create(:user, username: "supporterone")
+    create(:supporter_contribution, user:)
+    create_list(:supporter_contribution, 2)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"userUsernameCont" => "supporteron"}} do
+      assert_equal 1, parsed_body["items"].count
+    end
+  end
+
+  test "GET /supporter-contributions filters the unlinked ones by userIdNull" do
+    create(:supporter_contribution, user: create(:user))
+    create_list(:supporter_contribution, 2)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"userIdNull" => true}} do
+      assert_equal 2, parsed_body["items"].count
     end
   end
 
@@ -247,6 +305,18 @@ class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTe
 
     assert_api_response :put, 200, path_params: {id: contribution.id}, body: {name: "Updated Name", amountCents: 999, startedAt: Date.current.iso8601} do
       assert_equal "Updated Name", parsed_body["name"]
+    end
+  end
+
+  test "PUT /supporter-contributions/:id clears the link when userId is null" do
+    contribution = create(:supporter_contribution, user: create(:user))
+    sign_in @user
+
+    body = {amountCents: 500, startedAt: Date.current.iso8601, userId: nil}
+
+    assert_api_response :put, 200, path_params: {id: contribution.id}, body: body do
+      refute parsed_body.key?("userId")
+      assert_nil contribution.reload.user_id
     end
   end
 

--- a/test/integration/api/v1/public_users_show_test.rb
+++ b/test/integration/api/v1/public_users_show_test.rb
@@ -33,6 +33,32 @@ class Api::V1::PublicUsersShowTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /public/users/:username flags a supporter" do
+    user = create(:user, :public_hangar)
+    create(:supporter_contribution, user:, started_at: Date.current)
+
+    assert_api_response :get, 200, path_params: {username: user.username} do
+      assert_equal true, parsed_body["supporter"]
+    end
+  end
+
+  test "GET /public/users/:username does not flag an anonymous supporter" do
+    user = create(:user, :public_hangar)
+    create(:supporter_contribution, :anonymous, user:, started_at: Date.current)
+
+    assert_api_response :get, 200, path_params: {username: user.username} do
+      assert_equal false, parsed_body["supporter"]
+    end
+  end
+
+  test "GET /public/users/:username does not flag a plain user" do
+    user = create(:user, :public_hangar)
+
+    assert_api_response :get, 200, path_params: {username: user.username} do
+      assert_equal false, parsed_body["supporter"]
+    end
+  end
+
   test "GET /public/users/:username returns 404 when hangar is private" do
     user = create(:user, :private_hangar)
 

--- a/test/integration/api/v1/supporters_progress_test.rb
+++ b/test/integration/api/v1/supporters_progress_test.rb
@@ -50,6 +50,42 @@ class Api::V1::SupportersProgressTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /supporters/progress attributes a linked contribution to its profile" do
+    user = create(:user, :public_hangar, username: "linkedsupporter")
+    create(:supporter_contribution, name: nil, anonymous: false, user:, amount_cents: 700, started_at: Date.current)
+
+    assert_api_response :get, 200 do
+      entry = parsed_body["contributions"].find { |c| c["amountCents"] == 700 }
+
+      assert_equal "linkedsupporter", entry["displayName"]
+      assert_equal "linkedsupporter", entry["username"]
+    end
+  end
+
+  test "GET /supporters/progress keeps the name but omits the link for a private hangar" do
+    user = create(:user, :private_hangar)
+    create(:supporter_contribution, name: "Dora", user:, amount_cents: 800, started_at: Date.current)
+
+    assert_api_response :get, 200 do
+      entry = parsed_body["contributions"].find { |c| c["amountCents"] == 800 }
+
+      assert_equal "Dora", entry["displayName"]
+      refute entry.key?("username")
+    end
+  end
+
+  test "GET /supporters/progress never links an anonymous contribution" do
+    user = create(:user, :public_hangar)
+    create(:supporter_contribution, :anonymous, name: "Erin", user:, amount_cents: 900, started_at: Date.current)
+
+    assert_api_response :get, 200 do
+      entry = parsed_body["contributions"].find { |c| c["amountCents"] == 900 }
+
+      assert_equal "Anonymous", entry["displayName"]
+      refute entry.key?("username")
+    end
+  end
+
   test "GET /supporters/progress works without an active goal" do
     assert_api_response :get, 200 do
       assert_nil parsed_body["goal"]

--- a/test/models/supporter_contribution_test.rb
+++ b/test/models/supporter_contribution_test.rb
@@ -19,12 +19,18 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  patreon_member_id   :string
+#  user_id             :uuid
 #
 # Indexes
 #
 #  index_supporter_contributions_on_patreon_member_id       (patreon_member_id) UNIQUE WHERE (patreon_member_id IS NOT NULL)
 #  index_supporter_contributions_on_recurring_and_ended_at  (recurring,ended_at)
 #  index_supporter_contributions_on_started_at              (started_at)
+#  index_supporter_contributions_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require "test_helper"
 
@@ -96,6 +102,60 @@ class SupporterContributionTest < ActiveSupport::TestCase
   test "source defaults to manual" do
     assert_equal "manual", SupporterContribution.new.source
     assert SupporterContribution.new.manual?
+  end
+
+  test "rejects a user_id that points at no account" do
+    record = SupporterContribution.new(
+      amount_cents: 100,
+      started_at: Date.current,
+      user_id: SecureRandom.uuid
+    )
+
+    refute record.valid?
+    assert_includes record.errors.attribute_names, :user
+  end
+
+  test "a linked contribution keeps a blank name attributable" do
+    user = create(:user)
+    contribution = create(:supporter_contribution, name: nil, anonymous: false, user:)
+
+    refute contribution.anonymous?
+    assert_equal user.username, contribution.public_name
+  end
+
+  test "an explicit name wins over the linked username" do
+    user = create(:user)
+    contribution = create(:supporter_contribution, name: "Alice", user:)
+
+    assert_equal "Alice", contribution.public_name
+  end
+
+  test "anonymous withholds both the name and the profile link" do
+    user = create(:user, :public_hangar)
+    contribution = create(:supporter_contribution, :anonymous, name: "Alice", user:)
+
+    assert_nil contribution.public_name
+    assert_nil contribution.public_profile_username
+  end
+
+  test "the profile link only points at reachable hangars" do
+    public_user = create(:user, :public_hangar)
+    private_user = create(:user, :private_hangar)
+
+    assert_equal public_user.username,
+      create(:supporter_contribution, user: public_user).public_profile_username
+    assert_nil create(:supporter_contribution, user: private_user).public_profile_username
+    assert_nil create(:supporter_contribution).public_profile_username
+  end
+
+  test ".active_now spans the month around the given date" do
+    in_month = create(:supporter_contribution, started_at: Date.new(2026, 6, 10))
+    next_month = create(:supporter_contribution, started_at: Date.new(2026, 7, 2))
+
+    ids = SupporterContribution.active_now(Date.new(2026, 6, 15)).pluck(:id)
+
+    assert_includes ids, in_month.id
+    refute_includes ids, next_month.id
   end
 
   test "patreon scope and enum select source-tagged rows" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -154,6 +154,49 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  class SupporterTest < UserTest
+    setup do
+      @user = create(:user)
+    end
+
+    test "a live contribution makes the user a supporter" do
+      create(:supporter_contribution, user: @user, started_at: Date.current)
+
+      assert @user.supporter?
+      assert @user.public_supporter?
+    end
+
+    test "an anonymous contribution still earns supporter status but no public badge" do
+      create(:supporter_contribution, :anonymous, user: @user, started_at: Date.current)
+
+      assert @user.supporter?
+      refute @user.public_supporter?
+    end
+
+    test "a contribution that ended before this month counts for neither" do
+      create(:supporter_contribution, :recurring, user: @user,
+        started_at: 1.year.ago.to_date, ended_at: 2.months.ago.to_date)
+
+      refute @user.supporter?
+      refute @user.public_supporter?
+    end
+
+    test "an unlinked contribution belongs to nobody" do
+      create(:supporter_contribution, started_at: Date.current)
+
+      refute @user.supporter?
+    end
+
+    test "destroying the account keeps the contribution and drops the link" do
+      contribution = create(:supporter_contribution, user: @user)
+
+      assert @user.destroy
+
+      assert SupporterContribution.exists?(contribution.id)
+      assert_nil contribution.reload.user_id
+    end
+  end
+
   class UrlValidationTest < UserTest
     setup do
       @user = create(:user)


### PR DESCRIPTION
## What

A supporter contribution can now be linked to a FleetYards account. The link is admin-assigned, works for manual and Patreon-imported rows alike, and drives a supporter badge on the public profile plus profile links in the supporters list.

## Why the predicate is split in two

Anonymity and perks are different questions, so `User` answers them separately:

- **`supporter?`** — any contribution active this month, **ignoring** anonymity. This is the hook to gate perks on, so an anonymous supporter keeps whatever their contribution earns them. Not exposed anywhere.
- **`public_supporter?`** — the same, and additionally requires the contribution to be non-anonymous. This is the only one that reaches the API.

Patreon-imported rows arrive `anonymous: true`, so linking one publishes nothing until an admin also clears the flag. Attribution is opt-in.

## Data

`supporter_contributions.user_id` — nullable, indexed, FK to `users`, `dependent: :nullify`. Deleting an account drops the link but keeps the row: a closed account must not erase the bookkeeping for money that was actually received.

A `user_id` with no account behind it now fails validation rather than reaching the foreign key and turning a bad request into a 500.

## Surfaces

**Admin** — a user picker on the create and edit forms, an Account column linking through to the user, and filters for a specific account or for whether a contribution is linked at all. `UserFilterGroup` gained `valueAttr` so a form can bind the account id while existing filter usages keep binding the username.

**Public profile** — `UserPublic.supporter` drives a badge in the hangar heading.

**Supporters list** — the progress endpoint has returned a `contributions` array since it was added, but nothing ever rendered it. It now appears under the progress bar in the support modal, with each linked supporter's name pointing at their hangar.

Names come from `name`, falling back to the linked username, so linking an account and leaving the name blank attributes the contribution to the username instead of forcing it anonymous.

## Two details worth a second look

**Profile links are gated on `public_hangar?`.** `Public::UserPolicy#show?` requires it, so emitting a username for a private hangar would render a link straight to a 404.

**Two cache-invalidation paths that would otherwise silently break the badge.** `belongs_to :user, touch: true` propagates a contribution change to the cached public profile; and that profile's cache key carries the current month, because the badge turns over at the month boundary with no record changing. On the admin side, the embedded username joins the row's cache key so renaming an account cannot leave a stale row cached.

## Incidental

Ransack needed `"id"` allowed on `User` for the picker to resolve a preselected account by id. That also makes the already-declared `idIn` query parameter work, which it silently never did.

## Testing

- Backend: model coverage for the link, the two predicates, anonymity suppression, the private-hangar gate and nullify-on-destroy; integration coverage for assigning, clearing and filtering by account, and for what the public payloads do and don't reveal.
- Frontend: new specs for the supporters list (linked / unlinked / anonymous / compact) and the profile badge.
- Full backend suite passes apart from `Short::ModelCompareShareTest`, which fails the same way on `main` and passes when run alone.

🤖
