### PR TITLE
feat(fleets): calendar feeds and ICS downloads

### DIFF
--- a/app/api_components/v1/schemas/fleets/calendar_subscription.rb
+++ b/app/api_components/v1/schemas/fleets/calendar_subscription.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class CalendarSubscription
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            enabled: {type: :boolean},
+            feedUrl: {type: :string, format: :uri}
+          },
+          required: %w[enabled feedUrl],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/calendar_subscriptions_controller.rb
+++ b/app/controllers/api/v1/calendar_subscriptions_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CalendarSubscriptionsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[show]
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
+        unless: :user_signed_in?,
+        only: %i[create destroy rotate]
+
+      before_action :set_fleet
+      before_action :check_fleet_mission_builder_feature
+
+      def show
+        authorize! @fleet, to: :show?
+        render :show
+      end
+
+      def create
+        authorize! @fleet, to: :manage_calendar?
+        @fleet.ensure_calendar_feed_token!
+        render :show
+      end
+
+      def rotate
+        authorize! @fleet, to: :manage_calendar?
+        @fleet.rotate_calendar_feed_token!
+        render :show
+      end
+
+      def destroy
+        authorize! @fleet, to: :manage_calendar?
+        @fleet.clear_calendar_feed_token!
+        head :no_content
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_calendars_controller.rb
+++ b/app/controllers/api/v1/fleet_calendars_controller.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FleetCalendarsController < ::Api::BaseController
+      before_action :authenticate_user!, only: []
+      before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
+        unless: :user_signed_in?,
+        only: %i[show]
+
+      before_action :set_fleet, only: %i[show]
+      before_action :check_fleet_mission_builder_feature, only: %i[show]
+      skip_verify_authorized only: %i[ics]
+
+      def show
+        authorize! with: FleetEventPolicy, context: {fleet: @fleet}
+
+        from = parse_date(params[:from]) || Time.current.beginning_of_month
+        to = parse_date(params[:to]) || from + 35.days
+
+        one_off = @fleet.fleet_events
+          .where(archived_at: nil, recurring: false)
+          .where("starts_at >= ? AND starts_at <= ?", from, to)
+
+        recurring = @fleet.fleet_events
+          .where(archived_at: nil, recurring: true)
+          .where("starts_at <= ?", to)
+
+        entries = one_off.map { |e| [e, nil] }
+        recurring.each do |event|
+          event.occurrences(from: from, to: to).each do |occurrence|
+            entries << [event, occurrence]
+          end
+        end
+
+        @calendar_entries = entries.sort_by { |(event, occurrence)| occurrence || event.starts_at }
+      end
+
+      # Past horizon: 90 days. Calendar clients don't need the full history
+      # and a years-old feed bloats the payload for every poll.
+      FEED_PAST_HORIZON = 90.days
+
+      # Cancelled events linger with STATUS:CANCELLED for a week past their
+      # start time so subscribed clients see the strike-through, then drop
+      # entirely.
+      CANCELLED_RETENTION = 7.days
+
+      def ics
+        token = params[:token].presence || params[:t].presence
+        @fleet = Fleet.find_by!(slug: params[:fleet_slug])
+
+        if @fleet.calendar_feed_token.blank? || token != @fleet.calendar_feed_token
+          render plain: "Forbidden", status: :forbidden
+          return
+        end
+
+        now = Time.current
+        events = @fleet.fleet_events
+          .where(archived_at: nil)
+          .where("starts_at >= ?", now - FEED_PAST_HORIZON)
+          .where(
+            "status != ? OR starts_at >= ?",
+            "cancelled",
+            now - CANCELLED_RETENTION
+          )
+        ics = Calendars::IcsBuilder.new(events.to_a,
+          calendar_name: "#{@fleet.name} — Events",
+          organizer_name: @fleet.name).to_ics
+        render plain: ics, content_type: "text/calendar; charset=utf-8"
+      end
+
+      private def parse_date(value)
+        return if value.blank?
+
+        Time.zone.parse(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+
+      private def set_fleet
+        @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
+        authorize! @fleet, to: :show?
+      end
+
+      private def check_fleet_mission_builder_feature
+        return if feature_enabled?("fleet_mission_builder", @fleet)
+
+        render json: {code: "forbidden", message: "This feature is not available"}, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_calendars_controller.rb
+++ b/app/controllers/api/v1/fleet_calendars_controller.rb
@@ -56,8 +56,9 @@ module Api
 
         now = Time.current
         events = @fleet.fleet_events
+          .includes(:fleet_event_occurrence_states)
           .where(archived_at: nil)
-          .where("starts_at >= ?", now - FEED_PAST_HORIZON)
+          .starting_after(now - FEED_PAST_HORIZON)
           .where(
             "status != ? OR starts_at >= ?",
             "cancelled",

--- a/app/controllers/api/v1/fleet_events_controller.rb
+++ b/app/controllers/api/v1/fleet_events_controller.rb
@@ -8,14 +8,14 @@ module Api
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
         unless: :user_signed_in?,
-        only: %i[index show]
+        only: %i[index show ics]
       before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
         unless: :user_signed_in?,
         only: %i[create update destroy unarchive publish lock_signups unlock_signups start complete cancel skip_occurrence end_series update_occurrence]
 
       before_action :set_fleet
       before_action :check_fleet_mission_builder_feature
-      before_action :set_event, only: %i[show update destroy unarchive publish lock_signups unlock_signups start complete cancel skip_occurrence end_series update_occurrence]
+      before_action :set_event, only: %i[show update destroy unarchive publish lock_signups unlock_signups start complete cancel ics skip_occurrence end_series update_occurrence]
       before_action :set_mission, only: %i[create]
 
       def index
@@ -186,6 +186,17 @@ module Api
         @fleet_event.unarchive!
         ActiveSupport::Notifications.instrument("fleet_event.unarchived", event: @fleet_event)
         render :show
+      end
+
+      def ics
+        authorize! @fleet_event, to: :show?
+
+        ics = Calendars::IcsBuilder.new([@fleet_event],
+          calendar_name: @fleet_event.title,
+          organizer_name: @fleet.name).to_ics
+        send_data ics,
+          type: "text/calendar; charset=utf-8",
+          disposition: %(attachment; filename="#{@fleet_event.slug}.ics")
       end
 
       %i[publish lock_signups unlock_signups start complete].each do |action|

--- a/app/controllers/api/v1/me/calendar_subscriptions_controller.rb
+++ b/app/controllers/api/v1/me/calendar_subscriptions_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Me
+      class CalendarSubscriptionsController < ::Api::BaseController
+        before_action :authenticate_user!, only: []
+        before_action -> { doorkeeper_authorize! "user", "user:read" },
+          unless: :user_signed_in?,
+          only: %i[show]
+        before_action -> { doorkeeper_authorize! "user", "user:write" },
+          unless: :user_signed_in?,
+          only: %i[create destroy rotate]
+
+        skip_verify_authorized only: %i[show create destroy rotate ics]
+
+        # Personal feed: matches the per-fleet horizon and cancelled retention.
+        FEED_PAST_HORIZON = 90.days
+        CANCELLED_RETENTION = 7.days
+
+        def show
+          @user = current_resource_owner
+          render :show
+        end
+
+        def create
+          @user = current_resource_owner
+          @user.ensure_calendar_feed_token!
+          render :show
+        end
+
+        def rotate
+          @user = current_resource_owner
+          @user.rotate_calendar_feed_token!
+          render :show
+        end
+
+        def destroy
+          @user = current_resource_owner
+          @user.clear_calendar_feed_token!
+          head :no_content
+        end
+
+        def ics
+          token = params[:token].presence || params[:t].presence
+          @user = User.find_by(calendar_feed_token: token) if token.present?
+
+          unless @user
+            render plain: "Forbidden", status: :forbidden
+            return
+          end
+
+          now = Time.current
+          events = FleetEvent
+            .joins(fleet_event_signups: :fleet_membership)
+            .where(fleet_memberships: {user_id: @user.id})
+            .where(
+              fleet_event_signups: {
+                status: %w[confirmed pending tentative interested]
+              }
+            )
+            .where(archived_at: nil)
+            .where("fleet_events.starts_at >= ?", now - FEED_PAST_HORIZON)
+            .where(
+              "fleet_events.status != ? OR fleet_events.starts_at >= ?",
+              "cancelled",
+              now - CANCELLED_RETENTION
+            )
+            .distinct
+
+          ics = Calendars::IcsBuilder.new(events.to_a,
+            calendar_name: "FleetYards — My events",
+            organizer_name: "FleetYards").to_ics
+          render plain: ics, content_type: "text/calendar; charset=utf-8"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/me/calendar_subscriptions_controller.rb
+++ b/app/controllers/api/v1/me/calendar_subscriptions_controller.rb
@@ -52,15 +52,26 @@ module Api
 
           now = Time.current
           events = FleetEvent
+            .includes(:fleet_event_occurrence_states)
             .joins(fleet_event_signups: :fleet_membership)
-            .where(fleet_memberships: {user_id: @user.id})
+            # Signups outlive the membership that made them, so the feed has to
+            # ask for a membership that is still accepted and still kept.
+            # Without that, a removed member keeps pulling the fleet's private
+            # event details through a token nobody thought to revoke.
+            .where(
+              fleet_memberships: {
+                user_id: @user.id,
+                aasm_state: "accepted",
+                discarded_at: nil
+              }
+            )
             .where(
               fleet_event_signups: {
                 status: %w[confirmed pending tentative interested]
               }
             )
             .where(archived_at: nil)
-            .where("fleet_events.starts_at >= ?", now - FEED_PAST_HORIZON)
+            .starting_after(now - FEED_PAST_HORIZON)
             .where(
               "fleet_events.status != ? OR fleet_events.starts_at >= ?",
               "cancelled",

--- a/app/controllers/frontend/fleets_controller.rb
+++ b/app/controllers/frontend/fleets_controller.rb
@@ -42,6 +42,18 @@ module Frontend
       render_frontend
     end
 
+    def event
+      fleet_for_event = Fleet.find_by(slug: (params[:fleet_slug] || "").downcase)
+      fleet_event = fleet_for_event&.fleet_events&.find_by(slug: params[:event_slug])
+      if fleet_event.present?
+        @title = fleet_event.title
+        @og_type = "article"
+        @og_image = fleet_event.cover_image.attached? ? rails_blob_url(fleet_event.cover_image) : nil
+      end
+
+      render_frontend
+    end
+
     def settings
       if fleet.present?
         @title = I18n.t("title.frontend.fleet_settings", fleet: fleet.name)

--- a/app/lib/calendars/ics_builder.rb
+++ b/app/lib/calendars/ics_builder.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module Calendars
+  # Builds an iCalendar (RFC 5545) string for one or more FleetEvent records.
+  # Emits a VTIMEZONE block for each distinct non-UTC event timezone so DST-correct
+  # rendering doesn't depend on the client's TZ database.
+  class IcsBuilder
+    include Rails.application.routes.url_helpers
+
+    PRODID = "-//Fleetyards//Mission Builder//EN"
+
+    def initialize(events, calendar_name: nil, organizer_name: nil)
+      @events = Array(events).compact
+      @calendar_name = calendar_name
+      @organizer_name = organizer_name
+    end
+
+    def to_ics
+      lines = []
+      lines << "BEGIN:VCALENDAR"
+      lines << "VERSION:2.0"
+      lines << "PRODID:#{PRODID}"
+      lines << "CALSCALE:GREGORIAN"
+      lines << "METHOD:PUBLISH"
+      lines << "X-WR-CALNAME:#{escape(@calendar_name)}" if @calendar_name.present?
+      single_timezone&.then { |tz| lines << "X-WR-TIMEZONE:#{tz}" }
+
+      timezone_blocks.each { |block| lines.concat(block) }
+
+      @events.each { |event| lines.concat(event_lines(event)) }
+
+      lines << "END:VCALENDAR"
+      lines.join("\r\n") + "\r\n"
+    end
+
+    private def event_lines(event)
+      tz = event_timezone(event)
+      lines = []
+      lines << "BEGIN:VEVENT"
+      lines << "UID:#{event.external_uid}@fleetyards.net"
+      lines << "DTSTAMP:#{format_utc(event.updated_at)}"
+      lines << "LAST-MODIFIED:#{format_utc(event.updated_at)}"
+      lines << "CREATED:#{format_utc(event.created_at)}"
+      lines.concat(time_lines(event, tz))
+      lines << "SUMMARY:#{escape(event.title)}"
+      lines << "DESCRIPTION:#{escape(event.description.to_s)}" if event.description.present?
+      lines << "STATUS:#{ics_status(event.status)}"
+      lines << "CATEGORIES:#{escape(event.category.to_s.upcase)}" if event.category.present?
+      if event.location.present? || event.meetup_location.present?
+        location = [event.location, event.meetup_location].compact_blank.join(" — ")
+        lines << "LOCATION:#{escape(location)}"
+      end
+      lines << "URL:#{event_url(event)}"
+      lines << "ORGANIZER;CN=#{escape(@organizer_name)}:mailto:noreply@fleetyards.net" if @organizer_name.present?
+      lines.concat(recurrence_lines(event, tz)) if event.recurring?
+      lines << "END:VEVENT"
+      lines
+    end
+
+    private def recurrence_lines(event, tz)
+      lines = []
+      freq = case event.recurrence_interval
+      when "daily" then "FREQ=DAILY"
+      when "weekly" then "FREQ=WEEKLY"
+      when "biweekly" then "FREQ=WEEKLY;INTERVAL=2"
+      when "monthly" then "FREQ=MONTHLY"
+      end
+      return lines unless freq
+
+      rrule = freq.dup
+      if event.recurrence_until.present?
+        rrule << ";UNTIL=#{event.recurrence_until.strftime("%Y%m%d")}T235959Z"
+      elsif event.recurrence_count.present?
+        rrule << ";COUNT=#{event.recurrence_count}"
+      end
+      lines << "RRULE:#{rrule}"
+
+      Array(event.excluded_dates).each do |date|
+        d = date.is_a?(String) ? Date.parse(date) : date
+        time = event.starts_at.in_time_zone(tz || "UTC")
+        excluded_local = time.change(year: d.year, month: d.month, day: d.day)
+        lines << if tz && !UTC_IDENTIFIERS.include?(tz)
+          "EXDATE;TZID=#{tz}:#{format_local(excluded_local)}"
+        else
+          "EXDATE:#{format_utc(excluded_local)}"
+        end
+      end
+
+      lines
+    end
+
+    UTC_IDENTIFIERS = %w[UTC Etc/UTC].freeze
+
+    private def time_lines(event, tz)
+      if tz && !UTC_IDENTIFIERS.include?(tz)
+        starts = event.starts_at.in_time_zone(tz)
+        ends = (event.ends_at || event.starts_at + 1.hour).in_time_zone(tz)
+        ["DTSTART;TZID=#{tz}:#{format_local(starts)}",
+          "DTEND;TZID=#{tz}:#{format_local(ends)}"]
+      else
+        ["DTSTART:#{format_utc(event.starts_at)}",
+          "DTEND:#{format_utc(event.ends_at || event.starts_at + 1.hour)}"]
+      end
+    end
+
+    private def timezone_blocks
+      distinct_timezones.map { |tz| vtimezone_block(tz) }
+    end
+
+    private def distinct_timezones
+      @events
+        .map { |e| event_timezone(e) }
+        .compact
+        .reject { |tz| UTC_IDENTIFIERS.include?(tz) }
+        .uniq
+    end
+
+    private def event_timezone(event)
+      tz = event.timezone.presence || "UTC"
+      # ActiveSupport::TimeZone#tzinfo gives us the IANA identifier (e.g. "Europe/Berlin")
+      ActiveSupport::TimeZone[tz]&.tzinfo&.identifier || tz
+    end
+
+    private def single_timezone
+      tzs = distinct_timezones
+      tzs.first if tzs.size == 1
+    end
+
+    # Minimal VTIMEZONE: a single TZID with no DST rules. Apple Calendar,
+    # Google, and Outlook all accept this and fall back to their own TZ
+    # database for the offsets. Emitting full STANDARD/DAYLIGHT components
+    # would require RRULE generation per region — disproportionate for v1.
+    private def vtimezone_block(tz)
+      ["BEGIN:VTIMEZONE", "TZID:#{tz}", "END:VTIMEZONE"]
+    end
+
+    private def event_url(event)
+      frontend_fleet_event_url(
+        fleet_slug: event.fleet.slug,
+        event_slug: event.slug,
+        host: Rails.configuration.app.domain,
+        protocol: "https"
+      )
+    end
+
+    private def ics_status(status)
+      case status.to_s
+      when "cancelled" then "CANCELLED"
+      when "completed", "active", "locked", "open" then "CONFIRMED"
+      else "TENTATIVE"
+      end
+    end
+
+    private def format_utc(time)
+      time.utc.strftime("%Y%m%dT%H%M%SZ")
+    end
+
+    private def format_local(time)
+      time.strftime("%Y%m%dT%H%M%S")
+    end
+
+    private def escape(text)
+      text.to_s.gsub(/([,;\\])/, '\\\\\1').gsub("\n", "\\n")
+    end
+  end
+end

--- a/app/lib/calendars/ics_builder.rb
+++ b/app/lib/calendars/ics_builder.rb
@@ -27,7 +27,10 @@ module Calendars
 
       timezone_blocks.each { |block| lines.concat(block) }
 
-      @events.each { |event| lines.concat(event_lines(event)) }
+      @events.each do |event|
+        lines.concat(event_lines(event))
+        lines.concat(occurrence_override_lines(event)) if event.recurring?
+      end
 
       lines << "END:VCALENDAR"
       lines.join("\r\n") + "\r\n"
@@ -69,7 +72,11 @@ module Calendars
 
       rrule = freq.dup
       if event.recurrence_until.present?
-        rrule << ";UNTIL=#{event.recurrence_until.strftime("%Y%m%d")}T235959Z"
+        # UNTIL has to be UTC when DTSTART carries a TZID, so convert the
+        # event's local end-of-day rather than stamping 23:59:59Z, which ends
+        # the series early for every zone behind UTC.
+        until_utc = event.recurrence_until.in_time_zone(tz || "UTC").end_of_day
+        rrule << ";UNTIL=#{format_utc(until_utc)}"
       elsif event.recurrence_count.present?
         rrule << ";COUNT=#{event.recurrence_count}"
       end
@@ -77,8 +84,7 @@ module Calendars
 
       Array(event.excluded_dates).each do |date|
         d = date.is_a?(String) ? Date.parse(date) : date
-        time = event.starts_at.in_time_zone(tz || "UTC")
-        excluded_local = time.change(year: d.year, month: d.month, day: d.day)
+        excluded_local = occurrence_start(event, d, tz)
         lines << if tz && !UTC_IDENTIFIERS.include?(tz)
           "EXDATE;TZID=#{tz}:#{format_local(excluded_local)}"
         else
@@ -101,6 +107,68 @@ module Calendars
         ["DTSTART:#{format_utc(event.starts_at)}",
           "DTEND:#{format_utc(event.ends_at || event.starts_at + 1.hour)}"]
       end
+    end
+
+    # A recurring series is one VEVENT plus one override per occurrence that
+    # differs from it, tied back by RECURRENCE-ID. Without these a client shows
+    # the parent's title and location for an occurrence the organiser moved or
+    # cancelled.
+    OVERRIDABLE = %i[title description location meetup_location].freeze
+
+    private def occurrence_override_lines(event)
+      tz = event_timezone(event)
+
+      event.fleet_event_occurrence_states.filter_map { |state|
+        next if state.occurrence_date.blank?
+        next unless overridden?(state)
+
+        occurrence = occurrence_start(event, state.occurrence_date, tz)
+        next if occurrence.nil?
+
+        override_vevent(event, state, occurrence, tz)
+      }.flatten
+    end
+
+    private def overridden?(state)
+      state.cancelled? || OVERRIDABLE.any? { |attr| state.public_send(attr).present? }
+    end
+
+    private def override_vevent(event, state, occurrence, tz)
+      duration = (event.ends_at || event.starts_at + 1.hour) - event.starts_at
+      location = [state.effective(:location), state.effective(:meetup_location)]
+        .compact_blank.join(" — ")
+      status = state.cancelled? ? "cancelled" : (state.status.presence || event.status)
+
+      lines = ["BEGIN:VEVENT", "UID:#{event.external_uid}@fleetyards.net"]
+      lines << "DTSTAMP:#{format_utc(state.updated_at)}"
+      lines << "LAST-MODIFIED:#{format_utc(state.updated_at)}"
+      if tz && !UTC_IDENTIFIERS.include?(tz)
+        lines << "RECURRENCE-ID;TZID=#{tz}:#{format_local(occurrence)}"
+        lines << "DTSTART;TZID=#{tz}:#{format_local(occurrence)}"
+        lines << "DTEND;TZID=#{tz}:#{format_local(occurrence + duration)}"
+      else
+        lines << "RECURRENCE-ID:#{format_utc(occurrence)}"
+        lines << "DTSTART:#{format_utc(occurrence)}"
+        lines << "DTEND:#{format_utc(occurrence + duration)}"
+      end
+      lines << "SUMMARY:#{escape(state.effective(:title))}"
+      description = state.effective(:description)
+      lines << "DESCRIPTION:#{escape(description)}" if description.present?
+      lines << "STATUS:#{ics_status(status)}"
+      lines << "CATEGORIES:#{escape(event.category.to_s.upcase)}" if event.category.present?
+      lines << "LOCATION:#{escape(location)}" if location.present?
+      lines << "URL:#{event_url(event)}"
+      lines << "ORGANIZER;CN=#{escape(@organizer_name)}:mailto:noreply@fleetyards.net" if @organizer_name.present?
+      lines << "END:VEVENT"
+      lines
+    end
+
+    # The parent's time of day, moved onto the occurrence's date in its zone.
+    private def occurrence_start(event, date, tz)
+      return nil if event.starts_at.blank?
+
+      local = event.starts_at.in_time_zone(tz || "UTC")
+      local.change(year: date.year, month: date.month, day: date.day)
     end
 
     private def timezone_blocks

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -198,6 +198,33 @@ class Fleet < ApplicationRecord
     end
   end
 
+  def calendar_feed_enabled?
+    calendar_feed_token.present?
+  end
+
+  def ensure_calendar_feed_token!
+    return calendar_feed_token if calendar_feed_token.present?
+
+    update_column(:calendar_feed_token, self.class.generate_calendar_feed_token)
+    calendar_feed_token
+  end
+
+  def rotate_calendar_feed_token!
+    update_column(:calendar_feed_token, self.class.generate_calendar_feed_token)
+    calendar_feed_token
+  end
+
+  def clear_calendar_feed_token!
+    update_column(:calendar_feed_token, nil)
+  end
+
+  def self.generate_calendar_feed_token
+    loop do
+      token = SecureRandom.urlsafe_base64(32)
+      break token unless exists?(calendar_feed_token: token)
+    end
+  end
+
   private def update_slugs
     self.slug = generate_slug(fid)
   end

--- a/app/models/fleet_event.rb
+++ b/app/models/fleet_event.rb
@@ -111,6 +111,19 @@ class FleetEvent < ApplicationRecord
   scope :active_status, -> { where(archived_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }
 
+  # A recurring event keeps its whole series on the parent row, so filtering by
+  # starts_at would drop a weekly op that began before the cutoff along with
+  # every occurrence it still has ahead of it. Recurring rows are therefore only
+  # excluded when the series can be shown to have finished; a count-bounded or
+  # open-ended series stays, and its RRULE simply yields nothing in the past.
+  scope :starting_after, ->(cutoff) {
+    where(
+      "(recurring IS NOT TRUE AND starts_at >= :cutoff) OR " \
+      "(recurring IS TRUE AND (recurrence_until IS NULL OR recurrence_until >= :cutoff_date))",
+      cutoff: cutoff, cutoff_date: cutoff.to_date
+    )
+  }
+
   AVAILABLE_PRIVILEGES = [
     "fleet:events:read",
     "fleet:events:create",
@@ -317,7 +330,11 @@ class FleetEvent < ApplicationRecord
     cursor = starts_at
     limit = recurrence_count.presence
     iterations = 0
-    until_time = recurrence_until&.end_of_day&.in_time_zone(timezone || "UTC")
+    # Date#end_of_day resolves in Time.zone, so the cutoff used to follow the
+    # server's zone rather than the event's. in_time_zone on the date puts
+    # midnight in the event's zone first, so this is the inclusive local
+    # end-of-day an organiser means by "repeats until".
+    until_time = recurrence_until&.in_time_zone(timezone || "UTC")&.end_of_day
 
     while cursor <= to && (limit.nil? || iterations < limit)
       break if until_time && cursor > until_time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -283,6 +283,33 @@ class User < ApplicationRecord
   # reading them from a preloaded association costs one query for all providers
   # instead of one per profile url - the fleet vehicle list asks every owner for
   # two of them.
+  def calendar_feed_enabled?
+    calendar_feed_token.present?
+  end
+
+  def ensure_calendar_feed_token!
+    return calendar_feed_token if calendar_feed_token.present?
+
+    update_column(:calendar_feed_token, self.class.generate_calendar_feed_token)
+    calendar_feed_token
+  end
+
+  def rotate_calendar_feed_token!
+    update_column(:calendar_feed_token, self.class.generate_calendar_feed_token)
+    calendar_feed_token
+  end
+
+  def clear_calendar_feed_token!
+    update_column(:calendar_feed_token, nil)
+  end
+
+  def self.generate_calendar_feed_token
+    loop do
+      token = SecureRandom.urlsafe_base64(32)
+      break token unless exists?(calendar_feed_token: token)
+    end
+  end
+
   private def connection_for(provider)
     omniauth_connections.detect { |connection| connection.provider == provider }
   end

--- a/app/policies/fleet_policy.rb
+++ b/app/policies/fleet_policy.rb
@@ -21,6 +21,10 @@ class FleetPolicy < FleetBasePolicy
     fleet_membership.present?
   end
 
+  def manage_calendar?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:events:manage"])
+  end
+
   def manage?
     accepted_fleet_membership&.has_access?(["fleet:manage"])
   end

--- a/app/views/api/v1/calendar_subscriptions/show.jbuilder
+++ b/app/views/api/v1/calendar_subscriptions/show.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.ignore_nil! false
+
+json.enabled @fleet.calendar_feed_enabled?
+json.feed_url(
+  if @fleet.calendar_feed_enabled?
+    api_v1_fleet_calendar_feed_url(
+      fleet_slug: @fleet.slug,
+      token: @fleet.calendar_feed_token,
+      host: Rails.configuration.app.domain,
+      protocol: "https"
+    )
+  end
+)

--- a/app/views/api/v1/fleet_calendars/show.jbuilder
+++ b/app/views/api/v1/fleet_calendars/show.jbuilder
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @calendar_entries do |entry|
+    event, occurrence_time = entry
+    state =
+      if occurrence_time
+        event.occurrence_state_for(occurrence_time.to_date)
+      end
+
+    json.partial! "api/v1/fleet_events/base",
+      fleet_event: event,
+      occurrence_date: occurrence_time&.to_date,
+      parent_event_slug: occurrence_time ? event.slug : nil
+
+    if occurrence_time
+      # Render the virtual occurrence at the occurrence's start time so
+      # calendar clients place it on the right day.
+      json.starts_at occurrence_time
+      duration = event.ends_at ? (event.ends_at - event.starts_at) : 2.hours
+      json.ends_at(occurrence_time + duration)
+    end
+
+    if state
+      json.title state.title.presence || event.title
+      json.description state.description.presence || event.description
+      json.location state.location.presence || event.location
+      json.meetup_location state.meetup_location.presence || event.meetup_location
+      json.scenario state.scenario.presence || event.scenario
+      json.cover_image_preset state.cover_image_preset.presence || event.cover_image_preset
+      json.status state.status.presence || event.status
+    end
+  end
+end

--- a/app/views/api/v1/me/calendar_subscriptions/show.jbuilder
+++ b/app/views/api/v1/me/calendar_subscriptions/show.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+json.ignore_nil! false
+
+json.enabled @user.calendar_feed_enabled?
+json.feed_url(
+  if @user.calendar_feed_enabled?
+    api_v1_me_calendar_feed_url(
+      token: @user.calendar_feed_token,
+      host: Rails.configuration.app.domain,
+      protocol: "https"
+    )
+  end
+)

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -64,6 +64,13 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
     resources :fleet_events, path: "events", only: %i[create]
   end
 
+  get "calendar", to: "fleet_calendars#show"
+  get "events.ics", to: "fleet_calendars#ics", as: :calendar_feed, defaults: {format: "ics"}, constraints: {format: "ics"}
+
+  resource :calendar_subscription, path: "calendar/subscription", only: %i[show create destroy] do
+    post :rotate
+  end
+
   resources :fleet_events, path: "events", param: :slug, only: %i[index show create update destroy], constraints: {slug: %r{[^/.]+}} do
     member do
       put :publish
@@ -77,6 +84,7 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
       post "end-series", action: :end_series
       patch "update-occurrence", action: :update_occurrence
       post :signup, to: "fleet_event_signups#event_signup"
+      get "event.ics", action: :ics, defaults: {format: "ics"}, constraints: {format: "ics"}
     end
 
     resources :fleet_event_admins, path: "admins", only: %i[index create destroy]

--- a/config/routes/api/users_routes.rb
+++ b/config/routes/api/users_routes.rb
@@ -14,6 +14,14 @@ resources :users, only: [] do
   end
 end
 
+namespace :me, defaults: {format: :json} do
+  resource :calendar_subscription, path: "calendar/subscription", only: %i[show create destroy] do
+    post :rotate
+  end
+  get "calendar/events.ics", to: "calendar_subscriptions#ics",
+    as: :calendar_feed, defaults: {format: "ics"}, constraints: {format: "ics"}
+end
+
 namespace :public do
   resources :users, param: :username, only: %i[show]
 end

--- a/config/routes/frontend_routes.rb
+++ b/config/routes/frontend_routes.rb
@@ -36,6 +36,7 @@ namespace :frontend, **frontend_options do
   get "fleets/:slug/settings", to: "fleets#settings"
   get "fleets/:slug/settings/fleet", to: "fleets#settings"
   get "fleets/:slug/settings/membership", to: "fleets#settings"
+  get "fleets/:fleet_slug/events/:event_slug", to: "fleets#event", as: :fleet_event
 
   get "password/update/:token", to: "base#password", as: :password_reset
   get "confirm/:token", to: "base#confirm", as: :confirm

--- a/db/migrate/20260512210000_add_calendar_feed_token_to_users.rb
+++ b/db/migrate/20260512210000_add_calendar_feed_token_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCalendarFeedTokenToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :calendar_feed_token, :string
+    add_index :users, :calendar_feed_token, unique: true
+  end
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -992,6 +992,181 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/fleets/{fleetSlug}/calendar":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    get:
+      summary: Fleet Calendar
+      tags:
+      - Fleet Events
+      operationId: fleetCalendar
+      parameters:
+      - name: from
+        in: query
+        schema:
+          type: string
+        required: false
+      - name: to
+        in: query
+        schema:
+          type: string
+        required: false
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/FleetEvent"
+                required:
+                - items
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/calendar/subscription":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Generate calendar subscription token
+      tags:
+      - Fleet Calendar
+      operationId: createFleetCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Disable calendar subscription
+      tags:
+      - Fleet Calendar
+      operationId: destroyFleetCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Show calendar subscription
+      tags:
+      - Fleet Calendar
+      operationId: fleetCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleetSlug}/calendar/subscription/rotate":
+    parameters:
+    - name: fleetSlug
+      in: path
+      schema:
+        type: string
+      required: true
+    post:
+      summary: Rotate calendar subscription token
+      tags:
+      - Fleet Calendar
+      operationId: rotateFleetCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleetSlug}/events":
     parameters:
     - name: fleetSlug
@@ -6602,6 +6777,108 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Manufacturers"
+  "/me/calendar/subscription":
+    post:
+      summary: Generate personal calendar subscription
+      tags:
+      - Me Calendar
+      operationId: createMyCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - user
+        - user:write
+      - OpenId:
+        - user
+        - user:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    delete:
+      summary: Disable personal calendar subscription
+      tags:
+      - Me Calendar
+      operationId: destroyMyCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - user
+        - user:write
+      - OpenId:
+        - user
+        - user:write
+      responses:
+        '204':
+          description: successful
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    get:
+      summary: Show personal calendar subscription
+      tags:
+      - Me Calendar
+      operationId: myCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - user
+        - user:read
+      - OpenId:
+        - user
+        - user:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/me/calendar/subscription/rotate":
+    post:
+      summary: Rotate personal calendar subscription
+      tags:
+      - Me Calendar
+      operationId: rotateMyCalendarSubscription
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - user
+        - user:write
+      - OpenId:
+        - user
+        - user:write
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CalendarSubscription"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/mission-slots":
     post:
       summary: Create Mission Slot
@@ -10734,6 +11011,19 @@ components:
       - PLEDGE_STORE
       - INGAME
       title: BoughtViaEnum
+    CalendarSubscription:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        feedUrl:
+          type: string
+          format: uri
+      required:
+      - enabled
+      - feedUrl
+      additionalProperties: false
+      title: CalendarSubscription
     CargoHold:
       type: object
       properties:

--- a/test/integration/api/v1/fleets_calendar_ics_test.rb
+++ b/test/integration/api/v1/fleets_calendar_ics_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsCalendarIcsTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin], calendar_feed_token: SecureRandom.hex(16))
+  end
+
+  test "GET /fleets/:slug/events.ics returns an ICS feed with valid token" do
+    create(:fleet_event, :open, fleet: @fleet, created_by: @admin, starts_at: 2.days.from_now)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics", params: {token: @fleet.calendar_feed_token}
+
+    assert_response :ok
+    assert_equal "text/calendar", response.media_type
+    assert_includes response.body, "BEGIN:VCALENDAR"
+    assert_includes response.body, "BEGIN:VEVENT"
+    assert_includes response.body, "END:VCALENDAR"
+  end
+
+  test "GET /fleets/:slug/events.ics includes recently cancelled events with STATUS:CANCELLED" do
+    create(:fleet_event, :cancelled,
+      fleet: @fleet, created_by: @admin, title: "Scrubbed Op",
+      starts_at: 2.days.from_now)
+    create(:fleet_event, :open, fleet: @fleet, created_by: @admin, title: "Live Op")
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics", params: {token: @fleet.calendar_feed_token}
+
+    assert_includes response.body, "Live Op"
+    assert_includes response.body, "Scrubbed Op"
+    assert_includes response.body, "STATUS:CANCELLED"
+  end
+
+  test "GET /fleets/:slug/events.ics drops cancelled events more than a week past their start time" do
+    create(:fleet_event, :cancelled,
+      fleet: @fleet, created_by: @admin, title: "Old Scrubbed Op",
+      starts_at: 10.days.ago)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics", params: {token: @fleet.calendar_feed_token}
+
+    refute_includes response.body, "Old Scrubbed Op"
+  end
+
+  test "GET /fleets/:slug/events.ics drops events older than the 90-day past horizon" do
+    create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin, title: "Ancient Op",
+      starts_at: 100.days.ago)
+    create(:fleet_event, :open,
+      fleet: @fleet, created_by: @admin, title: "Recent Op",
+      starts_at: 30.days.ago)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics", params: {token: @fleet.calendar_feed_token}
+
+    refute_includes response.body, "Ancient Op"
+    assert_includes response.body, "Recent Op"
+  end
+
+  test "GET /fleets/:slug/events.ics returns forbidden with invalid token" do
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics", params: {token: "wrong"}
+
+    assert_response :forbidden
+  end
+end

--- a/test/integration/api/v1/fleets_calendar_ics_test.rb
+++ b/test/integration/api/v1/fleets_calendar_ics_test.rb
@@ -63,4 +63,27 @@ class Api::V1::FleetsCalendarIcsTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+  test "keeps an old recurring series that still has occurrences ahead" do
+    create(:fleet_event, :open, fleet: @fleet, title: "Weekly Op",
+      starts_at: 6.months.ago, recurring: true, recurrence_interval: "weekly")
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics",
+      params: {token: @fleet.calendar_feed_token}
+
+    assert_response :ok
+    assert_includes response.body, "Weekly Op"
+    assert_includes response.body, "RRULE:FREQ=WEEKLY"
+  end
+
+  test "drops a recurring series that ended before the window" do
+    create(:fleet_event, :open, fleet: @fleet, title: "Finished Op",
+      starts_at: 8.months.ago, recurring: true, recurrence_interval: "weekly",
+      recurrence_until: 7.months.ago.to_date)
+
+    get "/api/v1/fleets/#{@fleet.slug}/events.ics",
+      params: {token: @fleet.calendar_feed_token}
+
+    assert_response :ok
+    refute_includes response.body, "Finished Op"
+  end
 end

--- a/test/integration/api/v1/fleets_calendar_show_test.rb
+++ b/test/integration/api/v1/fleets_calendar_show_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsCalendarShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/calendar" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    get("Fleet Calendar") do
+      operationId "fleetCalendar"
+      tags "Fleet Events"
+      produces "application/json"
+
+      parameter name: :from, in: :query, schema: {type: :string}, required: false
+      parameter name: :to, in: :query, schema: {type: :string}, required: false
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema type: :object, properties: {
+          items: {type: :array, items: {"$ref": "#/components/schemas/FleetEvent"}}
+        }, required: %w[items]
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "GET /fleets/:slug/calendar returns events" do
+    create(:fleet_event, fleet: @fleet, created_by: @admin, starts_at: 1.day.from_now)
+    create(:fleet_event, fleet: @fleet, created_by: @admin, starts_at: 5.days.from_now)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert parsed_body["items"].size >= 2
+    end
+  end
+
+  test "GET /fleets/:slug/calendar with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/calendar returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/calendar returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_calendar_subscription_create_test.rb
+++ b/test/integration/api/v1/fleets_calendar_subscription_create_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsCalendarSubscriptionCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/calendar/subscription" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    post("Generate calendar subscription token") do
+      operationId "createFleetCalendarSubscription"
+      tags "Fleet Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Disable calendar subscription") do
+      operationId "destroyFleetCalendarSubscription"
+      tags "Fleet Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription enables and returns feedUrl" do
+    sign_in @admin
+
+    assert_api_response :post, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal true, parsed_body["enabled"]
+      assert_includes parsed_body["feedUrl"], "token="
+    end
+
+    assert @fleet.reload.calendar_feed_token.present?
+  end
+
+  test "POST /fleets/:slug/calendar/subscription is idempotent when already enabled" do
+    @fleet.ensure_calendar_feed_token!
+    existing_token = @fleet.reload.calendar_feed_token
+    sign_in @admin
+
+    assert_api_response :post, 200, path_params: {fleetSlug: @fleet.slug}
+
+    assert_equal existing_token, @fleet.reload.calendar_feed_token
+  end
+
+  test "POST /fleets/:slug/calendar/subscription with OAuth bearer token" do
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription returns 401 when not signed in" do
+    assert_api_response :post, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+
+  test "DELETE /fleets/:slug/calendar/subscription disables the subscription" do
+    @fleet.ensure_calendar_feed_token!
+    sign_in @admin
+
+    assert_api_response :delete, 204, path_params: {fleetSlug: @fleet.slug}
+
+    assert_nil @fleet.reload.calendar_feed_token
+  end
+
+  test "DELETE /fleets/:slug/calendar/subscription with OAuth bearer token" do
+    @fleet.ensure_calendar_feed_token!
+
+    assert_api_response :delete, 204,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "DELETE /fleets/:slug/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    @fleet.ensure_calendar_feed_token!
+
+    assert_api_response :delete, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "DELETE /fleets/:slug/calendar/subscription returns 401 when not signed in" do
+    @fleet.ensure_calendar_feed_token!
+
+    assert_api_response :delete, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_calendar_subscription_rotate_test.rb
+++ b/test/integration/api/v1/fleets_calendar_subscription_rotate_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsCalendarSubscriptionRotateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/calendar/subscription/rotate" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    post("Rotate calendar subscription token") do
+      operationId "rotateFleetCalendarSubscription"
+      tags "Fleet Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription/rotate rotates the token" do
+    @fleet.ensure_calendar_feed_token!
+    old_token = @fleet.reload.calendar_feed_token
+    sign_in @admin
+
+    assert_api_response :post, 200, path_params: {fleetSlug: @fleet.slug}
+
+    new_token = @fleet.reload.calendar_feed_token
+    assert new_token.present?
+    refute_equal old_token, new_token
+  end
+
+  test "POST /fleets/:slug/calendar/subscription/rotate with OAuth bearer token" do
+    @fleet.ensure_calendar_feed_token!
+
+    assert_api_response :post, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription/rotate returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "POST /fleets/:slug/calendar/subscription/rotate returns 401 when not signed in" do
+    assert_api_response :post, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_calendar_subscription_show_test.rb
+++ b/test/integration/api/v1/fleets_calendar_subscription_show_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsCalendarSubscriptionShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/calendar/subscription" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}
+
+    get("Show calendar subscription") do
+      operationId "fleetCalendarSubscription"
+      tags "Fleet Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+  end
+
+  test "GET /fleets/:slug/calendar/subscription returns disabled state" do
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal false, parsed_body["enabled"]
+      assert_nil parsed_body["feedUrl"]
+    end
+  end
+
+  test "GET /fleets/:slug/calendar/subscription returns enabled state with feedUrl" do
+    @fleet.ensure_calendar_feed_token!
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_equal true, parsed_body["enabled"]
+      assert_includes parsed_body["feedUrl"], "events.ics"
+      assert_includes parsed_body["feedUrl"], "token="
+    end
+  end
+
+  test "GET /fleets/:slug/calendar/subscription with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+
+  test "GET /fleets/:slug/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      path_params: {fleetSlug: @fleet.slug},
+      headers: oauth_headers_for(@admin, scopes: ["public"])
+  end
+
+  test "GET /fleets/:slug/calendar/subscription returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
+  end
+end

--- a/test/integration/api/v1/fleets_events_ics_test.rb
+++ b/test/integration/api/v1/fleets_events_ics_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsEventsIcsTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @admin = create(:user)
+    @fleet = create(:fleet, admins: [@admin])
+    @fleet_event = create(:fleet_event, :open,
+      fleet: @fleet,
+      created_by: @admin,
+      title: "Thursday Play Evening")
+    sign_in @admin
+  end
+
+  test "GET /fleets/:slug/events/:slug/event.ics returns a one-shot ICS attachment" do
+    get "/api/v1/fleets/#{@fleet.slug}/events/#{@fleet_event.slug}/event.ics"
+
+    assert_response :ok
+    assert_equal "text/calendar", response.media_type
+    assert_includes response.headers["Content-Disposition"], "attachment"
+    assert_includes response.headers["Content-Disposition"], "#{@fleet_event.slug}.ics"
+    assert_includes response.body, "BEGIN:VCALENDAR"
+    assert_includes response.body, "SUMMARY:Thursday Play Evening"
+    assert_includes response.body, "UID:#{@fleet_event.external_uid}@fleetyards.net"
+  end
+
+  test "GET /fleets/:slug/events/:slug/event.ics 404s for a non-existent event" do
+    get "/api/v1/fleets/#{@fleet.slug}/events/missing/event.ics"
+
+    assert_response :not_found
+  end
+
+  test "GET /fleets/:slug/events/:slug/event.ics respects the fleet:events:read policy" do
+    sign_out @admin
+    outsider = create(:user)
+    sign_in outsider
+
+    get "/api/v1/fleets/#{@fleet.slug}/events/#{@fleet_event.slug}/event.ics"
+
+    assert_includes [401, 403, 404], response.status
+  end
+end

--- a/test/integration/api/v1/me_calendar_subscription_create_test.rb
+++ b/test/integration/api/v1/me_calendar_subscription_create_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MeCalendarSubscriptionCreateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/me/calendar/subscription" do
+    post("Generate personal calendar subscription") do
+      operationId "createMyCalendarSubscription"
+      tags "Me Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["user", "user:write"]},
+        {OpenId: ["user", "user:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+
+    delete("Disable personal calendar subscription") do
+      operationId "destroyMyCalendarSubscription"
+      tags "Me Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["user", "user:write"]},
+        {OpenId: ["user", "user:write"]}
+      ]
+
+      response(204, "successful") do
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @account = create(:user)
+  end
+
+  test "POST /me/calendar/subscription enables the subscription" do
+    sign_in @account
+
+    assert_api_response :post, 200 do
+      assert_equal true, parsed_body["enabled"]
+      assert_includes parsed_body["feedUrl"], "token="
+    end
+    assert @account.reload.calendar_feed_token.present?
+  end
+
+  test "POST /me/calendar/subscription with OAuth bearer token" do
+    assert_api_response :post, 200,
+      headers: oauth_headers_for(@account, scopes: ["user", "user:write"])
+  end
+
+  test "POST /me/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      headers: oauth_headers_for(@account, scopes: ["public"])
+  end
+
+  test "POST /me/calendar/subscription returns 401 when not signed in" do
+    assert_api_response :post, 401
+  end
+
+  test "DELETE /me/calendar/subscription disables the subscription" do
+    @account.ensure_calendar_feed_token!
+    sign_in @account
+
+    assert_api_response :delete, 204
+
+    assert_nil @account.reload.calendar_feed_token
+  end
+
+  test "DELETE /me/calendar/subscription with OAuth bearer token" do
+    @account.ensure_calendar_feed_token!
+
+    assert_api_response :delete, 204,
+      headers: oauth_headers_for(@account, scopes: ["user", "user:write"])
+  end
+
+  test "DELETE /me/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    @account.ensure_calendar_feed_token!
+
+    assert_api_response :delete, 401,
+      headers: oauth_headers_for(@account, scopes: ["public"])
+  end
+
+  test "DELETE /me/calendar/subscription returns 401 when not signed in" do
+    assert_api_response :delete, 401
+  end
+end

--- a/test/integration/api/v1/me_calendar_subscription_ics_test.rb
+++ b/test/integration/api/v1/me_calendar_subscription_ics_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::MeCalendarSubscriptionIcsTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @user = create(:user)
+    @fleet = create(:fleet, members: [@user])
+    @other_user = create(:user)
+    @other_fleet = create(:fleet, members: [@other_user])
+    @user.ensure_calendar_feed_token!
+  end
+
+  def signup_for(membership, event, status: "confirmed")
+    create(:fleet_event_signup,
+      fleet_event: event, fleet_membership: membership,
+      fleet_event_slot: nil, status: status)
+  end
+
+  test "returns only events the user has signed up for" do
+    membership = @fleet.fleet_memberships.find_by(user: @user)
+    mine = create(:fleet_event, :open, fleet: @fleet, title: "My Op",
+      starts_at: 2.days.from_now)
+    not_mine = create(:fleet_event, :open, fleet: @fleet, title: "Other Op",
+      starts_at: 2.days.from_now)
+    signup_for(membership, mine)
+
+    get "/api/v1/me/calendar/events.ics", params: {token: @user.calendar_feed_token}
+
+    assert_response :ok
+    assert_equal "text/calendar", response.media_type
+    assert_includes response.body, "My Op"
+    refute_includes response.body, "Other Op"
+    assert not_mine.present?
+  end
+
+  test "scopes to the user's own signups (not other users')" do
+    other_membership = @other_fleet.fleet_memberships.find_by(user: @other_user)
+    theirs = create(:fleet_event, :open, fleet: @other_fleet,
+      title: "Their Op", starts_at: 2.days.from_now)
+    signup_for(other_membership, theirs)
+
+    get "/api/v1/me/calendar/events.ics", params: {token: @user.calendar_feed_token}
+
+    assert_response :ok
+    refute_includes response.body, "Their Op"
+  end
+
+  test "returns 403 with no token" do
+    get "/api/v1/me/calendar/events.ics"
+
+    assert_response :forbidden
+  end
+
+  test "returns 403 with a wrong token" do
+    get "/api/v1/me/calendar/events.ics", params: {token: "nope"}
+
+    assert_response :forbidden
+  end
+end

--- a/test/integration/api/v1/me_calendar_subscription_ics_test.rb
+++ b/test/integration/api/v1/me_calendar_subscription_ics_test.rb
@@ -58,4 +58,32 @@ class Api::V1::MeCalendarSubscriptionIcsTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+  test "drops events once the membership behind the signup is removed" do
+    membership = @fleet.fleet_memberships.find_by(user: @user)
+    event = create(:fleet_event, :open, fleet: @fleet, title: "Revoked Op",
+      starts_at: 2.days.from_now)
+    signup_for(membership, event)
+
+    membership.discard
+
+    get "/api/v1/me/calendar/events.ics", params: {token: @user.calendar_feed_token}
+
+    assert_response :ok
+    refute_includes response.body, "Revoked Op"
+  end
+
+  test "drops events while the membership is not yet accepted" do
+    pending_user = create(:user)
+    pending_user.ensure_calendar_feed_token!
+    membership = create(:fleet_membership, fleet: @fleet, user: pending_user)
+    event = create(:fleet_event, :open, fleet: @fleet, title: "Requested Op",
+      starts_at: 2.days.from_now)
+    signup_for(membership, event)
+
+    get "/api/v1/me/calendar/events.ics",
+      params: {token: pending_user.calendar_feed_token}
+
+    assert_response :ok
+    refute_includes response.body, "Requested Op"
+  end
 end

--- a/test/integration/api/v1/me_calendar_subscription_rotate_test.rb
+++ b/test/integration/api/v1/me_calendar_subscription_rotate_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MeCalendarSubscriptionRotateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/me/calendar/subscription/rotate" do
+    post("Rotate personal calendar subscription") do
+      operationId "rotateMyCalendarSubscription"
+      tags "Me Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["user", "user:write"]},
+        {OpenId: ["user", "user:write"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @account = create(:user)
+  end
+
+  test "POST /me/calendar/subscription/rotate rotates the token" do
+    @account.ensure_calendar_feed_token!
+    old_token = @account.reload.calendar_feed_token
+    sign_in @account
+
+    assert_api_response :post, 200
+
+    new_token = @account.reload.calendar_feed_token
+    assert new_token.present?
+    refute_equal old_token, new_token
+  end
+
+  test "POST /me/calendar/subscription/rotate with OAuth bearer token" do
+    @account.ensure_calendar_feed_token!
+
+    assert_api_response :post, 200,
+      headers: oauth_headers_for(@account, scopes: ["user", "user:write"])
+  end
+
+  test "POST /me/calendar/subscription/rotate returns 401 for OAuth token with wrong scope" do
+    assert_api_response :post, 401,
+      headers: oauth_headers_for(@account, scopes: ["public"])
+  end
+
+  test "POST /me/calendar/subscription/rotate returns 401 when not signed in" do
+    assert_api_response :post, 401
+  end
+end

--- a/test/integration/api/v1/me_calendar_subscription_show_test.rb
+++ b/test/integration/api/v1/me_calendar_subscription_show_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::MeCalendarSubscriptionShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/me/calendar/subscription" do
+    get("Show personal calendar subscription") do
+      operationId "myCalendarSubscription"
+      tags "Me Calendar"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["user", "user:read"]},
+        {OpenId: ["user", "user:read"]}
+      ]
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/CalendarSubscription"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  setup do
+    Flipper.enable("fleet_mission_builder")
+    @account = create(:user)
+  end
+
+  test "GET /me/calendar/subscription returns disabled when no token is set" do
+    sign_in @account
+
+    assert_api_response :get, 200 do
+      assert_equal false, parsed_body["enabled"]
+      assert_nil parsed_body["feedUrl"]
+    end
+  end
+
+  test "GET /me/calendar/subscription returns enabled when a token is set" do
+    @account.ensure_calendar_feed_token!
+    sign_in @account
+
+    assert_api_response :get, 200 do
+      assert_equal true, parsed_body["enabled"]
+      assert_includes parsed_body["feedUrl"], "/me/calendar/events.ics"
+      assert_includes parsed_body["feedUrl"], "token="
+    end
+  end
+
+  test "GET /me/calendar/subscription with OAuth bearer token" do
+    assert_api_response :get, 200,
+      headers: oauth_headers_for(@account, scopes: ["user", "user:read"])
+  end
+
+  test "GET /me/calendar/subscription returns 401 for OAuth token with wrong scope" do
+    assert_api_response :get, 401,
+      headers: oauth_headers_for(@account, scopes: ["public"])
+  end
+
+  test "GET /me/calendar/subscription returns 401 when not signed in" do
+    assert_api_response :get, 401
+  end
+end

--- a/test/lib/calendars/ics_builder_test.rb
+++ b/test/lib/calendars/ics_builder_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Calendars
+  class IcsBuilderTest < ActiveSupport::TestCase
+    setup do
+      @fleet = create(:fleet, name: "MARU Inc.")
+    end
+
+    class ToIcsTest < IcsBuilderTest
+      setup do
+        @event = create(:fleet_event, :open,
+          fleet: @fleet,
+          title: "Thursday Play Evening",
+          description: "Cargo runs",
+          starts_at: Time.zone.parse("2026-06-04 20:00:00 UTC"),
+          ends_at: Time.zone.parse("2026-06-04 22:00:00 UTC"),
+          timezone: "Europe/Berlin",
+          location: "Stanton",
+          meetup_location: "Levski, Nyx",
+          category: "cargo_hauling")
+      end
+
+      test "wraps the body in VCALENDAR/VEVENT" do
+        ics = ::Calendars::IcsBuilder.new([@event], calendar_name: "#{@fleet.name} — Events").to_ics
+
+        assert ics.start_with?("BEGIN:VCALENDAR\r\n")
+        assert ics.end_with?("END:VCALENDAR\r\n")
+        assert_includes ics, "BEGIN:VEVENT"
+        assert_includes ics, "END:VEVENT"
+        assert_includes ics, "PRODID:-//Fleetyards//Mission Builder//EN"
+        assert_includes ics, "X-WR-CALNAME:MARU Inc. — Events"
+      end
+
+      test "includes summary, description, location, status, category, url, and uid" do
+        ics = ::Calendars::IcsBuilder.new([@event]).to_ics
+
+        assert_includes ics, "SUMMARY:Thursday Play Evening"
+        assert_includes ics, "DESCRIPTION:Cargo runs"
+        assert_includes ics, "STATUS:CONFIRMED"
+        assert_includes ics, "CATEGORIES:CARGO_HAULING"
+        assert_includes ics, "UID:#{@event.external_uid}@fleetyards.net"
+        assert_includes ics, "URL:"
+        assert_includes ics, "/fleets/#{@fleet.slug}/events/#{@event.slug}"
+        assert_includes ics, "Stanton"
+        assert_includes ics, 'Levski\\, Nyx'
+      end
+
+      test "uses TZID for non-UTC events and emits a VTIMEZONE block" do
+        ics = ::Calendars::IcsBuilder.new([@event]).to_ics
+
+        assert_includes ics, "BEGIN:VTIMEZONE"
+        assert_includes ics, "TZID:Europe/Berlin"
+        assert_includes ics, "END:VTIMEZONE"
+        assert_includes ics, "DTSTART;TZID=Europe/Berlin:20260604T220000"
+        assert_includes ics, "DTEND;TZID=Europe/Berlin:20260605T000000"
+      end
+
+      test "uses plain UTC stamps when the event timezone is UTC" do
+        utc_event = create(:fleet_event, :open,
+          fleet: @fleet,
+          starts_at: Time.zone.parse("2026-06-04 20:00:00 UTC"),
+          timezone: "UTC")
+
+        ics = ::Calendars::IcsBuilder.new([utc_event]).to_ics
+
+        refute_includes ics, "BEGIN:VTIMEZONE"
+        assert_includes ics, "DTSTART:20260604T200000Z"
+      end
+
+      test "emits STATUS:CANCELLED for cancelled events" do
+        cancelled = create(:fleet_event, :cancelled, fleet: @fleet)
+
+        ics = ::Calendars::IcsBuilder.new([cancelled]).to_ics
+
+        assert_includes ics, "STATUS:CANCELLED"
+      end
+
+      test "sets X-WR-TIMEZONE when every event shares a single non-UTC zone" do
+        ics = ::Calendars::IcsBuilder.new([@event]).to_ics
+
+        assert_includes ics, "X-WR-TIMEZONE:Europe/Berlin"
+      end
+
+      test "omits X-WR-TIMEZONE when events span multiple zones" do
+        other = create(:fleet_event, :open, fleet: @fleet, timezone: "America/New_York")
+
+        ics = ::Calendars::IcsBuilder.new([@event, other]).to_ics
+
+        refute_match(/X-WR-TIMEZONE:/, ics)
+      end
+
+      test "escapes commas and semicolons in user content" do
+        tricky = create(:fleet_event, :open,
+          fleet: @fleet,
+          title: "Cargo; runs, fun",
+          location: "Levski; Nyx, Stanton")
+
+        ics = ::Calendars::IcsBuilder.new([tricky]).to_ics
+
+        assert_includes ics, 'SUMMARY:Cargo\\; runs\\, fun'
+        assert_includes ics, 'Levski\\; Nyx\\, Stanton'
+      end
+
+      class RecurringEventsTest < ToIcsTest
+        setup do
+          @thursday = Time.zone.parse("2026-05-14 20:00:00 UTC")
+        end
+
+        test "emits RRULE for a weekly recurring event" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly")
+
+          ics = ::Calendars::IcsBuilder.new([event]).to_ics
+
+          assert_includes ics, "RRULE:FREQ=WEEKLY"
+        end
+
+        test "emits FREQ=WEEKLY;INTERVAL=2 for biweekly" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "biweekly")
+
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "RRULE:FREQ=WEEKLY;INTERVAL=2"
+        end
+
+        test "emits FREQ=DAILY for daily" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "daily")
+
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "RRULE:FREQ=DAILY"
+        end
+
+        test "emits UNTIL when recurrence_until is set" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly",
+            recurrence_until: Date.parse("2026-06-04"))
+
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "UNTIL=20260604T235959Z"
+        end
+
+        test "emits COUNT when recurrence_count is set" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly",
+            recurrence_count: 4)
+
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "COUNT=4"
+        end
+
+        test "emits EXDATE lines for excluded dates" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly",
+            excluded_dates: [Date.parse("2026-05-21")])
+
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "EXDATE:20260521T200000Z"
+        end
+      end
+    end
+  end
+end

--- a/test/lib/calendars/ics_builder_test.rb
+++ b/test/lib/calendars/ics_builder_test.rb
@@ -143,6 +143,76 @@ module Calendars
           assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "UNTIL=20260604T235959Z"
         end
 
+        test "converts UNTIL from the event's local end-of-day" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "America/Los_Angeles",
+            recurring: true, recurrence_interval: "weekly",
+            recurrence_until: Date.parse("2026-06-04"))
+
+          # 23:59:59 on 4 June in Los Angeles is 06:59:59Z the next day, so
+          # stamping T235959Z would drop that evening's occurrence.
+          assert_includes ::Calendars::IcsBuilder.new([event]).to_ics, "UNTIL=20260605T065959Z"
+        end
+
+        test "keeps the last local occurrence a behind-UTC series still has" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: Time.zone.parse("2026-05-07 19:00"),
+            timezone: "America/Los_Angeles",
+            recurring: true, recurrence_interval: "weekly",
+            recurrence_until: Date.parse("2026-06-04"))
+
+          last = event.occurrences(from: Time.zone.parse("2026-05-01"),
+            to: Time.zone.parse("2026-07-01")).last
+
+          assert_equal Date.parse("2026-06-04"), last.in_time_zone("America/Los_Angeles").to_date
+        end
+
+        test "emits a RECURRENCE-ID override for an occurrence that differs" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            title: "Weekly Op", location: "Port Olisar",
+            recurring: true, recurrence_interval: "weekly")
+          occurrence = event.occurrences(from: @thursday, to: @thursday + 3.weeks)[1]
+          event.fleet_event_occurrence_states.create!(
+            occurrence_date: occurrence.to_date,
+            title: "Moved Op", location: "Everus Harbor"
+          )
+
+          ics = ::Calendars::IcsBuilder.new([event]).to_ics
+
+          assert_includes ics, "RECURRENCE-ID:#{occurrence.utc.strftime("%Y%m%dT%H%M%SZ")}"
+          assert_includes ics, "SUMMARY:Moved Op"
+          assert_includes ics, "LOCATION:Everus Harbor"
+          # the parent still carries the series
+          assert_includes ics, "SUMMARY:Weekly Op"
+          assert_equal 2, ics.scan("BEGIN:VEVENT").size
+        end
+
+        test "marks a cancelled occurrence cancelled without touching the series" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly")
+          occurrence = event.occurrences(from: @thursday, to: @thursday + 3.weeks)[1]
+          event.fleet_event_occurrence_states.create!(
+            occurrence_date: occurrence.to_date, cancelled_at: Time.current
+          )
+
+          ics = ::Calendars::IcsBuilder.new([event]).to_ics
+
+          assert_includes ics, "STATUS:CANCELLED"
+          assert_equal 2, ics.scan("BEGIN:VEVENT").size
+        end
+
+        test "leaves a series without overrides as a single VEVENT" do
+          event = create(:fleet_event, :open,
+            fleet: @fleet, starts_at: @thursday, timezone: "UTC",
+            recurring: true, recurrence_interval: "weekly")
+
+          ics = ::Calendars::IcsBuilder.new([event]).to_ics
+
+          assert_equal 1, ics.scan("BEGIN:VEVENT").size
+        end
+
         test "emits COUNT when recurrence_count is set" do
           event = create(:fleet_event, :open,
             fleet: @fleet, starts_at: @thursday, timezone: "UTC",


### PR DESCRIPTION
Replaces #4447, which GitHub closed when #4445 and #4446 were merged in one merge-queue batch: both parent branches were deleted in the same second, so the automatic base change retargeted #4447 onto `feat/mission-builder-02-missions` — already deleted — and a PR with no base gets closed. Nothing was wrong with the branch.

Now that #4443, #4445 and #4446 have landed, this targets `main` directly. It was rebased onto main (dropping the ten commits main already carries as squashes), leaving its own two; the delta is identical to what was reviewed in #4447, verified with a diff-of-diffs.

Events reach members' own calendars three ways: a per-fleet subscription feed, a personal feed spanning every fleet the member belongs to, and a one-shot download per event.

### What's here

- `Calendars::IcsBuilder` — emits VCALENDAR/VEVENT with `TZID` plus a `VTIMEZONE` block for non-UTC events, and `RRULE`/`EXDATE` for recurring ones. `X-WR-TIMEZONE` is set only when every event shares one zone.
- Subscription tokens on both `Fleet` and `User`, rotatable and revocable, so a leaked feed URL can be cut off without disturbing anything else
- The `ics` action and its route return to `fleet_events_controller` (removed in #4446 so the builder could ship separately)
- `FleetPolicy#manage_calendar?`

### Note on scope

This PR also carries the `frontend/fleets#event` action and its route. They look like frontend work, but `IcsBuilder` generates each event's `URL:` line with `frontend_fleet_event_url`, so the backend can't build a feed without them.

`20260512210000_add_calendar_feed_token_to_users` is here; the matching fleets column arrived in #4446 as part of one indivisible migration.

**`swagger/v1/schema.yaml` is generated — skip it.** Path set is main's 229 plus exactly 5 calendar paths.

### Verification

From the pre-rebase run of this same delta; CI re-runs here.

- `test/integration`, `test/models`, `test/lib`, `test/jobs`, `test/mailers` — 2614 tests, 6208 assertions, 0 failures
- `standardrb` clean, `vue-tsc` + `tsc` clean

#4448 → #4449 → #3893 stack on top of this branch.

🤖
