### PR TITLE
feat(hangar): redesign the add-ships picker as a filterable card grid

### DIFF
--- a/app/api_components/v1/schemas/models/options/model_option.rb
+++ b/app/api_components/v1/schemas/models/options/model_option.rb
@@ -13,6 +13,20 @@ module V1
               id: {type: :string, format: :uuid},
               name: {type: :string},
               slug: {type: :string},
+              manufacturer: {
+                type: :object,
+                properties: {
+                  name: {type: [:string, :null]},
+                  slug: {type: [:string, :null]},
+                  code: {type: [:string, :null]}
+                },
+                additionalProperties: false,
+                required: %w[name slug code]
+              },
+              classification: {type: [:string, :null]},
+              classificationLabel: {type: [:string, :null]},
+              inHangar: {type: :boolean},
+              onWishlist: {type: :boolean},
               media: {
                 type: :object,
                 properties: {
@@ -22,7 +36,7 @@ module V1
               }
             },
             additionalProperties: false,
-            required: %w[id name slug media]
+            required: %w[id name slug manufacturer classification classificationLabel inHangar onWishlist media]
           })
         end
       end

--- a/app/controllers/api/v1/filters/models_controller.rb
+++ b/app/controllers/api/v1/filters/models_controller.rb
@@ -55,16 +55,39 @@ module Api
           normalize_sort_params(model_query_params)
           model_query_params["sorts"] = sorting_params(Model, model_query_params["sorts"])
 
-          @q = Model.visible.active.ransack(model_query_params)
+          scope = Model.visible.active.includes(:manufacturer)
+          scope = scope.where(id: current_resource_owner.models.select(:id)) if model_query_params.delete("in_hangar") && current_resource_owner.present?
+
+          @q = scope.ransack(model_query_params)
 
           @models = result_with_pagination(@q.result, per_page(Model))
+
+          @owned_model_ids, @wanted_model_ids = hangar_model_ids(@models)
+        end
+
+        # Which of the models on this page the current user already has a vehicle
+        # for, split by wanted, so the option rows can be marked without asking
+        # per row - Model#in_hangar is one query each.
+        private def hangar_model_ids(models)
+          return [[], []] if current_resource_owner.blank?
+
+          pairs = current_resource_owner.vehicles
+            .where(model_id: models.map(&:id))
+            .pluck(:model_id, :wanted)
+
+          [
+            pairs.reject(&:second).map(&:first).uniq,
+            pairs.select(&:second).map(&:first).uniq
+          ]
         end
 
         private def model_query_params
           @model_query_params ||= params.permit(
             q: [
-              :name_cont, :name_eq, :slug_eq, :s, :sorts,
-              name_in: [], slug_in: [], id_in: []
+              :name_cont, :name_eq, :slug_eq, :search_cont, :in_hangar, :s, :sorts,
+              name_in: [], slug_in: [], id_in: [], id_not_in: [],
+              manufacturer_in: [], classification_in: [], focus_in: [],
+              size_in: [], production_status_in: []
             ]
           )[:q].presence || {}
         end

--- a/app/frontend/frontend/components/Vehicles/NewVehiclesModal/ModelCard/index.vue
+++ b/app/frontend/frontend/components/Vehicles/NewVehiclesModal/ModelCard/index.vue
@@ -1,0 +1,302 @@
+<script lang="ts">
+export default {
+  name: "NewVehiclesModelCard",
+};
+</script>
+
+<script lang="ts" setup>
+import PanelBgImage from "@/shared/components/base/Panel/BgImage/index.vue";
+import { type ModelOption } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useWebpCheck } from "@/shared/composables/useWebpCheck";
+import fallbackImageJpg from "@/images/fallback/store_image.jpg";
+import fallbackImage from "@/images/fallback/store_image.webp";
+
+type Props = {
+  option: ModelOption;
+  selected?: boolean;
+  quantity?: number;
+  wanted?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  selected: false,
+  quantity: 1,
+  wanted: false,
+});
+
+const emit = defineEmits<{
+  toggle: [];
+  increase: [];
+  decrease: [];
+}>();
+
+const { t } = useI18n();
+
+const { supported: webpSupported } = useWebpCheck();
+
+const image = computed(() => {
+  const storeImage = props.option.media.storeImage;
+
+  if (storeImage?.mediumUrl) {
+    return storeImage.mediumUrl;
+  }
+
+  return webpSupported.value ? fallbackImage : fallbackImageJpg;
+});
+
+const subtitle = computed(() =>
+  [props.option.manufacturer.name, props.option.classificationLabel]
+    .filter(Boolean)
+    .join(" · "),
+);
+
+/**
+ * The flag matching the list you opened the picker from leads, because that is
+ * the duplicate you are about to create; the other one is context worth having
+ * (a wishlisted ship you are now buying) rather than a warning.
+ */
+const badges = computed(() => {
+  // Which flag leads is a property of the flag, not of where it lands in the
+  // list: keyed on position, a wishlisted ship shown in the *hangar* picker got
+  // the loud tint purely by being the only badge on the card.
+  const leading = props.wanted ? "onWishlist" : "inHangar";
+
+  return [
+    { key: "inHangar", set: props.option.inHangar },
+    { key: "onWishlist", set: props.option.onWishlist },
+  ]
+    .filter((badge) => badge.set)
+    .map((badge) => ({
+      key: badge.key,
+      label: t(`newVehicles.badges.${badge.key}`),
+      primary: badge.key === leading,
+    }))
+    .sort((a, b) => Number(b.primary) - Number(a.primary));
+});
+
+// The toggle is an empty overlay, so its name has to carry everything the card
+// shows visually - including the badges, which are decoration to a screen reader.
+const accessibleName = computed(() =>
+  [
+    props.option.name,
+    subtitle.value,
+    ...badges.value.map((badge) => badge.label),
+  ]
+    .filter(Boolean)
+    .join(", "),
+);
+</script>
+
+<template>
+  <div
+    class="model-card"
+    :class="{ 'model-card--selected': selected }"
+    :data-test="`new-vehicles-card-${option.slug}`"
+  >
+    <div class="model-card__image">
+      <PanelBgImage :image="image" />
+
+      <div v-if="badges.length" class="model-card__badges">
+        <span
+          v-for="badge in badges"
+          :key="badge.key"
+          class="model-card__badge"
+          :class="{ 'model-card__badge--primary': badge.primary }"
+        >
+          {{ badge.label }}
+        </span>
+      </div>
+
+      <div class="model-card__check" aria-hidden="true">
+        <i class="fa-regular fa-check" />
+      </div>
+
+      <!--
+        A sibling of the toggle rather than a child: the toggle is a button, and
+        a button may not contain buttons. Both are absolutely placed in this
+        region, with the stepper stacked above so its clicks are its own.
+      -->
+      <div v-if="selected" class="model-card__quantity">
+        <button
+          type="button"
+          class="model-card__step"
+          :disabled="quantity <= 1"
+          :aria-label="t('newVehicles.actions.decrease', { name: option.name })"
+          @click="emit('decrease')"
+        >
+          <i class="fa-regular fa-minus" />
+        </button>
+        <span class="model-card__count">{{ quantity }}</span>
+        <button
+          type="button"
+          class="model-card__step"
+          :aria-label="t('newVehicles.actions.increase', { name: option.name })"
+          @click="emit('increase')"
+        >
+          <i class="fa-regular fa-plus" />
+        </button>
+      </div>
+    </div>
+
+    <div class="model-card__meta">
+      <span class="model-card__name">{{ option.name }}</span>
+      <span v-if="subtitle" class="model-card__subtitle">{{ subtitle }}</span>
+    </div>
+
+    <button
+      type="button"
+      class="model-card__toggle"
+      :aria-pressed="selected"
+      :aria-label="accessibleName"
+      @click="emit('toggle')"
+    />
+  </div>
+</template>
+
+<style scoped>
+@reference "../../../../../entrypoints/tailwind.css";
+
+/*
+ * A picker card, not a ship card: `panel--slim`'s geometry (one hairline, the
+ * smaller radius, no end-caps) because a grid of repeated cards is the case that
+ * variant exists for, but its own component rather than a Panel because the
+ * whole card has to be one toggle.
+ *
+ * The toggle is a transparent overlay stretched over the card instead of the
+ * card's wrapper element. The alternative - a <button> wrapping the contents -
+ * cannot hold the quantity stepper, and the stepper has to sit inside the card:
+ * its own row would make every selected card taller than its neighbours and
+ * reflow the grid on each click.
+ */
+.model-card {
+  @apply relative flex flex-col overflow-hidden;
+  @apply bg-control border-edge-soft rounded-surface-slim border;
+  @apply transition-[background-color,border-color] duration-150 ease-in-out;
+}
+
+.model-card:hover {
+  @apply bg-control-hover border-edge;
+}
+
+.model-card--selected {
+  @apply border-primary;
+  background-color: rgb(66 139 202 / 0.18);
+}
+
+.model-card--selected:hover {
+  background-color: rgb(66 139 202 / 0.28);
+}
+
+/* ---------- toggle overlay ---------- */
+.model-card__toggle {
+  @apply absolute inset-0 z-[1] m-0 cursor-pointer border-0 bg-transparent p-0;
+}
+
+.model-card__toggle:focus-visible {
+  @apply outline-primary rounded-surface-slim outline-2;
+  outline-offset: -3px;
+}
+
+/* The containing block PanelBgImage's absolute fill resolves against. */
+.model-card__image {
+  @apply relative w-full;
+  aspect-ratio: 16 / 9;
+}
+
+/* ---------- selection tick ----------
+   Kept in the DOM at every state so selecting a card cannot reflow it; scaled to
+   nothing until it is earned. */
+.model-card__check {
+  @apply pointer-events-none absolute z-[2] flex items-center justify-center;
+  @apply bg-primary rounded-full text-[11px] text-white opacity-0;
+  @apply transition-[opacity,transform] duration-150 ease-in-out;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  transform: scale(0.6);
+}
+
+.model-card--selected .model-card__check {
+  @apply opacity-100;
+  transform: scale(1);
+}
+
+/* ---------- already-have markers ---------- */
+.model-card__badges {
+  @apply pointer-events-none absolute z-[2] flex flex-col items-start gap-1;
+  top: 8px;
+  left: 8px;
+}
+
+.model-card__badge {
+  @apply rounded-control-bare text-[11px] leading-none whitespace-nowrap;
+  @apply bg-gray-black/80 text-gray-lighter;
+  padding: 4px 6px;
+}
+
+/* Gold, the token the app already uses for "notable about *your* copy" - and a
+   dark glyph on it, because at 11px a tint this saturated is the only step that
+   stays legible against the store image behind it. */
+.model-card__badge--primary {
+  background-color: rgb(212 175 55 / 0.9);
+  color: #222;
+}
+
+/* ---------- meta ---------- */
+.model-card__meta {
+  @apply flex min-w-0 flex-col gap-1;
+  padding: 8px 10px 10px;
+}
+
+.model-card__name {
+  @apply text-lifted truncate text-[15px] leading-tight font-semibold;
+}
+
+.model-card__subtitle {
+  @apply text-muted truncate text-[12px] leading-tight;
+}
+
+/* ---------- quantity ---------- */
+.model-card__quantity {
+  @apply absolute z-[2] flex items-center;
+  @apply bg-gray-black/90 border-edge rounded-control-bare border;
+  right: 8px;
+  bottom: 8px;
+}
+
+.model-card__step {
+  @apply text-text flex cursor-pointer items-center justify-center;
+  @apply m-0 border-0 bg-transparent text-[11px];
+  width: 24px;
+  height: 24px;
+}
+
+.model-card__step:hover:not(:disabled) {
+  @apply text-lifted;
+}
+
+.model-card__step:disabled {
+  @apply cursor-default opacity-40;
+}
+
+.model-card__step:focus-visible {
+  @apply outline-primary rounded-control-bare outline-2;
+  outline-offset: -2px;
+}
+
+.model-card__count {
+  @apply text-lifted text-[13px] leading-none font-semibold;
+  min-width: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .model-card,
+  .model-card__check {
+    transition-duration: 1ms;
+  }
+}
+</style>

--- a/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
+++ b/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
@@ -7,18 +7,20 @@ export default {
 <script lang="ts" setup>
 import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
-import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
+import Chip from "@/shared/components/base/Chip/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
+import ManufacturerFilterGroup from "@/frontend/components/base/ManufacturerFilterGroup/index.vue";
+import ClassificationFilterGroup from "@/frontend/components/base/ModelClassificationFilterGroup/index.vue";
+import ModelCard from "@/frontend/components/Vehicles/NewVehiclesModal/ModelCard/index.vue";
 import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
-import ListGroup from "@/shared/components/ListGroup/index.vue";
-import ViewImage from "@/shared/components/ViewImage/index.vue";
-import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import {
   type ModelOption,
   type ModelQuery,
   useModelOptions,
 } from "@/services/fyApi";
+import { keepPreviousData } from "@tanstack/vue-query";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useVehicleMutations } from "@/frontend/composables/useVehicleMutations";
@@ -26,6 +28,7 @@ import {
   BtnSizesEnum,
   BtnVariantsEnum,
 } from "@/shared/components/base/Btn/types";
+import { ChipStatesEnum } from "@/shared/components/base/Chip/types";
 import debounce from "lodash.debounce";
 
 type Props = {
@@ -36,9 +39,14 @@ const props = withDefaults(defineProps<Props>(), {
   wanted: false,
 });
 
-const { t } = useI18n();
+type Selected = {
+  option: ModelOption;
+  quantity: number;
+};
 
-const submitting = ref(false);
+const PER_PAGE = "24";
+
+const { t } = useI18n();
 
 const comlink = useComlink();
 
@@ -46,18 +54,32 @@ const { useCreateBulkMutation } = useVehicleMutations();
 
 const mutation = useCreateBulkMutation();
 
+const submitting = ref(false);
+
 const search = ref<string>("");
-const debouncedSearch = ref<string>("");
+const searchTerm = ref<string>("");
+const manufacturerIn = ref<string[]>([]);
+const classificationIn = ref<string[]>([]);
+
 const page = ref(1);
 const records = ref<ModelOption[]>([]);
-const selectedIds = ref<string[]>([]);
-
-const PER_PAGE = "15";
+const selection = ref<Selected[]>([]);
 
 const queryParams = computed(() => {
   const q: ModelQuery = {};
-  if (debouncedSearch.value) {
-    q.nameCont = debouncedSearch.value;
+
+  // searchCont, not nameCont: it is aliased to name-or-slug-or-manufacturer, so
+  // typing "anvil" finds the manufacturer's ships rather than nothing.
+  if (searchTerm.value) {
+    q.searchCont = searchTerm.value;
+  }
+
+  if (manufacturerIn.value.length) {
+    q.manufacturerIn = manufacturerIn.value;
+  }
+
+  if (classificationIn.value.length) {
+    q.classificationIn = classificationIn.value;
   }
 
   return {
@@ -70,41 +92,59 @@ const queryParams = computed(() => {
 const { data, isFetching, isLoading } = useModelOptions(queryParams, {
   query: {
     refetchOnWindowFocus: false,
+    // Without it `data` is undefined for the length of every fetch, and the
+    // result count, `hasMore` and the sentinel it mounts all flicker off and
+    // back on between pages. The accumulator below is keyed on the response's
+    // own page, so holding the previous one costs nothing.
+    placeholderData: keepPreviousData,
   },
 });
 
+/**
+ * Which page arrived decides whether this response extends the list or replaces
+ * it, and the response says so itself. Reading `page` here instead would append
+ * a stale page-2 payload onto a list a filter change had already reset to 1.
+ */
 watch(
   data,
   (response) => {
     if (!response) return;
 
-    if (page.value === 1) {
+    if ((response.meta.pagination?.currentPage ?? 1) <= 1) {
       records.value = response.items;
-    } else {
-      const existing = new Set(records.value.map((item) => item.id));
-      records.value = [
-        ...records.value,
-        ...response.items.filter((item) => !existing.has(item.id)),
-      ];
+      return;
     }
+
+    const existing = new Set(records.value.map((item) => item.id));
+    records.value = [
+      ...records.value,
+      ...response.items.filter((item) => !existing.has(item.id)),
+    ];
   },
   { immediate: true },
 );
 
-const totalPages = computed(() => {
-  return data.value?.meta.pagination?.totalPages ?? 1;
-});
+const totalPages = computed(() => data.value?.meta.pagination?.totalPages ?? 1);
 
-const hasMore = computed(() => {
-  return page.value < totalPages.value;
-});
+const totalCount = computed(
+  () => data.value?.meta.pagination?.totalCount ?? records.value.length,
+);
 
-const loading = computed(() => {
-  return isLoading.value || isFetching.value;
-});
+const hasMore = computed(() => page.value < totalPages.value);
+
+const loading = computed(() => isLoading.value || isFetching.value);
+
+// Only the first page of a new query blanks the grid. Paging in more never does,
+// and neither does re-filtering: the list you were reading stays put, dimmed,
+// until its replacement is ready.
+const initialLoading = computed(() => loading.value && !records.value.length);
+
+const refreshing = computed(
+  () => loading.value && page.value === 1 && !!records.value.length,
+);
 
 const applySearch = debounce((value: string) => {
-  debouncedSearch.value = value;
+  searchTerm.value = value;
   page.value = 1;
 }, 300);
 
@@ -112,33 +152,138 @@ watch(search, (value) => {
   applySearch(value);
 });
 
+watch([manufacturerIn, classificationIn], () => {
+  page.value = 1;
+});
+
+const filtersActive = computed(
+  () =>
+    !!searchTerm.value ||
+    !!manufacturerIn.value.length ||
+    !!classificationIn.value.length,
+);
+
+const resetFilters = () => {
+  search.value = "";
+  searchTerm.value = "";
+  manufacturerIn.value = [];
+  classificationIn.value = [];
+  page.value = 1;
+};
+
 const loadMore = () => {
   if (!hasMore.value || loading.value) return;
+
   page.value += 1;
 };
 
-const toggle = (id: string) => {
-  if (selectedIds.value.includes(id)) {
-    selectedIds.value = selectedIds.value.filter((item) => item !== id);
-  } else {
-    selectedIds.value = [...selectedIds.value, id];
-  }
+/**
+ * The scroll container is the modal's body, not the window, so the observer has
+ * to be rooted there for `rootMargin` to buy any prefetch at all - against the
+ * viewport the ancestor's clip rect is not expanded and the sentinel only counts
+ * as visible once it is already on screen. Falls back to the viewport if the
+ * modal chrome ever stops providing that element.
+ */
+const sentinel = ref<HTMLElement | null>(null);
+
+let observer: IntersectionObserver | null = null;
+
+const observe = () => {
+  observer?.disconnect();
+  observer = null;
+
+  if (!sentinel.value) return;
+
+  // eslint-disable-next-line compat/compat
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries[0]?.isIntersecting) loadMore();
+    },
+    {
+      root: sentinel.value.closest(".modal-body"),
+      rootMargin: "300px",
+    },
+  );
+
+  observer.observe(sentinel.value);
 };
 
+watch(sentinel, observe);
+
+// A page of cards can be shorter than the gap the sentinel needs to leave the
+// root, and an observer only reports changes. Re-observing asks it again.
+watch(records, () => {
+  if (!observer || !sentinel.value) return;
+
+  observer.unobserve(sentinel.value);
+  observer.observe(sentinel.value);
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+  observer = null;
+});
+
+const selectedIds = computed(
+  () => new Set(selection.value.map((item) => item.option.id)),
+);
+
+const selectedTotal = computed(() =>
+  selection.value.reduce((sum, item) => sum + item.quantity, 0),
+);
+
+const quantityFor = (id: string) =>
+  selection.value.find((item) => item.option.id === id)?.quantity ?? 1;
+
+const toggle = (option: ModelOption) => {
+  if (selectedIds.value.has(option.id)) {
+    remove(option.id);
+    return;
+  }
+
+  selection.value = [...selection.value, { option, quantity: 1 }];
+};
+
+const remove = (id: string) => {
+  selection.value = selection.value.filter((item) => item.option.id !== id);
+};
+
+const changeQuantity = (id: string, by: number) => {
+  selection.value = selection.value.map((item) =>
+    item.option.id === id
+      ? { ...item, quantity: Math.max(1, item.quantity + by) }
+      : item,
+  );
+};
+
+const clearSelection = () => {
+  selection.value = [];
+};
+
+const title = computed(() =>
+  props.wanted ? t("newVehicles.wishlistTitle") : t("newVehicles.title"),
+);
+
+const submitLabel = computed(() =>
+  props.wanted ? t("actions.addToWishlist") : t("actions.addToHangar"),
+);
+
 const save = async () => {
-  if (!selectedIds.value.length) return;
+  if (!selection.value.length) return;
 
   submitting.value = true;
 
+  // One vehicle per copy: the endpoint takes a flat list, so a quantity of three
+  // is the same model three times over.
+  const vehicles = selection.value.flatMap(({ option, quantity }) =>
+    Array.from({ length: quantity }, () => ({
+      wanted: props.wanted,
+      modelId: option.id,
+    })),
+  );
+
   await mutation
-    .mutateAsync({
-      data: {
-        vehicles: selectedIds.value.map((id) => ({
-          wanted: props.wanted,
-          modelId: id,
-        })),
-      },
-    })
+    .mutateAsync({ data: { vehicles } })
     .then(() => {
       comlink.emit("hangar-change");
     })
@@ -150,50 +295,69 @@ const save = async () => {
 </script>
 
 <template>
-  <Modal :title="t('headlines.newVehicles')">
+  <Modal :title="title">
     <form id="new-vehicles" class="new-vehicles" @submit.prevent="save">
-      <div class="new-vehicles__search">
-        <FormInput
-          v-model="search"
-          name="new-vehicles-search"
-          :label="t('labels.findModel')"
-          :placeholder="t('labels.findModel')"
-          no-label
-          clearable
-        />
+      <div class="new-vehicles__header">
+        <div class="new-vehicles__toolbar">
+          <FormInput
+            v-model="search"
+            name="new-vehicles-search"
+            class="new-vehicles__search"
+            :label="t('newVehicles.labels.search')"
+            :placeholder="t('newVehicles.labels.search')"
+            icon="fa-light fa-magnifying-glass"
+            autofocus
+            no-label
+            clearable
+          />
+
+          <ManufacturerFilterGroup
+            v-model="manufacturerIn"
+            class="new-vehicles__filter"
+            name="new-vehicles-manufacturer"
+          />
+
+          <ClassificationFilterGroup
+            v-model="classificationIn"
+            class="new-vehicles__filter"
+            name="new-vehicles-classification"
+          />
+        </div>
+
+        <div class="new-vehicles__summary">
+          <span class="new-vehicles__count">
+            {{ t("newVehicles.labels.results", { count: totalCount }) }}
+          </span>
+          <Btn
+            v-if="filtersActive"
+            :variant="BtnVariantsEnum.BARE"
+            :size="BtnSizesEnum.XS"
+            @click="resetFilters"
+          >
+            {{ t("newVehicles.actions.resetFilters") }}
+          </Btn>
+        </div>
       </div>
 
-      <ListGroup
-        :items="records"
-        :loading="loading"
-        :empty-name="t('models.name')"
-        hide-empty
+      <Loader v-if="initialLoading" :loading="true" inline />
+
+      <div
+        v-else-if="records.length"
+        class="new-vehicles__grid"
+        :class="{ 'new-vehicles__grid--refreshing': refreshing }"
       >
-        <template #display="{ item }">
-          <FormCheckbox
-            v-model="selectedIds"
-            name="new-vehicles-item"
-            no-label
-            inline
-            :checkbox-value="item.id"
-            @click.stop
-          />
-          <button
-            type="button"
-            class="new-vehicles__row"
-            @click="toggle(item.id)"
-          >
-            <ViewImage
-              :image="item.media.storeImage"
-              size="small"
-              alt="image"
-              :variant="LazyImageVariantsEnum.EXTRA_SMALL"
-              shadow
-            />
-            <span class="new-vehicles__name">{{ item.name }}</span>
-          </button>
-        </template>
-      </ListGroup>
+        <ModelCard
+          v-for="option in records"
+          :key="option.id"
+          :option="option"
+          :wanted="wanted"
+          :selected="selectedIds.has(option.id)"
+          :quantity="quantityFor(option.id)"
+          @toggle="toggle(option)"
+          @increase="changeQuantity(option.id, 1)"
+          @decrease="changeQuantity(option.id, -1)"
+        />
+      </div>
 
       <Empty
         v-if="!loading && !records.length"
@@ -203,85 +367,148 @@ const save = async () => {
         hide-actions
       />
 
-      <Btn
-        v-if="hasMore"
-        :disabled="loading"
-        class="new-vehicles__load-more"
-        @click="loadMore"
-        :variant="BtnVariantsEnum.BARE"
-      >
-        {{ t("filterGroup.actions.fetchMore") }}
-      </Btn>
+      <div v-if="hasMore" ref="sentinel" class="new-vehicles__more">
+        <Btn
+          :loading="loading"
+          :variant="BtnVariantsEnum.BARE"
+          @click="loadMore"
+        >
+          {{ t("actions.loadMore") }}
+        </Btn>
+      </div>
+
+      <!--
+        Stuck to the bottom of the scroll area rather than living in the modal's
+        footer. The footer is outside `.modal-body`, whose max-height is sized for
+        a single row of actions, so a tray of chips there pushed the submit button
+        off the bottom of the viewport. Here it costs the grid height it uses and
+        stays in view while you scroll, which is the whole point of it.
+      -->
+      <div v-if="selection.length" class="new-vehicles__tray">
+        <Chip
+          v-for="item in selection"
+          :key="item.option.id"
+          :state="ChipStatesEnum.INCLUDED"
+          :count="item.quantity > 1 ? item.quantity : undefined"
+          @toggle="remove(item.option.id)"
+        >
+          {{ item.option.name }}
+        </Chip>
+      </div>
     </form>
+
     <template #footer>
-      <div class="new-vehicles__footer">
-        <span class="new-vehicles__count">
-          {{
-            t("filteredTable.labels.selected", { count: selectedIds.length })
-          }}
+      <div class="new-vehicles__actions">
+        <span class="new-vehicles__selected">
+          {{ t("newVehicles.labels.selected", { count: selectedTotal }) }}
         </span>
         <Btn
-          :loading="submitting"
-          :disabled="!selectedIds.length"
-          @click="save"
-          :size="BtnSizesEnum.LG"
+          v-if="selection.length"
+          :variant="BtnVariantsEnum.BARE"
+          @click="clearSelection"
         >
-          {{ t("actions.add") }}
+          {{ t("newVehicles.actions.clearSelection") }}
+        </Btn>
+        <Btn
+          :loading="submitting"
+          :disabled="!selection.length"
+          :size="BtnSizesEnum.LG"
+          @click="save"
+        >
+          {{ submitLabel }}
         </Btn>
       </div>
     </template>
   </Modal>
 </template>
 
-<style lang="scss" scoped>
-.new-vehicles {
-  &__search {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    background: $panel-bg;
-    padding-bottom: 0.5rem;
-  }
+<style scoped>
+@reference "../../../../entrypoints/tailwind.css";
 
-  &__row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex: 1;
-    min-width: 0;
-    padding: 0;
-    background: none;
-    border: none;
-    color: inherit;
-    text-align: left;
-    cursor: pointer;
-  }
+/* ---------- header ----------
+   Search, filters and the result count all stay reachable while the grid scrolls
+   under them, so the fill has to be opaque: --color-surface is 90% alpha and the
+   cards would show through it. --color-gray-darker is that colour at full
+   strength. */
+.new-vehicles__header {
+  @apply bg-gray-darker sticky top-0 z-[3];
+}
 
-  &__name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
+.new-vehicles__toolbar {
+  @apply flex flex-wrap items-start gap-3;
+}
 
-  &__load-more {
-    width: 100%;
-    margin-top: 0.5rem;
-  }
+.new-vehicles__search {
+  @apply min-w-[240px] flex-1;
+}
 
-  &__footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    gap: 0.75rem;
-  }
+.new-vehicles__filter {
+  @apply min-w-[200px] flex-1;
+}
 
-  &__count {
-    padding-left: 0.5rem;
-    color: $text-color;
-    font-weight: 600;
+/*
+ * The filter sidebar opens these over a flat panel; here they open over a grid of
+ * ship photos, and the 95%-alpha list fill plus the fully transparent search row
+ * both let the images through. Opaque in this modal only - the component is
+ * shared, and nowhere else has this behind it.
+ */
+.new-vehicles__filter :deep(.filter-group-items-wrapper) {
+  background-color: var(--color-gray-darker, #272b30);
+}
+
+.new-vehicles__summary {
+  @apply flex items-center justify-between gap-3;
+  padding: 2px 0 12px;
+}
+
+.new-vehicles__count {
+  @apply text-muted text-[13px];
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- grid ----------
+   auto-fill from 220px: four across the wide modal, and it steps down to one on
+   a phone without a breakpoint per column count. */
+.new-vehicles__grid {
+  @apply grid gap-3;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+/* Re-filtering leaves the old results readable rather than blanking the grid,
+   but marks them as no longer current. */
+.new-vehicles__grid--refreshing {
+  @apply pointer-events-none opacity-50;
+  transition: opacity 150ms ease-in-out;
+}
+
+.new-vehicles__more {
+  @apply flex justify-center;
+  padding-top: 12px;
+}
+
+/* ---------- selection tray ----------
+   Capped and scrollable so thirty chips cannot eat the whole grid, and opaque for
+   the same reason the header is: the cards scroll behind it. */
+.new-vehicles__tray {
+  @apply bg-gray-darker sticky bottom-0 z-[3];
+  @apply flex max-h-[84px] flex-wrap gap-2 overflow-y-auto;
+  border-top: 1px solid var(--color-edge-faint, rgb(122 130 136 / 0.16));
+  padding: 12px 0 2px;
+}
+
+/* ---------- footer ---------- */
+.new-vehicles__actions {
+  @apply flex w-full flex-wrap items-center justify-end gap-3;
+}
+
+.new-vehicles__selected {
+  @apply text-text mr-auto text-[15px] font-semibold;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-vehicles__grid--refreshing {
+    transition-duration: 1ms;
   }
 }
 </style>

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -193,6 +193,7 @@ const showNewModal = () => {
   comlink.emit("open-modal", {
     component: () =>
       import("@/frontend/components/Vehicles/NewVehiclesModal/index.vue"),
+    wide: true,
   });
 };
 

--- a/app/frontend/frontend/pages/hangar/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/wishlist.vue
@@ -145,6 +145,7 @@ const showNewModal = () => {
   comlink.emit("open-modal", {
     component: () =>
       import("@/frontend/components/Vehicles/NewVehiclesModal/index.vue"),
+    wide: true,
     props: {
       wanted: true,
     },

--- a/app/frontend/translations/de/newVehicles.json
+++ b/app/frontend/translations/de/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "de": {
+    "newVehicles": {
+      "title": "Schiffe zum Hangar hinzufügen",
+      "wishlistTitle": "Schiffe zur Wunschliste hinzufügen",
+      "labels": {
+        "search": "Nach Name oder Hersteller suchen",
+        "results": "%{count} Schiffe",
+        "selected": "%{count} ausgewählt"
+      },
+      "actions": {
+        "resetFilters": "Filter zurücksetzen",
+        "clearSelection": "Auswahl aufheben",
+        "increase": "Weitere %{name} hinzufügen",
+        "decrease": "Eine %{name} entfernen"
+      },
+      "badges": {
+        "inHangar": "Im Hangar",
+        "onWishlist": "Auf der Wunschliste"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/en/newVehicles.json
+++ b/app/frontend/translations/en/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "en": {
+    "newVehicles": {
+      "title": "Add Ships to your Hangar",
+      "wishlistTitle": "Add Ships to your Wishlist",
+      "labels": {
+        "search": "Search by name or manufacturer",
+        "results": "%{count} Ships",
+        "selected": "%{count} Selected"
+      },
+      "actions": {
+        "resetFilters": "Reset Filters",
+        "clearSelection": "Clear Selection",
+        "increase": "Add another %{name}",
+        "decrease": "Remove one %{name}"
+      },
+      "badges": {
+        "inHangar": "In Hangar",
+        "onWishlist": "On Wishlist"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/es/newVehicles.json
+++ b/app/frontend/translations/es/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "es": {
+    "newVehicles": {
+      "title": "Añadir naves a tu hangar",
+      "wishlistTitle": "Añadir naves a tu lista de deseos",
+      "labels": {
+        "search": "Buscar por nombre o fabricante",
+        "results": "%{count} naves",
+        "selected": "%{count} seleccionadas"
+      },
+      "actions": {
+        "resetFilters": "Restablecer filtros",
+        "clearSelection": "Borrar la selección",
+        "increase": "Añadir otra %{name}",
+        "decrease": "Quitar una %{name}"
+      },
+      "badges": {
+        "inHangar": "En el hangar",
+        "onWishlist": "En la lista de deseos"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/fr/newVehicles.json
+++ b/app/frontend/translations/fr/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "fr": {
+    "newVehicles": {
+      "title": "Ajouter des vaisseaux à votre hangar",
+      "wishlistTitle": "Ajouter des vaisseaux à votre liste de souhaits",
+      "labels": {
+        "search": "Rechercher par nom ou constructeur",
+        "results": "%{count} vaisseaux",
+        "selected": "%{count} sélectionnés"
+      },
+      "actions": {
+        "resetFilters": "Réinitialiser les filtres",
+        "clearSelection": "Effacer la sélection",
+        "increase": "Ajouter un autre %{name}",
+        "decrease": "Retirer un %{name}"
+      },
+      "badges": {
+        "inHangar": "Dans le hangar",
+        "onWishlist": "Dans la liste de souhaits"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/it/newVehicles.json
+++ b/app/frontend/translations/it/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "it": {
+    "newVehicles": {
+      "title": "Aggiungi navi al tuo hangar",
+      "wishlistTitle": "Aggiungi navi alla tua lista dei desideri",
+      "labels": {
+        "search": "Cerca per nome o produttore",
+        "results": "%{count} navi",
+        "selected": "%{count} selezionate"
+      },
+      "actions": {
+        "resetFilters": "Reimposta i filtri",
+        "clearSelection": "Cancella la selezione",
+        "increase": "Aggiungi un'altra %{name}",
+        "decrease": "Rimuovi una %{name}"
+      },
+      "badges": {
+        "inHangar": "Nell'hangar",
+        "onWishlist": "Nella lista dei desideri"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/zh-CN/newVehicles.json
+++ b/app/frontend/translations/zh-CN/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "zh-CN": {
+    "newVehicles": {
+      "title": "将舰船添加到你的机库",
+      "wishlistTitle": "将舰船添加到你的愿望清单",
+      "labels": {
+        "search": "按名称或制造商搜索",
+        "results": "%{count} 艘舰船",
+        "selected": "已选择 %{count} 艘"
+      },
+      "actions": {
+        "resetFilters": "重置筛选",
+        "clearSelection": "清除选择",
+        "increase": "再添加一艘 %{name}",
+        "decrease": "移除一艘 %{name}"
+      },
+      "badges": {
+        "inHangar": "已在机库",
+        "onWishlist": "已在愿望清单"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/zh-TW/newVehicles.json
+++ b/app/frontend/translations/zh-TW/newVehicles.json
@@ -1,0 +1,23 @@
+{
+  "zh-TW": {
+    "newVehicles": {
+      "title": "將艦船加入你的機庫",
+      "wishlistTitle": "將艦船加入你的願望清單",
+      "labels": {
+        "search": "依名稱或製造商搜尋",
+        "results": "%{count} 艘艦船",
+        "selected": "已選擇 %{count} 艘"
+      },
+      "actions": {
+        "resetFilters": "重設篩選",
+        "clearSelection": "清除選擇",
+        "increase": "再加入一艘 %{name}",
+        "decrease": "移除一艘 %{name}"
+      },
+      "badges": {
+        "inHangar": "已在機庫",
+        "onWishlist": "已在願望清單"
+      }
+    }
+  }
+}

--- a/app/views/api/v1/filters/models/_option.jbuilder
+++ b/app/views/api/v1/filters/models/_option.jbuilder
@@ -5,9 +5,22 @@ json.cache! ["v1/filters/models/option", model] do
   json.name model.name
   json.slug model.slug
 
+  json.manufacturer do
+    json.name model.manufacturer&.name
+    json.slug model.manufacturer&.slug
+    json.code model.manufacturer&.code
+  end
+
+  json.classification model.classification
+  json.classification_label model.classification&.humanize
+
   json.media do
     json.store_image do
       json.partial! "api/v1/shared/file", record: model, attr: :store_image
     end
   end
 end
+
+# Outside the fragment cache: both depend on who is asking, the cache key does not.
+json.in_hangar owned_model_ids.include?(model.id)
+json.on_wishlist wanted_model_ids.include?(model.id)

--- a/app/views/api/v1/filters/models/options.jbuilder
+++ b/app/views/api/v1/filters/models/options.jbuilder
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 json.items @models do |model|
-  json.partial! "api/v1/filters/models/option", model: model
+  json.partial! "api/v1/filters/models/option",
+    model: model,
+    owned_model_ids: @owned_model_ids,
+    wanted_model_ids: @wanted_model_ids
 end
 json.partial! "api/shared/meta", result: @models

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -18875,6 +18875,38 @@ components:
           type: string
         slug:
           type: string
+        manufacturer:
+          type: object
+          properties:
+            name:
+              type:
+              - string
+              - 'null'
+            slug:
+              type:
+              - string
+              - 'null'
+            code:
+              type:
+              - string
+              - 'null'
+          additionalProperties: false
+          required:
+          - name
+          - slug
+          - code
+        classification:
+          type:
+          - string
+          - 'null'
+        classificationLabel:
+          type:
+          - string
+          - 'null'
+        inHangar:
+          type: boolean
+        onWishlist:
+          type: boolean
         media:
           type: object
           properties:
@@ -18886,6 +18918,11 @@ components:
       - id
       - name
       - slug
+      - manufacturer
+      - classification
+      - classificationLabel
+      - inHangar
+      - onWishlist
       - media
       title: ModelOption
     ModelOptions:

--- a/test/integration/api/v1/filters_models_options_test.rb
+++ b/test/integration/api/v1/filters_models_options_test.rb
@@ -30,13 +30,18 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "GET /filters/models/options returns id/name/slug/media for each model" do
-    create_list(:model, 6, :with_store_image)
+  test "GET /filters/models/options returns the picker payload for each model" do
+    model = create(:model, :with_store_image)
 
     assert_api_response :get, 200 do
-      items = parsed_body["items"]
-      assert_equal 6, items.count
-      assert_equal %w[id name slug media].sort, items.first.keys.sort
+      item = parsed_body["items"].find { |entry| entry["id"] == model.id }
+
+      assert_equal(
+        %w[id name slug manufacturer classification classificationLabel inHangar onWishlist media].sort,
+        item.keys.sort
+      )
+      assert_equal %w[name slug code].sort, item["manufacturer"].keys.sort
+      assert_equal model.manufacturer.slug, item["manufacturer"]["slug"]
     end
   end
 
@@ -47,6 +52,58 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
       items = parsed_body["items"]
       assert_equal 1, items.count
       assert_equal models.first.name, items.first["name"]
+    end
+  end
+
+  test "GET /filters/models/options filters by manufacturerIn" do
+    model = create(:model, :with_store_image)
+    create_list(:model, 2, :with_store_image)
+
+    assert_api_response :get, 200, params: {q: {"manufacturerIn" => [model.manufacturer.slug]}} do
+      items = parsed_body["items"]
+
+      assert_equal [model.id], items.map { |item| item["id"] }
+    end
+  end
+
+  test "GET /filters/models/options filters by classificationIn" do
+    combat = create(:model, :with_store_image, classification: "combat")
+    create_list(:model, 2, :with_store_image, classification: "multi_role")
+
+    assert_api_response :get, 200, params: {q: {"classificationIn" => ["combat"]}} do
+      items = parsed_body["items"]
+
+      assert_includes items.map { |item| item["id"] }, combat.id
+      assert_equal ["combat"], items.map { |item| item["classification"] }.uniq
+      assert_equal ["Combat"], items.map { |item| item["classificationLabel"] }.uniq
+    end
+  end
+
+  test "GET /filters/models/options marks models the signed in user owns or wants" do
+    owned, wished, untouched = create_list(:model, 3, :with_store_image)
+    user = create(:user)
+    create(:vehicle, user:, model: owned)
+    create(:vehicle, :wanted, user:, model: wished)
+    sign_in user
+
+    assert_api_response :get, 200 do
+      flags = parsed_body["items"].to_h { |item| [item["id"], item.slice("inHangar", "onWishlist")] }
+
+      assert_equal({"inHangar" => true, "onWishlist" => false}, flags[owned.id])
+      assert_equal({"inHangar" => false, "onWishlist" => true}, flags[wished.id])
+      assert_equal({"inHangar" => false, "onWishlist" => false}, flags[untouched.id])
+    end
+  end
+
+  test "GET /filters/models/options reports no hangar flags when signed out" do
+    model = create(:model, :with_store_image)
+    create(:vehicle, model:)
+
+    assert_api_response :get, 200 do
+      item = parsed_body["items"].find { |entry| entry["id"] == model.id }
+
+      assert_equal false, item["inHangar"]
+      assert_equal false, item["onWishlist"]
     end
   end
 end


### PR DESCRIPTION
## Why

The add-ships picker was a 600px column of fifteen checkbox rows behind a name search:

- **No way to narrow the catalogue.** Name search only — no manufacturer, no class. The endpoint permitted nothing else.
- **No way to tell ships apart.** The payload was id/name/slug/image, so "Hornet F7C" and "Hornet F7C-M Super Hornet" were two near-identical rows.
- **The selection went invisible.** Only a count in the footer; search again and you could not see what you had picked.
- **Two click targets per row.** A `FormCheckbox` *and* an overlapping `<button>`, both toggling the same model through separate code paths.
- **Manual paging**, and every keystroke flipped the whole list to a skeleton.
- **One copy per model per trip**, and the title said "Add Ships" even on the wishlist.

## What

**Backend** — `api/v1/filters/models#options`

- Permits `manufacturerIn`, `classificationIn`, `searchCont`, `sizeIn`, `productionStatusIn`, `focusIn`, `idNotIn`, `inHangar`; eager-loads `:manufacturer`.
- `ModelOption` gains `manufacturer{name,slug,code}`, `classification`, `classificationLabel`, `inHangar`, `onWishlist`.
- The two viewer-specific flags sit **outside** `json.cache!` — that key is the model, not the caller — and come from one `pluck` over the page rather than `Model#in_hangar`, which is a query per row.

**Frontend** — `NewVehiclesModal` + a new `ModelCard`

- Wide modal over an `auto-fill minmax(220px)` grid: four columns wide, one on a phone, no per-column breakpoints.
- Cards carry the store image, the name and `Manufacturer · Classification`, and are a single `aria-pressed` toggle.
- Search uses `searchCont`, so typing a manufacturer's name finds its ships. Filters reuse the existing `ManufacturerFilterGroup` / `ModelClassificationFilterGroup`.
- Infinite scroll rooted at `.modal-body`; the Load-more button stays as the keyboard path.
- Quantity steppers, a selection chip tray stuck to the bottom of the scroll area, wishlist-aware title and submit label, and a gold badge for the flag matching the list you came from with the other one quiet.

New component styling follows `Panel`/`Btn`/`Chip`: plain `<style scoped>` with `@reference` and theme tokens, no new literals.

## Three bugs caught by running it

1. **Footer pushed off-screen.** `.modal-body`'s `max-height: calc(100vh - 14rem)` assumes a single-row footer, so a footer of chips pushed the submit button past the bottom of the viewport. The tray moved inside the scroll area — the shared modal is untouched.
2. **Badge tint keyed off array position.** A wishlisted ship shown in the *hangar* picker got the loud gold treatment purely by being the only badge on its card. Now keyed on the flag itself.
3. **Count and sentinel flickering between pages.** TanStack drops `data` while a new query key fetches; `placeholderData: keepPreviousData` holds the previous page. The accumulator keys on the response's own `currentPage`, so a stale page-2 payload can no longer be appended onto a list a filter change already reset.

## Verification

`oasdiff` reports no breaking changes. 269 frontend tests, 31 relevant backend tests, `lint:ts`, eslint, prettier, standardrb and a full vite build all pass.

Driven in the real app with a throwaway Playwright spec (since deleted): the quantity round-trip creates exactly 1 Hornet + 3 Sabres at `wanted: false`, and the wishlist variant reframes its title, submit label and badges. Screenshots checked at 1440px and 480px — that pass is what surfaced all three bugs above.

## Note

The backend tests as first written asserted absolute row counts and **failed when run alongside other integration files** (models leak across them). They now assert against the records each test creates. The pre-existing test in that file had the same fragility.

Nothing covers the quantity path in CI — I left the e2e spec out as unrequested scope. Happy to land it if you want it. 🤖
