### PR TITLE
refactor(users): insert a new user's notification preferences in one statement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -544,16 +544,32 @@ class User < ApplicationRecord
     pref.update!(app: sale_notify?, mail: sale_notify?)
   end
 
+  # One statement for all two dozen types. A `create!` each ran a uniqueness
+  # SELECT before its INSERT -- 48 round trips on a signup -- and the row it
+  # went looking for cannot be there: the user was created a moment ago, and
+  # the (user_id, notification_type) pair is unique in the database.
+  #
+  # insert_all builds one statement from the first row's keys, so every row has
+  # to carry the same ones. The defaults are merged onto a full set rather than
+  # passed through as a type happens to configure them, and the timestamps are
+  # set here because insert_all does not fill them in and the columns are NOT
+  # NULL.
   private def create_default_notification_preferences
-    Notification.notification_types.each_key do |type|
-      defaults = NotificationPreference.defaults_for(type)
+    now = Time.zone.now
 
-      if type == "model_on_sale" && sale_notify?
-        defaults = {app: true, mail: true, push: false}
+    rows = Notification.notification_types.each_key.map do |type|
+      defaults = if type == "model_on_sale" && sale_notify?
+        {app: true, mail: true, push: false}
+      else
+        NotificationPreference.defaults_for(type)
       end
 
-      notification_preferences.create!(notification_type: type, **defaults)
+      {app: true, mail: false, push: false}
+        .merge(defaults)
+        .merge(user_id: id, notification_type: type, created_at: now, updated_at: now)
     end
+
+    NotificationPreference.insert_all(rows)
   end
 
   private def touch_fleet_memberships

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -200,6 +200,49 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  # Written with the rows going in through insert_all, which skips the
+  # validations and the timestamp defaults a create! would have handled.
+  class DefaultNotificationPreferencesTest < UserTest
+    test "a new user gets one preference per notification type" do
+      user = create(:user)
+
+      assert_equal Notification.notification_types.keys.sort,
+        user.notification_preferences.pluck(:notification_type).sort
+    end
+
+    test "each preference carries the defaults its type declares" do
+      user = create(:user, sale_notify: false)
+
+      expected = Notification.notification_types.each_key.to_h do |type|
+        [type, NotificationPreference.defaults_for(type).values_at(:app, :mail, :push)]
+      end
+
+      actual = user.notification_preferences.to_h do |preference|
+        [preference.notification_type, [preference.app, preference.mail, preference.push]]
+      end
+
+      assert_equal expected, actual
+    end
+
+    # The sale toggle predates the preferences and still seeds this one.
+    test "sale_notify turns the on-sale preference on for both channels" do
+      preference = create(:user, sale_notify: true)
+        .notification_preferences
+        .find_by(notification_type: "model_on_sale")
+
+      assert preference.app
+      assert preference.mail
+      assert_not preference.push
+    end
+
+    test "the rows are timestamped" do
+      preference = create(:user).notification_preferences.first
+
+      assert_not_nil preference.created_at
+      assert_not_nil preference.updated_at
+    end
+  end
+
   class UrlValidationTest < UserTest
     setup do
       @user = create(:user)


### PR DESCRIPTION
Every signup ran `create!` once per notification type, and there are two dozen of
them:

```
 24  SELECT 1 AS one FROM "notification_preferences" WHERE ...
 24  INSERT INTO "notification_preferences" (...)
  1  INSERT INTO "users" (...)
  6  (uniqueness checks, BEGIN, COMMIT, membership touch)
 --
 55  queries to create one user
```

48 of those 55 round trips are the preferences, and the row each SELECT goes
looking for cannot be there: the user was created a moment earlier, and
`(user_id, notification_type)` is unique in the database
(`idx_on_user_id_notification_type_2ab4363e9b`).

One `insert_all` instead.

## Measurement

`create(:user)`, 8 batches of 20, ABBA order so machine load hits both variants
the same way:

| variant | mean | min | max | queries |
| --- | --- | --- | --- | --- |
| `insert_all` | **16.4ms** | 14.9ms | 20.0ms | **8** |
| per-row `create!` | 72.6ms | 64.0ms | 80.2ms | 55 |

The bands do not overlap — the worst `insert_all` run is 20.0ms, the best
per-row run 64.0ms. The query counts are deterministic.

For the test suite that is 56.2ms × 1,937 outermost `create(:user)` calls ≈ 109s
of CPU time, and a lower bound, because other factories build users as
associations on top of that. I am deliberately not quoting a suite wall-time
figure measured locally: other test suites were running on the same machine, and
the numbers moved more than the effect. CI is the clean environment for that, so
the `ruby-tests` job on this PR is the measurement — compare its Minitest step
against recent runs on main.

## Three things insert_all does not do for you

Each is why the diff looks the way it does, and each is pinned by a new test:

1. **Uniform keys.** `insert_all` builds one statement from the first row's
   columns. `Notification.preference_defaults_for` allows a type to configure a
   partial `preference_defaults` (it is a `fetch` with a full-set fallback), so
   the defaults are merged onto a complete `app`/`mail`/`push` set rather than
   passed through. Today every type happens to declare all three; the merge is
   what keeps a future one from breaking the insert for everyone.
2. **Timestamps.** `insert_all` does not fill `created_at`/`updated_at`, and both
   columns are NOT NULL.
3. **Validations.** The uniqueness validation that cost a SELECT per row is gone;
   the unique index is what enforces it now.

## Tests

Four in `test/models/user_test.rb`: one row per notification type, the defaults
each type declares, `sale_notify` seeding `model_on_sale` on both channels, and
the rows being timestamped. The existing API test already asserted the count of
preferences a signed-in user has; none of the values were covered before.

🤖
