### PR TITLE
fix(ui): list add-action spacing, a form footer gap, and a grouped button's surface

### DIFF
--- a/app/frontend/admin/components/ModelHardpoints/Loadouts/index.vue
+++ b/app/frontend/admin/components/ModelHardpoints/Loadouts/index.vue
@@ -110,7 +110,7 @@ const onSaveCreate = async () => {
 
 <template>
   <div class="hardpoint-loadouts">
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between mb-4">
       <h4 class="hardpoint-loadouts__title">
         {{ t("labels.admin.modelHardpoint.loadouts") }}
       </h4>

--- a/app/frontend/admin/pages/components/[id]/edit/prices.vue
+++ b/app/frontend/admin/pages/components/[id]/edit/prices.vue
@@ -25,7 +25,7 @@ const itemPricesList = ref<{
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{
       t("headlines.admin.components.edit.itemPrices")
     }}</Heading>

--- a/app/frontend/admin/pages/equipment/[id]/edit/prices.vue
+++ b/app/frontend/admin/pages/equipment/[id]/edit/prices.vue
@@ -25,7 +25,7 @@ const itemPricesList = ref<{
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.equipment.edit.itemPrices") }}</Heading>
     <Btn
       :disabled="itemPricesList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/docks.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/docks.vue
@@ -150,7 +150,7 @@ const onSaveCreate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.docks") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
@@ -173,7 +173,7 @@ const onSaveCreate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.hardpoints") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/loaners.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/loaners.vue
@@ -134,7 +134,7 @@ const onSaveCreate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.loaners") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/modules.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/modules.vue
@@ -182,7 +182,7 @@ const onUnlink = (record: ModelModule) => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.modules") }}</Heading>
     <BtnGroup>
       <Btn

--- a/app/frontend/admin/pages/models/[id]/edit/packages.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/packages.vue
@@ -195,7 +195,7 @@ const onSaveCreate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.packages") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -173,7 +173,7 @@ const bulkCopy = (selectedIds: string[]) => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.paints") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/positions.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/positions.vue
@@ -173,7 +173,7 @@ const onRegenerate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>
       {{ t("headlines.admin.models.edit.positions") }}
       <BasePill v-if="model.positionsNeedCuration" uppercase margin-left>

--- a/app/frontend/admin/pages/models/[id]/edit/prices.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/prices.vue
@@ -102,7 +102,7 @@ const itemPricesList = ref<{
     </div>
   </ModelForm>
 
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.itemPrices") }}</Heading>
     <Btn
       :disabled="itemPricesList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
@@ -127,7 +127,7 @@ const onSaveCreate = async () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.snubCrafts") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
@@ -178,7 +178,7 @@ const onUnlink = (record: ModelUpgrade) => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.upgrades") }}</Heading>
     <BtnGroup>
       <Btn

--- a/app/frontend/admin/pages/models/[id]/edit/videos.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/videos.vue
@@ -152,7 +152,7 @@ const videoTypeOptions: FilterOption[] = Object.values(VideoTypeEnum).map(
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.videos") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/modules/[id]/edit/models.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/models.vue
@@ -86,7 +86,7 @@ const onUnlinkModel = (item: Model) => {
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.modelModules.models") }}</Heading>
     <Btn
       :disabled="editableList?.creating"

--- a/app/frontend/admin/pages/models/modules/[id]/edit/prices.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/prices.vue
@@ -133,7 +133,7 @@ const itemPricesList = ref<{
     />
   </form>
 
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.itemPrices") }}</Heading>
     <Btn
       :disabled="itemPricesList?.creating"

--- a/app/frontend/frontend/pages/visual-tests/lists.vue
+++ b/app/frontend/frontend/pages/visual-tests/lists.vue
@@ -260,7 +260,7 @@ const toggleFilteredListEmpty = () => {
     list in place. Rows are selectable, and the expand toggle opens the
     <code>expanded</code> slot.
   </p>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between mb-4">
     <div>
       <Btn
         :disabled="editableList?.creating"

--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -483,18 +483,28 @@ const handleClick = (event: MouseEvent) => {
    The group draws one border, one radius and one pair of end-caps for the whole
    control, so members carry no chrome at all. Applied here rather than from
    BtnGroup's stylesheet, so Btn owns its own appearance in every context. */
-/* Same surface as a standalone button, so a group does not read as a different
-   material. The track's fill only shows through the 1px gaps, as dividers. */
+/*
+ * Same surface as a standalone button, so a group does not read as a different
+ * material - and the member draws the hairline that divides it from the member
+ * before it, rather than the track showing through a gap behind it. The fill is
+ * translucent, so a track painting the seam sat *behind* every member and tinted
+ * it: a member's rest read four points lighter than the same token standalone,
+ * and the leading edge of that 1px shadow is clipped by the track's own
+ * overflow, so no member needs to know it is the first.
+ */
 .btn--grouped {
   @apply bg-control rounded-none border-0;
+  box-shadow: -1px 0 0 var(--color-seam, #3a3f44);
 }
 .btn--grouped::before,
 .btn--grouped::after {
   content: none;
 }
+/* The standalone hover fill, not a value of its own. The literal #2b3034 this
+   replaces lifted the member three points off its rest where a standalone button
+   lifts fifteen, so a group answered the pointer about a quarter as loudly. */
 .btn--grouped:hover:not([disabled]) {
-  @apply text-lifted;
-  background-color: #2b3034;
+  @apply bg-control-hover text-lifted;
 }
 /* Same reasoning as the menu item: a group member is a flat fill inside one
    shared surface, so flooding it edge to edge breaks the control it sits in. */
@@ -504,15 +514,18 @@ const handleClick = (event: MouseEvent) => {
 }
 /*
  * Engaged, not hovered. A grouped member has no end-caps to carry state, and a
- * 0.22 tint sat too close to the #2b3034 hover fill to be told apart - so this
+ * 0.22 tint sat too close to the neutral hover fill to be told apart - so this
  * adds a second signal the hover state cannot borrow: an inset rule along the
- * bottom edge, which reads as a pressed key rather than a lit one.
+ * bottom edge, which reads as a pressed key rather than a lit one. The divider
+ * comes along, since this shadow replaces rather than extends the base one.
  */
 .btn--grouped.active,
 .btn--grouped[aria-pressed="true"] {
   @apply text-white;
   background-color: rgb(66 139 202 / 0.26);
-  box-shadow: inset 0 -2px 0 var(--color-primary, #428bca);
+  box-shadow:
+    inset 0 -2px 0 var(--color-primary, #428bca),
+    -1px 0 0 var(--color-seam, #3a3f44);
 }
 
 /* Hovering something already on has to answer too: `.active` outranks the

--- a/app/frontend/shared/components/base/BtnGroup/index.vue
+++ b/app/frontend/shared/components/base/BtnGroup/index.vue
@@ -118,8 +118,8 @@ provide(BTN_CONTAINER, {
 
 /*
  * The metrics-card__hero pattern: the container owns the border and radius, and
- * the 1px gap lets the track's background read as hairline dividers between
- * members. Members are flat fills with no chrome of their own.
+ * the 1px gaps between members are filled by a hairline each member draws on its
+ * own leading edge. Members are flat fills with no chrome of their own.
  */
 .btn-group {
   @apply relative inline-flex;
@@ -136,12 +136,15 @@ provide(BTN_CONTAINER, {
  * The clipping lives here rather than on .btn-group because the group's end-caps
  * sit outside its border and overflow:hidden would crop them.
  *
- * --color-seam, not an edge token: this fill is only ever seen through the 1px
- * gaps, and at that width a translucent grey took its colour from whatever the
- * control was sitting on. See the token's note in tailwind.css.
+ * It also clips the members' dividers, which is the second job this element
+ * does. The seam used to be a fill *here*, seen through the 1px gaps - but a
+ * member's fill is translucent, so that fill also sat behind every member and
+ * tinted it away from the standalone surface it is meant to share. Each member
+ * paints its own leading hairline instead, and the one on the first member falls
+ * outside this box and is clipped.
  */
 .btn-group__track {
-  @apply bg-seam flex items-stretch overflow-hidden;
+  @apply flex items-stretch overflow-hidden;
   gap: 1px;
   width: 100%;
   border-radius: var(--radius-control-inner, 7px);
@@ -235,6 +238,8 @@ provide(BTN_CONTAINER, {
  */
 .btn-group__track > :deep(span) {
   @apply bg-control text-text flex items-center justify-center px-3.5;
+  /* And the divider a member would draw, for the same reason. */
+  box-shadow: -1px 0 0 var(--color-seam, #3a3f44);
   /* Mirrors .btn--sm's label and height, since a group with a label segment is a
      paginator and paginators are sm. If Btn's type scale moves, this moves with
      it - it cannot inherit, because size is a per-member prop the group cannot

--- a/app/frontend/shared/components/base/FormActions/index.scss
+++ b/app/frontend/shared/components/base/FormActions/index.scss
@@ -1,4 +1,8 @@
 .form-actions {
+  // The rule above the buttons already sets the section apart; without the same
+  // 20px below them the next block on the page sits flush against the buttons.
+  margin-bottom: 20px;
+
   &__inner {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
Three spacing and surface fixes in the shared button and list components, each in its own commit.

## An editable list's add action sat on the list

The row pairing a page heading with its Add button carried no bottom margin, so the button was flush against the first list row — the control and the content it acts on read as one block. The markup is identical in all 17 places it appears, so the same `mb-4` goes on each rather than introducing a wrapper component. The hangar loadouts page uses the same pattern but already carries its own toolbar margin, so it is left alone.

## The form actions footer had no bottom gap

The `<hr />` above the buttons sets the footer apart from the fields, but nothing set it apart from whatever follows the form. On the admin edit pages that is a list's Add button, which sat directly against Save. Now the same 20px below as above.

## A grouped button did not share the standalone button's surface

`.btn--grouped` is meant to carry the standalone surface so a group does not read as a different material. Neither its rest nor its hover fill did.

**Hover** was a literal `#2b3034` rather than the token the standalone states use. Measured on the rendered control, that lifted a member three points off its rest where a standalone button lifts fifteen — a group answered the pointer about a quarter as loudly.

**Rest** was off for a subtler reason, and fixing hover alone would have left it: `bg-control` is translucent, and the track painted an opaque seam fill *behind* every member, so a tenth of `#3a3f44` bled into each one. The seam is only ever meant to show through the 1px gaps, so each member now paints that hairline on its own leading edge and the track paints nothing. The first member's hairline falls outside the track and is clipped by the `overflow` it already sets — so no member needs to know its position, which is the constraint that ruled out `:first-child` here in the first place.

Sampling the rendered fill on `/visual-tests/buttons/`, clear of the label and end-caps:

| | rest | hover | lift |
|---|---|---|---|
| standalone, before and after | `#24282c` | `#31373d` | +13 / 15 / 17 |
| grouped, before | `#282d31` | `#2b3034` | **+3 / 3 / 3** |
| grouped, after | `#25292d` | `#32383e` | +13 / 15 / 17 |

The remaining 1-point offset is the different background-image pixel behind each control, not the styling — both now resolve from the same two tokens.

## Verification

Checked in the browser at 3–4× zoom: dividers render between group members and on both sides of the paginator's "1 of 9" label segment, no stray hairline on a group's leading edge, the segmented switch is unaffected (its `box-shadow: none` still wins on source order), disabled paginator arrows still dim. `Btn/index.spec.ts` passes 13/13, prettier is clean on the diff.

🤖
