### PR TITLE
fix(hangar): give the group highlight its own tone

### DIFF
--- a/app/frontend/frontend/components/Models/Panel/index.vue
+++ b/app/frontend/frontend/components/Models/Panel/index.vue
@@ -25,7 +25,7 @@ import {
 type Props = {
   model: Model;
   details?: boolean;
-  highlight?: boolean;
+  tone?: `${PanelTonesEnum}`;
   id?: string;
   storeImage?: string;
   level?: HeadingLevelEnum;
@@ -33,7 +33,7 @@ type Props = {
 
 const props = withDefaults(defineProps<Props>(), {
   details: false,
-  highlight: false,
+  tone: PanelTonesEnum.NEUTRAL,
   id: undefined,
   storeImage: undefined,
   level: HeadingLevelEnum.H2,
@@ -74,7 +74,7 @@ const route = useRoute();
     class="model-panel"
     :class="`model-panel-${model.slug}`"
     :data-test="`model-panel-${model.slug}`"
-    :tone="highlight ? PanelTonesEnum.HIGHLIGHT : PanelTonesEnum.NEUTRAL"
+    :tone="tone"
     :bg-image="image"
     :bg-rounded="details ? PanelRoundedEnum.TOP : PanelRoundedEnum.ALL"
   >

--- a/app/frontend/frontend/components/Vehicles/Panel/index.spec.ts
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.spec.ts
@@ -1,0 +1,127 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHashHistory } from "vue-router";
+import Component from "./index.vue";
+import { type Vehicle, BoughtViaEnum } from "@/services/fyApi";
+
+// The card carries a store image, and jsdom has no IntersectionObserver for
+// useLazyBackground to hand it to.
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+const NOW = "2026-08-24T12:00:00Z";
+
+const vehicle = (overrides: Partial<Vehicle> = {}): Vehicle =>
+  ({
+    id: "vehicle-1",
+    boughtVia: BoughtViaEnum.PLEDGE_STORE,
+    wanted: false,
+    flagship: false,
+    alternativeNames: [],
+    hangarGroupIds: [],
+    hangarGroups: [],
+    loaner: false,
+    bundled: false,
+    modelModuleIds: [],
+    modelUpgradeIds: [],
+    nameVisible: false,
+    public: false,
+    saleNotify: false,
+    model: {
+      id: "model-1",
+      name: "Odyssey",
+      slug: "odyssey",
+      media: {},
+      inGame: true,
+      crew: { min: 1, max: 6 },
+      speeds: { scmSpeed: 210, maxSpeed: 1125, groundMaxSpeed: 90 },
+      metrics: {
+        isGroundVehicle: false,
+        length: 110,
+        beam: 60,
+        height: 22,
+        mass: null,
+        cargo: 64,
+      },
+      manufacturer: {
+        id: "manufacturer-1",
+        name: "RSI",
+        slug: "rsi",
+      },
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  }) as Vehicle;
+
+// The title links to `ship`, and the manufacturer link is query-only - it
+// resolves against the current route, so the router has to be on one.
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: "/",
+      name: "hangar",
+      component: { template: "<div />" },
+    },
+    {
+      path: "/ships/:slug",
+      name: "ship",
+      component: { template: "<div />" },
+    },
+  ],
+});
+
+const mount = async (props: { vehicle: Vehicle; highlight?: boolean }) => {
+  await router.push({ name: "hangar" });
+  await router.isReady();
+
+  return mountWithDefaults<typeof Component>(Component, {
+    props,
+    plugins: [router],
+  });
+};
+
+describe("VehiclesPanel", () => {
+  it("leaves an ordinary ship untoned", async () => {
+    const wrapper = await mount({ vehicle: vehicle() });
+
+    expect(wrapper.find(".panel--highlight").exists()).toBe(false);
+    expect(wrapper.find(".panel--primary").exists()).toBe(false);
+  });
+
+  it("marks the flagship in gold, matching its certificate icon", async () => {
+    const wrapper = await mount({ vehicle: vehicle({ flagship: true }) });
+
+    expect(wrapper.find(".panel--highlight").exists()).toBe(true);
+    expect(wrapper.find(".vehicle-panel-flagship-icon").exists()).toBe(true);
+  });
+
+  it("gives a highlighted group its own tone, not the flagship's", async () => {
+    const wrapper = await mount({ vehicle: vehicle(), highlight: true });
+
+    expect(wrapper.find(".panel--primary").exists()).toBe(true);
+    expect(wrapper.find(".panel--highlight").exists()).toBe(false);
+  });
+
+  // Otherwise the flagship is the one ship in the hovered group whose membership
+  // cannot be read - the reason the two states stopped sharing gold.
+  it("shows a highlighted flagship as part of the group", async () => {
+    const wrapper = await mount({
+      vehicle: vehicle({ flagship: true }),
+      highlight: true,
+    });
+
+    expect(wrapper.find(".panel--primary").exists()).toBe(true);
+    expect(wrapper.find(".panel--highlight").exists()).toBe(false);
+    expect(wrapper.find(".vehicle-panel-flagship-icon").exists()).toBe(true);
+  });
+});

--- a/app/frontend/frontend/components/Vehicles/Panel/index.vue
+++ b/app/frontend/frontend/components/Vehicles/Panel/index.vue
@@ -19,6 +19,7 @@ import {
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import { BtnVariantsEnum } from "@/shared/components/base/Btn/types";
+import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
 
 type Props = {
   vehicle: Vehicle | VehiclePublic;
@@ -137,8 +138,21 @@ const openAddonsModal = () => {
 
 const activeLoadout = computed(() => props.vehicle.activeLoadout);
 
-const shouldHighlight = computed(() => {
-  return props.highlight || (props.vehicle as Vehicle).flagship;
+// Two separate meanings on one edge, so they cannot share a tone: gold is the
+// flagship, matching its certificate icon, and the group tone is the transient
+// hover on a group chip. The group wins while it is hovered - otherwise a
+// flagship inside the hovered group would be the one ship whose membership you
+// cannot read, which is what the shared gold broke.
+const tone = computed(() => {
+  if (props.highlight) {
+    return PanelTonesEnum.PRIMARY;
+  }
+
+  if ((props.vehicle as Vehicle).flagship) {
+    return PanelTonesEnum.HIGHLIGHT;
+  }
+
+  return PanelTonesEnum.NEUTRAL;
 });
 </script>
 
@@ -148,7 +162,7 @@ const shouldHighlight = computed(() => {
     :model="model"
     class="vehicle-panel"
     :details="details"
-    :highlight="shouldHighlight"
+    :tone="tone"
     :store-image="image"
   >
     <template #heading-title>

--- a/app/frontend/frontend/pages/visual-tests/panels.vue
+++ b/app/frontend/frontend/pages/visual-tests/panels.vue
@@ -68,6 +68,12 @@ const toggleVehiclePanelFlagship = () => {
   vehiclePanelFlagship.value = !vehiclePanelFlagship.value;
 };
 
+const vehiclePanelHighlight = ref(false);
+
+const toggleVehiclePanelHighlight = () => {
+  vehiclePanelHighlight.value = !vehiclePanelHighlight.value;
+};
+
 const vehiclePanelLoaner = ref(false);
 
 const toggleVehiclePanelLoaner = () => {
@@ -430,6 +436,7 @@ const vehicleTruncated = computed<Vehicle | undefined>(() => {
               :vehicle="vehicle"
               :details="vehiclePanelDetails"
               :editable="vehiclePanelEditable"
+              :highlight="vehiclePanelHighlight"
               :loaners-hint-visible="vehiclePanelLoanerHint"
             />
           </div>
@@ -440,6 +447,7 @@ const vehicleTruncated = computed<Vehicle | undefined>(() => {
               :vehicle="vehicleTruncated"
               :details="vehiclePanelDetails"
               :editable="vehiclePanelEditable"
+              :highlight="vehiclePanelHighlight"
               :loaners-hint-visible="vehiclePanelLoanerHint"
             />
           </div>
@@ -455,6 +463,9 @@ const vehicleTruncated = computed<Vehicle | undefined>(() => {
         </Btn>
         <Btn @click="toggleVehiclePanelFlagship">
           Toggle Flagship: {{ vehiclePanelFlagship }}
+        </Btn>
+        <Btn @click="toggleVehiclePanelHighlight">
+          Toggle Group Highlight: {{ vehiclePanelHighlight }}
         </Btn>
         <Btn @click="toggleVehiclePanelLoaner">
           Toggle Loaner: {{ vehiclePanelLoaner }}


### PR DESCRIPTION
## What

Hovering a group chip in the hangar highlighted that group's ships in gold — the same tone the flagship already wears — so the flagship read as a member of every group.

The two states now use different tones on the panel's end-caps:

- **flagship** → `highlight` (gold `#d4af37`), matching its certificate icon
- **group highlight** → `primary` (blue `#428bca`)

While a group chip is hovered the group tone wins over gold on a flagship. Otherwise the flagship would be the one ship in the hovered group whose membership you still can't read, which is the bug. The gold certificate icon stays visible, so it remains identifiable as the flagship.

`ModelPanel`'s `highlight` boolean was a hardcoded gold/neutral switch with a single caller, so it becomes a `tone` passthrough.

## Testing

- New `Vehicles/Panel/index.spec.ts` covers plain, flagship, highlighted, and highlighted-flagship
- Full vitest suite green (273 tests), `pnpm vue-tsc`, eslint and prettier clean
- `visual-tests/panels` gained a "Toggle Group Highlight" button next to the flagship one, so both tones and their combination are inspectable

## Alternative considered

Instead of a fixed blue, the highlight could take the hovered group's own colour (the value the chip's dot uses) via `--tone`. That reads more directly as "this group" but needs the colour threaded from the hangar page down to `Panel`. Happy to switch if preferred.

🤖