### PR TITLE
feat(features): list the flags granted to a user or fleet, and lock their switches

### DIFF
--- a/app/api_components/v1/schemas/fleet_feature.rb
+++ b/app/api_components/v1/schemas/fleet_feature.rb
@@ -9,10 +9,15 @@ module V1
         type: :object,
         properties: {
           name: {type: :string},
-          enabled: {type: :boolean}
+          enabled: {type: :boolean},
+          toggleable: {type: :boolean},
+          groups: {
+            type: :array,
+            items: {type: :string}
+          }
         },
         additionalProperties: false,
-        required: %w[name enabled]
+        required: %w[name enabled toggleable groups]
       })
     end
   end

--- a/app/api_components/v1/schemas/user_feature.rb
+++ b/app/api_components/v1/schemas/user_feature.rb
@@ -15,6 +15,7 @@ module V1
           enabled: {type: :boolean},
           enabledForSelf: {type: :boolean},
           scope: {type: :string, enum: FeatureFlags::Definition::SELF_SERVICE_SCOPES},
+          toggleable: {type: :boolean},
           fleets: {
             type: :array,
             items: {
@@ -26,10 +27,14 @@ module V1
               additionalProperties: false,
               required: %w[name slug]
             }
+          },
+          groups: {
+            type: :array,
+            items: {type: :string}
           }
         },
         additionalProperties: false,
-        required: %w[name enabled enabledForSelf scope fleets]
+        required: %w[name enabled enabledForSelf scope toggleable fleets groups]
       })
     end
   end

--- a/app/controllers/api/v1/fleet_features_controller.rb
+++ b/app/controllers/api/v1/fleet_features_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class FleetFeaturesController < ::Api::BaseController
+      include FeatureGrantsConcern
+
       rescue_from ActiveRecord::RecordNotFound do |_exception|
         not_found(I18n.t("messages.record_not_found.fleet", slug: params[:fleet_slug]))
       end
@@ -17,17 +19,17 @@ module Api
 
       before_action :set_fleet
 
+      # Every flag the fleet's admins may switch, plus every other flag something
+      # has already switched on for this fleet — its own actor gate or a group it
+      # belongs to. A feature the fleet has but cannot find here reads as
+      # unexplained magic.
+      #
+      # `toggleable` says whether the switch changes anything: it does not for a
+      # flag the registry never declared fleet self-service, and it cannot take
+      # away what a group grants as well, because the gates are ORed. `groups`
+      # names who is responsible, since nothing here can reach a group gate.
       def index
-        @features = fleet_self_service_feature_names.filter_map do |feature_name|
-          feature = Flipper.feature(feature_name)
-
-          next if feature.state == :on
-
-          {
-            name: feature.name,
-            enabled: Flipper.enabled?(feature.name, @fleet)
-          }
-        end
+        @features = Flipper.features.sort_by(&:key).filter_map { |feature| feature_entry(feature) }
       end
 
       def enable
@@ -48,6 +50,25 @@ module Api
         render json: {name: feature_name, enabled: Flipper.enabled?(feature_name, @fleet)}
       end
 
+      private def feature_entry(feature)
+        return if feature.state == :on
+
+        self_service = fleet_self_service_feature_names.include?(feature.key)
+        groups = feature_granting_groups(feature, @fleet)
+
+        # A flag the fleet cannot switch only belongs here once something granted
+        # it; listing the rest would name every flag in the registry on a page
+        # where none of them can be switched.
+        return if !self_service && groups.empty? && !feature_actor_gate?(feature, @fleet)
+
+        {
+          name: feature.name,
+          enabled: Flipper.enabled?(feature.name, @fleet),
+          toggleable: self_service && groups.empty?,
+          groups:
+        }
+      end
+
       private def set_fleet
         @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
 
@@ -57,13 +78,22 @@ module Api
       # Only flags the registry declared fleet-scoped. A user-scoped flag toggled
       # here would put a personal surface behind a fleet's admins.
       private def fleet_self_service_feature_names
-        FeatureSetting.self_service_feature_names(scope: FeatureFlags::Definition::FLEET_SCOPE)
+        @fleet_self_service_feature_names ||=
+          FeatureSetting.self_service_feature_names(scope: FeatureFlags::Definition::FLEET_SCOPE)
       end
 
       private def toggleable_feature?
-        return true if fleet_self_service_feature_names.include?(params[:id])
+        unless fleet_self_service_feature_names.include?(params[:id])
+          render json: {code: "forbidden", message: "This feature cannot be toggled for a fleet"}, status: :forbidden
 
-        render json: {code: "forbidden", message: "This feature cannot be toggled for a fleet"}, status: :forbidden
+          return false
+        end
+
+        # A group grant survives clearing the fleet's own gate, so the switch
+        # would report a change nobody sees.
+        return true if feature_granting_groups(Flipper.feature(params[:id]), @fleet).empty?
+
+        render json: {code: "forbidden", message: "This feature is enabled for a group this fleet is in"}, status: :forbidden
 
         false
       end

--- a/app/controllers/api/v1/user_features_controller.rb
+++ b/app/controllers/api/v1/user_features_controller.rb
@@ -3,43 +3,37 @@
 module Api
   module V1
     class UserFeaturesController < ::Api::BaseController
+      include FeatureGrantsConcern
+
       skip_verify_authorized
 
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "profile:write" },
         unless: :user_signed_in?
 
-      # Every self-service flag, whatever surface owns its fleet-wide switch.
+      # Every self-service flag, whatever surface owns its fleet-wide switch,
+      # plus every other flag something has already switched on for this user —
+      # their own actor gate, a group they are in, or one of their fleets. A
+      # feature the user has but cannot find here reads as unexplained magic.
       #
-      # Two states, because a fleet flag has two switches with different reach:
+      # Three states, because a flag has more switches than the one on this page:
       #
-      #   enabled_for_self — this user's own gate, the one the switch here flips.
-      #                      Turning a fleet flag on gives *you* the feature in
-      #                      the fleets you belong to, without it appearing for
-      #                      the rest of the fleet.
-      #   enabled          — what the user actually has, so a feature their fleet
-      #                      switched on for everyone reads as enabled rather
-      #                      than as something they still have to turn on.
+      #   enabled_for_self — this user's own actor gate, the one the switch here
+      #                      flips. For a fleet flag that is a preview for them
+      #                      alone, without it appearing for the rest of the
+      #                      fleet.
+      #   enabled          — what the user actually has, so a feature granted
+      #                      elsewhere reads as enabled rather than as something
+      #                      they still have to turn on.
+      #   toggleable       — whether the switch here changes anything. It does
+      #                      not without a self-service toggle, and it cannot
+      #                      take away what a fleet or a group grants too,
+      #                      because the gates are ORed.
       #
-      # `fleets` names the ones responsible, so a member can see where the feature
-      # came from instead of only that they cannot switch it off.
+      # `fleets` and `groups` name who is responsible, so a member can see where
+      # the feature came from instead of only that they cannot switch it off.
       def index
-        @features = FeatureSetting.self_service_scopes.filter_map do |feature_name, scope|
-          feature = Flipper.feature(feature_name)
-
-          next if feature.state == :on
-
-          enabled_for_self = Flipper.enabled?(feature.name, current_resource_owner)
-          fleets = granting_fleets(feature.name, scope)
-
-          {
-            name: feature.name,
-            enabled: enabled_for_self || fleets.any?,
-            enabled_for_self:,
-            scope:,
-            fleets: fleets.map { |fleet| {name: fleet.name, slug: fleet.slug} }
-          }
-        end
+        @features = Flipper.features.sort_by(&:key).filter_map { |feature| feature_entry(feature) }
       end
 
       def enable
@@ -48,7 +42,7 @@ module Api
         unless FeatureSetting.self_service_anywhere?(feature_name)
           return render json: {code: "forbidden", message: "This feature cannot be self-activated"}, status: :forbidden
         end
-        return if refuse_fleet_override(feature_name)
+        return if refuse_external_grant(feature_name)
 
         Flipper.feature(feature_name).enable_actor(current_resource_owner)
 
@@ -61,38 +55,79 @@ module Api
         unless FeatureSetting.self_service_anywhere?(feature_name)
           return render json: {code: "forbidden", message: "This feature cannot be self-deactivated"}, status: :forbidden
         end
-        return if refuse_fleet_override(feature_name)
+        return if refuse_external_grant(feature_name)
 
         Flipper.feature(feature_name).disable_actor(current_resource_owner)
 
         render json: {name: feature_name, enabled: Flipper.enabled?(feature_name, current_resource_owner)}
       end
 
-      # A fleet switched the feature on for every member, and a personal gate
-      # cannot take it away again — the backend ORs both actors. Refusing beats
-      # reporting a change the user will not see.
-      private def refuse_fleet_override(feature_name)
-        return false if granting_fleets(feature_name).empty?
+      private def feature_entry(feature)
+        return if feature.state == :on
 
-        render json: {code: "forbidden", message: "This feature is enabled for your fleet"}, status: :forbidden
+        scope = self_service_scopes[feature.key]
+        fleets = granting_fleets(feature, scope)
+        groups = granting_groups(feature)
+        enabled_for_self = personal_gate?(feature)
+
+        # A flag with no self-service toggle is only the user's business once
+        # something granted it to them; listing the rest would name every flag in
+        # the registry on a page where none of them can be switched.
+        return if scope.nil? && !enabled_for_self && fleets.empty? && groups.empty?
+
+        {
+          name: feature.name,
+          enabled: Flipper.enabled?(feature.name, current_resource_owner) || fleets.any?,
+          enabled_for_self:,
+          # A flag the registry never declared self-service has no owning
+          # surface, so the grant names it: a fleet gate makes this a fleet
+          # matter, anything else is the user's own.
+          scope: scope || (fleets.any? ? FeatureFlags::Definition::FLEET_SCOPE : FeatureFlags::Definition::USER_SCOPE),
+          toggleable: !scope.nil? && fleets.empty? && groups.empty?,
+          fleets: fleets.map { |fleet| {name: fleet.name, slug: fleet.slug} },
+          groups:
+        }
+      end
+
+      # A fleet or a group switched the feature on, and a personal gate cannot
+      # take it away again — the backend ORs every gate. Refusing beats reporting
+      # a change the user will not see.
+      private def refuse_external_grant(feature_name)
+        feature = Flipper.feature(feature_name)
+        fleets = granting_fleets(feature)
+        groups = granting_groups(feature)
+
+        return false if fleets.empty? && groups.empty?
+
+        message = fleets.any? ? "This feature is enabled for your fleet" : "This feature is enabled for a group you are in"
+        render json: {code: "forbidden", message:}, status: :forbidden
 
         true
       end
 
-      # The user's fleets that switched this feature on for their members.
-      #
-      # Only for a fleet-scoped flag: nothing reads a user-scoped one against a
-      # fleet actor, so a gate there would grant the user nothing and must not
-      # count. Accepted memberships only — a pending invitation does not give the
-      # user the feature yet.
-      private def granting_fleets(feature_name, scope = self_service_scope(feature_name))
-        return [] unless scope == FeatureFlags::Definition::FLEET_SCOPE
-
-        accepted_fleets.select { |fleet| Flipper.enabled?(feature_name, fleet) }
+      private def personal_gate?(feature)
+        feature_actor_gate?(feature, current_resource_owner)
       end
 
-      private def self_service_scope(feature_name)
-        FeatureSetting.find_by(feature_name:)&.self_service_scope
+      private def granting_groups(feature)
+        feature_granting_groups(feature, current_resource_owner)
+      end
+
+      # The user's fleets that switched this feature on for their members.
+      #
+      # Skipped for a user-scoped flag: nothing reads a personal surface's flag
+      # against a fleet actor, so a gate there would grant the user nothing and
+      # must not count. A flag with no self-service scope has no such surface, so
+      # its fleet gates do count. Accepted memberships only — a pending
+      # invitation does not give the user the feature yet.
+      private def granting_fleets(feature, scope = self_service_scopes[feature.key])
+        return [] if scope == FeatureFlags::Definition::USER_SCOPE
+
+        accepted_fleets.select { |fleet| Flipper.enabled?(feature.name, fleet) }
+      end
+
+      private def self_service_scopes
+        @self_service_scopes ||= FeatureSetting.self_service_scopes.to_h
       end
 
       private def accepted_fleets

--- a/app/controllers/concerns/feature_grants_concern.rb
+++ b/app/controllers/concerns/feature_grants_concern.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Reading Flipper's gates for one actor, rather than asking whether a feature is
+# enabled for them.
+#
+# A self-service page has to tell "you switched this on" apart from "someone
+# switched it on for you": the gates are ORed, so a switch that clears only the
+# actor's own gate cannot undo a group's or a fleet's, and a page that offers it
+# anyway reports a change nobody will see.
+module FeatureGrantsConcern
+  extend ActiveSupport::Concern
+
+  # The actor's own gate — the one a self-service switch flips. Deliberately not
+  # Flipper.enabled?, which a group gate or a percentage rollout satisfies too.
+  def feature_actor_gate?(feature, actor)
+    feature.actors_value.include?(Flipper::Types::Actor.new(actor).value)
+  end
+
+  # The groups this actor belongs to that switched the feature on. Nothing
+  # outside /admin/features can reach a group gate, so naming the group is the
+  # only way a page can explain why a switch is stuck.
+  def feature_granting_groups(feature, actor)
+    return [] if feature.groups_value.empty?
+
+    wrapped = Flipper::Types::Actor.new(actor)
+    context = Flipper::FeatureCheckContext.new(
+      feature_name: feature.name,
+      values: feature.gate_values,
+      actors: [wrapped]
+    )
+
+    feature.enabled_groups.filter_map { |group| group.name.to_s if group.match?(wrapped, context) }
+  end
+end

--- a/app/frontend/frontend/pages/fleets/[slug]/settings/features.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings/features.vue
@@ -62,7 +62,20 @@ const featureItems = computed<FeatureItem[]>(
     features.value?.map((feature) => ({ ...feature, id: feature.name })) ?? [],
 );
 
+// Nothing here can reach a group gate, and clearing the fleet's own gate would
+// not undo one, so a flag a group grants is listed to explain where it came from
+// and nothing else. Same for a flag the registry never declared fleet
+// self-service — the API refuses either way.
+const readOnly = (feature: FeatureItem) => !feature.toggleable;
+
+const grantTooltip = (feature: FeatureItem) =>
+  feature.groups.length
+    ? t("labels.features.groupFeatureGrantedFleet")
+    : t("labels.features.managedFeatureFleet");
+
 const toggleFeature = async (feature: FeatureItem) => {
+  if (readOnly(feature)) return;
+
   try {
     if (feature.enabled) {
       await disableFleetFeature(props.fleet.slug, feature.name);
@@ -116,11 +129,30 @@ const toggleFeature = async (feature: FeatureItem) => {
       <span class="feature-name">
         {{ item.name.replace(/_/g, " ").replace(/-/g, " ") }}
       </span>
+      <span
+        v-if="readOnly(item)"
+        v-tooltip="grantTooltip(item)"
+        class="feature-scope"
+      >
+        <BasePill uppercase>
+          {{
+            item.groups.length
+              ? t("labels.features.groupFeatureGrantedShort")
+              : t("labels.features.managedFeatureShort")
+          }}
+        </BasePill>
+      </span>
+      <span v-if="item.groups.length" class="feature-groups">
+        {{ item.groups.join(", ") }}
+      </span>
     </template>
 
     <template #actions="{ item, mobile }">
       <Btn
-        v-tooltip="t('labels.features.toggle')"
+        v-tooltip="
+          readOnly(item) ? grantTooltip(item) : t('labels.features.toggle')
+        "
+        :disabled="readOnly(item)"
         @click="toggleFeature(item)"
         :variant="BtnVariantsEnum.GHOST"
       >
@@ -143,5 +175,14 @@ const toggleFeature = async (feature: FeatureItem) => {
 .feature-name {
   font-weight: 600;
   text-transform: capitalize;
+}
+
+.feature-scope {
+  margin-left: 0.5rem;
+}
+
+.feature-groups {
+  margin-left: 0.5rem;
+  color: var(--text-muted);
 }
 </style>

--- a/app/frontend/frontend/pages/settings/features.vue
+++ b/app/frontend/frontend/pages/settings/features.vue
@@ -56,8 +56,33 @@ const isFleetFeature = (feature: FeatureItem) =>
 // personal switch to add — and it cannot take it away either.
 const grantedByFleet = (feature: FeatureItem) => feature.fleets.length > 0;
 
+// Same for a Flipper group: the gates are ORed, so clearing the personal one
+// changes nothing the user would see.
+const grantedByGroup = (feature: FeatureItem) => feature.groups.length > 0;
+
+// The API decides what this page may switch, and it lists features it will not
+// let the user touch: the ones an admin, a group or a fleet turned on for them.
+// Those rows are here to explain where a feature came from, nothing more.
+const readOnly = (feature: FeatureItem) => !feature.toggleable;
+
+const grantTooltip = (feature: FeatureItem) => {
+  if (grantedByFleet(feature)) return t("labels.features.fleetFeatureGranted");
+  if (grantedByGroup(feature)) return t("labels.features.groupFeatureGranted");
+
+  return t("labels.features.managedFeature");
+};
+
+const grantPill = (feature: FeatureItem) => {
+  if (grantedByFleet(feature))
+    return t("labels.features.fleetFeatureGrantedShort");
+  if (grantedByGroup(feature))
+    return t("labels.features.groupFeatureGrantedShort");
+
+  return t("labels.features.managedFeatureShort");
+};
+
 const toggleFeature = async (feature: FeatureItem) => {
-  if (grantedByFleet(feature)) return;
+  if (readOnly(feature)) return;
 
   try {
     if (feature.enabledForSelf) {
@@ -119,21 +144,18 @@ const toggleFeature = async (feature: FeatureItem) => {
         {{ item.name.replace(/_/g, " ").replace(/-/g, " ") }}
       </span>
       <span
-        v-if="isFleetFeature(item)"
-        v-tooltip="
-          grantedByFleet(item)
-            ? t('labels.features.fleetFeatureGranted')
-            : t('labels.features.fleetFeatureInfo')
-        "
+        v-if="readOnly(item)"
+        v-tooltip="grantTooltip(item)"
         class="feature-scope"
       >
-        <BasePill uppercase>
-          {{
-            grantedByFleet(item)
-              ? t("labels.features.fleetFeatureGrantedShort")
-              : t("labels.features.fleetFeature")
-          }}
-        </BasePill>
+        <BasePill uppercase>{{ grantPill(item) }}</BasePill>
+      </span>
+      <span
+        v-else-if="isFleetFeature(item)"
+        v-tooltip="t('labels.features.fleetFeatureInfo')"
+        class="feature-scope"
+      >
+        <BasePill uppercase>{{ t("labels.features.fleetFeature") }}</BasePill>
       </span>
       <span v-if="grantedByFleet(item)" class="feature-fleets">
         <template v-for="(fleet, index) in item.fleets" :key="fleet.slug">
@@ -143,18 +165,21 @@ const toggleFeature = async (feature: FeatureItem) => {
           </router-link>
         </template>
       </span>
+      <span v-else-if="grantedByGroup(item)" class="feature-fleets">
+        {{ item.groups.join(", ") }}
+      </span>
     </template>
 
     <template #actions="{ item, mobile }">
       <Btn
         v-tooltip="
-          grantedByFleet(item)
-            ? t('labels.features.fleetFeatureGranted')
+          readOnly(item)
+            ? grantTooltip(item)
             : isFleetFeature(item)
               ? t('labels.features.toggleForSelf')
               : t('labels.features.toggle')
         "
-        :disabled="grantedByFleet(item)"
+        :disabled="readOnly(item)"
         @click="toggleFeature(item)"
         :variant="BtnVariantsEnum.GHOST"
       >

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -62,7 +62,13 @@
         "fleetFeatureInfo": "Hier eingeschaltet gilt sie nur für Sie. Die Admins Ihrer Flotte können sie für die gesamte Flotte aktivieren.",
         "toggleForSelf": "Nur für Sie umschalten",
         "fleetFeatureGrantedShort": "Von Flotte aktiviert",
-        "fleetFeatureGranted": "Ihre Flotte hat dies für alle Mitglieder aktiviert, daher kann es hier nicht abgeschaltet werden."
+        "fleetFeatureGranted": "Ihre Flotte hat dies für alle Mitglieder aktiviert, daher kann es hier nicht abgeschaltet werden.",
+        "groupFeatureGrantedShort": "Von Gruppe aktiviert",
+        "groupFeatureGranted": "Eine Gruppe, in der Sie sind, hat diese Funktion aktiviert, daher kann sie hier nicht abgeschaltet werden.",
+        "groupFeatureGrantedFleet": "Eine Gruppe, in der diese Flotte ist, hat diese Funktion aktiviert, daher kann sie hier nicht abgeschaltet werden.",
+        "managedFeatureShort": "Verwaltet",
+        "managedFeature": "Diese Funktion wurde für Ihr Konto aktiviert und kann hier nicht geändert werden.",
+        "managedFeatureFleet": "Diese Funktion wurde für diese Flotte aktiviert und kann hier nicht geändert werden."
       },
       "oauthApplication": {
         "name": "Anwendungsname",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -67,7 +67,13 @@
         "fleetFeatureInfo": "Switching this on here enables it for you alone. Your fleet's admins can enable it for the whole fleet.",
         "toggleForSelf": "Toggle for yourself only",
         "fleetFeatureGrantedShort": "Enabled by fleet",
-        "fleetFeatureGranted": "Your fleet enabled this for all members, so it cannot be switched off here."
+        "fleetFeatureGranted": "Your fleet enabled this for all members, so it cannot be switched off here.",
+        "groupFeatureGrantedShort": "Enabled by group",
+        "groupFeatureGranted": "A group you are in has this feature enabled, so it cannot be switched off here.",
+        "groupFeatureGrantedFleet": "A group this fleet is in has this feature enabled, so it cannot be switched off here.",
+        "managedFeatureShort": "Managed",
+        "managedFeature": "This feature was enabled for your account and cannot be changed here.",
+        "managedFeatureFleet": "This feature was enabled for this fleet and cannot be changed here."
       },
       "oauthApplication": {
         "name": "Application Name",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -57,7 +57,13 @@
         "fleetFeatureInfo": "Activarla aquí la habilita solo para usted. Los administradores de su flota pueden habilitarla para toda la flota.",
         "toggleForSelf": "Activar solo para usted",
         "fleetFeatureGrantedShort": "Activado por la flota",
-        "fleetFeatureGranted": "Su flota lo activó para todos los miembros, por lo que no se puede desactivar aquí."
+        "fleetFeatureGranted": "Su flota lo activó para todos los miembros, por lo que no se puede desactivar aquí.",
+        "groupFeatureGrantedShort": "Activado por el grupo",
+        "groupFeatureGranted": "Un grupo al que pertenece tiene esta función activada, por lo que no se puede desactivar aquí.",
+        "groupFeatureGrantedFleet": "Un grupo al que pertenece esta flota tiene esta función activada, por lo que no se puede desactivar aquí.",
+        "managedFeatureShort": "Gestionado",
+        "managedFeature": "Esta función se activó para su cuenta y no se puede cambiar aquí.",
+        "managedFeatureFleet": "Esta función se activó para esta flota y no se puede cambiar aquí."
       },
       "oauthApplication": {
         "name": "Nombre de la aplicación",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -57,7 +57,13 @@
         "fleetFeatureInfo": "L'activer ici ne l'active que pour vous. Les administrateurs de votre flotte peuvent l'activer pour toute la flotte.",
         "toggleForSelf": "Activer pour vous uniquement",
         "fleetFeatureGrantedShort": "Activé par la flotte",
-        "fleetFeatureGranted": "Votre flotte l'a activé pour tous les membres, il ne peut donc pas être désactivé ici."
+        "fleetFeatureGranted": "Votre flotte l'a activé pour tous les membres, il ne peut donc pas être désactivé ici.",
+        "groupFeatureGrantedShort": "Activé par le groupe",
+        "groupFeatureGranted": "Un groupe dont vous faites partie a activé cette fonctionnalité, elle ne peut donc pas être désactivée ici.",
+        "groupFeatureGrantedFleet": "Un groupe dont cette flotte fait partie a activé cette fonctionnalité, elle ne peut donc pas être désactivée ici.",
+        "managedFeatureShort": "Géré",
+        "managedFeature": "Cette fonctionnalité a été activée pour votre compte et ne peut pas être modifiée ici.",
+        "managedFeatureFleet": "Cette fonctionnalité a été activée pour cette flotte et ne peut pas être modifiée ici."
       },
       "oauthApplication": {
         "name": "Nom de l'application",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -57,7 +57,13 @@
         "fleetFeatureInfo": "Attivandola qui vale solo per te. Gli amministratori della tua flotta possono attivarla per tutta la flotta.",
         "toggleForSelf": "Attiva solo per te",
         "fleetFeatureGrantedShort": "Attivato dalla flotta",
-        "fleetFeatureGranted": "La tua flotta l'ha attivata per tutti i membri, quindi non può essere disattivata qui."
+        "fleetFeatureGranted": "La tua flotta l'ha attivata per tutti i membri, quindi non può essere disattivata qui.",
+        "groupFeatureGrantedShort": "Attivato dal gruppo",
+        "groupFeatureGranted": "Un gruppo di cui fai parte ha questa funzionalità attiva, quindi non può essere disattivata qui.",
+        "groupFeatureGrantedFleet": "Un gruppo di cui fa parte questa flotta ha questa funzionalità attiva, quindi non può essere disattivata qui.",
+        "managedFeatureShort": "Gestito",
+        "managedFeature": "Questa funzionalità è stata attivata per il tuo account e non può essere modificata qui.",
+        "managedFeatureFleet": "Questa funzionalità è stata attivata per questa flotta e non può essere modificata qui."
       },
       "oauthApplication": {
         "name": "Nome applicazione",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -57,7 +57,13 @@
         "fleetFeatureInfo": "在此启用仅对您生效。您舰队的管理员可为整个舰队启用。",
         "toggleForSelf": "仅为自己切换",
         "fleetFeatureGrantedShort": "舰队已启用",
-        "fleetFeatureGranted": "您的舰队已为所有成员启用此功能，因此无法在此处关闭。"
+        "fleetFeatureGranted": "您的舰队已为所有成员启用此功能，因此无法在此处关闭。",
+        "groupFeatureGrantedShort": "群组已启用",
+        "groupFeatureGranted": "您所在的某个群组已启用此功能，因此无法在此处关闭。",
+        "groupFeatureGrantedFleet": "该舰队所在的某个群组已启用此功能，因此无法在此处关闭。",
+        "managedFeatureShort": "受管理",
+        "managedFeature": "此功能已为您的账户启用，无法在此处更改。",
+        "managedFeatureFleet": "此功能已为该舰队启用，无法在此处更改。"
       },
       "oauthApplication": {
         "name": "应用名称",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -57,7 +57,13 @@
         "fleetFeatureInfo": "在此啟用僅對您生效。您艦隊的管理員可為整個艦隊啟用。",
         "toggleForSelf": "僅為自己切換",
         "fleetFeatureGrantedShort": "艦隊已啟用",
-        "fleetFeatureGranted": "您的艦隊已為所有成員啟用此功能，因此無法在此處關閉。"
+        "fleetFeatureGranted": "您的艦隊已為所有成員啟用此功能，因此無法在此處關閉。",
+        "groupFeatureGrantedShort": "群組已啟用",
+        "groupFeatureGranted": "您所在的某個群組已啟用此功能，因此無法在此處關閉。",
+        "groupFeatureGrantedFleet": "該艦隊所在的某個群組已啟用此功能，因此無法在此處關閉。",
+        "managedFeatureShort": "受管理",
+        "managedFeature": "此功能已為您的帳戶啟用，無法在此處變更。",
+        "managedFeatureFleet": "此功能已為該艦隊啟用，無法在此處變更。"
       },
       "oauthApplication": {
         "name": "應用程式名稱",

--- a/app/views/api/v1/fleet_features/index.jbuilder
+++ b/app/views/api/v1/fleet_features/index.jbuilder
@@ -3,4 +3,6 @@
 json.array! @features do |feature|
   json.name feature[:name]
   json.enabled feature[:enabled]
+  json.toggleable feature[:toggleable]
+  json.groups feature[:groups]
 end

--- a/app/views/api/v1/user_features/index.jbuilder
+++ b/app/views/api/v1/user_features/index.jbuilder
@@ -5,8 +5,10 @@ json.array! @features do |feature|
   json.enabled feature[:enabled]
   json.enabled_for_self feature[:enabled_for_self]
   json.scope feature[:scope]
+  json.toggleable feature[:toggleable]
   json.fleets feature[:fleets] do |fleet|
     json.name fleet[:name]
     json.slug fleet[:slug]
   end
+  json.groups feature[:groups]
 end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -14188,10 +14188,18 @@ components:
           type: string
         enabled:
           type: boolean
+        toggleable:
+          type: boolean
+        groups:
+          type: array
+          items:
+            type: string
       additionalProperties: false
       required:
       - name
       - enabled
+      - toggleable
+      - groups
       title: FleetFeature
     FleetInventoriesList:
       type: object
@@ -20178,6 +20186,8 @@ components:
           enum:
           - user
           - fleet
+        toggleable:
+          type: boolean
         fleets:
           type: array
           items:
@@ -20191,13 +20201,19 @@ components:
             required:
             - name
             - slug
+        groups:
+          type: array
+          items:
+            type: string
       additionalProperties: false
       required:
       - name
       - enabled
       - enabledForSelf
       - scope
+      - toggleable
       - fleets
+      - groups
       title: UserFeature
     UserPublic:
       type: object

--- a/test/integration/api/v1/fleets_features_disable_test.rb
+++ b/test/integration/api/v1/fleets_features_disable_test.rb
@@ -101,4 +101,17 @@ class Api::V1::FleetsFeaturesDisableTest < ActionDispatch::IntegrationTest
 
     assert_api_response :put, 404, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
   end
+
+  test "PUT /fleets/:slug/features/:id/disable returns 403 when a group the fleet is in enabled it" do
+    with_flipper_group(:fleets, ->(actor, _context) { actor.respond_to?(:slug) }) do
+      Flipper.enable_group("FleetWideFeature", :fleets)
+      sign_in @admin
+
+      assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+        assert Flipper.enabled?("FleetWideFeature", @fleet),
+          "clearing the fleet's own gate would not take the group's grant away, so the API refuses " \
+          "rather than reporting a change nobody will see"
+      end
+    end
+  end
 end

--- a/test/integration/api/v1/fleets_features_enable_test.rb
+++ b/test/integration/api/v1/fleets_features_enable_test.rb
@@ -106,4 +106,16 @@ class Api::V1::FleetsFeaturesEnableTest < ActionDispatch::IntegrationTest
 
     assert_api_response :put, 404, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"}
   end
+
+  test "PUT /fleets/:slug/features/:id/enable returns 403 when a group the fleet is in already enabled it" do
+    with_flipper_group(:fleets, ->(actor, _context) { actor.respond_to?(:slug) }) do
+      Flipper.enable_group("FleetWideFeature", :fleets)
+      sign_in @admin
+
+      assert_api_response :put, 403, path_params: {fleetSlug: @fleet.slug, id: "FleetWideFeature"} do
+        assert_not_includes Flipper.feature("FleetWideFeature").actors_value, @fleet.flipper_id,
+          "there is nothing to enable — the group already grants it"
+      end
+    end
+  end
 end

--- a/test/integration/api/v1/fleets_features_index_test.rb
+++ b/test/integration/api/v1/fleets_features_index_test.rb
@@ -52,7 +52,8 @@ class Api::V1::FleetsFeaturesIndexTest < ActionDispatch::IntegrationTest
     sign_in @admin
 
     assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
-      assert_equal [{"name" => "FleetWideFeature", "enabled" => false}], parsed_body
+      assert_equal [{"name" => "FleetWideFeature", "enabled" => false, "toggleable" => true, "groups" => []}],
+        parsed_body
     end
   end
 
@@ -116,5 +117,71 @@ class Api::V1::FleetsFeaturesIndexTest < ActionDispatch::IntegrationTest
     sign_in create(:user)
 
     assert_api_response :get, 404, path_params: {fleetSlug: @fleet.slug}
+  end
+
+  test "GET /fleets/:slug/features lists a flag with no toggle that was enabled for the fleet" do
+    Flipper.add("AdminGrantedFeature")
+    Flipper.enable_actor("AdminGrantedFeature", @fleet)
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      feature = parsed_body.find { |item| item["name"] == "AdminGrantedFeature" }
+
+      assert_not_nil feature, "a feature the fleet has must not be missing from the page listing its features"
+      assert feature["enabled"]
+      assert_not feature["toggleable"], "the registry never declared this one fleet self-service"
+    end
+  end
+
+  test "GET /fleets/:slug/features omits a flag with no toggle that nothing granted" do
+    Flipper.add("AdminGrantedFeature")
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+      assert_not_includes parsed_body.map { |item| item["name"] }, "AdminGrantedFeature",
+        "without a toggle and without a grant the row would say nothing"
+    end
+  end
+
+  test "GET /fleets/:slug/features lists a flag enabled for a group the fleet is in" do
+    with_flipper_group(:fleets, ->(actor, _context) { actor.respond_to?(:slug) }) do
+      Flipper.add("GroupFeature")
+      Flipper.enable_group("GroupFeature", :fleets)
+      sign_in @admin
+
+      assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+        feature = parsed_body.find { |item| item["name"] == "GroupFeature" }
+
+        assert_not_nil feature
+        assert feature["enabled"]
+        assert_not feature["toggleable"]
+        assert_equal ["fleets"], feature["groups"],
+          "naming the group tells the admins where the feature came from"
+      end
+    end
+  end
+
+  test "GET /fleets/:slug/features marks a group-granted fleet feature as not toggleable" do
+    with_flipper_group(:fleets, ->(actor, _context) { actor.respond_to?(:slug) }) do
+      Flipper.enable_group("FleetWideFeature", :fleets)
+      sign_in @admin
+
+      assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+        assert_not parsed_body.first["toggleable"],
+          "switching the fleet's own gate off would not take the feature away"
+      end
+    end
+  end
+
+  test "GET /fleets/:slug/features omits a flag whose group the fleet is not in" do
+    with_flipper_group(:nobody, ->(_actor, _context) { false }) do
+      Flipper.add("GroupFeature")
+      Flipper.enable_group("GroupFeature", :nobody)
+      sign_in @admin
+
+      assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug} do
+        assert_not_includes parsed_body.map { |item| item["name"] }, "GroupFeature"
+      end
+    end
   end
 end

--- a/test/integration/api/v1/user_features_disable_test.rb
+++ b/test/integration/api/v1/user_features_disable_test.rb
@@ -114,4 +114,16 @@ class Api::V1::UserFeaturesDisableTest < ActionDispatch::IntegrationTest
         "a pending invitation does not hand the fleet control of the user's toggle"
     end
   end
+
+  test "PUT /user-features/:id/disable returns 403 when a group the user is in enabled it" do
+    tester = create(:user, :tester)
+    Flipper.enable_group("TestFeature", :testers)
+    sign_in tester
+
+    assert_api_response :put, 403, path_params: {id: "TestFeature"} do
+      assert Flipper.enabled?("TestFeature", tester),
+        "clearing the personal gate would not take the group's grant away, so the API refuses " \
+        "rather than reporting a change the user will not see"
+    end
+  end
 end

--- a/test/integration/api/v1/user_features_enable_test.rb
+++ b/test/integration/api/v1/user_features_enable_test.rb
@@ -102,4 +102,15 @@ class Api::V1::UserFeaturesEnableTest < ActionDispatch::IntegrationTest
         "there is nothing to enable — the fleet already grants it"
     end
   end
+
+  test "PUT /user-features/:id/enable returns 403 when a group the user is in already enabled it" do
+    tester = create(:user, :tester)
+    Flipper.enable_group("TestFeature", :testers)
+    sign_in tester
+
+    assert_api_response :put, 403, path_params: {id: "TestFeature"} do
+      assert_not_includes Flipper.feature("TestFeature").actors_value, tester.flipper_id,
+        "there is nothing to enable — the group already grants it"
+    end
+  end
 end

--- a/test/integration/api/v1/user_features_index_test.rb
+++ b/test/integration/api/v1/user_features_index_test.rb
@@ -195,4 +195,132 @@ class Api::V1::UserFeaturesIndexTest < ActionDispatch::IntegrationTest
         "the toggle covers the viewer, so it does not depend on which fleets they are in"
     end
   end
+
+  test "GET /user-features lists a flag with no toggle that was enabled for the user" do
+    Flipper.add("AdminGrantedFeature")
+    Flipper.enable_actor("AdminGrantedFeature", @user)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      feature = parsed_body.find { |item| item["name"] == "AdminGrantedFeature" }
+
+      assert_not_nil feature, "a feature the user has must not be missing from the page listing their features"
+      assert feature["enabled"]
+      assert feature["enabledForSelf"]
+      assert_not feature["toggleable"], "there is no self-service toggle to flip"
+    end
+  end
+
+  test "GET /user-features omits a flag with no toggle that nothing granted" do
+    Flipper.add("AdminGrantedFeature")
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body.map { |item| item["name"] }, "AdminGrantedFeature",
+        "without a toggle and without a grant the row would say nothing"
+    end
+  end
+
+  test "GET /user-features lists a flag enabled for a group the user is in" do
+    tester = create(:user, :tester)
+    Flipper.add("TesterFeature")
+    Flipper.enable_group("TesterFeature", :testers)
+    sign_in tester
+
+    assert_api_response :get, 200 do
+      feature = parsed_body.find { |item| item["name"] == "TesterFeature" }
+
+      assert_not_nil feature
+      assert feature["enabled"]
+      assert_not feature["enabledForSelf"], "the group holds the gate, not the user"
+      assert_not feature["toggleable"]
+      assert_equal ["testers"], feature["groups"],
+        "naming the group tells the user where the feature came from"
+    end
+  end
+
+  test "GET /user-features omits a flag whose group the user is not in" do
+    Flipper.add("TesterFeature")
+    Flipper.enable_group("TesterFeature", :testers)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body.map { |item| item["name"] }, "TesterFeature"
+    end
+  end
+
+  test "GET /user-features lists a flag with no toggle that the user's fleet enabled" do
+    Flipper.add("FleetGrantedFeature")
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetGrantedFeature", fleet)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      feature = parsed_body.find { |item| item["name"] == "FleetGrantedFeature" }
+
+      assert_not_nil feature
+      assert feature["enabled"]
+      assert_not feature["toggleable"]
+      assert_equal "fleet", feature["scope"], "the fleet gate is what makes this a fleet matter"
+      assert_equal [{"name" => fleet.name, "slug" => fleet.slug}], feature["fleets"]
+    end
+  end
+
+  test "GET /user-features omits a flag enabled for a fleet the user is not in" do
+    Flipper.add("FleetGrantedFeature")
+    Flipper.enable_actor("FleetGrantedFeature", create(:fleet))
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body.map { |item| item["name"] }, "FleetGrantedFeature"
+    end
+  end
+
+  test "GET /user-features omits a flag rolled out to a percentage of actors" do
+    Flipper.add("PercentageFeature")
+    Flipper.enable_percentage_of_actors("PercentageFeature", 100)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not_includes parsed_body.map { |item| item["name"] }, "PercentageFeature",
+        "a percentage rollout targets nobody in particular, so there is nothing to explain here"
+    end
+  end
+
+  test "GET /user-features marks a self-service feature as toggleable" do
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert parsed_body.find { |item| item["name"] == "TestFeature" }["toggleable"]
+    end
+  end
+
+  test "GET /user-features marks a fleet-granted self-service feature as not toggleable" do
+    Flipper.add("FleetWideFeature")
+    FeatureSetting.create!(feature_name: "FleetWideFeature", self_service: true, self_service_scope: "fleet")
+    fleet = create(:fleet, members: [@user])
+    Flipper.enable_actor("FleetWideFeature", fleet)
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      assert_not parsed_body.find { |item| item["name"] == "FleetWideFeature" }["toggleable"],
+        "the switch cannot take away what the fleet grants"
+    end
+  end
+
+  test "GET /user-features marks a group-granted self-service feature as not toggleable" do
+    tester = create(:user, :tester)
+    Flipper.enable_group("TestFeature", :testers)
+    sign_in tester
+
+    assert_api_response :get, 200 do
+      feature = parsed_body.find { |item| item["name"] == "TestFeature" }
+
+      assert feature["enabled"]
+      assert_not feature["enabledForSelf"]
+      assert_not feature["toggleable"],
+        "switching the personal gate off would not take the feature away"
+      assert_equal ["testers"], feature["groups"]
+    end
+  end
 end

--- a/test/openapi_helper.rb
+++ b/test/openapi_helper.rb
@@ -3,3 +3,4 @@
 require "test_helper"
 require "openapi_ruby/minitest"
 require "support/oauth_test_helpers"
+require "support/flipper_group_test_helpers"

--- a/test/support/flipper_group_test_helpers.rb
+++ b/test/support/flipper_group_test_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module FlipperGroupTestHelpers
+  # Registers a Flipper group for the duration of the block.
+  #
+  # The app's own groups match users (`testers`, `admins`), so the fleet side has
+  # no real group to test against. The registry is swapped rather than added to
+  # because Flipper.register raises on a duplicate name, and unregistering clears
+  # every group — including the ones an initializer set up and will not set up
+  # again.
+  def with_flipper_group(name, matcher)
+    registered = Flipper.groups_registry
+    Flipper.groups_registry = Flipper::Registry.new
+    Flipper.register(name, &matcher)
+
+    yield
+  ensure
+    Flipper.groups_registry = registered
+  end
+end
+
+module ActionDispatch
+  class IntegrationTest
+    include FlipperGroupTestHelpers
+  end
+end


### PR DESCRIPTION
Both feature lists only ever showed flags declared `self_service` in the registry. Everything else a gate grants was invisible: switch a flag on for one user at `/admin/features`, or for a group, or for a fleet, and the feature appears in the app with nothing anywhere to explain where it came from. The two index actions now walk every flag and return the ones a gate actually grants the viewer.

A flag with no self-service toggle earns a row only once something grants it — otherwise the page would list the whole registry on a surface where none of it can be switched.

## What the payload gained

Two fields on `UserFeature` and `FleetFeature`, both additive (the `swagger/v1/schema.yaml` diff is insertions only):

- **`toggleable`** — whether the switch on this page changes anything.
- **`groups`** — the Flipper groups responsible. Nothing outside `/admin/features` can reach a group gate, so naming it is the only way a page can explain why a switch is stuck.

`fleets` already named the fleets responsible; it now also covers a flag that has no self-service scope at all.

## Three deliberate calls

**`enabledForSelf` now means the user's own actor gate**, not `Flipper.enabled?(user)`. It drives the toggle direction, and `disable_actor` can only ever clear that one gate — so a group or percentage grant reading as "you turned this on" produced a switch that lied. The documented intent was always the personal gate; the old expression was an approximation of it.

**Percentage rollouts are excluded.** Gates are read explicitly rather than through `Flipper.enabled?`, which a percentage also satisfies. A rollout targets nobody in particular, so there is nothing to explain on a page about who granted what — and `percentage_of_time` would have rows flickering between requests. There's a test pinning this.

**A flag with no declared scope derives one from its grant.** `scope` says which surface owns the fleet-wide switch, and a flag the registry never declared self-service has no such surface. A fleet gate makes it a fleet matter, anything else is the user's own.

## The switches are locked at both layers

The lists now carry rows the viewer is not allowed to change, so both ends refuse them:

- **UI** — `readOnly(item)` disables the button and short-circuits the handler. A pill beside the name says which: *Enabled by fleet*, *Enabled by group*, or *Managed*, with a tooltip and the fleet links or group names spelled out.
- **API** — a flag without a self-service toggle was already a 403 on both controllers. I extended the fleet-grant refusal to cover group grants too, for exactly the reason it existed for fleets: every gate is ORed, so clearing the caller's own would report a change they never get to see.

Shared gate reading lives in `FeatureGrantsConcern` — `feature_actor_gate?` and `feature_granting_groups`, both surfaces on it.

## Tests

15 new integration cases over the two indexes and the four toggle endpoints: granted by actor / by group / by fleet, granted by a fleet the user is not in, granted by a group they don't match, granted by nothing, percentage rollouts, and a 403 per toggle endpoint for a group grant.

`test/support/flipper_group_test_helpers.rb` is new and worth a look. The registered groups (`testers`, `admins`) only ever match users, so the fleet-side group cases had no real group to test against. `with_flipper_group` swaps `Flipper.groups_registry` for the duration of a block and restores it after — `Flipper.register` raises on a duplicate name, and `unregister_groups` would clear the groups the initializer set up and will not set up again.

75 tests / 244 assertions green locally across the six feature files. `standardrb` clean, `vue-tsc` clean, eslint clean. Leaving the full Ruby suite to CI.

🤖
