### PR TITLE
feat(hangar): render missing roles as a stats tile

### DIFF
--- a/app/frontend/frontend/components/Fleets/FleetStats/index.vue
+++ b/app/frontend/frontend/components/Fleets/FleetStats/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import StatsPanel from "@/shared/components/StatsPanel/index.vue";
+import MissingRolesPanel from "@/shared/components/MissingRolesPanel/index.vue";
 import Panel from "@/shared/components/base/Panel/index.vue";
 import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
@@ -72,12 +73,7 @@ const uniqueModelsCount = ref(0);
 const manufacturerCount = ref(0);
 
 const missingClassifications = computed(
-  () =>
-    vehicleStats.value?.metrics.missingClassifications
-      ?.map((c: string) =>
-        c.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()),
-      )
-      .join(", ") || "",
+  () => vehicleStats.value?.metrics.missingClassifications || [],
 );
 
 // use refs and watch for stats to trigger animation on every page visit
@@ -321,16 +317,9 @@ const totalIngameValueCompact = computed(() =>
     </div>
   </div>
 
-  <div v-if="missingClassifications" class="row">
-    <div class="col-12 col-sm-6">
-      <Panel>
-        <PanelHeading :level="HeadingLevelEnum.H2">
-          {{ t("labels.hangarMetrics.missingClassifications") }}
-        </PanelHeading>
-        <PanelBody>
-          <p>{{ missingClassifications }}</p>
-        </PanelBody>
-      </Panel>
+  <div v-if="missingClassifications.length" class="row">
+    <div class="col-12 col-sm-6 col-lg-3">
+      <MissingRolesPanel :roles="missingClassifications" />
     </div>
   </div>
 

--- a/app/frontend/frontend/pages/hangar/stats.vue
+++ b/app/frontend/frontend/pages/hangar/stats.vue
@@ -90,9 +90,9 @@ const missingClassifications = computed(
   () => quickStats.value?.metrics.missingClassifications || [],
 );
 
-const wishlistToHangarRatio = computed(() => {
-  if (!totalCount.value) return "";
-  return `${wishlistTotal.value} / ${totalCount.value}`;
+const wishlistPercent = computed(() => {
+  if (!totalCount.value || !wishlistTotal.value) return "";
+  return `(${Math.round((wishlistTotal.value / totalCount.value) * 100)}%)`;
 });
 
 // use refs and watch for stats to trigger animation on every page visit
@@ -330,8 +330,8 @@ const wishlistTotalCreditsCompact = computed(() =>
       <StatsPanel
         icon="fa-duotone fa-heart fa-4x"
         :value="wishlistTotal"
-        :label="t('labels.hangar')"
-        :suffix="wishlistToHangarRatio"
+        :label="t('labels.wishlist')"
+        :suffix="wishlistPercent"
       />
     </div>
   </div>

--- a/app/frontend/frontend/pages/hangar/stats.vue
+++ b/app/frontend/frontend/pages/hangar/stats.vue
@@ -15,6 +15,7 @@ import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import StatsPanel from "@/shared/components/StatsPanel/index.vue";
+import MissingRolesPanel from "@/shared/components/MissingRolesPanel/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { storeToRefs } from "pinia";
 import { useSessionStore } from "@/frontend/stores/session";
@@ -86,12 +87,7 @@ const flightReadyPercent = computed(() => {
 });
 
 const missingClassifications = computed(
-  () =>
-    quickStats.value?.metrics.missingClassifications
-      ?.map((c: string) =>
-        c.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()),
-      )
-      .join(", ") || "",
+  () => quickStats.value?.metrics.missingClassifications || [],
 );
 
 const wishlistToHangarRatio = computed(() => {
@@ -326,24 +322,16 @@ const wishlistTotalCreditsCompact = computed(() =>
     </div>
   </div>
 
-  <div v-if="missingClassifications" class="row">
-    <div class="col-12 col-sm-6">
-      <Panel>
-        <PanelHeading :level="HeadingLevelEnum.H2">
-          {{ t("labels.hangarMetrics.missingClassifications") }}
-        </PanelHeading>
-        <PanelBody>
-          <p>{{ missingClassifications }}</p>
-        </PanelBody>
-      </Panel>
+  <div class="row">
+    <div v-if="missingClassifications.length" class="col-12 col-sm-6 col-lg-3">
+      <MissingRolesPanel :roles="missingClassifications" />
     </div>
-    <div class="col-12 col-sm-6">
+    <div class="col-12 col-sm-6 col-lg-3">
       <StatsPanel
         icon="fa-duotone fa-heart fa-4x"
         :value="wishlistTotal"
         :label="t('labels.hangar')"
         :suffix="wishlistToHangarRatio"
-        :outer-spacing="false"
       />
     </div>
   </div>

--- a/app/frontend/frontend/pages/visual-tests/metrics.vue
+++ b/app/frontend/frontend/pages/visual-tests/metrics.vue
@@ -11,6 +11,8 @@ import Panel from "@/shared/components/base/Panel/index.vue";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
 import MetricsList from "@/shared/components/MetricsList/index.vue";
+import StatsPanel from "@/shared/components/StatsPanel/index.vue";
+import MissingRolesPanel from "@/shared/components/MissingRolesPanel/index.vue";
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
 import ModelSpeedMetrics from "@/frontend/components/Models/SpeedMetrics/index.vue";
@@ -316,6 +318,65 @@ const sampleMetrics = [
     </div>
     <div class="col-12 col-lg-4">
       <ModelHullMetrics />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Stats Panels</Heading>
+  <p>
+    The stats-grid tiles. MissingRolesPanel is the same tile with its detail
+    carried as chips, so it lines up with its neighbours instead of reading as a
+    headed panel of prose.
+  </p>
+  <div class="row">
+    <div class="col-12 col-sm-6 col-lg-3">
+      <StatsPanel
+        icon="fa-duotone fa-rocket fa-4x"
+        :value="62"
+        label="Total Ships"
+      />
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <StatsPanel
+        icon="fa-duotone fa-heart fa-4x"
+        :value="8"
+        label="Wishlist"
+        suffix="(13%)"
+      />
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <MissingRolesPanel :roles="['competition']" />
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <StatsPanel
+        icon="fa-duotone fa-coins fa-4x"
+        :value="206.91"
+        label="Hangar aUEC Value"
+        suffix="M aUEC"
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-sm-6 col-lg-3">
+      <MissingRolesPanel :roles="['competition', 'ground_vehicle']" />
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <MissingRolesPanel
+        :roles="[
+          'competition',
+          'exploration',
+          'ground_vehicle',
+          'multi_role',
+          'support',
+          'transport',
+        ]"
+      />
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <StatsPanel
+        icon="fa-duotone fa-industry fa-4x"
+        :value="12"
+        label="Manufacturers"
+      />
     </div>
   </div>
 </template>

--- a/app/frontend/shared/components/MissingRolesPanel/index.vue
+++ b/app/frontend/shared/components/MissingRolesPanel/index.vue
@@ -1,0 +1,128 @@
+<script lang="ts">
+export default {
+  name: "MissingRolesPanel",
+};
+</script>
+
+<script lang="ts" setup>
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  roles: string[];
+  outerSpacing?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  outerSpacing: true,
+});
+
+const { t } = useI18n();
+
+const labels = computed(() =>
+  props.roles.map((role) =>
+    role.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase()),
+  ),
+);
+</script>
+
+<template>
+  <!--
+    Same tile as StatsPanel rather than a headed Panel with a prose paragraph:
+    this sits in the stats grid beside a dozen tiles, and an H2 plus a
+    comma-joined sentence was the one block on the page in a different language.
+    The chips stand in for the figure - a count above a list of that many chips
+    said the same thing twice and cost the tile a whole line of height.
+  -->
+  <Panel
+    class="missing-roles-panel"
+    :variant="PanelVariantsEnum.SLIM"
+    :outer-spacing="outerSpacing"
+    fill-height
+  >
+    <PanelBody class="missing-roles-panel__body">
+      <div class="metrics-card__tile metrics-card__tile--primary">
+        <div class="metrics-card__tile__label">
+          {{ t("labels.hangarMetrics.missingClassifications") }}
+        </div>
+        <i class="fa-duotone fa-puzzle-piece fa-4x missing-roles-panel__icon" />
+        <ul class="missing-roles-panel__list">
+          <li
+            v-for="label in labels"
+            :key="label"
+            class="missing-roles-panel__chip"
+          >
+            {{ label }}
+          </li>
+        </ul>
+      </div>
+    </PanelBody>
+  </Panel>
+</template>
+
+<style lang="scss" scoped>
+@import "@/shared/components/metricsCard";
+
+// Stretched so the box matches the figure-bearing tiles beside it - one or two
+// chips make a shorter panel, and a short tile in a row of tall ones reads as a
+// rendering fault. The content stays top-aligned inside it, so the label sits on
+// the same line as every other tile's.
+.missing-roles-panel__body {
+  display: flex;
+  flex: 1 0 auto;
+  padding: 0;
+}
+
+.missing-roles-panel {
+  .metrics-card__tile {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    background: transparent;
+    padding: 16px 18px;
+  }
+
+  // Both keep clear of the icon: it is centred on the tile as StatsPanel's is,
+  // so with three rows of chips the glyph sits over the middle one.
+  .metrics-card__tile__label,
+  .missing-roles-panel__list {
+    padding-right: 46px;
+  }
+
+  .missing-roles-panel__icon {
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    font-size: 34px;
+    color: $gray-lighter;
+    opacity: 0.4;
+    --fa-secondary-opacity: 1;
+    pointer-events: none;
+  }
+
+  .missing-roles-panel__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  // The toggle pill's shape without its affordances - these are read-only, so
+  // no hover and a quieter edge than a control would carry.
+  .missing-roles-panel__chip {
+    font-family: "Orbitron", tahoma, sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 5px 11px;
+    color: $text-color;
+    border: 1px solid rgba($gray-light, 0.35);
+    border-radius: 999px;
+  }
+}
+</style>


### PR DESCRIPTION
## What

Missing Roles was the one block on the hangar and fleet stats pages that did not speak the grid's language — an `H2` over a comma-joined sentence, in a full-frame `Panel`, sitting beside a dozen slim metric tiles.

It is now the same tile as its neighbours: Orbitron micro-label, the faded glyph centred on the right, and the roles as chips where the figure would be. There is deliberately no count above the chips — a number over a list of that many items said the same thing twice and cost the tile a line of height.

New shared component `MissingRolesPanel`, used by `pages/hangar/stats.vue` and `components/Fleets/FleetStats`. Those are the only two consumers; the public hangar stats do not render missing roles at all.

## Two fixes that came with it

**The wishlist tile disappeared with the missing roles.** Both lived in a row behind `v-if="missingClassifications"`, so a hangar that covered every role lost its wishlist figure too. They are now independent.

**The wishlist tile was labelled "Hangar".** It reads its value from `wishlistTotal`, and its suffix repeated that same figure a second time — `8`, then `8 / 62`. It is now labelled for what it shows, and the suffix carries the share of the hangar as a percentage, the form the unique-models and flight-ready tiles above it already use.

## Verification

`StatsPanel` had no entry on the metrics visual-test page, so these tiles could previously only be checked by logging in with a hangar that happened to hold the right data. Added a **Stats Panels** section covering both components; `MissingRolesPanel` appears with one, two and six roles, because its height is the thing that moves — six roles is the only case that wraps past a single line of chips.

Checked at 1800px against the local dev server: label and icon sit flush with the neighbouring tiles, and the tile fills the row's height rather than reading as a short box in a row of tall ones.

`vue-tsc`, eslint and prettier are clean.

## Note

`labels.hangarMetrics.missingClassifications` keeps its key. The user-facing string was already "Missing Roles"; renaming the key would have touched the fleet stats and both API schemas for no gain.

🤖
