### PR TITLE
feat(admin): read notifications in a reading pane, with an archive

### DIFF
--- a/app/api_components/admin/v1/schemas/admin_notification.rb
+++ b/app/api_components/admin/v1/schemas/admin_notification.rb
@@ -20,12 +20,14 @@ module Admin
             lastOccurredAt: {type: :string, format: "date-time"},
             read: {type: :boolean},
             readAt: {type: :string, format: "date-time"},
+            archived: {type: :boolean},
+            archivedAt: {type: :string, format: "date-time"},
             expiresAt: {type: :string, format: "date-time"},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id notificationType severity title occurrences lastOccurredAt read expiresAt createdAt updatedAt]
+          required: %w[id notificationType severity title occurrences lastOccurredAt read archived expiresAt createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
@@ -13,6 +13,7 @@ module Admin
               notificationTypeEq: {"$ref": "#/components/schemas/AdminNotificationTypeEnum"},
               severityEq: {"$ref": "#/components/schemas/AdminNotificationSeverityEnum"},
               readAtNull: {type: :boolean},
+              archivedAtNull: {type: :boolean},
               searchCont: {type: :string},
               sorts: {anyOf: [{
                 type: :array, items: {"$ref": "#/components/schemas/AdminNotificationSortEnum"}

--- a/app/controllers/admin/api/v1/notifications_controller.rb
+++ b/app/controllers/admin/api/v1/notifications_controller.rb
@@ -6,10 +6,12 @@ module Admin
       class NotificationsController < ::Admin::Api::BaseController
         after_action -> { pagination_header(:notifications) }, only: %i[index]
 
-        before_action :set_notification, only: %i[read destroy]
+        before_action :set_notification, only: %i[read unread archive unarchive destroy]
 
         def index
           authorize! with: ::Admin::NotificationPolicy
+
+          notification_query_params["archived_at_null"] = true unless notification_query_params.key?("archived_at_null")
 
           notification_query_params["sorts"] = unread_first(
             sorting_params(AdminNotification, notification_query_params["sorts"])
@@ -26,7 +28,7 @@ module Admin
         def unread_count
           authorize! with: ::Admin::NotificationPolicy
 
-          @unread_count = scope.unread.count
+          @unread_count = scope.inbox.unread.count
         end
 
         def read
@@ -37,10 +39,36 @@ module Admin
           render :show
         end
 
+        def unread
+          authorize! @notification, with: ::Admin::NotificationPolicy
+
+          @notification.mark_as_unread!
+
+          render :show
+        end
+
+        def archive
+          authorize! @notification, with: ::Admin::NotificationPolicy
+
+          @notification.archive!
+
+          render :show
+        end
+
+        def unarchive
+          authorize! @notification, with: ::Admin::NotificationPolicy
+
+          @notification.unarchive!
+
+          render :show
+        end
+
         def read_all
           authorize! with: ::Admin::NotificationPolicy
 
-          scope.unread.update_all(read_at: Time.current, updated_at: Time.current)
+          # The inbox, not the archive: this clears what the unread badge counts,
+          # and an archived notification left unread on purpose stays that way.
+          scope.inbox.unread.update_all(read_at: Time.current, updated_at: Time.current)
 
           head :no_content
         end
@@ -76,7 +104,7 @@ module Admin
 
         private def notification_query_params
           @notification_query_params ||= params.permit(q: [
-            :notification_type_eq, :severity_eq, :read_at_null, :search_cont, :sorts, sorts: []
+            :notification_type_eq, :severity_eq, :read_at_null, :archived_at_null, :search_cont, :sorts, sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/frontend/admin/components/Notifications/Detail/index.vue
+++ b/app/frontend/admin/components/Notifications/Detail/index.vue
@@ -1,0 +1,313 @@
+<script lang="ts">
+export default {
+  name: "AdminNotificationsDetail",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import Markdown from "@/shared/components/Markdown/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  hasSeverityLabel,
+  severityPillVariant,
+} from "@/admin/components/Notifications/severity";
+import { type AdminNotification } from "@/services/fyAdminApi";
+
+type Props = {
+  notification?: AdminNotification;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  notification: undefined,
+});
+
+const emit = defineEmits<{
+  close: [];
+  unread: [];
+  archive: [];
+  unarchive: [];
+  destroy: [];
+}>();
+
+const { t, l } = useI18n();
+
+const body = ref<HTMLElement>();
+
+// Reading pane, so a long report left scrolled down must not carry that offset
+// into the next notification.
+watch(
+  () => props.notification?.id,
+  () => {
+    if (body.value) {
+      body.value.scrollTop = 0;
+    }
+  },
+);
+</script>
+
+<template>
+  <!-- No severity tone: a framed red or amber edge around the whole pane shouts
+       where the pill already says it, the same reason the rows dropped it. -->
+  <Panel :variant="PanelVariantsEnum.SLIM" :outer-spacing="false">
+    <div
+      v-if="notification"
+      ref="body"
+      class="notification-detail"
+      data-test="notification-detail"
+    >
+      <div class="notification-detail__header">
+        <Btn
+          class="notification-detail__back"
+          :aria-label="t('actions.back')"
+          @click="emit('close')"
+        >
+          <i class="fa-duotone fa-arrow-left" />
+        </Btn>
+        <i
+          class="notification-detail__icon"
+          :class="notification.icon || 'fa-duotone fa-bell'"
+        />
+        <div class="notification-detail__heading">
+          <h2
+            class="notification-detail__title"
+            data-test="notification-detail-title"
+          >
+            {{ notification.title }}
+            <span
+              v-if="notification.occurrences > 1"
+              class="notification-detail__count"
+            >
+              &times;{{ notification.occurrences }}
+            </span>
+          </h2>
+          <div class="notification-detail__meta">
+            <BasePill
+              v-if="hasSeverityLabel(notification.severity)"
+              :variant="severityPillVariant(notification.severity)"
+              uppercase
+            >
+              {{
+                t(
+                  `labels.adminNotifications.severities.${notification.severity}`,
+                )
+              }}
+            </BasePill>
+            <span>
+              {{
+                t(
+                  `labels.adminNotifications.types.${notification.notificationType}`,
+                )
+              }}
+            </span>
+            <span>{{ l(notification.createdAt) }}</span>
+          </div>
+        </div>
+        <div class="notification-detail__actions">
+          <Btn v-if="notification.link" :to="notification.link">
+            <i class="fa-duotone fa-arrow-up-right-from-square" />
+            {{ t("actions.open") }}
+          </Btn>
+          <Btn
+            v-if="notification.read"
+            v-tooltip="t('actions.adminNotifications.unread')"
+            :aria-label="t('actions.adminNotifications.unread')"
+            data-test="notification-detail-unread"
+            @click="emit('unread')"
+          >
+            <i class="fa-duotone fa-envelope-dot" />
+          </Btn>
+          <Btn
+            v-if="notification.archived"
+            v-tooltip="t('actions.adminNotifications.unarchive')"
+            :aria-label="t('actions.adminNotifications.unarchive')"
+            data-test="notification-detail-unarchive"
+            @click="emit('unarchive')"
+          >
+            <i class="fa-duotone fa-inbox-in" />
+          </Btn>
+          <Btn
+            v-else
+            v-tooltip="t('actions.adminNotifications.archive')"
+            :aria-label="t('actions.adminNotifications.archive')"
+            data-test="notification-detail-archive"
+            @click="emit('archive')"
+          >
+            <i class="fa-duotone fa-box-archive" />
+          </Btn>
+          <Btn
+            v-tooltip="t('actions.delete')"
+            :aria-label="t('actions.delete')"
+            :tone="BtnTonesEnum.DANGER"
+            @click="emit('destroy')"
+          >
+            <i class="fa-duotone fa-trash" />
+          </Btn>
+        </div>
+      </div>
+
+      <Markdown
+        v-if="notification.body"
+        class="notification-detail__body"
+        data-test="notification-detail-body"
+        :source="notification.body"
+      />
+      <p
+        v-else
+        class="notification-detail__body notification-detail__body--empty"
+        data-test="notification-detail-no-body"
+      >
+        {{ t("labels.adminNotifications.noBody") }}
+      </p>
+
+      <dl class="notification-detail__facts">
+        <div v-if="notification.occurrences > 1">
+          <dt>{{ t("labels.adminNotifications.lastSeen") }}</dt>
+          <dd>{{ l(notification.lastOccurredAt) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t("labels.adminNotifications.expires") }}</dt>
+          <dd>{{ l(notification.expiresAt) }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div
+      v-else
+      class="notification-detail notification-detail--empty"
+      data-test="notification-detail-empty"
+    >
+      <i class="fa-duotone fa-envelope-open-text" />
+      <p>{{ t("labels.adminNotifications.selectPrompt") }}</p>
+    </div>
+  </Panel>
+</template>
+
+<style lang="scss" scoped>
+.notification-detail {
+  padding: 16px 18px;
+  max-height: calc(100vh - 60px);
+  overflow: auto;
+}
+
+.notification-detail--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 240px;
+  color: $gray-lighter;
+  text-align: center;
+
+  i {
+    font-size: 2.5em;
+    opacity: 0.6;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+.notification-detail__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.notification-detail__icon {
+  flex-shrink: 0;
+  margin-top: 4px;
+  color: var(--color-primary, #{$primary});
+  font-size: 1.5em;
+}
+
+.notification-detail__heading {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-detail__title {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.notification-detail__count {
+  color: $gray-lighter;
+  font-size: 0.8em;
+}
+
+.notification-detail__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 6px;
+  color: $gray-lighter;
+  font-size: 0.85em;
+}
+
+.notification-detail__actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 5px;
+}
+
+.notification-detail__body {
+  margin: 16px 0 0;
+  padding: 12px 14px;
+  color: $text-color;
+  font-size: 0.9em;
+  background-color: rgba($gray-darker, 0.6);
+  border-radius: $border-radius-base;
+
+  // The global reset strips list markers, which turns a report's "missing
+  // models" into an indented run of names with nothing to separate them.
+  :deep(ul) {
+    margin: 0;
+    padding-left: 18px;
+    list-style: disc;
+  }
+}
+
+.notification-detail__body--empty {
+  color: $gray-lighter;
+  font-style: italic;
+}
+
+.notification-detail__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+  margin: 16px 0 0;
+  color: $gray-lighter;
+  font-size: 0.8em;
+
+  dt {
+    font-weight: normal;
+    opacity: 0.8;
+  }
+
+  dd {
+    margin: 0;
+  }
+}
+
+// The reading pane only sits beside the list on a wide screen; below that it
+// replaces the list, and needs the way back the two-pane layout does not.
+.notification-detail__back {
+  flex-shrink: 0;
+}
+
+@media (min-width: $notifications-two-pane-breakpoint) {
+  .notification-detail__back {
+    display: none;
+  }
+}
+</style>

--- a/app/frontend/admin/components/Notifications/ListItem/index.vue
+++ b/app/frontend/admin/components/Notifications/ListItem/index.vue
@@ -1,0 +1,253 @@
+<script lang="ts">
+export default {
+  name: "AdminNotificationsListItem",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  hasSeverityLabel,
+  severityPillVariant,
+} from "@/admin/components/Notifications/severity";
+import { type AdminNotification } from "@/services/fyAdminApi";
+
+type Props = {
+  notification: AdminNotification;
+  selected?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  selected: false,
+});
+
+const emit = defineEmits<{
+  select: [];
+  archive: [];
+  unarchive: [];
+  destroy: [];
+  previous: [];
+  next: [];
+}>();
+
+const { t, l } = useI18n();
+
+const select = ref<HTMLButtonElement>();
+
+// The page moves the selection with the arrow keys, and focus has to follow it
+// so the next keypress lands on the row the reader is looking at.
+defineExpose({ focus: () => select.value?.focus() });
+</script>
+
+<template>
+  <div
+    class="notification-item"
+    data-test="notification-item"
+    :class="{
+      'notification-item--unread': !notification.read,
+      'notification-item--selected': props.selected,
+    }"
+  >
+    <button
+      ref="select"
+      type="button"
+      class="notification-item__select"
+      data-test="notification-select"
+      :aria-current="props.selected ? 'true' : undefined"
+      @click="emit('select')"
+      @keydown.down.prevent="emit('next')"
+      @keydown.up.prevent="emit('previous')"
+    >
+      <i
+        class="notification-item__icon"
+        :class="notification.icon || 'fa-duotone fa-bell'"
+      />
+      <span class="notification-item__content">
+        <span class="notification-item__title">
+          {{ notification.title }}
+          <span
+            v-if="notification.occurrences > 1"
+            class="notification-item__count"
+          >
+            &times;{{ notification.occurrences }}
+          </span>
+        </span>
+        <span class="notification-item__meta">
+          <BasePill
+            v-if="hasSeverityLabel(notification.severity)"
+            :variant="severityPillVariant(notification.severity)"
+            uppercase
+          >
+            {{
+              t(`labels.adminNotifications.severities.${notification.severity}`)
+            }}
+          </BasePill>
+          <span>
+            {{
+              t(
+                `labels.adminNotifications.types.${notification.notificationType}`,
+              )
+            }}
+          </span>
+          <span>
+            {{ l(notification.createdAt, "datetime.formats.short") }}
+          </span>
+        </span>
+      </span>
+    </button>
+    <div class="notification-item__actions">
+      <Btn
+        v-if="notification.archived"
+        v-tooltip="t('actions.adminNotifications.unarchive')"
+        :aria-label="t('actions.adminNotifications.unarchive')"
+        @click="emit('unarchive')"
+      >
+        <i class="fa-duotone fa-inbox-in" />
+      </Btn>
+      <Btn
+        v-else
+        v-tooltip="t('actions.adminNotifications.archive')"
+        :aria-label="t('actions.adminNotifications.archive')"
+        @click="emit('archive')"
+      >
+        <i class="fa-duotone fa-box-archive" />
+      </Btn>
+      <Btn
+        v-tooltip="t('actions.delete')"
+        :aria-label="t('actions.delete')"
+        :tone="BtnTonesEnum.DANGER"
+        @click="emit('destroy')"
+      >
+        <i class="fa-duotone fa-trash" />
+      </Btn>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+// The row surface a list of records wears elsewhere (ListGroup): a hairline and
+// a tint instead of a Panel's framed edge. The tint is over $panel-bg rather
+// than bare, because this page sits on a photo and ListGroup's translucent fill
+// alone let the ship show through the titles. Severity used to colour the edge
+// per row, which made a list of imports read as an alarm; the pill carries it
+// now.
+.notification-item {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  padding: 4px 8px 4px 0;
+  background: $panel-bg;
+  border: 1px solid rgba(#fff, 0.1);
+  border-radius: 6px;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: color.mix(#fff, $gray-darker, 6%);
+  }
+}
+
+.notification-item--selected {
+  background: color.mix(#fff, $gray-darker, 10%);
+
+  // A bar rather than a border: an outline inside a row that already has one
+  // reads as a box in a box.
+  &::before {
+    content: "";
+    position: absolute;
+    top: 6px;
+    bottom: 6px;
+    left: 0;
+    width: 3px;
+    background-color: var(--color-primary, #{$primary});
+    // Rounded on the inner edge only - the outer edge sits against the row's
+    // own border, where a curve would leave a sliver of it showing through.
+    border-radius: 0 $border-radius-base $border-radius-base 0;
+  }
+}
+
+.notification-item__select {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+  padding: 8px 4px 8px 14px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.notification-item__icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: $gray-lighter;
+  font-size: 1.15em;
+}
+
+.notification-item--unread .notification-item__icon {
+  color: var(--color-primary, #{$primary});
+}
+
+.notification-item__content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.notification-item__title {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.notification-item--unread .notification-item__title {
+  font-weight: bold;
+}
+
+.notification-item__count {
+  color: $gray-lighter;
+  font-size: 0.85em;
+}
+
+.notification-item__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: $gray-lighter;
+  font-size: 0.8em;
+}
+
+// Out of the way until the row is pointed at, so a page of notifications is
+// titles rather than a column of buttons. Focus counts as pointing at it, and a
+// device without a pointer never gets the chance to hover.
+.notification-item__actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 5px;
+  margin-top: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.notification-item:hover .notification-item__actions,
+.notification-item:focus-within .notification-item__actions {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .notification-item__actions {
+    opacity: 1;
+  }
+}
+</style>

--- a/app/frontend/admin/components/Notifications/severity.ts
+++ b/app/frontend/admin/components/Notifications/severity.ts
@@ -1,0 +1,21 @@
+import {
+  AdminNotificationSeverityEnum,
+  type AdminNotification,
+} from "@/services/fyAdminApi";
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+
+type Severity = AdminNotification["severity"];
+
+export const severityPillVariant = (severity: Severity) => {
+  switch (severity) {
+    case AdminNotificationSeverityEnum.ERROR:
+      return PillVariantsEnum.DANGER;
+    case AdminNotificationSeverityEnum.WARNING:
+      return PillVariantsEnum.WARNING;
+    default:
+      return PillVariantsEnum.DEFAULT;
+  }
+};
+
+export const hasSeverityLabel = (severity: Severity) =>
+  severity !== AdminNotificationSeverityEnum.INFO;

--- a/app/frontend/admin/composables/useAdminNotificationFilters.ts
+++ b/app/frontend/admin/composables/useAdminNotificationFilters.ts
@@ -1,10 +1,16 @@
 import { type AdminNotificationQuery } from "@/services/fyAdminApi";
 import { useFilters } from "@/shared/composables/useFilters";
 
+// The tab lives in the route so it survives a reload, but it selects a list
+// rather than narrowing one - `useFilters` has to leave it out of "a filter is
+// active", the way the model lists do with their fleetchart view switch.
+export const NOTIFICATION_TAB_QUERY_KEY = "t";
+
 export const useAdminNotificationFilters = (
   updateCallback?: (() => void) | (() => Promise<void>),
 ) => {
   return useFilters<AdminNotificationQuery>({
+    ignoreKeys: [NOTIFICATION_TAB_QUERY_KEY],
     updateCallback,
   });
 };

--- a/app/frontend/admin/composables/useAdminNotificationUpdates.ts
+++ b/app/frontend/admin/composables/useAdminNotificationUpdates.ts
@@ -9,22 +9,51 @@ import {
   getAdminNotificationsQueryKey,
   getAdminNotificationsUnreadCountQueryKey,
   type AdminNotification,
+  type AdminNotifications,
   AdminNotificationSeverityEnum,
 } from "@/services/fyAdminApi";
 
 export const useAdminNotificationInvalidation = () => {
   const queryClient = useQueryClient();
 
-  const invalidate = () => {
-    void queryClient.invalidateQueries({
-      queryKey: getAdminNotificationsQueryKey(),
-    });
+  const invalidateUnreadCount = () => {
     void queryClient.invalidateQueries({
       queryKey: getAdminNotificationsUnreadCountQueryKey(),
     });
   };
 
-  return { invalidate };
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: getAdminNotificationsQueryKey(),
+    });
+    invalidateUnreadCount();
+  };
+
+  // Swaps one row for the version the server just returned. Refetching would
+  // reorder the list - the query sorts unread first - and pull the notification
+  // the reader has open out from under them, so marking one read patches the
+  // cache it came from instead.
+  const patchCached = (notification: AdminNotification) => {
+    queryClient.setQueriesData<AdminNotifications>(
+      { queryKey: getAdminNotificationsQueryKey() },
+      (data) => {
+        // The list key is also a prefix of the unread-count key, whose payload
+        // carries no items.
+        if (!data?.items) {
+          return data;
+        }
+
+        return {
+          ...data,
+          items: data.items.map((item) =>
+            item.id === notification.id ? notification : item,
+          ),
+        };
+      },
+    );
+  };
+
+  return { invalidate, invalidateUnreadCount, patchCached };
 };
 
 // Subscribe once, from the navigation: the invalidation is global, so a page

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -9,34 +9,36 @@ import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
-import Panel from "@/shared/components/base/Panel/index.vue";
-import {
-  PanelTonesEnum,
-  PanelVariantsEnum,
-} from "@/shared/components/base/Panel/types";
-import BasePill from "@/shared/components/base/Pill/index.vue";
-import Markdown from "@/shared/components/Markdown/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
+import Detail from "@/admin/components/Notifications/Detail/index.vue";
 import FilterForm from "@/admin/components/Notifications/FilterForm/index.vue";
+import ListItem from "@/admin/components/Notifications/ListItem/index.vue";
 import { usePagination } from "@/shared/composables/usePagination";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
-import { useAdminNotificationFilters } from "@/admin/composables/useAdminNotificationFilters";
+import {
+  useAdminNotificationFilters,
+  NOTIFICATION_TAB_QUERY_KEY,
+} from "@/admin/composables/useAdminNotificationFilters";
 import { useAdminNotificationInvalidation } from "@/admin/composables/useAdminNotificationUpdates";
 import {
   useAdminNotifications as useAdminNotificationsQuery,
+  useAdminNotificationsUnreadCount,
   getAdminNotificationsQueryKey,
   readAdminNotification,
+  unreadAdminNotification,
   readAllAdminNotifications,
+  archiveAdminNotification,
+  unarchiveAdminNotification,
   destroyAdminNotification,
   destroyAllAdminNotifications,
   type AdminNotification,
   type AdminNotificationSortEnum,
-  AdminNotificationSeverityEnum,
 } from "@/services/fyAdminApi";
 
-const { t, l } = useI18n();
+const { t } = useI18n();
 const { displaySuccess, displayAlert } = useAppNotifications();
 
 const route = useRoute();
@@ -46,6 +48,21 @@ const sorts = computed((): AdminNotificationSortEnum[] => {
 });
 
 const oldestFirst = computed(() => route.query.s === "createdAt asc");
+
+// The tab is not a filter: it decides which of the two lists this is, so it
+// stays out of `q` and off the filter form's "a filter is active" indicator.
+const archive = computed(
+  () => route.query[NOTIFICATION_TAB_QUERY_KEY] === "archive",
+);
+
+const tabLink = (archived: boolean) => ({
+  query: {
+    ...route.query,
+    [NOTIFICATION_TAB_QUERY_KEY]: archived ? "archive" : undefined,
+    // Page 4 of the inbox says nothing about the archive.
+    page: undefined,
+  },
+});
 
 const sortLink = computed(() => ({
   query: {
@@ -64,11 +81,23 @@ const { filters, isFilterSelected } = useAdminNotificationFilters(async () => {
   await refetch();
 });
 
+// Everything in the route that `useFilters` did not recognise counts as a
+// filter, so the tab has to be taken back out: left in it reaches the API as
+// `q[t]`, which the query schema rejects.
+const filterParams = computed(() => {
+  const params: Record<string, unknown> = { ...filters.value };
+
+  delete params[NOTIFICATION_TAB_QUERY_KEY];
+
+  return params;
+});
+
 const queryParams = computed(() => ({
   page: page.value,
   perPage: perPage.value,
   q: {
-    ...filters.value,
+    ...filterParams.value,
+    archivedAtNull: !archive.value,
     sorts: sorts.value,
   },
 }));
@@ -79,49 +108,74 @@ const {
   ...asyncStatus
 } = useAdminNotificationsQuery(queryParams);
 
-const { invalidate } = useAdminNotificationInvalidation();
+const { invalidate, invalidateUnreadCount, patchCached } =
+  useAdminNotificationInvalidation();
 
-watch(
-  () => sorts.value,
-  async () => {
-    await refetch();
-  },
+watch([sorts, archive], async () => {
+  await refetch();
+});
+
+const { data: unreadCount } = useAdminNotificationsUnreadCount();
+
+const records = computed(() => notifications.value?.items || []);
+
+const selectedId = ref<string>();
+
+const selected = computed(() =>
+  records.value.find((record) => record.id === selectedId.value),
 );
 
-const expanded = ref<string[]>([]);
+// A deletion, a filter or another page takes the open notification with it.
+watch(records, () => {
+  if (selectedId.value && !selected.value) {
+    selectedId.value = undefined;
+  }
+});
 
-const isExpanded = (notification: AdminNotification) =>
-  expanded.value.includes(notification.id);
+type FocusableRow = { focus: () => void };
 
-const toggle = (notification: AdminNotification) => {
-  if (isExpanded(notification)) {
-    expanded.value = expanded.value.filter((id) => id !== notification.id);
+const rows = new Map<string, FocusableRow>();
+
+const registerRow = (notification: AdminNotification) => (row: unknown) => {
+  if (row) {
+    rows.set(notification.id, row as FocusableRow);
+  } else {
+    rows.delete(notification.id);
+  }
+};
+
+const markRead = async (notification: AdminNotification) => {
+  try {
+    patchCached(await readAdminNotification(notification.id));
+    invalidateUnreadCount();
+  } catch {
+    displayAlert({ text: t("messages.adminNotifications.error") });
+  }
+};
+
+// Opening a notification is what reading it means, so it costs no second click.
+const select = (notification: AdminNotification) => {
+  selectedId.value = notification.id;
+
+  if (!notification.read) {
+    void markRead(notification);
+  }
+};
+
+const move = (offset: number) => {
+  const current = records.value.findIndex(
+    (record) => record.id === selectedId.value,
+  );
+
+  const next = records.value[current + offset];
+
+  if (!next) {
     return;
   }
 
-  expanded.value = [...expanded.value, notification.id];
-};
+  select(next);
 
-const severityVariant = (severity: AdminNotification["severity"]) => {
-  switch (severity) {
-    case AdminNotificationSeverityEnum.ERROR:
-      return "danger";
-    case AdminNotificationSeverityEnum.WARNING:
-      return "warning";
-    default:
-      return "default";
-  }
-};
-
-const severityTone = (severity: AdminNotification["severity"]) => {
-  switch (severity) {
-    case AdminNotificationSeverityEnum.ERROR:
-      return PanelTonesEnum.ERROR;
-    case AdminNotificationSeverityEnum.WARNING:
-      return PanelTonesEnum.HIGHLIGHT;
-    default:
-      return PanelTonesEnum.NEUTRAL;
-  }
+  void nextTick(() => rows.get(next.id)?.focus());
 };
 
 const withFeedback = async (
@@ -137,10 +191,28 @@ const withFeedback = async (
   }
 };
 
-const markRead = (notification: AdminNotification) =>
+// Closes the reading pane: leaving it open on a notification that is now unread
+// invites a click that would only mark it read again, and the point of marking
+// it unread is to come back to it later.
+const markUnread = async (notification: AdminNotification) => {
+  selectedId.value = undefined;
+
+  await withFeedback(
+    () => unreadAdminNotification(notification.id),
+    t("messages.adminNotifications.unread"),
+  );
+};
+
+const archiveNotification = (notification: AdminNotification) =>
   withFeedback(
-    () => readAdminNotification(notification.id),
-    t("messages.adminNotifications.read"),
+    () => archiveAdminNotification(notification.id),
+    t("messages.adminNotifications.archived"),
+  );
+
+const unarchiveNotification = (notification: AdminNotification) =>
+  withFeedback(
+    () => unarchiveAdminNotification(notification.id),
+    t("messages.adminNotifications.unarchived"),
   );
 
 const markAllRead = () =>
@@ -200,7 +272,7 @@ const destroyAll = () =>
 
   <FilteredList
     name="admin-notifications"
-    :records="notifications?.items || []"
+    :records="records"
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
   >
@@ -223,114 +295,70 @@ const destroyAll = () =>
         }}
       </Btn>
     </template>
-    <template #default="{ records }">
-      <TransitionGroup tag="ul" name="fade-list" class="admin-notifications">
-        <li
-          v-for="notification in records"
-          :key="notification.id"
-          class="fade-list-item"
+    <template #default="{ records: shown }">
+      <div
+        class="admin-notifications"
+        :class="{ 'admin-notifications--reading': !!selected }"
+      >
+        <TransitionGroup
+          tag="ul"
+          name="fade-list"
+          class="admin-notifications__list"
         >
-          <Panel
-            :variant="PanelVariantsEnum.SLIM"
-            :tone="severityTone(notification.severity)"
-            :outer-spacing="false"
+          <li
+            v-for="notification in shown"
+            :key="notification.id"
+            class="fade-list-item"
           >
-            <div
-              class="admin-notification"
-              :class="{
-                'admin-notification--unread': !notification.read,
-              }"
-            >
-              <i
-                class="admin-notification__icon"
-                :class="notification.icon || 'fa-duotone fa-bell'"
-              />
-              <div class="admin-notification__content">
-                <div class="admin-notification__title">
-                  <span>{{ notification.title }}</span>
-                  <span
-                    v-if="notification.occurrences > 1"
-                    class="admin-notification__count"
-                  >
-                    &times;{{ notification.occurrences }}
-                  </span>
-                </div>
-                <div class="admin-notification__meta">
-                  <BasePill
-                    v-if="
-                      notification.severity !==
-                      AdminNotificationSeverityEnum.INFO
-                    "
-                    :variant="severityVariant(notification.severity)"
-                    uppercase
-                  >
-                    {{
-                      t(
-                        `labels.adminNotifications.severities.${notification.severity}`,
-                      )
-                    }}
-                  </BasePill>
-                  <span>
-                    {{
-                      t(
-                        `labels.adminNotifications.types.${notification.notificationType}`,
-                      )
-                    }}
-                  </span>
-                  <span>{{
-                    l(notification.createdAt, "datetime.formats.short")
-                  }}</span>
-                </div>
-                <Markdown
-                  v-if="isExpanded(notification)"
-                  class="admin-notification__body"
-                  :source="notification.body || ''"
-                />
-              </div>
-              <div class="admin-notification__actions">
-                <Btn
-                  v-if="notification.body"
-                  v-tooltip="
-                    isExpanded(notification)
-                      ? t('actions.hideDetails')
-                      : t('actions.showDetails')
-                  "
-                  @click="toggle(notification)"
-                >
-                  <i
-                    :class="
-                      isExpanded(notification)
-                        ? 'fa-duotone fa-chevron-up'
-                        : 'fa-duotone fa-chevron-down'
-                    "
-                  />
-                </Btn>
-                <Btn
-                  v-if="notification.link"
-                  v-tooltip="t('actions.open')"
-                  :to="notification.link"
-                >
-                  <i class="fa-duotone fa-arrow-up-right-from-square" />
-                </Btn>
-                <Btn
-                  v-if="!notification.read"
-                  v-tooltip="t('actions.adminNotifications.read')"
-                  @click="markRead(notification)"
-                >
-                  <i class="fa-duotone fa-check" />
-                </Btn>
-                <Btn
-                  v-tooltip="t('actions.delete')"
-                  :tone="BtnTonesEnum.DANGER"
-                  @click="destroy(notification)"
-                >
-                  <i class="fa-duotone fa-trash" />
-                </Btn>
-              </div>
-            </div>
-          </Panel>
-        </li>
-      </TransitionGroup>
+            <ListItem
+              :ref="registerRow(notification)"
+              :notification="notification"
+              :selected="notification.id === selectedId"
+              @select="select(notification)"
+              @archive="archiveNotification(notification)"
+              @unarchive="unarchiveNotification(notification)"
+              @destroy="destroy(notification)"
+              @previous="move(-1)"
+              @next="move(1)"
+            />
+          </li>
+        </TransitionGroup>
+
+        <Detail
+          class="admin-notifications__detail"
+          :notification="selected"
+          @close="selectedId = undefined"
+          @unread="selected && markUnread(selected)"
+          @archive="selected && archiveNotification(selected)"
+          @unarchive="selected && unarchiveNotification(selected)"
+          @destroy="selected && destroy(selected)"
+        />
+      </div>
+    </template>
+    <template #actions-right>
+      <BtnGroup segmented>
+        <Btn
+          :to="tabLink(false)"
+          :active="!archive"
+          route-active-class=""
+          data-test="notifications-tab-inbox"
+        >
+          <i class="fa-duotone fa-inbox" />
+          {{ t("labels.adminNotifications.inbox") }}
+          <span v-if="unreadCount?.count" class="admin-notifications__badge">
+            {{ unreadCount.count }}
+          </span>
+        </Btn>
+        <Btn
+          :to="tabLink(true)"
+          :active="archive"
+          route-active-class=""
+          data-test="notifications-tab-archive"
+        >
+          <i class="fa-duotone fa-box-archive" />
+          {{ t("labels.adminNotifications.archive") }}
+        </Btn>
+      </BtnGroup>
     </template>
     <template #pagination-top>
       <Paginator
@@ -352,21 +380,76 @@ const destroyAll = () =>
 </template>
 
 <style lang="scss" scoped>
+.admin-notifications__badge {
+  padding: 0 6px;
+  color: $gray-black;
+  font-size: 0.8em;
+  font-weight: bold;
+  background-color: var(--color-primary, #{$primary});
+  border-radius: 10px;
+}
+
 .admin-notifications {
-  position: relative;
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 20px;
   // Matches the margin a Panel carries by itself, which the list turns off in
   // favour of its own gap - without it the bottom paginator sits flush.
   margin: 0 0 21px;
+}
+
+.admin-notifications__list {
+  position: relative;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  margin: 0;
   padding: 0;
   list-style: none;
 }
 
-// Rows change place under you - marking one read sorts it out of the unread
-// group - so the list slides rather than jumping. The shared `fade-list`
-// classes still carry Vue 2 names, hence the local ones.
+.admin-notifications__detail {
+  display: none;
+}
+
+// One pane at a time until there is room for both: opening a notification
+// replaces the list, and the reading pane brings its own way back.
+.admin-notifications--reading {
+  .admin-notifications__list {
+    display: none;
+  }
+
+  .admin-notifications__detail {
+    display: block;
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+@media (min-width: $notifications-two-pane-breakpoint) {
+  .admin-notifications,
+  .admin-notifications--reading {
+    .admin-notifications__list {
+      display: flex;
+      flex: 0 0 38%;
+      max-width: 38%;
+    }
+
+    .admin-notifications__detail {
+      display: block;
+      position: sticky;
+      top: 20px;
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}
+
+// Rows change place under you - a new notification arrives at the top, a
+// deleted one leaves a gap - so the list slides rather than jumping. The shared
+// `fade-list` classes still carry Vue 2 names, hence the local ones.
 .fade-list-enter-active,
 .fade-list-leave-active,
 .fade-list-move {
@@ -384,70 +467,5 @@ const destroyAll = () =>
 .fade-list-leave-active {
   position: absolute;
   width: 100%;
-}
-
-.admin-notification {
-  display: flex;
-  align-items: flex-start;
-  gap: 15px;
-  padding: 14px 16px;
-}
-
-.admin-notification__icon {
-  flex-shrink: 0;
-  margin-top: 2px;
-  color: $gray-lighter;
-  font-size: 1.3em;
-}
-
-.admin-notification--unread .admin-notification__icon {
-  color: var(--color-primary, #{$primary});
-}
-
-.admin-notification__content {
-  flex: 1;
-  min-width: 0;
-}
-
-.admin-notification__title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.admin-notification--unread .admin-notification__title {
-  font-weight: bold;
-}
-
-.admin-notification__count {
-  color: $gray-lighter;
-  font-size: 0.85em;
-}
-
-.admin-notification__meta {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 4px;
-  color: $gray-lighter;
-  font-size: 0.85em;
-}
-
-.admin-notification__actions {
-  display: flex;
-  flex-shrink: 0;
-  gap: 5px;
-}
-
-.admin-notification__body {
-  margin: 10px 0 0;
-  padding: 10px 12px;
-  max-height: 320px;
-  overflow: auto;
-  color: $text-color;
-  font-size: 0.9em;
-  background-color: rgba($gray-darker, 0.6);
-  border-radius: $border-radius-base;
 }
 </style>

--- a/app/frontend/stylesheets/variables.scss
+++ b/app/frontend/stylesheets/variables.scss
@@ -28,6 +28,10 @@ $tablet-breakpoint: 768px;
 $desktop-breakpoint: 992px;
 $large-desktop-breakpoint: 1800px;
 
+// Where the notification center splits into a list and a reading pane. Below
+// it the two panes would each be too narrow to read, so one shows at a time.
+$notifications-two-pane-breakpoint: 1200px;
+
 $border-radius-base: 4px;
 
 $panel-bg: rgba($gray-darker, 0.9);

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -288,7 +288,9 @@
         "clearCargo": "Clear Cargo"
       },
       "adminNotifications": {
-        "read": "Mark as read",
+        "unread": "Mark as unread",
+        "archive": "Archive",
+        "unarchive": "Move back to inbox",
         "readAll": "Mark all as read",
         "destroyAll": "Delete all",
         "sortOldest": "Oldest first",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1854,10 +1854,16 @@
       },
       "hangarInventories": "Inventories",
       "adminNotifications": {
+        "inbox": "Inbox",
+        "archive": "Archive",
         "unreadOnly": "Unread only",
         "status": "Status",
         "severity": "Severity",
         "type": "Type",
+        "selectPrompt": "Select a notification to read it",
+        "noBody": "This notification carries no further details.",
+        "lastSeen": "Last seen",
+        "expires": "Expires",
         "severities": {
           "info": "Info",
           "warning": "Warning",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -567,7 +567,9 @@
         }
       },
       "adminNotifications": {
-        "read": "Notification marked as read",
+        "unread": "Notification marked as unread",
+        "archived": "Notification archived",
+        "unarchived": "Notification moved back to the inbox",
         "readAll": "All notifications marked as read",
         "destroyed": "Notification deleted",
         "destroyedAll": "All notifications deleted",

--- a/app/lib/admin_notification_examples.rb
+++ b/app/lib/admin_notification_examples.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+# Fixture data for the notification center, shared by the
+# `admin_notifications:examples` rake task and the e2e scenario. Covers what the
+# list and the reading pane have to survive: every type and severity, read and
+# unread, a body that scrolls and no body at all, a repeat report, and an age
+# spread so the list is not one timestamp.
+module AdminNotificationExamples
+  module_function
+
+  def create_for(admin_user)
+    examples.each do |example|
+      occurred_at = example[:age].ago
+
+      AdminNotification.create!(
+        admin_user:,
+        notification_type: example[:type],
+        title: example[:title],
+        body: example[:body],
+        severity: example.fetch(:severity, :info),
+        link: example[:link],
+        icon: AdminNotification.icon_for(example[:type]),
+        occurrences: example.fetch(:occurrences, 1),
+        read_at: example[:read] ? occurred_at + 1.minute : nil,
+        last_occurred_at: occurred_at,
+        created_at: occurred_at,
+        updated_at: occurred_at
+      )
+    end.size
+  end
+
+  def examples
+    [
+      {
+        type: :rsi_api_blocked,
+        severity: :error,
+        title: "RSI blocked a request",
+        body: "https://robertsspaceindustries.com/ship-matrix/index",
+        link: "/maintenance/rsi-api-status",
+        occurrences: 12,
+        age: 8.minutes
+      },
+      {
+        type: :modules_import,
+        severity: :warning,
+        title: "Modules Import Results",
+        body: <<~BODY,
+          ## Missing Models (3)
+
+          - **Retaliator Bomber**
+          - **Reclaimer**
+          - **Hull C**
+
+          Add a mapping for each in `modules_importer.rb`, then run the import again.
+        BODY
+        link: "/models",
+        occurrences: 3,
+        age: 42.minutes
+      },
+      {
+        type: :loaner_sync,
+        title: "Loaner Sync finished",
+        age: 2.hours
+      },
+      {
+        type: :new_supporter,
+        title: "New Patreon Supporter",
+        body: "Jane Doe — $10.00",
+        link: "/supporter-contributions",
+        age: 5.hours
+      },
+      {
+        type: :uex_commodity_prices_import,
+        severity: :warning,
+        title: "UEX Commodity Sync Results",
+        body: <<~BODY,
+          ## Unmatched Commodities (2)
+
+          - **Quantanium (Raw)**
+          - **Ranta Dung**
+
+          Everything else updated.
+        BODY
+        link: "/commodities",
+        age: 9.hours
+      },
+      {
+        type: :paints_import,
+        title: "Paints Import Results",
+        body: <<~BODY,
+          ## Imported (2 models)
+
+          - **Aurora MR** — 4 paints
+          - **Cutlass Black** — 2 paints
+
+          Nothing needed a decision.
+        BODY
+        link: "/models",
+        read: true,
+        age: 1.day
+      },
+      {
+        type: :uex_prices_import,
+        title: "UEX Price Sync Results",
+        body: long_body,
+        read: true,
+        age: 2.days
+      },
+      {
+        type: :rsi_api_unblocked,
+        title: "RSI unblocked a request",
+        body: "https://robertsspaceindustries.com/ship-matrix/index",
+        link: "/maintenance/rsi-api-status",
+        read: true,
+        age: 4.days
+      },
+      {
+        type: :weekly_stats,
+        title: "Weekly Report",
+        body: <<~BODY,
+          ## Last Week
+
+          - **Users**: 412 (+18)
+          - **Hangars**: 1.204 ships added
+          - **Fleets**: 9 created
+          - **Supporters**: 3 new
+
+          Full numbers on the [stats page](/stats).
+        BODY
+        link: "/stats",
+        read: true,
+        age: 12.days
+      }
+    ]
+  end
+
+  # Long enough that the reading pane has to scroll rather than grow past the
+  # viewport.
+  def long_body
+    models = [
+      "Aurora ES", "Aurora LN", "Avenger Titan", "Buccaneer", "Carrack",
+      "Constellation Andromeda", "Cutlass Black", "Cutter", "Defender",
+      "Dragonfly Black", "Freelancer", "Gladius", "Hammerhead", "Herald",
+      "Hornet F7C", "Hull A", "Khartu-al", "Mercury Star Runner", "Mustang Alpha",
+      "Nomad", "Prospector", "Reclaimer", "Redeemer", "Sabre", "Scorpius",
+      "Spirit C1", "Starfarer", "Terrapin", "Valkyrie", "Vanguard Warden"
+    ]
+
+    <<~BODY
+      ## Updated Prices (#{models.size})
+
+      #{models.map { |model| "- **#{model}**" }.join("\n")}
+
+      No model was left without a price.
+    BODY
+  end
+end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -5,6 +5,7 @@
 # Table name: admin_notifications
 #
 #  id                :uuid             not null, primary key
+#  archived_at       :datetime
 #  body              :text
 #  dedupe_key        :string
 #  expires_at        :datetime         not null
@@ -24,12 +25,13 @@
 #
 # Indexes
 #
-#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
-#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
-#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
-#  index_admin_notifications_on_expires_at                    (expires_at)
-#  index_admin_notifications_on_notification_type             (notification_type)
-#  index_admin_notifications_on_record                        (record_type,record_id)
+#  index_admin_notifications_on_admin_user_id_and_archived_at  (admin_user_id,archived_at)
+#  index_admin_notifications_on_admin_user_id_and_created_at   (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at      (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                         (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (archived_at IS NULL) AND (dedupe_key IS NOT NULL))
+#  index_admin_notifications_on_expires_at                     (expires_at)
+#  index_admin_notifications_on_notification_type              (notification_type)
+#  index_admin_notifications_on_record                         (record_type,record_id)
 #
 # Foreign Keys
 #
@@ -110,6 +112,8 @@ class AdminNotification < ApplicationRecord
 
   scope :unread, -> { where(read_at: nil) }
   scope :read, -> { where.not(read_at: nil) }
+  scope :inbox, -> { where(archived_at: nil) }
+  scope :archived, -> { where.not(archived_at: nil) }
   scope :expired, -> { where(expires_at: ...Time.current) }
   scope :active, -> { where(expires_at: Time.current..) }
 
@@ -127,7 +131,7 @@ class AdminNotification < ApplicationRecord
   end
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[notification_type severity read_at created_at title body search unread]
+    %w[notification_type severity read_at archived_at created_at title body search unread]
   end
 
   def self.ransackable_associations(_auth_object = nil)
@@ -179,7 +183,9 @@ class AdminNotification < ApplicationRecord
     retried = false
 
     begin
-      existing = dedupe_key.presence && unread.find_by(
+      # Matching the partial unique index: an archived notification has been
+      # dealt with, so a repeat report starts a new row in the inbox.
+      existing = dedupe_key.presence && inbox.unread.find_by(
         admin_user:, notification_type: type, dedupe_key:
       )
 
@@ -234,8 +240,38 @@ class AdminNotification < ApplicationRecord
     read_at.present?
   end
 
+  def archived?
+    archived_at.present?
+  end
+
   def mark_as_read!
     update!(read_at: Time.current)
+  end
+
+  def mark_as_unread!
+    without_dedupe_conflict { update!(read_at: nil) }
+  end
+
+  def archive!
+    update!(archived_at: Time.current)
+  end
+
+  def unarchive!
+    without_dedupe_conflict { update!(archived_at: nil) }
+  end
+
+  # The dedupe index only covers what is unread and still in the inbox, so
+  # moving a notification back into that set can collide with the row that
+  # absorbed the repeats in the meantime. This one gives up its claim on the key
+  # rather than the move failing - it is the older report of the two.
+  private def without_dedupe_conflict
+    yield
+  rescue ActiveRecord::RecordNotUnique
+    raise if dedupe_key.nil?
+
+    self.dedupe_key = nil
+
+    yield
   end
 
   private def set_expires_at

--- a/app/policies/admin/notification_policy.rb
+++ b/app/policies/admin/notification_policy.rb
@@ -4,7 +4,8 @@ module Admin
   # Not a BasePolicy subclass on purpose: notifications are not a gated resource
   # but every admin's own inbox, so access is ownership rather than a privilege.
   class NotificationPolicy < ApplicationPolicy
-    alias_rule :index?, :destroy?, :update?, :read?, :unread_count?, to: :show?
+    alias_rule :index?, :destroy?, :update?, :read?, :unread?, :archive?, :unarchive?,
+      :unread_count?, to: :show?
 
     def show?
       user.present?

--- a/app/views/admin/api/v1/notifications/_base.jbuilder
+++ b/app/views/admin/api/v1/notifications/_base.jbuilder
@@ -11,5 +11,7 @@ json.occurrences notification.occurrences
 json.last_occurred_at notification.last_occurred_at.utc.iso8601
 json.read notification.read?
 json.read_at notification.read_at&.utc&.iso8601
+json.archived notification.archived?
+json.archived_at notification.archived_at&.utc&.iso8601
 json.expires_at notification.expires_at.utc.iso8601
 json.partial! "api/shared/dates", record: notification

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -154,6 +154,9 @@ v1_admin_api_routes = lambda do
   resources :notifications, only: %i[index destroy] do
     member do
       put :read
+      put :unread
+      put :archive
+      put :unarchive
     end
     collection do
       get "unread-count", to: "notifications#unread_count"

--- a/db/migrate/20260824120000_add_archived_at_to_admin_notifications.rb
+++ b/db/migrate/20260824120000_add_archived_at_to_admin_notifications.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddArchivedAtToAdminNotifications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :admin_notifications, :archived_at, :datetime
+    add_index :admin_notifications, [:admin_user_id, :archived_at]
+
+    # A repeat report belongs back in the inbox rather than folded into a row
+    # somebody already archived, so an archived notification stops absorbing
+    # its dedupe key.
+    remove_index :admin_notifications, column: [:admin_user_id, :notification_type, :dedupe_key],
+      unique: true, where: "read_at IS NULL AND dedupe_key IS NOT NULL",
+      name: "index_admin_notifications_on_dedupe"
+    add_index :admin_notifications, [:admin_user_id, :notification_type, :dedupe_key],
+      unique: true, where: "read_at IS NULL AND archived_at IS NULL AND dedupe_key IS NOT NULL",
+      name: "index_admin_notifications_on_dedupe"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
 
   create_table "admin_notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "admin_user_id", null: false
+    t.datetime "archived_at"
     t.text "body"
     t.datetime "created_at", null: false
     t.string "dedupe_key"
@@ -62,8 +63,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_120000) do
     t.string "severity", default: "info", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["admin_user_id", "archived_at"], name: "index_admin_notifications_on_admin_user_id_and_archived_at"
     t.index ["admin_user_id", "created_at"], name: "index_admin_notifications_on_admin_user_id_and_created_at", order: { created_at: :desc }
-    t.index ["admin_user_id", "notification_type", "dedupe_key"], name: "index_admin_notifications_on_dedupe", unique: true, where: "((read_at IS NULL) AND (dedupe_key IS NOT NULL))"
+    t.index ["admin_user_id", "notification_type", "dedupe_key"], name: "index_admin_notifications_on_dedupe", unique: true, where: "((read_at IS NULL) AND (archived_at IS NULL) AND (dedupe_key IS NOT NULL))"
     t.index ["admin_user_id", "read_at"], name: "index_admin_notifications_on_admin_user_id_and_read_at"
     t.index ["expires_at"], name: "index_admin_notifications_on_expires_at"
     t.index ["notification_type"], name: "index_admin_notifications_on_notification_type"

--- a/lib/tasks/admin_notifications.rake
+++ b/lib/tasks/admin_notifications.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :admin_notifications do
+  desc "Fill the notification center with a spread of example notifications (never in production). ADMIN_USER=<username|email> narrows the recipients."
+  task examples: :environment do
+    abort "Refusing to create example notifications in production" if Rails.env.production?
+
+    admin_users = AdminNotificationRecipients.find
+
+    abort "No matching admin user found" if admin_users.empty?
+
+    created = admin_users.sum { |admin_user| AdminNotificationExamples.create_for(admin_user) }
+
+    puts "Created #{created} example notifications for #{admin_users.map(&:username).join(", ")}"
+  end
+
+  desc "Delete every notification of the admin users the examples task targets (never in production)."
+  task clear: :environment do
+    abort "Refusing to delete notifications in production" if Rails.env.production?
+
+    admin_users = AdminNotificationRecipients.find
+
+    abort "No matching admin user found" if admin_users.empty?
+
+    deleted = AdminNotification.where(admin_user: admin_users).delete_all
+
+    puts "Deleted #{deleted} notifications"
+  end
+end
+
+module AdminNotificationRecipients
+  module_function
+
+  def find
+    login = ENV["ADMIN_USER"].presence
+
+    return AdminUser.all.to_a if login.nil?
+
+    AdminUser.where(
+      "normalized_username = :value OR normalized_email = :value",
+      value: login.downcase
+    ).to_a
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5737,6 +5737,41 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/{id}/archive":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: Admin Notification id
+      required: true
+    put:
+      summary: Archive Admin Notification
+      tags:
+      - Notifications
+      operationId: archiveAdminNotification
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotification"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/{id}/read":
     parameters:
     - name: id
@@ -5751,6 +5786,76 @@ paths:
       tags:
       - Notifications
       operationId: readAdminNotification
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotification"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/{id}/unarchive":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: Admin Notification id
+      required: true
+    put:
+      summary: Move Admin Notification back to the inbox
+      tags:
+      - Notifications
+      operationId: unarchiveAdminNotification
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotification"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/{id}/unread":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: Admin Notification id
+      required: true
+    put:
+      summary: Mark Admin Notification as unread
+      tags:
+      - Notifications
+      operationId: unreadAdminNotification
       responses:
         '200':
           description: successful
@@ -7382,6 +7487,11 @@ components:
         readAt:
           type: string
           format: date-time
+        archived:
+          type: boolean
+        archivedAt:
+          type: string
+          format: date-time
         expiresAt:
           type: string
           format: date-time
@@ -7400,6 +7510,7 @@ components:
       - occurrences
       - lastOccurredAt
       - read
+      - archived
       - expiresAt
       - createdAt
       - updatedAt
@@ -7412,6 +7523,8 @@ components:
         severityEq:
           "$ref": "#/components/schemas/AdminNotificationSeverityEnum"
         readAtNull:
+          type: boolean
+        archivedAtNull:
           type: boolean
         searchCont:
           type: string

--- a/test/factories/admin_notifications.rb
+++ b/test/factories/admin_notifications.rb
@@ -5,6 +5,7 @@
 # Table name: admin_notifications
 #
 #  id                :uuid             not null, primary key
+#  archived_at       :datetime
 #  body              :text
 #  dedupe_key        :string
 #  expires_at        :datetime         not null
@@ -24,12 +25,13 @@
 #
 # Indexes
 #
-#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
-#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
-#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
-#  index_admin_notifications_on_expires_at                    (expires_at)
-#  index_admin_notifications_on_notification_type             (notification_type)
-#  index_admin_notifications_on_record                        (record_type,record_id)
+#  index_admin_notifications_on_admin_user_id_and_archived_at  (admin_user_id,archived_at)
+#  index_admin_notifications_on_admin_user_id_and_created_at   (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at      (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                         (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (archived_at IS NULL) AND (dedupe_key IS NOT NULL))
+#  index_admin_notifications_on_expires_at                     (expires_at)
+#  index_admin_notifications_on_notification_type              (notification_type)
+#  index_admin_notifications_on_record                         (record_type,record_id)
 #
 # Foreign Keys
 #
@@ -51,6 +53,10 @@ FactoryBot.define do
 
     trait :unread do
       read_at { nil }
+    end
+
+    trait :archived do
+      archived_at { Time.current }
     end
 
     trait :expired do

--- a/test/integration/admin/api/v1/notifications_test.rb
+++ b/test/integration/admin/api/v1/notifications_test.rb
@@ -67,6 +67,72 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  api_path "/notifications/{id}/unread" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "Admin Notification id", required: true
+
+    put("Mark Admin Notification as unread") do
+      operationId "unreadAdminNotification"
+      tags "Notifications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotification"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/{id}/archive" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "Admin Notification id", required: true
+
+    put("Archive Admin Notification") do
+      operationId "archiveAdminNotification"
+      tags "Notifications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotification"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
+  api_path "/notifications/{id}/unarchive" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "Admin Notification id", required: true
+
+    put("Move Admin Notification back to the inbox") do
+      operationId "unarchiveAdminNotification"
+      tags "Notifications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref": "#/components/schemas/AdminNotification"
+      end
+
+      response(404, "not found") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+
+      response(401, "unauthorized") do
+        schema "$ref": "#/components/schemas/StandardError"
+      end
+    end
+  end
+
   api_path "/notifications/read-all" do
     put("Mark all Admin Notifications as read") do
       operationId "readAllAdminNotifications"
@@ -203,7 +269,7 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     notification = create(:admin_notification, admin_user: @admin_user)
     sign_in @admin_user
 
-    assert_api_response :put, 200, path_params: {id: notification.id} do
+    assert_api_response :put, 200, api_path: "/notifications/{id}/read", path_params: {id: notification.id} do
       assert parsed_body["read"]
     end
   end
@@ -212,20 +278,143 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     notification = create(:admin_notification, admin_user: @other_admin)
     sign_in @admin_user
 
-    assert_api_response :put, 404, path_params: {id: notification.id}
+    assert_api_response :put, 404, api_path: "/notifications/{id}/read", path_params: {id: notification.id}
   end
 
   test "PUT /notifications/:id/read does not reach a type the admin lost access to" do
     notification = create(:admin_notification, admin_user: @admin_user, notification_type: "new_supporter")
     sign_in @admin_user
 
-    assert_api_response :put, 404, path_params: {id: notification.id}
+    assert_api_response :put, 404, api_path: "/notifications/{id}/read", path_params: {id: notification.id}
   end
 
   test "PUT /notifications/:id/read returns 401 when not signed in" do
     notification = create(:admin_notification, admin_user: @admin_user)
 
-    assert_api_response :put, 401, path_params: {id: notification.id}
+    assert_api_response :put, 401, api_path: "/notifications/{id}/read", path_params: {id: notification.id}
+  end
+
+  test "GET /notifications leaves archived notifications out of the inbox" do
+    create(:admin_notification, admin_user: @admin_user, title: "inbox")
+    create(:admin_notification, :archived, admin_user: @admin_user, title: "archived")
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications" do
+      assert_equal ["inbox"], parsed_body["items"].pluck("title")
+    end
+  end
+
+  test "GET /notifications lists the archive when asked for it" do
+    create(:admin_notification, admin_user: @admin_user, title: "inbox")
+    create(:admin_notification, :archived, admin_user: @admin_user, title: "archived")
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications", params: {q: {archivedAtNull: false}} do
+      assert_equal ["archived"], parsed_body["items"].pluck("title")
+    end
+  end
+
+  test "GET /notifications/unread-count ignores archived notifications" do
+    create(:admin_notification, admin_user: @admin_user)
+    create(:admin_notification, :archived, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :get, 200, api_path: "/notifications/unread-count" do
+      assert_equal 1, parsed_body["count"]
+    end
+  end
+
+  test "PUT /notifications/:id/unread marks a read notification unread again" do
+    notification = create(:admin_notification, :read, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/{id}/unread", path_params: {id: notification.id} do
+      refute parsed_body["read"]
+    end
+
+    assert_nil notification.reload.read_at
+  end
+
+  test "PUT /notifications/:id/unread gives up the dedupe key a newer report holds" do
+    notification = create(:admin_notification, :read, admin_user: @admin_user, dedupe_key: "same")
+    create(:admin_notification, admin_user: @admin_user, dedupe_key: "same")
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/{id}/unread", path_params: {id: notification.id} do
+      refute parsed_body["read"]
+    end
+
+    assert_nil notification.reload.dedupe_key
+  end
+
+  test "PUT /notifications/:id/unread does not reach another admin's notification" do
+    notification = create(:admin_notification, :read, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 404, api_path: "/notifications/{id}/unread", path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/unread returns 401 when not signed in" do
+    notification = create(:admin_notification, :read, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/{id}/unread", path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/archive moves it out of the inbox" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/{id}/archive", path_params: {id: notification.id} do
+      assert parsed_body["archived"]
+    end
+
+    assert_predicate notification.reload, :archived?
+  end
+
+  test "PUT /notifications/:id/archive leaves the read state alone" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/{id}/archive", path_params: {id: notification.id} do
+      refute parsed_body["read"]
+    end
+  end
+
+  test "PUT /notifications/:id/archive does not reach another admin's notification" do
+    notification = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 404, api_path: "/notifications/{id}/archive", path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/archive returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/{id}/archive", path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/unarchive brings it back to the inbox" do
+    notification = create(:admin_notification, :archived, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/{id}/unarchive", path_params: {id: notification.id} do
+      refute parsed_body["archived"]
+    end
+
+    refute_predicate notification.reload, :archived?
+  end
+
+  test "PUT /notifications/:id/unarchive does not reach another admin's notification" do
+    notification = create(:admin_notification, :archived, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 404, api_path: "/notifications/{id}/unarchive", path_params: {id: notification.id}
+  end
+
+  test "PUT /notifications/:id/unarchive returns 401 when not signed in" do
+    notification = create(:admin_notification, :archived, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/{id}/unarchive", path_params: {id: notification.id}
   end
 
   test "PUT /notifications/read-all leaves other admins untouched" do
@@ -237,6 +426,15 @@ class Admin::Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
 
     assert_equal 0, AdminNotification.where(admin_user: @admin_user).unread.count
     assert_nil other.reload.read_at
+  end
+
+  test "PUT /notifications/read-all leaves the archive alone" do
+    archived = create(:admin_notification, :archived, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 204, api_path: "/notifications/read-all"
+
+    assert_nil archived.reload.read_at
   end
 
   test "PUT /notifications/read-all returns 401 when not signed in" do

--- a/test/models/admin_notification_test.rb
+++ b/test/models/admin_notification_test.rb
@@ -7,6 +7,7 @@ require "test_helper"
 # Table name: admin_notifications
 #
 #  id                :uuid             not null, primary key
+#  archived_at       :datetime
 #  body              :text
 #  dedupe_key        :string
 #  expires_at        :datetime         not null
@@ -26,12 +27,13 @@ require "test_helper"
 #
 # Indexes
 #
-#  index_admin_notifications_on_admin_user_id_and_created_at  (admin_user_id,created_at DESC)
-#  index_admin_notifications_on_admin_user_id_and_read_at     (admin_user_id,read_at)
-#  index_admin_notifications_on_dedupe                        (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (dedupe_key IS NOT NULL))
-#  index_admin_notifications_on_expires_at                    (expires_at)
-#  index_admin_notifications_on_notification_type             (notification_type)
-#  index_admin_notifications_on_record                        (record_type,record_id)
+#  index_admin_notifications_on_admin_user_id_and_archived_at  (admin_user_id,archived_at)
+#  index_admin_notifications_on_admin_user_id_and_created_at   (admin_user_id,created_at DESC)
+#  index_admin_notifications_on_admin_user_id_and_read_at      (admin_user_id,read_at)
+#  index_admin_notifications_on_dedupe                         (admin_user_id,notification_type,dedupe_key) UNIQUE WHERE ((read_at IS NULL) AND (archived_at IS NULL) AND (dedupe_key IS NOT NULL))
+#  index_admin_notifications_on_expires_at                     (expires_at)
+#  index_admin_notifications_on_notification_type              (notification_type)
+#  index_admin_notifications_on_record                         (record_type,record_id)
 #
 # Foreign Keys
 #
@@ -142,6 +144,58 @@ class AdminNotificationTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, AdminNotification.count
+  end
+
+  test "starts a new row once the deduped one has been archived" do
+    create(:admin_user, resource_access: [:models])
+
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same").first.archive!
+    AdminNotification.notify!(type: :paints_import, title: "Paints Import Results", dedupe_key: "same")
+
+    assert_equal 2, AdminNotification.count
+    assert_equal 1, AdminNotification.inbox.count
+  end
+
+  test "archiving leaves the read state alone" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    notification = create(:admin_notification, admin_user:)
+
+    notification.archive!
+
+    assert_predicate notification, :archived?
+    refute_predicate notification, :read?
+  end
+
+  test "inbox and archived split on archived_at" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    inbox = create(:admin_notification, admin_user:)
+    archived = create(:admin_notification, :archived, admin_user:)
+
+    assert_includes AdminNotification.inbox, inbox
+    assert_includes AdminNotification.archived, archived
+  end
+
+  test "marking unread gives up a dedupe key the newer report holds" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    older = create(:admin_notification, :read, admin_user:, dedupe_key: "same")
+    newer = create(:admin_notification, admin_user:, dedupe_key: "same")
+
+    older.mark_as_unread!
+
+    refute_predicate older.reload, :read?
+    assert_nil older.dedupe_key
+    assert_equal "same", newer.reload.dedupe_key
+  end
+
+  test "unarchiving gives up a dedupe key the newer report holds" do
+    admin_user = create(:admin_user, resource_access: [:models])
+    older = create(:admin_notification, :archived, admin_user:, dedupe_key: "same")
+    create(:admin_notification, admin_user:, dedupe_key: "same")
+
+    older.unarchive!
+
+    refute_predicate older.reload, :archived?
+    assert_nil older.dedupe_key
   end
 
   test "active and expired split on expires_at" do

--- a/test/playwright/app_commands/scenarios/admin_notifications.rb
+++ b/test/playwright/app_commands/scenarios/admin_notifications.rb
@@ -1,0 +1,15 @@
+# You can setup your Rails state here
+require "factory_bot_rails"
+
+Rails.logger.info "E2E: Creating admin_notifications scenario test data..."
+
+admin_user = AdminUser.find_or_create_by!(username: "admin_notifications") do |u|
+  u.email = "admin_notifications@test.com"
+  u.password = "password123"
+  u.password_confirmation = "password123"
+  u.super_admin = true
+end
+
+AdminNotificationExamples.create_for(admin_user)
+
+Rails.logger.info "E2E: Created admin_notifications scenario test data"

--- a/test/playwright/e2e/AdminNotifications.spec.ts
+++ b/test/playwright/e2e/AdminNotifications.spec.ts
@@ -1,0 +1,167 @@
+import { app, appScenario } from "../support/on-rails";
+import { test, expect } from "../support/commands";
+
+const row = (page: import("@playwright/test").Page, title: string) =>
+  page.getByTestId("notification-item").filter({ hasText: title });
+
+test.describe("Admin Notifications", () => {
+  test.beforeEach(async ({ page }) => {
+    // Against a dev vite server the first visit compiles the route's module
+    // graph, which on its own can outrun the default timeout.
+    test.slow();
+
+    await app("clean");
+    await appScenario("admin_notifications");
+
+    await page.goto("/admin/login/", { waitUntil: "domcontentloaded" });
+    await page.locator("input[name='login']").fill("admin_notifications");
+    await page.locator("input[name='password']").fill("password123");
+    await page.getByTestId("submit-login").click();
+
+    await expect(page).toHaveURL(/\/admin\/?$/);
+
+    // The URL turns over before the app has the session; navigating on top of
+    // that lands back on the login form.
+    await page.waitForLoadState("networkidle");
+
+    await page.goto("/admin/notifications/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("notification-item").first()).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test("Lists the notifications with an empty reading pane", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("notification-item")).toHaveCount(9);
+    await expect(page.getByTestId("notification-detail-empty")).toBeVisible();
+  });
+
+  test("Opens a notification in the reading pane with one click", async ({
+    page,
+  }) => {
+    await row(page, "Modules Import Results")
+      .getByTestId("notification-select")
+      .click();
+
+    await expect(page.getByTestId("notification-detail-title")).toContainText(
+      "Modules Import Results",
+    );
+    await expect(page.getByTestId("notification-detail-body")).toContainText(
+      "Retaliator Bomber",
+    );
+  });
+
+  test("Marks a notification as read by opening it", async ({ page }) => {
+    const unread = row(page, "Modules Import Results");
+
+    await expect(unread).toHaveClass(/notification-item--unread/);
+
+    await unread.getByTestId("notification-select").click();
+
+    await expect(unread).not.toHaveClass(/notification-item--unread/);
+  });
+
+  test("Keeps the opened notification in place instead of resorting", async ({
+    page,
+  }) => {
+    const first = page.getByTestId("notification-item").first();
+
+    await first.getByTestId("notification-select").click();
+
+    await expect(first).toContainText("RSI blocked a request");
+  });
+
+  test("Moves through the list with the arrow keys", async ({ page }) => {
+    await page
+      .getByTestId("notification-item")
+      .first()
+      .getByTestId("notification-select")
+      .click();
+
+    await expect(page.getByTestId("notification-detail-title")).toContainText(
+      "RSI blocked a request",
+    );
+
+    await page.keyboard.press("ArrowDown");
+
+    await expect(page.getByTestId("notification-detail-title")).toContainText(
+      "Modules Import Results",
+    );
+
+    await page.keyboard.press("ArrowUp");
+
+    await expect(page.getByTestId("notification-detail-title")).toContainText(
+      "RSI blocked a request",
+    );
+  });
+
+  test("Marks an opened notification unread again", async ({ page }) => {
+    const target = row(page, "Modules Import Results");
+
+    await target.getByTestId("notification-select").click();
+
+    await expect(target).not.toHaveClass(/notification-item--unread/);
+
+    await page.getByTestId("notification-detail-unread").click();
+
+    await expect(target).toHaveClass(/notification-item--unread/);
+  });
+
+  test("Archives a notification out of the inbox and into the archive", async ({
+    page,
+    notification,
+  }) => {
+    await row(page, "Loaner Sync finished")
+      .getByLabel("Archive", { exact: true })
+      .click();
+
+    await notification.success("Notification archived");
+
+    await expect(row(page, "Loaner Sync finished")).toHaveCount(0);
+
+    await page.getByTestId("notifications-tab-archive").click();
+
+    await expect(row(page, "Loaner Sync finished")).toHaveCount(1);
+  });
+
+  test("Moves an archived notification back to the inbox", async ({
+    page,
+    notification,
+  }) => {
+    await row(page, "Loaner Sync finished")
+      .getByLabel("Archive", { exact: true })
+      .click();
+
+    // Dismissed rather than waited out: a toast left standing covers the tabs.
+    await notification.success("Notification archived");
+
+    await page.getByTestId("notifications-tab-archive").click();
+
+    await row(page, "Loaner Sync finished")
+      .getByLabel("Move back to inbox", { exact: true })
+      .click();
+
+    await notification.success("Notification moved back to the inbox");
+
+    await expect(row(page, "Loaner Sync finished")).toHaveCount(0);
+
+    await page.getByTestId("notifications-tab-inbox").click();
+
+    await expect(row(page, "Loaner Sync finished")).toHaveCount(1);
+  });
+
+  test("Shows a placeholder for a notification without a body", async ({
+    page,
+  }) => {
+    await row(page, "Loaner Sync finished")
+      .getByTestId("notification-select")
+      .click();
+
+    await expect(page.getByTestId("notification-detail-title")).toContainText(
+      "Loaner Sync finished",
+    );
+    await expect(page.getByTestId("notification-detail-no-body")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Reading one admin notification took two clicks on two small targets at the far right of a row — a chevron to unfold the body, then a check to mark it read — and the unfolded body pushed the rest of the list down. A page of reports was a page of clicking.

## Reading

The list is a reading pane now. Click a row anywhere to open it beside the list, and opening it is what marking it read means, so the second click is gone. Arrow keys move through the list, which makes triaging a page cost no clicks at all. Below 1200px the pane replaces the list and brings a way back.

Opening a notification patches it in the cache rather than refetching: the query sorts unread first, so a refetch would pull the row the reader just opened out from under them.

Row actions stay out of the way until the row is pointed at, and the pane carries the rest — open the link, put it back to unread (which closes the pane, so the row can be opened again), archive, delete.

## Archive

Deleting was the only way to clear the inbox, which made *dealing with* a report and *losing* it the same act. An `archived_at` column separates them: archiving moves a notification out of the inbox, deleting is still permanent, and read/unread is independent of both. Inbox and Archive are a switch above the list. Retention is unchanged — the archive is a quieter inbox, not a record, so `expires_at` still decides when a row goes.

The index is the inbox unless a request asks for the archive, and both the unread count and read-all follow it, so an unread notification archived on purpose keeps its marker and the badge only counts what is in front of you.

Two edges the new state introduces:

- The dedupe index now excludes archived rows, so a repeat report opens a new row in the inbox rather than resurrecting one somebody has dealt with.
- Moving a row back into "unread and in the inbox" can collide with the row that absorbed its dedupe key meanwhile. The older of the two gives up its claim on the key instead of the move failing.

## Severity

Severity no longer colours a per-row border — a list of imports read as an alarm. The pill carries it, in the row and in the pane. Rows wear the surface `ListGroup` gives a list of records, over `$panel-bg` because this page sits on a photograph.

## Reviewing this locally

`bin/rails admin_notifications:examples` fills the table with a spread that covers what the list and the pane have to survive: every type and severity, read and unread, a body long enough to scroll and none at all, a repeat report, and an age spread so the list is not one timestamp. `:clear` empties it again. Both refuse to run in production.

**Restart your dev server after pulling** — request validation holds the OpenAPI document from boot, so the new `archivedAtNull` filter is rejected with a 400 (which the page shows as a generic "Server Error") until it reboots.

## Verified

- `bin/rails test` over everything touching `AdminNotification`: 81 tests green, including new model and integration coverage for archive, unread, the dedupe edges, and the inbox scoping.
- New Playwright spec: 8 of 9 green locally. The one failure is the first test racing the cold Vite module graph during login (the page was still on the login form when the list wait began); the login handoff now waits for the network to settle. CI serves prebuilt assets and does not hit this.
- `pnpm lint`, `lint:ts`, `standardrb` clean. Schema and Orval clients regenerated.

🤖
