### PR TITLE
fix(hardpoints): repair the metrics and hardpoint rows on mobile

### DIFF
--- a/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.scss
@@ -40,37 +40,18 @@
   transition: color 0.2s;
 }
 
+// A basis rather than `auto`: the name block asks for enough room to read
+// before the headline is allowed to share its line, so on a narrow row the
+// headline wraps below instead of shrinking this to a few clipped characters.
+// `min-width: 0` still lets it shrink past the basis once it has a line of its
+// own.
 .hardpoint-item__main {
-  flex: 1 1 auto;
+  flex: 1 1 120px;
   min-width: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 1px;
-}
-
-// erkul-style inline stat strip: label/value pairs, always visible.
-.hardpoint-item__stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1px 12px;
-  margin-top: 5px;
-}
-
-.hardpoint-item__stat {
-  font-size: 11.5px;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-
-.hardpoint-item__stat-k {
-  color: $gray-light;
-}
-
-.hardpoint-item__stat-v {
-  margin-left: 4px;
-  color: lighten($text-color, 15%);
-  font-weight: 600;
 }
 
 .hardpoint-item__loadout {

--- a/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/BaseItem/index.vue
@@ -13,6 +13,7 @@ import HardpointSize from "@/frontend/components/Models/Hardpoints/Size/index.vu
 import HardpointComponent from "@/frontend/components/Models/Hardpoints/Component/index.vue";
 import HardpointHeadline from "@/frontend/components/Models/Hardpoints/Headline/index.vue";
 import HardpointManufacturer from "@/frontend/components/Models/Hardpoints/Manufacturer/index.vue";
+import HardpointStats from "@/frontend/components/Models/Hardpoints/Stats/index.vue";
 import Collapsed from "@/shared/components/Collapsed.vue";
 import { useHardpointStats } from "@/frontend/composables/useHardpointStats";
 import {
@@ -196,22 +197,13 @@ const hardpointNames = computed(() => {
         <HardpointManufacturer
           :manufacturer="hardpoint.component?.manufacturer"
         />
-        <div v-if="inlineStats.length" class="hardpoint-item__stats">
-          <span
-            v-for="(s, i) in inlineStats"
-            :key="i"
-            class="hardpoint-item__stat"
-          >
-            <span class="hardpoint-item__stat-k">{{ s.label }}</span>
-            <span class="hardpoint-item__stat-v">{{ s.value }}</span>
-          </span>
-        </div>
       </div>
       <HardpointHeadline
         v-if="primaryStat"
         :value="primaryStat.value"
         :unit="primaryStat.label"
       />
+      <HardpointStats :stats="inlineStats" />
     </template>
     <template #loadout>
       <div v-if="loadout.length" class="hardpoint-item__loadout">

--- a/app/frontend/frontend/components/Models/Hardpoints/CargoItem/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/CargoItem/index.scss
@@ -1,12 +1,8 @@
-.hardpoint-item__cargo-container {
-  padding-right: 10px;
-  color: $gray-light;
-  white-space: nowrap;
-}
-
+// A basis rather than `width: 100%`, which made the name claim the whole row as
+// its hypothetical size and left the other two parts fighting over what was
+// left once the row could not wrap.
 .hardpoint-item__cargo-component {
-  width: 100%;
-  flex-grow: 1;
+  flex: 1 1 120px;
   margin-right: 5px;
   text-transform: capitalize;
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/CargoItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/CargoItem/index.vue
@@ -8,7 +8,9 @@ export default {
 import HardpointItem from "@/frontend/components/Models/Hardpoints/Item/index.vue";
 import HardpointComponent from "@/frontend/components/Models/Hardpoints/Component/index.vue";
 import HardpointHeadline from "@/frontend/components/Models/Hardpoints/Headline/index.vue";
+import HardpointStats from "@/frontend/components/Models/Hardpoints/Stats/index.vue";
 import { type Hardpoint, type CargoHold } from "@/services/fyApi";
+import type { HardpointStat } from "@/frontend/composables/useHardpointStats";
 import { useI18n } from "@/shared/composables/useI18n";
 import { humanizeHoldName } from "@/shared/utils/CargoHolds";
 
@@ -44,6 +46,23 @@ const name = computed(() => {
 const label = computed(() => {
   return humanizeHoldName(name.value);
 });
+
+// The max container size reads as a metric, like every other stat on a hardpoint
+// row, rather than as a sentence beside the name.
+const stats = computed<HardpointStat[]>(() => {
+  const maxContainerSize = typeData.value?.maxContainerSize?.size;
+
+  if (!maxContainerSize) {
+    return [];
+  }
+
+  return [
+    {
+      label: t("labels.hardpoint.maxContainerSize"),
+      value: String(toNumber(maxContainerSize, "cargo")),
+    },
+  ];
+});
 </script>
 
 <template>
@@ -55,15 +74,12 @@ const label = computed(() => {
         </template>
         <template v-else>TBD</template>
       </HardpointComponent>
-      <div class="hardpoint-item__cargo-container text-muted">
-        {{ t("labels.hardpoint.maxContainerSize") }}:
-        {{ toNumber(typeData?.maxContainerSize?.size || "", "cargo") }}
-      </div>
       <HardpointHeadline
         v-if="typeData?.capacity"
         :value="toNumber(typeData.capacity, 'cargo')"
         :unit="t('labels.cargoGridViewer.capacity')"
       />
+      <HardpointStats :stats="stats" />
     </template>
   </HardpointItem>
 </template>

--- a/app/frontend/frontend/components/Models/Hardpoints/Component/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/Component/index.scss
@@ -1,6 +1,10 @@
 .hardpoint-item__component {
   flex-grow: 1;
   min-width: 0;
+  // Backstop for a name with no space to break at (`ColdSnap`, `Cargogrid`) in
+  // a cell too narrow for it: break the word rather than let the row's
+  // `overflow: hidden` clip it mid-letter.
+  overflow-wrap: break-word;
   margin-right: 5px;
   gap: 0 5px;
   display: flex;

--- a/app/frontend/frontend/components/Models/Hardpoints/Item/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/Item/index.scss
@@ -34,7 +34,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 4px 8px;
+  gap: 8px;
   width: 100%;
   margin-bottom: 6px;
   padding: 8px 11px 8px 14px;
@@ -66,4 +66,28 @@
     border-radius: 2px;
     opacity: 0.85;
   }
+}
+
+// The row content wraps, so a narrow card (a phone, or a metrics card at
+// three-up) drops the gold headline onto its own line instead of squeezing the
+// component name down to a few clipped characters. Each part declares a
+// flex-basis it would like, so wrapping is decided by the space actually
+// available rather than by a breakpoint.
+.hardpoint-item__content {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 8px;
+}
+
+// Count badge and row controls stay pinned to the right on the first line
+// however the content behind them wraps, so the chevron never moves.
+.hardpoint-item__rail {
+  flex: none;
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/Item/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Item/index.vue
@@ -22,14 +22,21 @@ withDefaults(defineProps<Props>(), {
   <div class="hardpoint-item">
     <div class="hardpoint-item__wrapper">
       <div class="hardpoint-item__inner">
-        <slot name="default" />
-        <HardpointQuantity
-          v-if="count && count > 1"
-          :quantity="count"
-          tag="span"
-          class="hardpoint-item__count"
-        />
-        <slot name="actions" />
+        <div class="hardpoint-item__content">
+          <slot name="default" />
+        </div>
+        <div
+          v-if="(count && count > 1) || $slots.actions"
+          class="hardpoint-item__rail"
+        >
+          <HardpointQuantity
+            v-if="count && count > 1"
+            :quantity="count"
+            tag="span"
+            class="hardpoint-item__count"
+          />
+          <slot name="actions" />
+        </div>
       </div>
       <slot name="loadout" />
     </div>

--- a/app/frontend/frontend/components/Models/Hardpoints/Manufacturer/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Manufacturer/index.vue
@@ -25,3 +25,7 @@ withDefaults(defineProps<Props>(), {
   />
   <!-- eslint-enable vue/no-v-html -->
 </template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Models/Hardpoints/Stats/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/Stats/index.scss
@@ -1,0 +1,34 @@
+// erkul-style inline stat strip: label/value pairs, always visible. A full-width
+// basis puts it on its own line under the identity, where it packs several pairs
+// per line - confined to the name column it managed one per line on a phone and
+// left the space beside the headline empty.
+.hardpoint-item__stats {
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px 12px;
+  margin-top: 5px;
+}
+
+.hardpoint-item__stat {
+  font-size: 11.5px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+
+  // A stat whose label and value run long (the boom's quantum fuel flow rate)
+  // asks for room rather than demanding a line: it shares one where the band is
+  // wide enough and drops to its own where it is not.
+  &--wide {
+    flex: 1 1 240px;
+  }
+}
+
+.hardpoint-item__stat-k {
+  color: $gray-light;
+}
+
+.hardpoint-item__stat-v {
+  margin-left: 4px;
+  color: lighten($text-color, 15%);
+  font-weight: 600;
+}

--- a/app/frontend/frontend/components/Models/Hardpoints/Stats/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/Stats/index.vue
@@ -1,0 +1,33 @@
+<script lang="ts">
+export default {
+  name: "HardpointStats",
+};
+</script>
+
+<script lang="ts" setup>
+import type { HardpointStat } from "@/frontend/composables/useHardpointStats";
+
+type Props = {
+  stats: HardpointStat[];
+};
+
+defineProps<Props>();
+</script>
+
+<template>
+  <div v-if="stats.length" class="hardpoint-item__stats">
+    <span
+      v-for="(stat, index) in stats"
+      :key="index"
+      class="hardpoint-item__stat"
+      :class="{ 'hardpoint-item__stat--wide': stat.wide }"
+    >
+      <span class="hardpoint-item__stat-k">{{ stat.label }}</span>
+      <span class="hardpoint-item__stat-v">{{ stat.value }}</span>
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/frontend/components/Models/Hardpoints/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.scss
@@ -22,6 +22,20 @@
     margin-inline-start: auto;
   }
 
+  // Beside the link group, not inside it. As a member of the BtnGroup track it
+  // added its own width to a control that cannot wrap, so on a phone the two
+  // buttons were pushed off the viewport and their labels clipped against the
+  // track's `overflow: hidden`. Out here it wraps onto its own line instead.
+  &__links-label {
+    flex: 0 1 auto;
+  }
+
+  // Safety net for a translation long enough that even the two buttons alone
+  // overrun the row: the group clips inside the page rather than widening it.
+  &__links {
+    max-width: 100%;
+  }
+
   // The metrics cards are modelled on erkul's formulas, so the credit sits once
   // under the whole grid instead of being repeated in every card. Right-aligned
   // to answer the loadout links at the top of the block: the same attribution,

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -181,21 +181,25 @@ useMetricsMasonry(metricsGrid);
   <div id="hardpoints" class="row hardpoints">
     <div class="col-12">
       <div class="hardpoints__controls">
-        <BtnGroup v-if="model.inGame" class="hardpoints__links">
-          <span class="text-muted">{{ t("labels.hardpoints.prefix") }}</span>
-          <Btn :href="erkulUrl" class="erkul-link w-full md:w-auto">
-            <i />
-            {{ t("labels.hardpoints.erkul") }}
-          </Btn>
-          <Btn
-            v-tooltip="t('labels.hardpoints.spviewerTitle')"
-            :href="spviewerUrl"
-            class="spviewer-link w-full md:w-auto"
-          >
-            <i />
-            {{ t("labels.hardpoints.spviewer") }}
-          </Btn>
-        </BtnGroup>
+        <template v-if="model.inGame">
+          <span class="hardpoints__links-label text-muted">
+            {{ t("labels.hardpoints.prefix") }}
+          </span>
+          <BtnGroup class="hardpoints__links">
+            <Btn :href="erkulUrl" class="erkul-link">
+              <i />
+              {{ t("labels.hardpoints.erkul") }}
+            </Btn>
+            <Btn
+              v-tooltip="t('labels.hardpoints.spviewerTitle')"
+              :href="spviewerUrl"
+              class="spviewer-link"
+            >
+              <i />
+              {{ t("labels.hardpoints.spviewer") }}
+            </Btn>
+          </BtnGroup>
+        </template>
         <BtnGroup segmented class="hardpoints__source">
           <Btn
             :active="source === HardpointSourceEnum.GAME_FILES"

--- a/app/frontend/frontend/components/Models/PowerDistribution/index.vue
+++ b/app/frontend/frontend/components/Models/PowerDistribution/index.vue
@@ -567,12 +567,15 @@ const cellHeight = (span: number) =>
 // The columns wrap, so the row never needs to scroll — and an `overflow-x`
 // scroll container here also turns overflow-y into `auto`, which put scrollbars
 // on the pane as soon as a ship had enough columns to wrap.
+// Centred, not `space-between`: a row that does wrap leaves its last row short,
+// and space-between parked that remainder against the left edge as if columns
+// were missing rather than continued.
 .power-bars {
   display: flex;
   align-items: flex-end;
-  justify-content: space-between;
+  justify-content: center;
   flex-wrap: wrap;
-  gap: 14px 10px;
+  gap: 14px 6px;
   min-height: 170px;
 }
 
@@ -581,12 +584,16 @@ const cellHeight = (span: number) =>
   flex-direction: column;
   align-items: center;
   flex: 1 1 0;
-  min-width: 34px;
+  // Narrow enough that the eight families a typical ship carries still fit one
+  // row in ~290px - the width of this card both on a phone and at three-up on
+  // desktop. They grow to `max-width` whenever there is more room.
+  min-width: 30px;
   max-width: 72px;
   gap: 6px;
 
   &__count {
-    font-size: 13px;
+    // Sized so "8 / 8" fits a column at its minimum width instead of wrapping.
+    font-size: 12px;
     font-variant-numeric: tabular-nums;
     color: $text-color;
     min-height: 16px;

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -54,6 +54,9 @@ export const useHardpointStats = (
   // power-plant Category, so each plant can show its own pip share.
   const powerPlantContext = inject(powerPlantContextKey, undefined);
 
+  // `integer`, not a unit format, wherever the label already names the unit
+  // ("Sustained DPS", "HP", "Cooling Rate", "Output", "Pips"): every consumer
+  // renders `label` beside `value`, so a unit format there prints it twice.
   const stat = (
     labelKey: string,
     value: number,
@@ -247,15 +250,20 @@ export const useHardpointStats = (
         const burstTotal = burstValue * stackCount;
         if (efficiency < 1) {
           result.push(
-            stat("weapons.sustainedDps", burstTotal * efficiency, "dps", true),
+            stat(
+              "weapons.sustainedDps",
+              burstTotal * efficiency,
+              "integer",
+              true,
+            ),
           );
-          result.push(stat("weapons.burstDps", burstTotal, "dps"));
+          result.push(stat("weapons.burstDps", burstTotal, "integer"));
           result.push({
             label: t("labels.hardpoint.weapons.efficiency"),
             value: `${Math.round(efficiency * 100)}%`,
           });
         } else {
-          result.push(stat("weapons.burstDps", burstTotal, "dps", true));
+          result.push(stat("weapons.burstDps", burstTotal, "integer", true));
         }
       };
 
@@ -396,7 +404,7 @@ export const useHardpointStats = (
       const shield = typeData as ComponentShield;
 
       if (shield.maxHealth) {
-        result.push(stat("shields.hp", shield.maxHealth, "shieldHp", true));
+        result.push(stat("shields.hp", shield.maxHealth, "integer", true));
       }
       if (shield.maxHealth && shield.maxRegen) {
         result.push(
@@ -450,7 +458,7 @@ export const useHardpointStats = (
       const cooler = typeData as ComponentCooler;
       if (cooler.coolingRate) {
         result.push(
-          stat("coolers.coolingRate", cooler.coolingRate, "coolingRate", true),
+          stat("coolers.coolingRate", cooler.coolingRate, "integer", true),
         );
       }
     } else if (category === HardpointCategoryEnum.POWERPLANT) {
@@ -460,9 +468,7 @@ export const useHardpointStats = (
       // total the category header used to show).
       const stackCount = Math.max(1, Math.round(Number(toValue(count) ?? 1)));
       if (pp.powerBase) {
-        result.push(
-          stat("powerPlants.output", pp.powerBase, "powerOutput", true),
-        );
+        result.push(stat("powerPlants.output", pp.powerBase, "integer", true));
       }
       const context = toValue(powerPlantContext);
       const size = Number(hp.component?.size);
@@ -471,7 +477,7 @@ export const useHardpointStats = (
           stat(
             "powerPlants.pips",
             powerPlantPips(pp.powerBase, size, context) * stackCount,
-            "powerPips",
+            "integer",
           ),
         );
       }

--- a/app/frontend/stylesheets/frontend/partials/erkul.scss
+++ b/app/frontend/stylesheets/frontend/partials/erkul.scss
@@ -40,17 +40,3 @@
     transition: all ease 0.5s;
   }
 }
-
-@media (max-width: $desktop-breakpoint) {
-  .erkul-link {
-    .btn__content {
-      flex-direction: column;
-    }
-  }
-
-  .spviewer-link {
-    .btn__content {
-      flex-direction: column;
-    }
-  }
-}


### PR DESCRIPTION
## What

The new metrics and hardpoints work had several problems at phone widths. Five separate causes behind them:

**A stat value repeated its own label.** `useHardpointStats` builds `value` with a unit-bearing number format *and* passes `label` separately, but every consumer renders them side by side — so the gold headline read `34 Cooling Rate` over `COOLING RATE`, `7200 HP` over `HP`. Five of the ten primary stats did this. It also made the headline wide enough to squeeze the component name off the row.

**Rows could not wrap.** `hardpoint-item__inner` was a nowrap flex line with a `flex: none` headline, so the name column absorbed the whole shortfall — measured at **53px** on a 390px viewport, clipping `ColdSnap` to `ColdSr`. On a narrower cell the count badge and chevron were pushed past the card's right edge.

**The stat band was stuck in the name column,** so it managed one pair per line on a phone while the space beside the headline sat empty.

**`w-full` inside a BtnGroup.** The two loadout link buttons carried `w-full md:w-auto`, but a `.btn-group__track` is a nowrap flex row with `overflow: hidden` — each button demanded the full track, taking the row to **411px inside a 390px viewport** and clipping the labels mid-word. The prefix sentence sitting inside the track added its width to a control that cannot wrap.

**The power columns had a 34px floor,** so eight families needed 342px against the ~290px this card gets — one column orphaned onto a second row. That hit the desktop three-up card too, not just phones.

Two things found along the way: `Manufacturer/index.scss` has existed since the Vue 3 migration but the component never imported it, so the manufacturer name rendered at full body colour and read as a second title; and `HardpointStat.wide` was set on one stat but never consumed.

## Also

The cargo row's max container size is now a metric in the stat band like every other hardpoint row, instead of a prose line beside the name — and it is omitted when the size is absent rather than rendering a bare label.

## How

Row content sits in a wrapping box with the count badge and controls in a rail that stays put, and the stat band takes its own full-width line. Everything is sized by flex-basis rather than a breakpoint, so it adapts to the compare table's narrow cells as well as to phones.

## Verified

Rendered the real compiled CSS from the production bundle at 320/390/480/640/900px and measured overflow, clipping and row heights:

| | before | after |
|---|---|---|
| document width @390px | 411px (overflows) | 390px |
| name column @390px | clipped 58→53px | no clipping |
| shield row height @390px | 146px | 119px |
| stat lines @390px | 5 | 3 |
| power rows @390px | 2 (orphan) | 1 |
| escapes viewport @260px | headline, badge, chevron, subtitle | none |

Clean at every width down to 220px — the compare table's own column floor. `pnpm run lint` (prettier + eslint + vue-tsc + tsc) and all 269 vitest tests pass.

## Left alone

- Five number formats in `translations/*/number.json` (`dps`, `shieldHp`, `coolingRate`, `powerOutput`, `powerPips`) are now unused. They are Crowdin source strings, so deleting them affects translation state.
- `stylesheets/frontend/partials/erkul.scss` aside, `partials/hardpoints.scss` is entirely scoped under `.hardpoints-legacy`, which no longer appears in any template — ~170 lines of dead CSS since #4176.
- `ModuleItem`'s expand toggle is in the default slot rather than `actions`, so it wraps with the content instead of joining the rail like other rows' chevrons.

🤖
