### PR TITLE
refactor(models): coalesce the model broadcasts a bulk load sends

### DIFF
--- a/app/lib/rsi/models_loader.rb
+++ b/app/lib/rsi/models_loader.rb
@@ -15,10 +15,12 @@ module Rsi
     def all
       models = load_data
 
-      models.each do |data|
-        next if blocked(data["id"])
+      Model.coalescing_broadcasts do
+        models.each do |data|
+          next if blocked(data["id"])
 
-        sync_model(data)
+          sync_model(data)
+        end
       end
 
       cleanup_variants

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -4,8 +4,10 @@ module ScData
       def all
         update_in_game_flags
 
-        Model.where(in_game: true).find_each do |model|
-          load_model(model)
+        Model.coalescing_broadcasts do
+          Model.where(in_game: true).find_each do |model|
+            load_model(model)
+          end
         end
 
         Hardpoint.find_each(&:save) # hack to generate correct group_keys

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -705,7 +705,53 @@ class Model < ApplicationRecord
     slug&.start_with?(prefix) ? slug.delete_prefix(prefix) : slug
   end
 
+  # A bulk load saves the same model several times over -- the matrix pass, the
+  # store pass, the hidden flag -- and every one of those saves rendered the
+  # whole model through jbuilder and published it. That is 37% of a full RSI
+  # import, measured, and 950 messages for 240 models.
+  #
+  # Inside this block the ids are collected instead, and each model is published
+  # once at the end carrying the state it ended up in rather than the three it
+  # passed through. ModelsChannel is in the public schema, so the updates still
+  # have to go out; what a subscriber loses is the intermediate states, which
+  # were never a coherent view of the model anyway.
+  #
+  # A load that raises partway publishes nothing: the job retries, and the run
+  # that gets through announces the state the models actually ended on.
+  def self.coalescing_broadcasts
+    return yield if broadcast_buffer
+
+    self.broadcast_buffer = Set.new
+
+    begin
+      result = yield
+
+      where(id: broadcast_buffer.to_a).find_each { |model| model.send(:publish_update) }
+
+      result
+    ensure
+      self.broadcast_buffer = nil
+    end
+  end
+
+  def self.broadcast_buffer
+    ActiveSupport::IsolatedExecutionState[:model_broadcast_buffer]
+  end
+
+  def self.broadcast_buffer=(buffer)
+    ActiveSupport::IsolatedExecutionState[:model_broadcast_buffer] = buffer
+  end
+  private_class_method :broadcast_buffer=
+
   private def broadcast_update
+    buffer = self.class.broadcast_buffer
+
+    return buffer << id if buffer
+
+    publish_update
+  end
+
+  private def publish_update
     ActionCable.server.broadcast("models", to_json)
   end
 

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -165,4 +165,72 @@ class ModelTest < ActiveSupport::TestCase
 
     assert_nil model.personal_inventory_label
   end
+
+  test ".coalescing_broadcasts holds a model's messages back and sends one at the end" do
+    model = create(:model, name: "Before")
+    published = capture_model_broadcasts
+
+    Model.coalescing_broadcasts do
+      model.update!(name: "During")
+      model.update!(name: "Final")
+
+      assert_empty published, "a load in progress is not a state to publish"
+    end
+
+    assert_equal 1, published.size
+    assert_equal "Final", JSON.parse(published.sole)["name"]
+  end
+
+  test ".coalescing_broadcasts sends one message per model, not one per save" do
+    first = create(:model, name: "First")
+    second = create(:model, name: "Second")
+    published = capture_model_broadcasts
+
+    Model.coalescing_broadcasts do
+      2.times { |run| first.update!(description: "run #{run}") }
+      second.update!(description: "run 0")
+    end
+
+    assert_equal %w[First Second],
+      published.map { |payload| JSON.parse(payload)["name"] }.sort
+  end
+
+  # A run that dies partway is retried by the job that owns it, and the run that
+  # gets through publishes the state the models actually ended on.
+  test ".coalescing_broadcasts publishes nothing when the load raises" do
+    model = create(:model, name: "Half Done")
+    published = capture_model_broadcasts
+
+    assert_raises(RuntimeError) do
+      Model.coalescing_broadcasts do
+        model.update!(name: "Written")
+        raise "the load went bad partway through"
+      end
+    end
+
+    assert_empty published
+    assert_equal "Written", model.reload.name
+  end
+
+  test ".coalescing_broadcasts publishes on every save once the block is over" do
+    model = create(:model, name: "After")
+
+    Model.coalescing_broadcasts { model.touch }
+
+    published = capture_model_broadcasts
+    model.update!(name: "Live")
+
+    assert_equal 1, published.size
+  end
+
+  private def capture_model_broadcasts
+    payloads = []
+
+    ActionCable.server.stubs(:broadcast).with do |channel, payload|
+      payloads << payload if channel == "models"
+      true
+    end
+
+    payloads
+  end
 end


### PR DESCRIPTION
> **Correction — read this first.** This PR was opened with the claim that
> broadcasting is ~37% of a full RSI import. That number was wrong, and with it
> the reason this change existed. A trend-controlled measurement (below) shows
> **no performance benefit at all**. My recommendation is to close this unless the
> message-count reduction is wanted on its own merits. The history of how the
> wrong number came about is kept below, because the measurement mistake is the
> more useful takeaway.

## What this changes

A full RSI import saves each model about four times — the matrix pass, the store
pass, the hidden flag — and every save renders the whole model through jbuilder
and publishes it on `ModelsChannel`. `Model.coalescing_broadcasts` collects the
ids inside the block and publishes each model once when it ends, carrying the
state it ended up in.

Verified: **240 messages instead of 950** for the same import.

Wrapped around `Rsi::ModelsLoader#all` and `ScData::Loader::ModelsLoader#all`.
`#one` is untouched — a single model's update publishes immediately, as before.

## The measurement that matters

Eight runs in one process, ABBA order so a warming trend cannot line up with the
variants, identical starting state each time (transaction rolled back), jbuilder
templates pre-compiled before timing:

| # | variant | time | messages | queries |
| --- | --- | --- | --- | --- |
| 1 | coalesced | 38.23s | 240 | 34,140 |
| 2 | per-save | 36.20s | 950 | 34,609 |
| 3 | per-save | 34.27s | 950 | 34,609 |
| 4 | coalesced | 31.75s | 240 | 34,140 |
| 5 | coalesced | 33.18s | 240 | 34,140 |
| 6 | per-save | 35.93s | 950 | 34,609 |
| 7 | per-save | 30.81s | 950 | 34,609 |
| 8 | coalesced | 30.76s | 240 | 34,140 |

coalesced mean **33.48s**, per-save mean **34.30s** — a 0.82s difference against a
within-variant spread of 7.47s and 5.39s. Noise.

The query counts say why: only 469 queries saved. The flush reloads its 240
models through `find_each`, so each render hits cold associations, while the 950
in-loop renders ran on objects that were already loaded. 240 cold renders cost
about what 950 warm ones do.

## How the wrong number happened

Two mistakes, both mine:

1. I first measured a single `one(7)` with and without the callback: 0.88s vs
   0.06s. That gap was almost entirely the one-time jbuilder template
   compilation landing on whichever run went first, not per-model cost.
2. I then measured a full import four times, alternating on/off/on/off, and got
   131.7s → 82.8s → 41.1s → 25.8s. I read the on/off pairs as a 37% effect. The
   times fall monotonically across all four runs regardless of variant — it was
   a warming trend, and the alternating order let it masquerade as the variant.

The fix was the ABBA ordering plus a discarded warm-up run, and reporting the
within-variant spread next to the difference so noise is visible.

## What is left standing

- The two slow RSI loader tests (`Rsi::ModelsLoaderTest#all` at ~41s and
  `manufacturers_loader_test`'s matrix test at ~68s) are genuine full imports of
  240 models and 4,973 hardpoints. There is no cheap win in them: the fixtures
  are not the cost either — `matrix.json` is fetched once per import, not once
  per model.
- `test/loaders/rsi/hardpoints_loader_test.rb` was never slow. The 43s I
  attributed to it earlier was an artifact of a per-file attribution script that
  keyed test times by name, and `test_#all` collides across many files.
- If this PR is kept, the five tests in `test/models/model_test.rb` pin the
  coalescing behaviour, and the 40 tests exercising the wrapped loaders pass.

🤖
