### PR TITLE
fix(scdata): load catalogues added after the current build was imported

### DIFF
--- a/app/jobs/loaders/uex_commodity_prices_job.rb
+++ b/app/jobs/loaders/uex_commodity_prices_job.rb
@@ -20,7 +20,8 @@ module Loaders
         title: unmapped ? "UEX Commodity Sync — Unmapped Commodities" : "UEX Commodity Mapping Results",
         body: ::Uex::CommodityMapper.github_issue_body(mapping),
         actionable: unmapped,
-        record: import
+        record: import,
+        report_key: "uex_commodity_mapping"
       )
 
       AdminReport.deliver(
@@ -28,7 +29,8 @@ module Loaders
         title: unknown ? "UEX Commodity Sync — Priced Commodities We Do Not Carry" : "UEX Commodity Price Sync Results",
         body: ::Uex::CommodityPriceSyncer.github_issue_body(result),
         actionable: unknown,
-        record: import
+        record: import,
+        report_key: "uex_commodity_prices"
       )
 
       import.update!(

--- a/app/jobs/sc_data/check_job.rb
+++ b/app/jobs/sc_data/check_job.rb
@@ -2,12 +2,34 @@
 
 module ScData
   class CheckJob < ApplicationJob
+    # Every catalogue BaseLoader.all fills that stamps the build it was last
+    # seen in. A finished import on its own is not proof the current build was
+    # fully loaded: a loader added to BaseLoader.all after that import ran would
+    # never get a chance, because the version it waits on has already been
+    # imported. Commodity and Equipment sat empty for a week that way.
+    VERSIONED_CATALOGUES = [Component, Commodity, Equipment].freeze
+
+    # Bounded on purpose. Should the export stop shipping one of those
+    # catalogues for good, an open-ended coverage check would reload the whole
+    # of sc_data every night rather than leave the gap for someone to look at.
+    MAX_IMPORTS_PER_VERSION = 2
+
     def perform
       new_version = Rails.configuration.sc_data[:version]
 
-      return if new_version.blank? || Imports::ScData::AllImport.finished.exists?(version: new_version)
+      return if new_version.blank?
+      return if loaded?(new_version)
 
       Loaders::ScData::AllJob.perform_async(new_version)
+    end
+
+    private def loaded?(version)
+      imports = Imports::ScData::AllImport.finished.where(version:).count
+
+      return false if imports.zero?
+      return true if imports >= MAX_IMPORTS_PER_VERSION
+
+      VERSIONED_CATALOGUES.all? { |catalogue| catalogue.exists?(version:) }
     end
   end
 end

--- a/app/lib/admin_report.rb
+++ b/app/lib/admin_report.rb
@@ -5,17 +5,18 @@
 # report contains something a human has to act on, so clean runs stop opening
 # issues nobody can close.
 class AdminReport
-  def self.deliver(task_type:, title:, body:, actionable:, link: nil, record: nil)
-    new(task_type:, title:, body:, actionable:, link:, record:).deliver
+  def self.deliver(task_type:, title:, body:, actionable:, link: nil, record: nil, report_key: nil)
+    new(task_type:, title:, body:, actionable:, link:, record:, report_key:).deliver
   end
 
-  def initialize(task_type:, title:, body:, actionable:, link: nil, record: nil)
+  def initialize(task_type:, title:, body:, actionable:, link: nil, record: nil, report_key: nil)
     @task_type = task_type.to_sym
     @title = title
     @body = body
     @actionable = actionable
     @link = link
     @record = record
+    @report_key = report_key
   end
 
   def deliver
@@ -31,6 +32,11 @@ class AdminReport
 
     return unless @actionable
 
-    GithubIssueCreator.new(task_type: @task_type.to_s, title: @title, body: @body).run
+    GithubIssueCreator.new(
+      task_type: @task_type.to_s,
+      report_key: @report_key,
+      title: @title,
+      body: @body
+    ).run
   end
 end

--- a/app/lib/github_issue_creator.rb
+++ b/app/lib/github_issue_creator.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class GithubIssueCreator
-  def initialize(task_type:, title:, body:)
+  # One task type can deliver more than one report -- the commodity sync sends
+  # both its mapping and its price result under "uex_commodity_prices_import".
+  # The dedupe below only ever looks at the newest log, so the reports need
+  # separate keys or each run reads the other one's digest as "last seen" and
+  # opens a duplicate issue for both.
+  def initialize(task_type:, title:, body:, report_key: nil)
     @task_type = task_type
+    @report_key = report_key.presence || task_type
     @title = title
     @body = body
   end
@@ -12,7 +18,7 @@ class GithubIssueCreator
 
     digest = Digest::SHA256.hexdigest(@body)
 
-    last_log = GithubIssueLog.where(task_type: @task_type).order(created_at: :desc).first
+    last_log = GithubIssueLog.where(report_key: @report_key).order(created_at: :desc).first
 
     return if last_log&.content_digest == digest
 
@@ -20,6 +26,7 @@ class GithubIssueCreator
 
     GithubIssueLog.create!(
       task_type: @task_type,
+      report_key: @report_key,
       content_digest: digest,
       issue_number: issue[:number]
     )

--- a/app/models/github_issue_log.rb
+++ b/app/models/github_issue_log.rb
@@ -7,15 +7,18 @@
 #  id             :uuid             not null, primary key
 #  content_digest :string           not null
 #  issue_number   :integer
+#  report_key     :string           not null
 #  task_type      :string           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
 # Indexes
 #
-#  index_github_issue_logs_on_task_type  (task_type)
+#  index_github_issue_logs_on_report_key  (report_key)
+#  index_github_issue_logs_on_task_type   (task_type)
 #
 class GithubIssueLog < ApplicationRecord
   validates :task_type, presence: true
+  validates :report_key, presence: true
   validates :content_digest, presence: true
 end

--- a/db/migrate/20260823120000_add_report_key_to_github_issue_logs.rb
+++ b/db/migrate/20260823120000_add_report_key_to_github_issue_logs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddReportKeyToGithubIssueLogs < ActiveRecord::Migration[8.1]
+  def up
+    add_column :github_issue_logs, :report_key, :string
+
+    # One task type can deliver more than one report, and the dedupe compares a
+    # body against the newest log for its key. Every log written so far came
+    # from a job delivering a single report, so its task type is that key.
+    execute "UPDATE github_issue_logs SET report_key = task_type WHERE report_key IS NULL"
+
+    change_column_null :github_issue_logs, :report_key, false
+    add_index :github_issue_logs, :report_key
+  end
+
+  def down
+    remove_index :github_issue_logs, :report_key
+    remove_column :github_issue_logs, :report_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -642,8 +642,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
     t.string "content_digest", null: false
     t.datetime "created_at", null: false
     t.integer "issue_number"
+    t.string "report_key", null: false
     t.string "task_type", null: false
     t.datetime "updated_at", null: false
+    t.index ["report_key"], name: "index_github_issue_logs_on_report_key"
     t.index ["task_type"], name: "index_github_issue_logs_on_task_type"
   end
 

--- a/test/jobs/loaders/loaner_job_test.rb
+++ b/test/jobs/loaders/loaner_job_test.rb
@@ -24,6 +24,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "loaner_sync",
+        report_key: nil,
         title: "Missing Loaners",
         body: anything
       ).returns(creator)

--- a/test/jobs/loaders/modules_import_job_test.rb
+++ b/test/jobs/loaders/modules_import_job_test.rb
@@ -41,6 +41,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "modules_import",
+        report_key: nil,
         title: "Modules Import Results",
         body: anything
       ).returns(creator)

--- a/test/jobs/loaders/paints_import_job_test.rb
+++ b/test/jobs/loaders/paints_import_job_test.rb
@@ -41,6 +41,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "paints_import",
+        report_key: nil,
         title: "Paints Import Results",
         body: anything
       ).returns(creator)

--- a/test/jobs/loaders/uex_commodity_prices_job_test.rb
+++ b/test/jobs/loaders/uex_commodity_prices_job_test.rb
@@ -46,6 +46,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "uex_commodity_prices_import",
+        report_key: "uex_commodity_mapping",
         title: "UEX Commodity Sync — Unmapped Commodities",
         body: anything
       ).returns(creator)
@@ -62,6 +63,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "uex_commodity_prices_import",
+        report_key: "uex_commodity_prices",
         title: "UEX Commodity Sync — Priced Commodities We Do Not Carry",
         body: anything
       ).returns(creator)

--- a/test/jobs/loaders/uex_prices_job_test.rb
+++ b/test/jobs/loaders/uex_prices_job_test.rb
@@ -27,6 +27,7 @@ module Loaders
       creator.expects(:run).returns(true)
       GithubIssueCreator.expects(:new).with(
         task_type: "uex_prices_import",
+        report_key: nil,
         title: "UEX Price Sync — Unmatched Vehicles",
         body: anything
       ).returns(creator)

--- a/test/jobs/sc_data/check_job_test.rb
+++ b/test/jobs/sc_data/check_job_test.rb
@@ -4,11 +4,16 @@ require "test_helper"
 
 module ScData
   class CheckJobTest < ActiveJob::TestCase
-    test "#perform enqueues AllJob when version is new" do
-      Rails.configuration.stubs(:sc_data).returns({version: "3.24.0"})
-      Imports::ScData::AllImport.stubs(:finished).returns(stub(exists?: false))
+    VERSION = "3.24.0"
 
-      Loaders::ScData::AllJob.expects(:perform_async).with("3.24.0")
+    setup do
+      Rails.configuration.stubs(:sc_data).returns({version: VERSION})
+    end
+
+    test "#perform enqueues AllJob when version is new" do
+      stub_finished_imports(0)
+
+      Loaders::ScData::AllJob.expects(:perform_async).with(VERSION)
 
       ::ScData::CheckJob.new.perform
     end
@@ -21,13 +26,47 @@ module ScData
       ::ScData::CheckJob.new.perform
     end
 
-    test "#perform does not enqueue AllJob when import already finished for version" do
-      Rails.configuration.stubs(:sc_data).returns({version: "3.24.0"})
-      Imports::ScData::AllImport.stubs(:finished).returns(stub(exists?: true))
+    test "#perform does not enqueue AllJob when the version is imported and every catalogue carries it" do
+      stub_finished_imports(1)
+      load_every_catalogue
 
       Loaders::ScData::AllJob.expects(:perform_async).never
 
       ::ScData::CheckJob.new.perform
+    end
+
+    # The version guard on its own let a loader added to BaseLoader.all after the
+    # current build was imported sit unrun until the next patch moved the version.
+    test "#perform enqueues AllJob when the version is imported but a catalogue was never loaded" do
+      stub_finished_imports(1)
+      load_every_catalogue
+      Commodity.update_all(version: nil)
+
+      Loaders::ScData::AllJob.expects(:perform_async).with(VERSION)
+
+      ::ScData::CheckJob.new.perform
+    end
+
+    # Otherwise a catalogue the export has stopped shipping for good would
+    # reload the whole of sc_data every night.
+    test "#perform stops retrying a version the loaders have already had two goes at" do
+      stub_finished_imports(::ScData::CheckJob::MAX_IMPORTS_PER_VERSION)
+      load_every_catalogue
+      Commodity.update_all(version: nil)
+
+      Loaders::ScData::AllJob.expects(:perform_async).never
+
+      ::ScData::CheckJob.new.perform
+    end
+
+    private def stub_finished_imports(count)
+      Imports::ScData::AllImport.stubs(:finished).returns(stub(where: stub(count:)))
+    end
+
+    private def load_every_catalogue
+      create(:component, version: VERSION)
+      create(:commodity, version: VERSION)
+      create(:equipment, version: VERSION)
     end
   end
 end

--- a/test/lib/github_issue_creator_test.rb
+++ b/test/lib/github_issue_creator_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GithubIssueCreatorTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.credentials.stubs(:github_token).returns("token")
+
+    @client = mock("octokit")
+    Octokit::Client.stubs(:new).returns(@client)
+  end
+
+  test "#run opens an issue and records the body it was opened for" do
+    @client.expects(:create_issue).once.returns({number: 42})
+
+    creator(body: "something to fix").run
+
+    log = GithubIssueLog.sole
+    assert_equal "uex_commodity_prices", log.report_key
+    assert_equal 42, log.issue_number
+  end
+
+  test "#run does not reopen an issue for a body it already opened" do
+    @client.expects(:create_issue).once.returns({number: 42})
+
+    2.times { creator(body: "something to fix").run }
+
+    assert_equal 1, GithubIssueLog.count
+  end
+
+  test "#run opens a fresh issue once the body changes" do
+    @client.expects(:create_issue).twice.returns({number: 42}, {number: 43})
+
+    creator(body: "something to fix").run
+    creator(body: "something else to fix").run
+
+    assert_equal 2, GithubIssueLog.count
+  end
+
+  # Both reports of the commodity sync share one task type. Deduping on the task
+  # type alone made each run read the other report's digest as the last one seen,
+  # so every run reopened both issues.
+  test "#run keeps two reports of one task type from reopening each other" do
+    @client.expects(:create_issue).twice.returns({number: 42}, {number: 43})
+
+    2.times do
+      creator(report_key: "uex_commodity_mapping", body: "commodities we cannot price").run
+      creator(report_key: "uex_commodity_prices", body: "prices we cannot place").run
+    end
+
+    assert_equal 2, GithubIssueLog.count
+  end
+
+  test "#run falls back to the task type when no report key is given" do
+    @client.expects(:create_issue).once.returns({number: 42})
+
+    GithubIssueCreator.new(task_type: "paints_import", title: "Paints", body: "a paint").run
+
+    assert_equal "paints_import", GithubIssueLog.sole.report_key
+  end
+
+  test "#run does nothing without a github token" do
+    Rails.application.credentials.stubs(:github_token).returns(nil)
+    @client.expects(:create_issue).never
+
+    creator(body: "something to fix").run
+
+    assert_empty GithubIssueLog.all
+  end
+
+  private def creator(body:, report_key: "uex_commodity_prices")
+    GithubIssueCreator.new(
+      task_type: "uex_commodity_prices_import",
+      report_key:,
+      title: "UEX Commodity Sync",
+      body:
+    )
+  end
+end


### PR DESCRIPTION
Closes #4475 — though not the way the issue reads. The 123 commodities it lists are not a `MAPPINGS` gap; they are every commodity UEX prices at a terminal, unresolved because the `commodities` table is empty in production.

## Why it is empty

`Loaders::ScData::AllJob` is not on the schedule. `ScData::CheckJob` is the only thing that enqueues it, and it gated purely on version:

```ruby
return if new_version.blank? || Imports::ScData::AllImport.finished.exists?(version: new_version)
```

`sc_data.version` is `4.9.0-live.12344265`, set 2026-08-04, and its import finished then. `CommoditiesLoader` joined `BaseLoader.all` on 2026-08-15 (#4385) and `EquipmentLoader` on 2026-08-16 (#4396) — both after that import. The guard has been satisfied every night since, so neither loader has ever run, and the parsed JSON has sat in the image unread: 168 commodity files, 4821 equipment files.

Confirmed from outside: `/v1/commodities` and `/v1/equipment` both return `totalCount 0`, while `/v1/models` is 243, `/v1/manufacturers` 137, `/v1/components` 8717.

`CheckJob` now also asks whether each versioned catalogue carries the current build, so a loader added mid-version is picked up the next night instead of waiting for the next patch. Bounded to two imports per version — an open-ended coverage check would reload the whole of sc_data nightly if the export ever stopped shipping a catalogue for good.

## The duplicate-issue bug this would have exposed

`UexCommodityPricesJob` delivers two reports under one `task_type`, and `GithubIssueCreator` deduped against only the newest `GithubIssueLog` row for that type. That is fine today because only one report is actionable — but the moment the catalogue loads, both are (18 of our commodities have no UEX row, 18 priced UEX rows have no commodity of ours), and each run then reads the other report's digest as "last seen" and opens a duplicate. Two new issues per day, indefinitely.

The log now carries a `report_key`. The migration backfills it from `task_type`, so the jobs that deliver a single report keep matching the rows they have already written and nothing re-opens on deploy.

## What the load buys

Measured against the live UEX feed with the 168-row parsed catalogue: 150 of 205 UEX rows map, and **105 of the 123 in #4475 resolve**. The 18 that remain are not mappable — 10 ammunition rows against our single "Ammo Crate" mission crate, 6 metals and minerals the export does not name at all (44 Iron; we carry only "Iron (Ore)"), 186 Organics which the matcher deliberately excludes, and 192 Year of the Rat Envelope where we carry Dog, Pig and Rooster.

Separately worth a decision, not touched here: UEX has added id 217 "Construction Pieces", which name-matches our commodity of exactly that name, but `MAPPINGS[182]` already claims it for "Construction Material Pebbles". Neither row is priced, so no price is lost, but which of 181/182/183/217 pairs with our powder/scraps/chunks trio is now ambiguous.

## Testing

`test/lib/github_issue_creator_test.rb` is new — 6 tests, including the ping-pong regression, which I confirmed fails on the old task-type scoping (a third `create_issue` on the second run) and passes on the new. `check_job_test.rb` gains the two coverage cases. 30 tests / 87 assertions green across every affected file; `standardrb` clean.

## After merge

The catalogues still need one manual load — admin `reload-scdata`, or `Loaders::ScData::AllJob.perform_async`. Expect the "Unmapped Commodities" report to open for the first time afterwards; that one is legitimate.

🤖
