### PR TITLE
feat(models): trim padding from view uploads, and upload views by the folder

### DIFF
--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.scss
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.scss
@@ -2,21 +2,19 @@
   margin-bottom: 30px;
 }
 
-.views-folder-upload__hint,
-.views-folder-upload__ignored {
+.views-folder-upload__hint {
   color: $gray-lighter;
   font-size: 0.9rem;
 }
 
 .views-folder-upload__summary {
-  margin-top: 15px;
-  margin-bottom: 5px;
+  margin: 20px 0 10px;
 }
 
 .views-folder-upload__matched {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 5px 20px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px 30px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -24,11 +22,42 @@
   li {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
+    min-width: 0;
   }
 }
 
+// A fixed box for either icon keeps the labels lined up down the column,
+// whether a row is still uploading or done.
+.views-folder-upload__state {
+  flex: 0 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 16px;
+}
+
+.views-folder-upload__field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.views-folder-upload__label,
 .views-folder-upload__filename {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.views-folder-upload__filename {
+  color: $gray-lighter;
+  font-size: 0.8rem;
+}
+
+.views-folder-upload__ignored {
+  margin-top: 20px;
   color: $gray-lighter;
   font-size: 0.85rem;
 }

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.scss
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.scss
@@ -1,0 +1,34 @@
+.views-folder-upload {
+  margin-bottom: 30px;
+}
+
+.views-folder-upload__hint,
+.views-folder-upload__ignored {
+  color: $gray-lighter;
+  font-size: 0.9rem;
+}
+
+.views-folder-upload__summary {
+  margin-top: 15px;
+  margin-bottom: 5px;
+}
+
+.views-folder-upload__matched {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 5px 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.views-folder-upload__filename {
+  color: $gray-lighter;
+  font-size: 0.85rem;
+}

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
@@ -10,40 +10,38 @@ import DirectUpload, {
   type FileUpload,
 } from "@/shared/components/DirectUpload/index.vue";
 import {
-  AllowedFileTypes,
-  fileTypeMap,
-} from "@/shared/components/DirectUpload/types";
-import SmallLoader from "@/shared/components/SmallLoader/index.vue";
-import {
-  mapViewFiles,
-  type MappedView,
+  isViewField,
+  mapFolderFiles,
+  type FolderField,
+  type MappedFile,
   type ViewField,
 } from "@/admin/components/Models/ViewsFolderUpload/mapping";
 
-type PlannedView = MappedView & { file: File };
+type PlannedFile = MappedFile & { file: File };
 
 const { t } = useI18n();
 
 const emit = defineEmits<{
   selected: [previews: Partial<Record<ViewField, string>>];
-  mapped: [views: Partial<Record<ViewField, string>>];
+  mapped: [fields: Partial<Record<FolderField, string>>];
 }>();
 
-const plan = ref<PlannedView[]>([]);
-const previews = new Map<ViewField, string>();
+const plan = ref<PlannedFile[]>([]);
 const ignored = ref<string[]>([]);
 const uploaded = ref<File[]>([]);
 const uploading = ref(false);
+const previews = new Map<ViewField, string>();
 
 // The file input reports the folder in webkitRelativePath, a drop does not.
 const nameOf = (file: File) => file.webkitRelativePath || file.name;
 
 const basename = (filename: string) => filename.split("/").pop() || filename;
 
-// Runs before a single byte goes up, so a folder's odds and ends never become
-// blobs that no view is ever attached to.
-const filterViews = (files: File[]) => {
-  const { matched } = mapViewFiles(files, nameOf);
+// Runs before a single byte goes up, and it is the only gate: a name that spells
+// out a field, with the extension that field takes, or the file stays where it
+// is. So a folder's odds and ends never become blobs no view is attached to.
+const filterFolder = (files: File[]) => {
+  const { matched } = mapFolderFiles(files, nameOf);
 
   plan.value = matched.map(({ field, filename, item }) => ({
     field,
@@ -52,9 +50,14 @@ const filterViews = (files: File[]) => {
   }));
   uploaded.value = [];
 
-  // A signed id only arrives once the upload finishes, but the picture can be
+  // A signed id only arrives once the upload finishes, but a picture can be
   // shown from the local file at once, so no input sits there empty meanwhile.
+  // A holo has no still to show, and is left to its own viewer.
   plan.value.forEach(({ field, file }) => {
+    if (!isViewField(field)) {
+      return;
+    }
+
     const previous = previews.get(field);
 
     if (previous) {
@@ -86,16 +89,18 @@ const onUploadDone = (files: FileUpload[]) => {
   uploading.value = false;
   uploaded.value = files.filter((file) => !!file.blob).map((file) => file.file);
 
-  const views = plan.value.flatMap(({ field, file }): [ViewField, string][] => {
-    const upload = files.find((candidate) => candidate.file === file);
+  const fields = plan.value.flatMap(
+    ({ field, file }): [FolderField, string][] => {
+      const upload = files.find((candidate) => candidate.file === file);
 
-    return upload?.blob ? [[field, upload.blob.signed_id]] : [];
-  });
+      return upload?.blob ? [[field, upload.blob.signed_id]] : [];
+    },
+  );
 
-  emit("mapped", Object.fromEntries(views));
+  emit("mapped", Object.fromEntries(fields));
 };
 
-const isUploaded = (view: PlannedView) => uploaded.value.includes(view.file);
+const isUploaded = (entry: PlannedFile) => uploaded.value.includes(entry.file);
 </script>
 
 <template>
@@ -109,8 +114,7 @@ const isUploaded = (view: PlannedView) => uploaded.value.includes(view.file);
       inline
       directory
       direct-upload
-      :allowed-types="fileTypeMap[AllowedFileTypes.IMAGE]"
-      :filter="filterViews"
+      :filter="filterFolder"
       @upload:start="onUploadStart"
       @upload:done="onUploadDone"
       @files:rejected="onFilesRejected"
@@ -129,14 +133,22 @@ const isUploaded = (view: PlannedView) => uploaded.value.includes(view.file);
         }}
       </p>
       <ul class="views-folder-upload__matched">
-        <li v-for="view in plan" :key="view.field">
-          <i
-            v-if="isUploaded(view)"
-            class="fa-duotone fa-circle-check text-success"
-          />
-          <SmallLoader v-else loading />
-          <span>{{ t(`labels.model.${view.field}`) }}</span>
-          <span class="views-folder-upload__filename">{{ view.filename }}</span>
+        <li v-for="entry in plan" :key="entry.field">
+          <span class="views-folder-upload__state">
+            <i
+              v-if="isUploaded(entry)"
+              class="fa-duotone fa-circle-check text-success"
+            />
+            <i v-else class="fa-light fa-cloud-upload" />
+          </span>
+          <span class="views-folder-upload__field">
+            <span class="views-folder-upload__label">
+              {{ t(`labels.model.${entry.field}`) }}
+            </span>
+            <span class="views-folder-upload__filename">
+              {{ entry.filename }}
+            </span>
+          </span>
         </li>
       </ul>
     </template>

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
@@ -10,6 +10,7 @@ import DirectUpload, {
   type FileUpload,
 } from "@/shared/components/DirectUpload/index.vue";
 import {
+  isHoloField,
   mapFolderFiles,
   type FolderField,
   type MappedFile,
@@ -35,6 +36,33 @@ const nameOf = (file: File) => file.webkitRelativePath || file.name;
 
 const basename = (filename: string) => filename.split("/").pop() || filename;
 
+// What the preview beside a single upload has always handed the holo viewer,
+// and what three's FileLoader decodes where it stands rather than fetching. The
+// pictures are happy behind a blob: URL; a model behind one was not.
+const readDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+
+    reader.readAsDataURL(file);
+  });
+
+const publishPreviews = () => {
+  emit("selected", Object.fromEntries(previews));
+};
+
+const forget = (field: FolderField) => {
+  const previous = previews.get(field);
+
+  if (previous?.startsWith("blob:")) {
+    URL.revokeObjectURL(previous);
+  }
+
+  previews.delete(field);
+};
+
 // Runs before a single byte goes up, and it is the only gate: a name that spells
 // out a field, with the extension that field takes, or the file stays where it
 // is. So a folder's odds and ends never become blobs no view is attached to.
@@ -50,25 +78,30 @@ const filterFolder = (files: File[]) => {
 
   // A signed id only arrives once the upload finishes, but the file itself can
   // be shown at once -- a picture as a picture, a holo in its viewer -- so no
-  // input sits there empty meanwhile.
+  // input sits there empty meanwhile. Reading a holo takes a moment, so it
+  // lands in a second round.
   plan.value.forEach(({ field, file }) => {
-    const previous = previews.get(field);
+    forget(field);
 
-    if (previous) {
-      URL.revokeObjectURL(previous);
+    if (isHoloField(field)) {
+      void readDataUrl(file).then((url) => {
+        previews.set(field, url);
+        publishPreviews();
+      });
+
+      return;
     }
 
     previews.set(field, URL.createObjectURL(file));
   });
 
-  emit("selected", Object.fromEntries(previews));
+  publishPreviews();
 
   return matched.map(({ item }) => item);
 };
 
 onBeforeUnmount(() => {
-  previews.forEach((url) => URL.revokeObjectURL(url));
-  previews.clear();
+  Array.from(previews.keys()).forEach(forget);
 });
 
 const onFilesRejected = (files: File[]) => {

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
@@ -1,0 +1,156 @@
+<script lang="ts">
+export default {
+  name: "ModelsViewsFolderUpload",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import DirectUpload, {
+  type FileUpload,
+} from "@/shared/components/DirectUpload/index.vue";
+import {
+  AllowedFileTypes,
+  fileTypeMap,
+} from "@/shared/components/DirectUpload/types";
+import SmallLoader from "@/shared/components/SmallLoader/index.vue";
+import {
+  mapViewFiles,
+  type MappedView,
+  type ViewField,
+} from "@/admin/components/Models/ViewsFolderUpload/mapping";
+
+type PlannedView = MappedView & { file: File };
+
+const { t } = useI18n();
+
+const emit = defineEmits<{
+  selected: [previews: Partial<Record<ViewField, string>>];
+  mapped: [views: Partial<Record<ViewField, string>>];
+}>();
+
+const plan = ref<PlannedView[]>([]);
+const previews = new Map<ViewField, string>();
+const ignored = ref<string[]>([]);
+const uploaded = ref<File[]>([]);
+const uploading = ref(false);
+
+// The file input reports the folder in webkitRelativePath, a drop does not.
+const nameOf = (file: File) => file.webkitRelativePath || file.name;
+
+const basename = (filename: string) => filename.split("/").pop() || filename;
+
+// Runs before a single byte goes up, so a folder's odds and ends never become
+// blobs that no view is ever attached to.
+const filterViews = (files: File[]) => {
+  const { matched } = mapViewFiles(files, nameOf);
+
+  plan.value = matched.map(({ field, filename, item }) => ({
+    field,
+    filename: basename(filename),
+    file: item,
+  }));
+  uploaded.value = [];
+
+  // A signed id only arrives once the upload finishes, but the picture can be
+  // shown from the local file at once, so no input sits there empty meanwhile.
+  plan.value.forEach(({ field, file }) => {
+    const previous = previews.get(field);
+
+    if (previous) {
+      URL.revokeObjectURL(previous);
+    }
+
+    previews.set(field, URL.createObjectURL(file));
+  });
+
+  emit("selected", Object.fromEntries(previews));
+
+  return matched.map(({ item }) => item);
+};
+
+onBeforeUnmount(() => {
+  previews.forEach((url) => URL.revokeObjectURL(url));
+  previews.clear();
+});
+
+const onFilesRejected = (files: File[]) => {
+  ignored.value = files.map((file) => basename(nameOf(file)));
+};
+
+const onUploadStart = () => {
+  uploading.value = plan.value.length > 0;
+};
+
+const onUploadDone = (files: FileUpload[]) => {
+  uploading.value = false;
+  uploaded.value = files.filter((file) => !!file.blob).map((file) => file.file);
+
+  const views = plan.value.flatMap(({ field, file }): [ViewField, string][] => {
+    const upload = files.find((candidate) => candidate.file === file);
+
+    return upload?.blob ? [[field, upload.blob.signed_id]] : [];
+  });
+
+  emit("mapped", Object.fromEntries(views));
+};
+
+const isUploaded = (view: PlannedView) => uploaded.value.includes(view.file);
+</script>
+
+<template>
+  <div class="views-folder-upload">
+    <p class="views-folder-upload__hint">
+      {{ t("texts.admin.models.viewsFolder.hint") }}
+    </p>
+
+    <DirectUpload
+      multiple
+      inline
+      directory
+      direct-upload
+      :allowed-types="fileTypeMap[AllowedFileTypes.IMAGE]"
+      :filter="filterViews"
+      @upload:start="onUploadStart"
+      @upload:done="onUploadDone"
+      @files:rejected="onFilesRejected"
+    />
+
+    <template v-if="plan.length">
+      <p class="views-folder-upload__summary">
+        {{
+          uploading
+            ? t("texts.admin.models.viewsFolder.uploading", {
+                count: plan.length,
+              })
+            : t("texts.admin.models.viewsFolder.matched", {
+                count: plan.length,
+              })
+        }}
+      </p>
+      <ul class="views-folder-upload__matched">
+        <li v-for="view in plan" :key="view.field">
+          <i
+            v-if="isUploaded(view)"
+            class="fa-duotone fa-circle-check text-success"
+          />
+          <SmallLoader v-else loading />
+          <span>{{ t(`labels.model.${view.field}`) }}</span>
+          <span class="views-folder-upload__filename">{{ view.filename }}</span>
+        </li>
+      </ul>
+    </template>
+
+    <p v-if="ignored.length" class="views-folder-upload__ignored">
+      {{
+        t("texts.admin.models.viewsFolder.ignored", {
+          files: ignored.join(", "),
+        })
+      }}
+    </p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/index.vue
@@ -10,11 +10,9 @@ import DirectUpload, {
   type FileUpload,
 } from "@/shared/components/DirectUpload/index.vue";
 import {
-  isViewField,
   mapFolderFiles,
   type FolderField,
   type MappedFile,
-  type ViewField,
 } from "@/admin/components/Models/ViewsFolderUpload/mapping";
 
 type PlannedFile = MappedFile & { file: File };
@@ -22,7 +20,7 @@ type PlannedFile = MappedFile & { file: File };
 const { t } = useI18n();
 
 const emit = defineEmits<{
-  selected: [previews: Partial<Record<ViewField, string>>];
+  selected: [previews: Partial<Record<FolderField, string>>];
   mapped: [fields: Partial<Record<FolderField, string>>];
 }>();
 
@@ -30,7 +28,7 @@ const plan = ref<PlannedFile[]>([]);
 const ignored = ref<string[]>([]);
 const uploaded = ref<File[]>([]);
 const uploading = ref(false);
-const previews = new Map<ViewField, string>();
+const previews = new Map<FolderField, string>();
 
 // The file input reports the folder in webkitRelativePath, a drop does not.
 const nameOf = (file: File) => file.webkitRelativePath || file.name;
@@ -50,14 +48,10 @@ const filterFolder = (files: File[]) => {
   }));
   uploaded.value = [];
 
-  // A signed id only arrives once the upload finishes, but a picture can be
-  // shown from the local file at once, so no input sits there empty meanwhile.
-  // A holo has no still to show, and is left to its own viewer.
+  // A signed id only arrives once the upload finishes, but the file itself can
+  // be shown at once -- a picture as a picture, a holo in its viewer -- so no
+  // input sits there empty meanwhile.
   plan.value.forEach(({ field, file }) => {
-    if (!isViewField(field)) {
-      return;
-    }
-
     const previous = previews.get(field);
 
     if (previous) {

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.spec.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { mapViewFiles, viewFieldFor } from "./mapping";
+
+describe("viewFieldFor", () => {
+  it("maps the four viewpoints", () => {
+    expect(viewFieldFor("top.png")).toBe("topView");
+    expect(viewFieldFor("side.png")).toBe("sideView");
+    expect(viewFieldFor("front.png")).toBe("frontView");
+    expect(viewFieldFor("angled.png")).toBe("angledView");
+  });
+
+  it("maps the colored variants", () => {
+    expect(viewFieldFor("angled_colored.png")).toBe("angledViewColored");
+    expect(viewFieldFor("top-colored.webp")).toBe("topViewColored");
+  });
+
+  it("maps the extended variants", () => {
+    expect(viewFieldFor("extended_front.png")).toBe("extendedFrontView");
+    expect(viewFieldFor("extended_angled_colored.png")).toBe(
+      "extendedAngledViewColored",
+    );
+  });
+
+  it("takes a spelled-out view and any case", () => {
+    expect(viewFieldFor("top_view.png")).toBe("topView");
+    expect(viewFieldFor("Extended_Side_View_Colored.PNG")).toBe(
+      "extendedSideViewColored",
+    );
+  });
+
+  it("reads through the folder a file was picked from", () => {
+    expect(viewFieldFor("Carrack/angled.png")).toBe("angledView");
+  });
+
+  it("leaves anything else alone", () => {
+    expect(viewFieldFor(".DS_Store")).toBeUndefined();
+    expect(viewFieldFor("hero.png")).toBeUndefined();
+    expect(viewFieldFor("holo.png")).toBeUndefined();
+    expect(viewFieldFor("top_left.png")).toBeUndefined();
+  });
+});
+
+describe("mapViewFiles", () => {
+  const map = (filenames: string[]) =>
+    mapViewFiles(filenames, (filename) => filename);
+
+  it("reports what it could not place", () => {
+    const { matched, ignored } = map(["top.png", "notes.txt"]);
+
+    expect(matched.map((view) => view.field)).toEqual(["topView"]);
+    expect(ignored).toEqual(["notes.txt"]);
+  });
+
+  it("keeps the first of two files claiming one view", () => {
+    const { matched, ignored } = map(["top.png", "top_view.png"]);
+
+    expect(matched.map((view) => view.filename)).toEqual(["top.png"]);
+    expect(ignored).toEqual(["top_view.png"]);
+  });
+
+  it("places a whole folder", () => {
+    const { matched, ignored } = map([
+      "Carrack/top.png",
+      "Carrack/side.png",
+      "Carrack/front.png",
+      "Carrack/angled.png",
+      "Carrack/angled_colored.png",
+      "Carrack/extended_top.png",
+    ]);
+
+    expect(matched.map((view) => view.field)).toEqual([
+      "topView",
+      "sideView",
+      "frontView",
+      "angledView",
+      "angledViewColored",
+      "extendedTopView",
+    ]);
+    expect(ignored).toEqual([]);
+  });
+});

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.spec.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.spec.ts
@@ -1,61 +1,103 @@
 import { describe, expect, it } from "vitest";
-import { mapViewFiles, viewFieldFor } from "./mapping";
+import { fieldFor, mapFolderFiles } from "./mapping";
 
-describe("viewFieldFor", () => {
+describe("fieldFor", () => {
   it("maps the four viewpoints", () => {
-    expect(viewFieldFor("top.png")).toBe("topView");
-    expect(viewFieldFor("side.png")).toBe("sideView");
-    expect(viewFieldFor("front.png")).toBe("frontView");
-    expect(viewFieldFor("angled.png")).toBe("angledView");
+    expect(fieldFor("top.png")).toBe("topView");
+    expect(fieldFor("side.png")).toBe("sideView");
+    expect(fieldFor("front.png")).toBe("frontView");
+    expect(fieldFor("angled.png")).toBe("angledView");
   });
 
   it("maps the colored variants", () => {
-    expect(viewFieldFor("angled_colored.png")).toBe("angledViewColored");
-    expect(viewFieldFor("top-colored.webp")).toBe("topViewColored");
+    expect(fieldFor("angled_colored.png")).toBe("angledViewColored");
+    expect(fieldFor("top-colored.webp")).toBe("topViewColored");
   });
 
   it("maps the extended variants", () => {
-    expect(viewFieldFor("extended_front.png")).toBe("extendedFrontView");
-    expect(viewFieldFor("extended_angled_colored.png")).toBe(
+    expect(fieldFor("extended_front.png")).toBe("extendedFrontView");
+    expect(fieldFor("extended_angled_colored.png")).toBe(
       "extendedAngledViewColored",
     );
   });
 
+  it("maps the holo models", () => {
+    expect(fieldFor("holo.gltf")).toBe("holo");
+    expect(fieldFor("holo.glb")).toBe("holo");
+    expect(fieldFor("extended_holo.gltf")).toBe("extendedHolo");
+  });
+
+  // A Blender export drops these beside the glTF, and every one of them answers
+  // to "holo".
+  it("leaves the rest of a 3D export alone", () => {
+    expect(fieldFor("holo.blend")).toBeUndefined();
+    expect(fieldFor("holo.blend1")).toBeUndefined();
+    expect(fieldFor("holo.obj")).toBeUndefined();
+    expect(fieldFor("holo.mtl")).toBeUndefined();
+    expect(fieldFor("holo.png")).toBeUndefined();
+  });
+
   it("takes a spelled-out view and any case", () => {
-    expect(viewFieldFor("top_view.png")).toBe("topView");
-    expect(viewFieldFor("Extended_Side_View_Colored.PNG")).toBe(
+    expect(fieldFor("top_view.png")).toBe("topView");
+    expect(fieldFor("Extended_Side_View_Colored.PNG")).toBe(
       "extendedSideViewColored",
     );
   });
 
   it("reads through the folder a file was picked from", () => {
-    expect(viewFieldFor("Carrack/angled.png")).toBe("angledView");
+    expect(fieldFor("Carrack/angled.png")).toBe("angledView");
+  });
+
+  it("wants a picture where it expects one", () => {
+    expect(fieldFor("top.gltf")).toBeUndefined();
+    expect(fieldFor("angled")).toBeUndefined();
   });
 
   it("leaves anything else alone", () => {
-    expect(viewFieldFor(".DS_Store")).toBeUndefined();
-    expect(viewFieldFor("hero.png")).toBeUndefined();
-    expect(viewFieldFor("holo.png")).toBeUndefined();
-    expect(viewFieldFor("top_left.png")).toBeUndefined();
+    expect(fieldFor(".DS_Store")).toBeUndefined();
+    expect(fieldFor("hero.png")).toBeUndefined();
+    expect(fieldFor("export.obj")).toBeUndefined();
+    expect(fieldFor("top_left.png")).toBeUndefined();
   });
 });
 
-describe("mapViewFiles", () => {
+describe("mapFolderFiles", () => {
   const map = (filenames: string[]) =>
-    mapViewFiles(filenames, (filename) => filename);
+    mapFolderFiles(filenames, (filename) => filename);
 
   it("reports what it could not place", () => {
     const { matched, ignored } = map(["top.png", "notes.txt"]);
 
-    expect(matched.map((view) => view.field)).toEqual(["topView"]);
+    expect(matched.map((entry) => entry.field)).toEqual(["topView"]);
     expect(ignored).toEqual(["notes.txt"]);
   });
 
-  it("keeps the first of two files claiming one view", () => {
+  it("keeps the first of two files claiming one field", () => {
     const { matched, ignored } = map(["top.png", "top_view.png"]);
 
-    expect(matched.map((view) => view.filename)).toEqual(["top.png"]);
+    expect(matched.map((entry) => entry.filename)).toEqual(["top.png"]);
     expect(ignored).toEqual(["top_view.png"]);
+  });
+
+  // However the folder was read: base set, colored set, extended set, holos.
+  it("lists the fields in a fixed order", () => {
+    const { matched } = map([
+      "Carrack/front-colored.png",
+      "Carrack/holo.gltf",
+      "Carrack/angled.png",
+      "Carrack/extended_top.png",
+      "Carrack/top.png",
+      "Carrack/top-colored.png",
+    ]);
+
+    expect(matched.map((entry) => entry.field)).toEqual([
+      "topView",
+      "angledView",
+      "topViewColored",
+      "frontViewColored",
+      "extendedTopView",
+      "holo",
+    ]);
   });
 
   it("places a whole folder", () => {
@@ -65,17 +107,18 @@ describe("mapViewFiles", () => {
       "Carrack/front.png",
       "Carrack/angled.png",
       "Carrack/angled_colored.png",
-      "Carrack/extended_top.png",
+      "Carrack/holo.gltf",
+      "Carrack/holo.blend",
     ]);
 
-    expect(matched.map((view) => view.field)).toEqual([
+    expect(matched.map((entry) => entry.field)).toEqual([
       "topView",
       "sideView",
       "frontView",
       "angledView",
       "angledViewColored",
-      "extendedTopView",
+      "holo",
     ]);
-    expect(ignored).toEqual([]);
+    expect(ignored).toEqual(["holo.blend"]);
   });
 });

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
@@ -31,9 +31,6 @@ export type FolderField = ViewField | HoloField;
 // The order the fields are listed in, whatever order the folder was read in.
 const FIELD_ORDER: readonly FolderField[] = [...VIEW_FIELDS, ...HOLO_FIELDS];
 
-export const isViewField = (field: FolderField): field is ViewField =>
-  (VIEW_FIELDS as readonly string[]).includes(field);
-
 export type MappedFile = {
   field: FolderField;
   filename: string;

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
@@ -19,33 +19,64 @@ export const VIEW_FIELDS = [
   "extendedAngledViewColored",
 ] as const satisfies readonly (keyof ModelUpdateInput)[];
 
-export type ViewField = (typeof VIEW_FIELDS)[number];
+export const HOLO_FIELDS = [
+  "holo",
+  "extendedHolo",
+] as const satisfies readonly (keyof ModelUpdateInput)[];
 
-export type MappedView = {
-  field: ViewField;
+export type ViewField = (typeof VIEW_FIELDS)[number];
+export type HoloField = (typeof HOLO_FIELDS)[number];
+export type FolderField = ViewField | HoloField;
+
+// The order the fields are listed in, whatever order the folder was read in.
+const FIELD_ORDER: readonly FolderField[] = [...VIEW_FIELDS, ...HOLO_FIELDS];
+
+export const isViewField = (field: FolderField): field is ViewField =>
+  (VIEW_FIELDS as readonly string[]).includes(field);
+
+export type MappedFile = {
+  field: FolderField;
   filename: string;
 };
 
-// top.png, angled_colored.png, extended-side.png. The separator, the case and a
-// spelled-out "view" are all optional so a folder named by hand lands in the
-// same place as one named by a script.
-const FILENAME =
+// top.png, angled_colored.png, extended-side.png, holo.gltf. The separator, the
+// case and a spelled-out "view" are all optional, so a folder named by hand
+// lands where one named by a script does.
+const VIEW_NAME =
   /^(extended[-_ ]?)?(top|side|front|angled)([-_ ]?view)?([-_ ]?colored)?$/i;
+const HOLO_NAME = /^(extended[-_ ]?)?holo$/i;
+
+// The name alone is not enough: a Blender export drops holo.blend, holo.obj and
+// holo.mtl beside the glTF, and every one of them answers to "holo".
+const VIEW_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif"];
+const HOLO_EXTENSIONS = ["gltf", "glb"];
 
 const capitalize = (word: string) =>
   `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`;
 
-export const viewFieldFor = (filename: string): ViewField | undefined => {
+export const fieldFor = (filename: string): FolderField | undefined => {
   // A folder picked through the file input carries its path in the name.
-  const stem = (filename.split("/").pop() ?? "").replace(/\.[^.]+$/, "").trim();
+  const basename = filename.split("/").pop() ?? "";
+  const stem = basename.replace(/\.[^.]+$/, "").trim();
+  const extension = basename.slice(stem.length + 1).toLowerCase();
 
-  const match = FILENAME.exec(stem);
+  const holo = HOLO_NAME.exec(stem);
 
-  if (!match) {
+  if (holo) {
+    if (!HOLO_EXTENSIONS.includes(extension)) {
+      return undefined;
+    }
+
+    return holo[1] ? "extendedHolo" : "holo";
+  }
+
+  const view = VIEW_NAME.exec(stem);
+
+  if (!view || !VIEW_EXTENSIONS.includes(extension)) {
     return undefined;
   }
 
-  const [, extended, viewpoint, , colored] = match;
+  const [, extended, viewpoint, , colored] = view;
 
   const base = extended
     ? `extended${capitalize(viewpoint)}View`
@@ -55,30 +86,35 @@ export const viewFieldFor = (filename: string): ViewField | undefined => {
 };
 
 export type MappedFolder<T> = {
-  matched: (MappedView & { item: T })[];
+  matched: (MappedFile & { item: T })[];
   ignored: string[];
 };
 
-// Two files claiming one view is a mistake in the folder, not something to
+// Two files claiming one field is a mistake in the folder, not something to
 // resolve by guessing: the first one is taken and the other is reported.
-export const mapViewFiles = <T>(
+export const mapFolderFiles = <T>(
   items: T[],
   filenameOf: (item: T) => string,
 ): MappedFolder<T> => {
-  const matched: (MappedView & { item: T })[] = [];
+  const matched: (MappedFile & { item: T })[] = [];
   const ignored: string[] = [];
 
   items.forEach((item) => {
     const filename = filenameOf(item);
-    const field = viewFieldFor(filename);
+    const field = fieldFor(filename);
 
-    if (!field || matched.some((view) => view.field === field)) {
+    if (!field || matched.some((entry) => entry.field === field)) {
       ignored.push(filename.split("/").pop() ?? filename);
       return;
     }
 
     matched.push({ field, filename, item });
   });
+
+  matched.sort(
+    (left, right) =>
+      FIELD_ORDER.indexOf(left.field) - FIELD_ORDER.indexOf(right.field),
+  );
 
   return { matched, ignored };
 };

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
@@ -1,0 +1,84 @@
+import { type ModelUpdateInput } from "@/services/fyAdminApi";
+
+export const VIEW_FIELDS = [
+  "topView",
+  "sideView",
+  "frontView",
+  "angledView",
+  "topViewColored",
+  "sideViewColored",
+  "frontViewColored",
+  "angledViewColored",
+  "extendedTopView",
+  "extendedSideView",
+  "extendedFrontView",
+  "extendedAngledView",
+  "extendedTopViewColored",
+  "extendedSideViewColored",
+  "extendedFrontViewColored",
+  "extendedAngledViewColored",
+] as const satisfies readonly (keyof ModelUpdateInput)[];
+
+export type ViewField = (typeof VIEW_FIELDS)[number];
+
+export type MappedView = {
+  field: ViewField;
+  filename: string;
+};
+
+// top.png, angled_colored.png, extended-side.png. The separator, the case and a
+// spelled-out "view" are all optional so a folder named by hand lands in the
+// same place as one named by a script.
+const FILENAME =
+  /^(extended[-_ ]?)?(top|side|front|angled)([-_ ]?view)?([-_ ]?colored)?$/i;
+
+const capitalize = (word: string) =>
+  `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`;
+
+export const viewFieldFor = (filename: string): ViewField | undefined => {
+  // A folder picked through the file input carries its path in the name.
+  const stem = (filename.split("/").pop() ?? "").replace(/\.[^.]+$/, "").trim();
+
+  const match = FILENAME.exec(stem);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const [, extended, viewpoint, , colored] = match;
+
+  const base = extended
+    ? `extended${capitalize(viewpoint)}View`
+    : `${viewpoint.toLowerCase()}View`;
+
+  return (colored ? `${base}Colored` : base) as ViewField;
+};
+
+export type MappedFolder<T> = {
+  matched: (MappedView & { item: T })[];
+  ignored: string[];
+};
+
+// Two files claiming one view is a mistake in the folder, not something to
+// resolve by guessing: the first one is taken and the other is reported.
+export const mapViewFiles = <T>(
+  items: T[],
+  filenameOf: (item: T) => string,
+): MappedFolder<T> => {
+  const matched: (MappedView & { item: T })[] = [];
+  const ignored: string[] = [];
+
+  items.forEach((item) => {
+    const filename = filenameOf(item);
+    const field = viewFieldFor(filename);
+
+    if (!field || matched.some((view) => view.field === field)) {
+      ignored.push(filename.split("/").pop() ?? filename);
+      return;
+    }
+
+    matched.push({ field, filename, item });
+  });
+
+  return { matched, ignored };
+};

--- a/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
+++ b/app/frontend/admin/components/Models/ViewsFolderUpload/mapping.ts
@@ -31,6 +31,9 @@ export type FolderField = ViewField | HoloField;
 // The order the fields are listed in, whatever order the folder was read in.
 const FIELD_ORDER: readonly FolderField[] = [...VIEW_FIELDS, ...HOLO_FIELDS];
 
+export const isHoloField = (field: FolderField): field is HoloField =>
+  (HOLO_FIELDS as readonly string[]).includes(field);
+
 export type MappedFile = {
   field: FolderField;
   filename: string;

--- a/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
@@ -15,7 +15,10 @@ import { useForm } from "vee-validate";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import ModelForm from "@/admin/components/Models/Form/index.vue";
 import ViewsFolderUpload from "@/admin/components/Models/ViewsFolderUpload/index.vue";
-import { type ViewField } from "@/admin/components/Models/ViewsFolderUpload/mapping";
+import {
+  type FolderField,
+  type ViewField,
+} from "@/admin/components/Models/ViewsFolderUpload/mapping";
 import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
 
 type Props = {
@@ -61,9 +64,9 @@ const onFolderSelected = (views: Partial<Record<ViewField, string>>) => {
   previews.value = views;
 };
 
-const onFolderMapped = (views: Partial<Record<ViewField, string>>) => {
-  Object.entries(views).forEach(([field, signedId]) => {
-    setFieldValue(field as ViewField, signedId);
+const onFolderMapped = (fields: Partial<Record<FolderField, string>>) => {
+  Object.entries(fields).forEach(([field, signedId]) => {
+    setFieldValue(field as FolderField, signedId);
   });
 };
 

--- a/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
@@ -15,10 +15,7 @@ import { useForm } from "vee-validate";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import ModelForm from "@/admin/components/Models/Form/index.vue";
 import ViewsFolderUpload from "@/admin/components/Models/ViewsFolderUpload/index.vue";
-import {
-  type FolderField,
-  type ViewField,
-} from "@/admin/components/Models/ViewsFolderUpload/mapping";
+import { type FolderField } from "@/admin/components/Models/ViewsFolderUpload/mapping";
 import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
 
 type Props = {
@@ -58,10 +55,10 @@ const { defineField, handleSubmit, meta, setFieldValue } =
 // Kept for as long as the page lives. A save refetches the model, but the trim
 // that follows replaces the blob and purges the one that refetch named, so the
 // local file is the picture that stays true.
-const previews = ref<Partial<Record<ViewField, string>>>({});
+const previews = ref<Partial<Record<FolderField, string>>>({});
 
-const onFolderSelected = (views: Partial<Record<ViewField, string>>) => {
-  previews.value = views;
+const onFolderSelected = (fields: Partial<Record<FolderField, string>>) => {
+  previews.value = fields;
 };
 
 const onFolderMapped = (fields: Partial<Record<FolderField, string>>) => {
@@ -118,6 +115,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           translation-key="model.defaultHolo"
           v-bind="holoProps"
           name="holo"
+          :preview-src="previews.holo"
           :allowed-types="AllowedFileTypes.HOLO"
           clearable
         />
@@ -129,6 +127,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           translation-key="model.extendedHolo"
           v-bind="extendedHoloProps"
           name="extendedHolo"
+          :preview-src="previews.extendedHolo"
           :allowed-types="AllowedFileTypes.HOLO"
           clearable
         />

--- a/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/fleetchart.vue
@@ -14,6 +14,8 @@ import {
 import { useForm } from "vee-validate";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import ModelForm from "@/admin/components/Models/Form/index.vue";
+import ViewsFolderUpload from "@/admin/components/Models/ViewsFolderUpload/index.vue";
+import { type ViewField } from "@/admin/components/Models/ViewsFolderUpload/mapping";
 import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
 
 type Props = {
@@ -45,9 +47,25 @@ const initialValues = ref<ModelUpdateInput>({
   extendedAngledViewColored: undefined,
 });
 
-const { defineField, handleSubmit, meta } = useForm<ModelUpdateInput>({
-  initialValues: initialValues.value,
-});
+const { defineField, handleSubmit, meta, setFieldValue } =
+  useForm<ModelUpdateInput>({
+    initialValues: initialValues.value,
+  });
+
+// Kept for as long as the page lives. A save refetches the model, but the trim
+// that follows replaces the blob and purges the one that refetch named, so the
+// local file is the picture that stays true.
+const previews = ref<Partial<Record<ViewField, string>>>({});
+
+const onFolderSelected = (views: Partial<Record<ViewField, string>>) => {
+  previews.value = views;
+};
+
+const onFolderMapped = (views: Partial<Record<ViewField, string>>) => {
+  Object.entries(views).forEach(([field, signedId]) => {
+    setFieldValue(field as ViewField, signedId);
+  });
+};
 
 const [holo, holoProps] = defineField("holo");
 const [extendedHolo, extendedHoloProps] = defineField("extendedHolo");
@@ -85,6 +103,10 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
 <template>
   <Heading hero>{{ t("headlines.admin.models.edit.fleetchart") }}</Heading>
   <ModelForm :model="model" :handle-submit="handleSubmit" :meta="meta">
+    <ViewsFolderUpload @selected="onFolderSelected" @mapped="onFolderMapped" />
+
+    <hr />
+
     <div class="row">
       <div class="col-12 col-md-6">
         <FormFileInput
@@ -121,6 +143,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           v-bind="topViewProps"
           :allowed-types="AllowedFileTypes.IMAGE"
           name="topView"
+          :preview-src="previews.topView"
           transparent
           clearable
         />
@@ -133,6 +156,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="sideViewProps"
           name="sideView"
+          :preview-src="previews.sideView"
           transparent
           clearable
         />
@@ -145,6 +169,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="frontViewProps"
           name="frontView"
+          :preview-src="previews.frontView"
           transparent
           clearable
         />
@@ -157,6 +182,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="angledViewProps"
           name="angledView"
+          :preview-src="previews.angledView"
           transparent
           clearable
         />
@@ -172,6 +198,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="topViewColoredProps"
           name="topViewColored"
+          :preview-src="previews.topViewColored"
           transparent
           clearable
         />
@@ -184,6 +211,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="sideViewColoredProps"
           name="sideViewColored"
+          :preview-src="previews.sideViewColored"
           transparent
           clearable
         />
@@ -196,6 +224,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="frontViewColoredProps"
           name="frontViewColored"
+          :preview-src="previews.frontViewColored"
           transparent
           clearable
         />
@@ -208,6 +237,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="angledViewColoredProps"
           name="angledViewColored"
+          :preview-src="previews.angledViewColored"
           transparent
           clearable
         />
@@ -225,6 +255,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           v-bind="extendedTopViewProps"
           :allowed-types="AllowedFileTypes.IMAGE"
           name="extendedTopView"
+          :preview-src="previews.extendedTopView"
           transparent
           clearable
         />
@@ -237,6 +268,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedSideViewProps"
           name="extendedSideView"
+          :preview-src="previews.extendedSideView"
           transparent
           clearable
         />
@@ -249,6 +281,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedFrontViewProps"
           name="extendedFrontView"
+          :preview-src="previews.extendedFrontView"
           transparent
           clearable
         />
@@ -261,6 +294,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedAngledViewProps"
           name="extendedAngledView"
+          :preview-src="previews.extendedAngledView"
           transparent
           clearable
         />
@@ -276,6 +310,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedTopViewColoredProps"
           name="extendedTopViewColored"
+          :preview-src="previews.extendedTopViewColored"
           transparent
           clearable
         />
@@ -288,6 +323,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedSideViewColoredProps"
           name="extendedSideViewColored"
+          :preview-src="previews.extendedSideViewColored"
           transparent
           clearable
         />
@@ -300,6 +336,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedFrontViewColoredProps"
           name="extendedFrontViewColored"
+          :preview-src="previews.extendedFrontViewColored"
           transparent
           clearable
         />
@@ -312,6 +349,7 @@ const [extendedAngledViewColored, extendedAngledViewColoredProps] = defineField(
           :allowed-types="AllowedFileTypes.IMAGE"
           v-bind="extendedAngledViewColoredProps"
           name="extendedAngledViewColored"
+          :preview-src="previews.extendedAngledViewColored"
           transparent
           clearable
         />

--- a/app/frontend/shared/components/DirectUpload/Uploader/index.vue
+++ b/app/frontend/shared/components/DirectUpload/Uploader/index.vue
@@ -12,6 +12,7 @@ import DirectUploadPreview from "@/shared/components/DirectUpload/Preview/index.
 import ProgressBar from "@/shared/components/ProgressBar/index.vue";
 import { type Blob } from "@rails/activestorage";
 import { useDirectUpload } from "@/shared/composables/useDirectUpload";
+import { filesFromDataTransfer } from "@/shared/components/DirectUpload/directoryFiles";
 import { v4 as uuidv4 } from "uuid";
 
 export type FileUpload = {
@@ -31,6 +32,8 @@ type Props = {
   allowedSizeMb?: number;
   directUpload?: boolean;
   inputOnly?: boolean;
+  directory?: boolean;
+  filter?: (files: File[]) => File[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -42,6 +45,8 @@ const props = withDefaults(defineProps<Props>(), {
   allowedSizeMb: undefined,
   directUpload: false,
   inputOnly: false,
+  directory: false,
+  filter: undefined,
 });
 
 const { t } = useI18n();
@@ -53,7 +58,7 @@ const input = ref<HTMLInputElement | undefined>();
 const dropzone = ref<HTMLDivElement | undefined>();
 const isDragging = ref<boolean>(false);
 
-const handleFileSelect = async (fileList?: FileList) => {
+const handleFileSelect = async (fileList?: FileList | File[]) => {
   if (!fileList) {
     return;
   }
@@ -62,7 +67,15 @@ const handleFileSelect = async (fileList?: FileList) => {
     files.value = [];
   }
 
-  Array.from(fileList).forEach((file) => {
+  const selected = Array.from(fileList);
+
+  // A caller that wants only some of what was picked -- a folder of views, say
+  // -- says so here, before anything is uploaded, so nothing it cannot use ends
+  // up in storage as a blob nobody attaches.
+  const accepted = props.filter ? props.filter(selected) : selected;
+  const rejected = selected.filter((file) => !accepted.includes(file));
+
+  accepted.forEach((file) => {
     if (files.value.some((f) => f.file === file)) {
       return;
     }
@@ -75,12 +88,18 @@ const handleFileSelect = async (fileList?: FileList) => {
       });
 
       if (!isAllowed) {
-        displayAlert({
-          text: t("errors.upload.invalidFileType", {
-            filename: file.name,
-            types: props.allowedTypes.join(", "),
-          }),
-        });
+        rejected.push(file);
+
+        // A folder carries whatever else happens to sit in it -- .DS_Store,
+        // sidecar files -- and alerting on each of them would bury the upload.
+        if (!props.directory) {
+          displayAlert({
+            text: t("errors.upload.invalidFileType", {
+              filename: file.name,
+              types: props.allowedTypes.join(", "),
+            }),
+          });
+        }
         return;
       }
     }
@@ -91,6 +110,8 @@ const handleFileSelect = async (fileList?: FileList) => {
       const isAllowed = fileSizeMB <= props.allowedSizeMb;
 
       if (!isAllowed) {
+        rejected.push(file);
+
         displayAlert({
           text: t("errors.upload.fileTooLarge", {
             filename: file.name,
@@ -104,6 +125,10 @@ const handleFileSelect = async (fileList?: FileList) => {
     files.value.push({ key: uuidv4(), file, progress: 0, status: "pending" });
   });
 
+  // Emitted for every selection, empty included, so a caller reporting what was
+  // dropped is not left showing the last pick's leftovers.
+  emit("files:rejected", rejected);
+
   if (!props.multiple || props.directUpload) {
     await upload();
   }
@@ -113,9 +138,23 @@ const onDrop = async (event: DragEvent) => {
   event.preventDefault();
   event.stopPropagation();
 
-  await handleFileSelect(event.dataTransfer?.files);
+  await handleFileSelect(await droppedFiles(event));
 
   isDragging.value = false;
+};
+
+// A folder is dropped as a directory entry rather than as its files, so in
+// directory mode the entries are walked instead of read off `files`.
+const droppedFiles = async (event: DragEvent) => {
+  if (!event.dataTransfer) {
+    return undefined;
+  }
+
+  if (!props.directory) {
+    return event.dataTransfer.files;
+  }
+
+  return filesFromDataTransfer(event.dataTransfer);
 };
 
 const onInputChange = async (event: Event) => {
@@ -223,6 +262,7 @@ const emit = defineEmits<{
   "upload:start": [files: FileUpload[]];
   "upload:progress": [progress: number];
   "upload:done": [files: FileUpload[]];
+  "files:rejected": [files: File[]];
   clear: [];
 }>();
 
@@ -295,7 +335,10 @@ defineExpose({
     >
       <i class="fa-light fa-cloud-upload"></i>
       <span class="direct-upload__dropzone-title">
-        <template v-if="multiple">
+        <template v-if="directory">
+          {{ t("directUpload.dropzone.textDirectory") }}
+        </template>
+        <template v-else-if="multiple">
           {{ t("directUpload.dropzone.textMultiple") }}
         </template>
         <template v-else>
@@ -304,7 +347,9 @@ defineExpose({
       </span>
       <span>{{ t("directUpload.dropzone.or") }}</span>
       <Btn @click="chooseFile" :variant="BtnVariantsEnum.BARE">{{
-        t("directUpload.dropzone.browse")
+        directory
+          ? t("directUpload.dropzone.browseDirectory")
+          : t("directUpload.dropzone.browse")
       }}</Btn>
     </div>
     <input
@@ -312,6 +357,7 @@ defineExpose({
       type="file"
       class="direct-upload__input"
       :multiple="props.multiple"
+      :webkitdirectory="props.directory || null"
       @change="onInputChange"
     />
     <Transition name="fade">

--- a/app/frontend/shared/components/DirectUpload/directoryFiles.ts
+++ b/app/frontend/shared/components/DirectUpload/directoryFiles.ts
@@ -1,0 +1,61 @@
+// A dropped folder arrives as a directory entry rather than as files, so it has
+// to be walked. `dataTransfer.items` is only readable while the drop event is
+// being handled, which is why every entry is taken up front and traversed after.
+const readFile = (entry: FileSystemFileEntry): Promise<File> =>
+  new Promise((resolve, reject) => entry.file(resolve, reject));
+
+const readEntries = (
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> =>
+  new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+
+// readEntries hands back a batch at a time and signals the end with an empty
+// one, so a folder has to be read until it runs dry.
+const readDirectory = async (
+  entry: FileSystemDirectoryEntry,
+): Promise<FileSystemEntry[]> => {
+  const reader = entry.createReader();
+  const entries: FileSystemEntry[] = [];
+
+  let batch = await readEntries(reader);
+
+  while (batch.length) {
+    entries.push(...batch);
+    batch = await readEntries(reader);
+  }
+
+  return entries;
+};
+
+export const filesFromEntry = async (
+  entry: FileSystemEntry,
+): Promise<File[]> => {
+  if (entry.isFile) {
+    return [await readFile(entry as FileSystemFileEntry)];
+  }
+
+  if (!entry.isDirectory) {
+    return [];
+  }
+
+  const entries = await readDirectory(entry as FileSystemDirectoryEntry);
+  const files = await Promise.all(entries.map(filesFromEntry));
+
+  return files.flat();
+};
+
+export const filesFromDataTransfer = async (
+  dataTransfer: DataTransfer,
+): Promise<File[]> => {
+  const entries = Array.from(dataTransfer.items)
+    .map((item) => item.webkitGetAsEntry())
+    .filter((entry): entry is FileSystemEntry => !!entry);
+
+  if (!entries.length) {
+    return Array.from(dataTransfer.files);
+  }
+
+  const files = await Promise.all(entries.map(filesFromEntry));
+
+  return files.flat();
+};

--- a/app/frontend/shared/components/DirectUpload/index.vue
+++ b/app/frontend/shared/components/DirectUpload/index.vue
@@ -25,6 +25,8 @@ type Props = {
   allowedSizeMb?: number;
   directUpload?: boolean;
   inputOnly?: boolean;
+  directory?: boolean;
+  filter?: (files: File[]) => File[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -37,6 +39,8 @@ const props = withDefaults(defineProps<Props>(), {
   allowedSizeMb: undefined,
   directUpload: false,
   inputOnly: false,
+  directory: false,
+  filter: undefined,
 });
 
 const uploader = ref<InstanceType<typeof DirectUploadUploader>>();
@@ -55,6 +59,7 @@ const emit = defineEmits<{
   "upload:start": [files: FileUpload[]];
   "upload:progress": [progress: number];
   "upload:done": [files: FileUpload[]];
+  "files:rejected": [files: File[]];
   clear: [];
 }>();
 
@@ -68,6 +73,10 @@ const handleUploadProgress = (progress: number) => {
 
 const handleUploadDone = (files: FileUpload[]) => {
   emit("upload:done", files);
+};
+
+const handleFilesRejected = (files: File[]) => {
+  emit("files:rejected", files);
 };
 
 const handleClear = () => {
@@ -103,9 +112,12 @@ defineExpose({
         :allowed-size-mb="allowedSizeMb"
         :direct-upload="directUpload"
         :input-only="inputOnly"
+        :directory="directory"
+        :filter="filter"
         @upload:done="handleUploadDone"
         @upload:progress="handleUploadProgress"
         @upload:start="handleUploadStart"
+        @files:rejected="handleFilesRejected"
         @clear="handleClear"
       />
       <DirectUploadActions

--- a/app/frontend/shared/components/HoloViewer/index.vue
+++ b/app/frontend/shared/components/HoloViewer/index.vue
@@ -382,6 +382,7 @@ defineExpose({
       <Suspense>
         <Model
           v-for="model in models"
+          :key="model.path"
           :model="model"
           :color="modelColor"
           :on-grid="grid"

--- a/app/frontend/shared/components/base/FormFileInput/index.vue
+++ b/app/frontend/shared/components/base/FormFileInput/index.vue
@@ -242,6 +242,32 @@ watch(
   },
 );
 
+// The types this input takes, however they were passed.
+const allowedTypeList = computed(() => {
+  if (!props.allowedTypes) {
+    return [];
+  }
+
+  return Array.isArray(props.allowedTypes)
+    ? props.allowedTypes
+    : [props.allowedTypes];
+});
+
+// A holo is drawn by its viewer rather than shown as a picture, so a previewSrc
+// for one is a local file to load, not an image to display.
+const previewHoloModel = computed(() => {
+  if (
+    !props.previewSrc ||
+    !allowedTypeList.value.includes(AllowedFileTypes.HOLO)
+  ) {
+    return undefined;
+  }
+
+  return {
+    path: props.previewSrc,
+  };
+});
+
 const holoModel = computed(() => {
   if (props.file?.url && isHolo.value) {
     return {
@@ -279,10 +305,16 @@ defineExpose({
     </transition>
     <div class="base-image-input__wrapper">
       <template v-if="!uploadedHere">
-        <!-- A value set from outside brings its own picture: the upload that
+        <!-- A value set from outside brings its own file: the upload that
              filled it happened elsewhere, so this input has none to show. -->
+        <HoloViewer
+          v-if="previewHoloModel"
+          :controllable="false"
+          :models="[previewHoloModel]"
+          inline
+        />
         <LazyImage
-          v-if="previewSrc"
+          v-else-if="previewSrc"
           v-tooltip.right="hasErrors && errorMessage"
           :src="previewSrc"
           :transparent="transparent || avatar"

--- a/app/frontend/shared/components/base/FormFileInput/index.vue
+++ b/app/frontend/shared/components/base/FormFileInput/index.vue
@@ -25,6 +25,7 @@ type Props = {
   file?: MediaFile;
   icon?: string;
   modelValue?: string | null;
+  previewSrc?: string;
   translationKey?: string;
   autofocus?: boolean;
   autocomplete?: string;
@@ -52,6 +53,7 @@ const props = withDefaults(defineProps<Props>(), {
   file: undefined,
   icon: undefined,
   modelValue: undefined,
+  previewSrc: undefined,
   translationKey: undefined,
   autofocus: false,
   autocomplete: undefined,
@@ -264,9 +266,18 @@ defineExpose({
       </label>
     </transition>
     <div class="base-image-input__wrapper">
-      <template v-if="!inputValue">
+      <template v-if="!inputValue || previewSrc">
+        <!-- A value set from outside brings its own picture: the upload that
+             filled it happened elsewhere, so this input has none to show. -->
         <LazyImage
-          v-if="(isImage || isPdf) && internalSrc"
+          v-if="previewSrc"
+          v-tooltip.right="hasErrors && errorMessage"
+          :src="previewSrc"
+          :transparent="transparent || avatar"
+          :shadow="!transparent && !avatar"
+        />
+        <LazyImage
+          v-else-if="(isImage || isPdf) && internalSrc"
           v-tooltip.right="hasErrors && errorMessage"
           :src="internalSrc"
           :transparent="transparent || avatar"

--- a/app/frontend/shared/components/base/FormFileInput/index.vue
+++ b/app/frontend/shared/components/base/FormFileInput/index.vue
@@ -130,6 +130,11 @@ const isHolo = computed(() => {
 
 const internalSrc = ref<string>();
 
+// Whether this input's own upload is showing what it uploaded. A value set from
+// outside -- the views folder filling the whole form -- is not that, and hiding
+// the picture for it left the input blank.
+const uploadedHere = ref(false);
+
 const hasErrors = computed(() => {
   return errors.value.length;
 });
@@ -153,6 +158,8 @@ onMounted(() => {
 const emit = defineEmits(["update:modelValue"]);
 
 const clear = () => {
+  uploadedHere.value = false;
+
   if (inputValue.value) {
     directUpload.value?.clear();
   } else {
@@ -167,11 +174,14 @@ const onUploadDone = (files: FileUpload[]) => {
     return;
   }
 
+  uploadedHere.value = true;
   inputValue.value = files[0].blob.signed_id;
   emit("update:modelValue", files[0].blob.signed_id);
 };
 
 const onUploadClear = () => {
+  uploadedHere.value = false;
+
   resetField({
     value: props.modelValue,
   });
@@ -209,6 +219,8 @@ const slots = useSlots();
 const directUpload = ref<InstanceType<typeof DirectUpload>>();
 
 const setup = () => {
+  uploadedHere.value = false;
+
   directUpload.value?.clear();
 
   internalSrc.value = isHolo.value ? props.file?.url : props.file?.smallUrl;
@@ -266,7 +278,7 @@ defineExpose({
       </label>
     </transition>
     <div class="base-image-input__wrapper">
-      <template v-if="!inputValue || previewSrc">
+      <template v-if="!uploadedHere">
         <!-- A value set from outside brings its own picture: the upload that
              filled it happened elsewhere, so this input has none to show. -->
         <LazyImage

--- a/app/frontend/translations/en/directUpload.json
+++ b/app/frontend/translations/en/directUpload.json
@@ -5,9 +5,11 @@
       "chooseFiles": "Choose files",
       "dropzone": {
         "textMultiple": "Drop files here",
+        "textDirectory": "Drop a folder here",
         "text": "Drop file here",
         "or": "or",
-        "browse": "browse"
+        "browse": "browse",
+        "browseDirectory": "choose a folder"
       },
       "previewImage": {
         "remove": "Remove"

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -34,6 +34,14 @@
       "admin": {
         "destroyedFleets": {
           "purgedWarning": "Restoring a purged fleet is best-effort. Roles, images, invite links and fleet vehicles are not restored."
+        },
+        "models": {
+          "viewsFolder": {
+            "hint": "Drop a folder of views named top.png, side.png, front.png and angled.png. Suffix _colored for the painted set, prefix extended_ for the extended one.",
+            "uploading": "Uploading %{count} views…",
+            "matched": "%{count} views ready — save to apply them.",
+            "ignored": "Ignored: %{files}"
+          }
         }
       },
       "hangarGuide": {

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -37,9 +37,15 @@
         },
         "models": {
           "viewsFolder": {
-            "hint": "Drop a folder of views named top.png, side.png, front.png and angled.png. Suffix _colored for the painted set, prefix extended_ for the extended one.",
-            "uploading": "Uploading %{count} views…",
-            "matched": "%{count} views ready — save to apply them.",
+            "hint": "Drop a folder of views named top.png, side.png, front.png and angled.png. Suffix _colored for the painted set, prefix extended_ for the extended one. holo.gltf and extended_holo.gltf come along too.",
+            "uploading": {
+              "one": "Uploading one file…",
+              "other": "Uploading %{count} files…"
+            },
+            "matched": {
+              "one": "One file ready — save to apply it.",
+              "other": "%{count} files ready — save to apply them."
+            },
             "ignored": "Ignored: %{files}"
           }
         }

--- a/app/jobs/trim_attachment_job.rb
+++ b/app/jobs/trim_attachment_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class TrimAttachmentJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: "preprocessing", retry: 5
+
+  # ActiveStorage uploads the file in its own after_commit, which runs after the
+  # one that enqueues this job, so the first attempt can arrive before the bytes
+  # do. ActiveStorage::FileNotFoundError is deliberately left to raise: a retry
+  # picks the file up seconds later, where swallowing it would leave the padding
+  # in place for good.
+  def perform(record_class, record_id, attachment_name)
+    record = record_class.safe_constantize&.find_by(id: record_id)
+    attachment = record&.public_send(attachment_name)
+    return unless attachment&.attached?
+
+    return if AttachmentTrimmer.new(attachment).call
+
+    # Nothing was cropped, so no new blob arrives to trigger preprocessing.
+    PreprocessRepresentationsJob.perform_async(attachment.blob.id)
+  end
+end

--- a/app/lib/attachment_trimmer.rb
+++ b/app/lib/attachment_trimmer.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Views come out of the render pipeline framed loosely: the ship sits inside a
+# canvas of transparency, and how much of that canvas is padding differs from
+# render to render. Everything downstream reads the padding as part of the hull
+# -- the fleetchart sizes each ship from the blob's own width and height -- and
+# the four webp representations carry it into every size they build.
+#
+# So the crop happens once, to the original, before any representation exists.
+# Only transparency counts as empty: an image without an alpha channel is left
+# alone rather than guessed at from its corner pixel, which would eat into a
+# subject that legitimately reaches the frame.
+class AttachmentTrimmer
+  # A pixel counts as content from alpha 1 up, so a canvas exported with a
+  # not-quite-zero transparent border still trims.
+  ALPHA_THRESHOLD = 1
+
+  # The views uploaded up to now are already tight against the hull, bar the
+  # pixel or two of near-transparency an antialiased edge leaves behind. That is
+  # not a border, and cropping it would replace the blob and re-save the record
+  # for nothing, so a margin only counts as padding from here out.
+  MIN_MARGIN = 2
+
+  def initialize(attachment)
+    @attachment = attachment
+    @blob = attachment.blob
+  end
+
+  # True when the crop replaced the blob, which brings the record's own
+  # callback round again on what it attached. False when there was nothing to
+  # crop, leaving the caller to carry on with the blob it already has.
+  def call
+    return false if trimmed?
+
+    buffer = trimmed_buffer
+
+    return mark_trimmed if buffer.nil?
+
+    attach(buffer)
+    true
+  end
+
+  private
+
+  attr_reader :attachment, :blob
+
+  def trimmed?
+    blob.metadata[:trimmed].present?
+  end
+
+  def trimmed_buffer
+    return if ActiveStorageVariants::VECTOR_CONTENT_TYPES.include?(blob.content_type)
+
+    require "vips"
+
+    image = Vips::Image.new_from_buffer(blob.download, "")
+    return unless image.has_alpha?
+
+    left, top, width, height = image[image.bands - 1]
+      .find_trim(background: [0], threshold: ALPHA_THRESHOLD)
+
+    # An image that is transparent throughout trims away to nothing.
+    return if width.zero? || height.zero?
+
+    margins = [left, top, image.width - (left + width), image.height - (top + height)]
+    return if margins.max < MIN_MARGIN
+
+    image.crop(left, top, width, height).write_to_buffer(".png")
+  end
+
+  def attach(buffer)
+    attachment.attach(
+      io: StringIO.new(buffer),
+      filename: png_filename,
+      content_type: "image/png",
+      metadata: {trimmed: true}
+    )
+  end
+
+  # The crop is written out as PNG whatever came in, so a name that promised
+  # something else must not survive it.
+  def png_filename
+    "#{File.basename(blob.filename.to_s, ".*")}.png"
+  end
+
+  # Nothing to crop is an answer, not a gap. Recording it keeps every later
+  # save of the record from downloading the file to find that out again.
+  def mark_trimmed
+    blob.update!(metadata: blob.metadata.merge(trimmed: true))
+    false
+  end
+end

--- a/app/models/concerns/active_storage_variants.rb
+++ b/app/models/concerns/active_storage_variants.rb
@@ -18,31 +18,59 @@ module ActiveStorageVariants
   }.freeze
 
   included do
+    class_attribute :trimmed_attachment_names, default: [], instance_writer: false
+
     after_commit :preprocess_representations, if: :has_new_attachments?
   end
 
+  class_methods do
+    # Opts an attachment into being cropped to its opaque bounds on the way in,
+    # before any representation of it exists. See AttachmentTrimmer for what
+    # counts as empty and why nothing without an alpha channel is touched.
+    def trim_attachment(*names)
+      self.trimmed_attachment_names = trimmed_attachment_names + names.map(&:to_s)
+    end
+  end
+
+  # Only what this save attached: the trim re-attaches what it crops, and a
+  # record with twenty views would otherwise queue every one of them again for
+  # every single crop.
   def preprocess_representations
-    image_attachments.each do |name|
+    new_attachment_names.each do |name|
       attachment = send(name)
       next unless attachment.attached? && attachment.representable?
 
-      PreprocessRepresentationsJob.perform_async(attachment.blob.id)
+      # Representations of the padded original would only be thrown away by the
+      # crop that follows, which re-attaches and brings this callback round
+      # again on the blob worth building them from.
+      if trim_pending?(name)
+        TrimAttachmentJob.perform_async(self.class.name, id, name)
+      else
+        PreprocessRepresentationsJob.perform_async(attachment.blob.id)
+      end
     end
   end
 
   private
 
-  def image_attachments
+  def trim_pending?(name)
+    return false unless trimmed_attachment_names.include?(name)
+
+    attachment = send(name)
+    attachment.attached? && attachment.blob.metadata[:trimmed].blank?
+  end
+
+  def new_attachment_names
+    one_attachment_names.select { |name| attachment_changes.key?(name) }
+  end
+
+  def one_attachment_names
     self.class.reflect_on_all_attachments
-      .select { |a| a.macro == :has_one_attached }
-      .map(&:name)
-      .select { |name| send(name).attached? && send(name).representable? }
+      .select { |attachment| attachment.macro == :has_one_attached }
+      .map { |attachment| attachment.name.to_s }
   end
 
   def has_new_attachments?
-    self.class.reflect_on_all_attachments
-      .select { |a| a.macro == :has_one_attached }
-      .map(&:name)
-      .any? { |name| attachment_changes.key?(name.to_s) }
+    new_attachment_names.any?
   end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -250,6 +250,16 @@ class Model < ApplicationRecord
   has_one_attached :extended_front_view_colored
   has_one_attached :extended_angled_view_colored
 
+  # The fleetchart sizes a ship from the pixel dimensions of the view it draws,
+  # so transparent padding around the hull reads as part of the ship. The store
+  # images are left alone: they are framed artwork, not measured against
+  # anything. See AttachmentTrimmer.
+  trim_attachment :top_view, :side_view, :front_view, :angled_view,
+    :top_view_colored, :side_view_colored, :front_view_colored, :angled_view_colored,
+    :extended_top_view, :extended_side_view, :extended_front_view, :extended_angled_view,
+    :extended_top_view_colored, :extended_side_view_colored,
+    :extended_front_view_colored, :extended_angled_view_colored
+
   before_save :update_slugs
 
   before_save :update_from_hardpoints

--- a/app/models/model_module_package.rb
+++ b/app/models/model_module_package.rb
@@ -33,6 +33,12 @@ class ModelModulePackage < ApplicationRecord
   has_one_attached :front_view
   has_one_attached :angled_view
 
+  # A fleetchart item takes each viewpoint from the first of paint, package and
+  # model that has one, and scales all of them against the largest. Leaving the
+  # package views padded would skew that comparison for every ship carrying a
+  # package. See Model.
+  trim_attachment :top_view, :side_view, :front_view, :angled_view
+
   accepts_nested_attributes_for :module_package_items, allow_destroy: true
 
   ALLOWED_SORTING_PARAMS = [

--- a/app/models/model_paint.rb
+++ b/app/models/model_paint.rb
@@ -58,6 +58,10 @@ class ModelPaint < ApplicationRecord
   has_one_attached :front_view
   has_one_attached :angled_view
 
+  # A painted ship is drawn on the fleetchart from its own views, on the same
+  # terms as the model's. See Model.
+  trim_attachment :top_view, :side_view, :front_view, :angled_view
+
   def self.ransackable_attributes(auth_object = nil)
     [
       "active", "created_at",

--- a/test/jobs/trim_attachment_job_test.rb
+++ b/test/jobs/trim_attachment_job_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "vips"
+
+class TrimAttachmentJobTest < ActiveSupport::TestCase
+  setup do
+    Sidekiq::Worker.clear_all
+
+    @model = create(:model)
+  end
+
+  # The crop re-attaches, and the record's own callback asks for the
+  # representations of what it attached. Asking for them here as well would
+  # build the padded original's too, and then throw them away.
+  test "#perform hands the cropped blob on to preprocessing, once" do
+    @model.top_view.attach(io: StringIO.new(padded_png), filename: "top.png", content_type: "image/png")
+    Sidekiq::Worker.clear_all
+
+    TrimAttachmentJob.new.perform("Model", @model.id, "top_view")
+
+    assert_equal [[@model.reload.top_view.blob.id]], PreprocessRepresentationsJob.jobs.map { |job| job["args"] }
+  end
+
+  test "#perform preprocesses what it did not crop" do
+    @model.top_view.attach(io: file_fixture("image.jpg").open, filename: "top.jpg")
+    Sidekiq::Worker.clear_all
+
+    TrimAttachmentJob.new.perform("Model", @model.id, "top_view")
+
+    assert_equal [[@model.reload.top_view.blob.id]], PreprocessRepresentationsJob.jobs.map { |job| job["args"] }
+  end
+
+  test "#perform passes over a record that has gone" do
+    assert_nothing_raised do
+      TrimAttachmentJob.new.perform("Model", SecureRandom.uuid, "top_view")
+    end
+  end
+
+  test "#perform passes over an attachment that has gone" do
+    assert_nothing_raised do
+      TrimAttachmentJob.new.perform("Model", @model.id, "top_view")
+    end
+
+    assert_equal 0, PreprocessRepresentationsJob.jobs.size
+  end
+
+  private def padded_png
+    opaque = Vips::Image.black(100, 40, bands: 3).new_from_image([255, 0, 0]).bandjoin(255).cast(:uchar)
+
+    Vips::Image.black(200, 150, bands: 4).cast(:uchar).insert(opaque, 50, 55).write_to_buffer(".png")
+  end
+end

--- a/test/lib/attachment_trimmer_test.rb
+++ b/test/lib/attachment_trimmer_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "vips"
+
+class AttachmentTrimmerTest < ActiveSupport::TestCase
+  setup do
+    Sidekiq::Worker.clear_all
+
+    @model = create(:model)
+  end
+
+  test "#call crops the transparent padding away" do
+    attach(padded_png)
+
+    assert AttachmentTrimmer.new(view).call
+
+    assert_equal [100, 40], dimensions_of(view)
+  end
+
+  # The fleetchart sizes a ship from these two numbers, so a crop nothing reads
+  # afterwards would be worse than none at all.
+  test "#call leaves the blob to report the cropped size" do
+    attach(padded_png)
+
+    AttachmentTrimmer.new(view).call
+    view.blob.analyze
+
+    assert_equal 100, view.blob.metadata[:width]
+    assert_equal 40, view.blob.metadata[:height]
+  end
+
+  test "#call replaces the blob rather than editing the one in place" do
+    attach(padded_png)
+    original = view.blob
+
+    AttachmentTrimmer.new(view).call
+
+    assert_not_equal original.id, reloaded_view.blob.id
+    assert_not_equal original.key, reloaded_view.blob.key
+  end
+
+  test "#call names the crop for what it wrote" do
+    attach(padded_png, filename: "angled.jpg")
+
+    AttachmentTrimmer.new(view).call
+
+    assert_equal "angled.png", view.blob.filename.to_s
+    assert_equal "image/png", view.blob.content_type
+  end
+
+  test "#call leaves an image that is already tight against its subject" do
+    attach(padded_png(canvas: [100, 40], at: [0, 0]))
+    original = view.blob
+
+    assert_not AttachmentTrimmer.new(view).call
+
+    assert_equal original.id, reloaded_view.blob.id
+  end
+
+  # What the renders actually carry: a pixel of near-transparency where the hull
+  # meets the canvas. Replacing the blob over that would be churn.
+  test "#call leaves an antialiased edge where it is" do
+    attach(padded_png(canvas: [102, 42], at: [1, 1]))
+    original = view.blob
+
+    assert_not AttachmentTrimmer.new(view).call
+
+    assert_equal original.id, reloaded_view.blob.id
+  end
+
+  # Without an alpha channel there is no transparency to go by, and guessing
+  # from the corner pixel would eat into a subject that reaches the frame.
+  test "#call leaves an image without an alpha channel" do
+    view.attach(io: file_fixture("image.jpg").open, filename: "image.jpg")
+    original = view.blob
+
+    assert_not AttachmentTrimmer.new(view).call
+
+    assert_equal original.id, reloaded_view.blob.id
+  end
+
+  test "#call leaves a vector alone" do
+    view.attach(io: file_fixture("vector.svg").open, filename: "vector.svg")
+    original = view.blob
+
+    assert_not AttachmentTrimmer.new(view).call
+
+    assert_equal original.id, reloaded_view.blob.id
+  end
+
+  # An image that is transparent throughout trims away to nothing, which is not
+  # a crop anyone asked for.
+  test "#call leaves an image with nothing opaque in it" do
+    attach(padded_png(block: nil))
+    original = view.blob
+
+    assert_not AttachmentTrimmer.new(view).call
+
+    assert_predicate reloaded_view, :attached?
+    assert_equal original.id, reloaded_view.blob.id
+  end
+
+  test "#call does not crop what it has already cropped" do
+    attach(padded_png)
+
+    AttachmentTrimmer.new(view).call
+    cropped = reloaded_view.blob
+
+    assert_not AttachmentTrimmer.new(reloaded_view).call
+
+    assert_equal cropped.id, reloaded_view.blob.id
+    assert_equal [100, 40], dimensions_of(reloaded_view)
+  end
+
+  # Recording the decision is what keeps every later save of the record from
+  # downloading the file to reach it again.
+  test "#call records that it looked at an image it left alone" do
+    attach(padded_png(canvas: [100, 40], at: [0, 0]))
+
+    AttachmentTrimmer.new(view).call
+
+    assert view.blob.reload.metadata[:trimmed]
+  end
+
+  private def view
+    @model.top_view
+  end
+
+  private def reloaded_view
+    @model.reload.top_view
+  end
+
+  private def attach(buffer, filename: "angled.png")
+    view.attach(io: StringIO.new(buffer), filename:, content_type: "image/png")
+  end
+
+  private def dimensions_of(attachment)
+    image = Vips::Image.new_from_buffer(attachment.download, "")
+
+    [image.width, image.height]
+  end
+
+  # Transparency with a single opaque block in it, so the crop has one right
+  # answer. `block: nil` leaves the canvas empty.
+  private def padded_png(canvas: [200, 150], block: [100, 40], at: [50, 55])
+    image = Vips::Image.black(*canvas, bands: 4).cast(:uchar)
+
+    if block
+      opaque = Vips::Image.black(*block, bands: 3)
+        .new_from_image([255, 0, 0])
+        .bandjoin(255)
+        .cast(:uchar)
+
+      image = image.insert(opaque, *at)
+    end
+
+    image.write_to_buffer(".png")
+  end
+end

--- a/test/models/concerns/active_storage_variants_test.rb
+++ b/test/models/concerns/active_storage_variants_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorageVariantsTest < ActiveSupport::TestCase
+  setup do
+    Sidekiq::Worker.clear_all
+
+    @model = create(:model)
+  end
+
+  test "a declared attachment goes to the trimmer first" do
+    @model.top_view.attach(attachable)
+
+    assert_equal 1, TrimAttachmentJob.jobs.size
+    assert_equal ["Model", @model.id, "top_view"], TrimAttachmentJob.jobs.first["args"]
+  end
+
+  # Representations of the padded original would only be thrown away by the
+  # crop that follows.
+  test "a declared attachment builds no representations until it is trimmed" do
+    @model.top_view.attach(attachable)
+
+    assert_equal 0, PreprocessRepresentationsJob.jobs.size
+  end
+
+  test "an attachment nobody declared is preprocessed as before" do
+    @model.store_image.attach(attachable)
+
+    assert_equal 0, TrimAttachmentJob.jobs.size
+    assert_equal 1, PreprocessRepresentationsJob.jobs.size
+  end
+
+  test "a model that declares nothing trims nothing" do
+    create(:manufacturer).logo.attach(attachable)
+
+    assert_equal 0, TrimAttachmentJob.jobs.size
+    assert_equal 1, PreprocessRepresentationsJob.jobs.size
+  end
+
+  # What the trimmer re-attaches comes back through here, and this time it is
+  # the representations that are wanted.
+  test "an attachment the trimmer has been over is preprocessed" do
+    @model.top_view.attach(trimmed_blob)
+
+    assert_equal 0, TrimAttachmentJob.jobs.size
+    assert_equal 1, PreprocessRepresentationsJob.jobs.size
+  end
+
+  # A record carrying twenty views would otherwise queue every one of them again
+  # for every crop the trimmer makes.
+  test "only what a save attached is preprocessed" do
+    @model.store_image.attach(attachable)
+    Sidekiq::Worker.clear_all
+
+    @model.rsi_store_image.attach(attachable)
+
+    assert_equal 1, PreprocessRepresentationsJob.jobs.size
+    assert_equal [@model.reload.rsi_store_image.blob.id], PreprocessRepresentationsJob.jobs.first["args"]
+  end
+
+  private def attachable
+    {io: file_fixture("test.png").open, filename: "view.png"}
+  end
+
+  private def trimmed_blob
+    ActiveStorage::Blob.create_and_upload!(**attachable, metadata: {trimmed: true})
+  end
+end


### PR DESCRIPTION
Two halves of the same job: getting a set of views onto a model without sixteen trips through a file dialog, and making sure what lands is cropped to the ship.

## Trim on upload

A view arrives framed inside a canvas of transparency, and everything downstream reads that padding as part of the hull — the fleetchart sizes each ship from the blob's own `width`/`height` metadata, and the four representations carry the padding into every size they build. `AttachmentTrimmer` crops to the alpha bounding box once, on the original, before any representation exists, and stamps `blob.metadata[:trimmed]` so it never runs twice.

Opt-in per attachment, next to the declaration:

```ruby
trim_attachment :top_view, :side_view, :front_view, :angled_view, ...
```

Declared on the Model, ModelPaint and ModelModulePackage views — a fleetchart item takes each viewpoint from the first of paint, package and model that has one and scales all of them against the largest, so trimming only some would skew that comparison for every ship carrying a package.

Two deliberate limits:

- **Transparency only.** Without an alpha channel the image is left alone rather than guessed at from its corner pixel, which would eat into a subject that legitimately reaches the frame.
- **A 2px floor** (`MIN_MARGIN`). I sampled 250 existing view blobs: every one is already tight to the hull bar the pixel an antialiased edge leaves behind. Without the floor, every view would be re-attached for a 1px gain.

Preprocessing now covers only the attachments a save attached. It walked every image attachment before, which with a crop re-attaching would turn one submit of sixteen views into a couple of hundred jobs. Blobs from before this exists are what `Maintenance::PreprocessRepresentationsTask` is for — there's no backfill here, by design.

**Worth knowing:** a crop replaces the blob and purges the old one, so a client that fetched a view's URL in the seconds between the save and the trim finishing holds a URL that 404s until its next fetch. The admin form is covered (it keeps the local file on screen). Overwriting the blob in place would never break a URL but could leave a padded variant cached under one that stays valid — the worse failure, which is why it re-attaches.

## Folder upload

Drop a folder on the fleetchart page and each file fills the field it names:

| file | field |
| --- | --- |
| `top.png` | Top View |
| `angled_colored.png` | Angled View Colored |
| `extended_side.png` | Extended Side View |
| `extended_angled_colored.png` | Extended Angled View Colored |
| `holo.gltf` | Default Holo |
| `extended_holo.glb` | Extended Holo |

Separator, case and a spelled-out `view` are all optional, so a folder named by hand lands where one named by a script does. The extension has to be one the field can use, though — pictures for the views, glTF for the holos — because a Blender export drops `holo.blend`, `holo.obj` and `holo.mtl` beside the glTF and every one of them answers to "holo".

That filter is the only gate, and it runs before a byte goes up, so a folder's odds and ends never become blobs no record attaches — they're listed under "Ignored" instead. Same for two files claiming one field: the first is taken, the second is reported. The fields are filled but not submitted; you still press save.

`DirectUpload` gained the pieces this needs, and nothing else changes behaviour: `directory` (webkitdirectory on the picker, plus walking the entries a dropped folder actually arrives as), a `filter` over the selection, and a `files:rejected` emit that finally surfaces the types the dropzone used to discard in silence.

## Two fixes it turned up

- **`FormFileInput` went blank when its value was set from outside.** It hid the picture as soon as the field held a value, on the assumption its own `DirectUpload` is showing what it just uploaded. Now that turns on whether *this input* did the upload, and a `previewSrc` lets the caller offer the local file — so a mapped input shows the picture from the moment the folder is dropped instead of sitting on its placeholder icon and then going empty.
- **`HoloViewer` never reloaded.** The model list was rendered without a key and the loader reads its path once in setup, so handing it a different file patched the props of the instance already on screen and left the old glTF there. Visible any time a holo is replaced — the admin form refetches after a save and the viewer went on showing what was there before.

## Tests

20 Minitest cases across the trimmer, the job and the concern's dispatch; 13 vitest cases over the filename mapping. Ruby suite for `test/models test/jobs test/lib` (565) and the admin model integration tests green locally, full frontend suite (252) and `lint:ts` clean, `standardrb` clean. Leaving the full Ruby suite to CI.

🤖
