### PR TITLE
fix(admin): notification center on a phone, and the archive switch back to the left

### DIFF
--- a/app/frontend/admin/components/Notifications/Detail/index.vue
+++ b/app/frontend/admin/components/Notifications/Detail/index.vue
@@ -190,8 +190,6 @@ watch(
 <style lang="scss" scoped>
 .notification-detail {
   padding: 16px 18px;
-  max-height: calc(100vh - 60px);
-  overflow: auto;
 }
 
 .notification-detail--empty {
@@ -214,9 +212,13 @@ watch(
   }
 }
 
+// Wraps rather than shrinking past the point where the title is readable: the
+// actions drop to a row of their own once the heading would fall below its
+// min-width, which is what the reading pane does on a phone.
 .notification-detail__header {
   display: flex;
   align-items: flex-start;
+  flex-wrap: wrap;
   gap: 14px;
 }
 
@@ -227,9 +229,11 @@ watch(
   font-size: 1.5em;
 }
 
+// The min-width is what the header measures its line break against - at 0 the
+// actions would stay beside a title squeezed to two words a line.
 .notification-detail__heading {
   flex: 1;
-  min-width: 0;
+  min-width: 180px;
 }
 
 .notification-detail__title {
@@ -256,6 +260,7 @@ watch(
 .notification-detail__actions {
   display: flex;
   flex-shrink: 0;
+  flex-wrap: wrap;
   gap: 5px;
 }
 
@@ -305,9 +310,27 @@ watch(
   flex-shrink: 0;
 }
 
+@media (max-width: $tablet-breakpoint) {
+  .notification-detail {
+    padding: 12px 12px 14px;
+  }
+
+  .notification-detail__header {
+    gap: 10px;
+  }
+}
+
 @media (min-width: $notifications-two-pane-breakpoint) {
   .notification-detail__back {
     display: none;
+  }
+
+  // Only the pane that sits beside the list scrolls on its own: it is sticky,
+  // so it has to stay inside the viewport. Alone on the page it is the page
+  // that scrolls, and a second scroll region inside it hid the end of a report.
+  .notification-detail {
+    max-height: calc(100vh - 60px);
+    overflow: auto;
   }
 }
 </style>

--- a/app/frontend/admin/components/Notifications/ListItem/index.vue
+++ b/app/frontend/admin/components/Notifications/ListItem/index.vue
@@ -250,4 +250,22 @@ defineExpose({ focus: () => select.value?.focus() });
     opacity: 1;
   }
 }
+
+// A phone has no hover, so the actions are permanently part of the row and take
+// their width off the title. The row gives back what padding it can.
+@media (max-width: $tablet-breakpoint) {
+  .notification-item {
+    gap: 2px;
+    padding-right: 6px;
+  }
+
+  .notification-item__select {
+    gap: 10px;
+    padding-left: 10px;
+  }
+
+  .notification-item__actions {
+    gap: 2px;
+  }
+}
 </style>

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -280,7 +280,32 @@ const destroyAll = () =>
       <FilterForm />
     </template>
     <template #actions-left>
-      <Btn :to="sortLink" route-active-class="">
+      <BtnGroup segmented>
+        <Btn
+          :to="tabLink(false)"
+          :active="!archive"
+          route-active-class=""
+          mobile-icon-only
+          data-test="notifications-tab-inbox"
+        >
+          <i class="fa-duotone fa-inbox" />
+          {{ t("labels.adminNotifications.inbox") }}
+          <span v-if="unreadCount?.count" class="admin-notifications__badge">
+            {{ unreadCount.count }}
+          </span>
+        </Btn>
+        <Btn
+          :to="tabLink(true)"
+          :active="archive"
+          route-active-class=""
+          mobile-icon-only
+          data-test="notifications-tab-archive"
+        >
+          <i class="fa-duotone fa-box-archive" />
+          {{ t("labels.adminNotifications.archive") }}
+        </Btn>
+      </BtnGroup>
+      <Btn :to="sortLink" route-active-class="" mobile-icon-only>
         <i
           :class="
             oldestFirst
@@ -335,31 +360,6 @@ const destroyAll = () =>
         />
       </div>
     </template>
-    <template #actions-right>
-      <BtnGroup segmented>
-        <Btn
-          :to="tabLink(false)"
-          :active="!archive"
-          route-active-class=""
-          data-test="notifications-tab-inbox"
-        >
-          <i class="fa-duotone fa-inbox" />
-          {{ t("labels.adminNotifications.inbox") }}
-          <span v-if="unreadCount?.count" class="admin-notifications__badge">
-            {{ unreadCount.count }}
-          </span>
-        </Btn>
-        <Btn
-          :to="tabLink(true)"
-          :active="archive"
-          route-active-class=""
-          data-test="notifications-tab-archive"
-        >
-          <i class="fa-duotone fa-box-archive" />
-          {{ t("labels.adminNotifications.archive") }}
-        </Btn>
-      </BtnGroup>
-    </template>
     <template #pagination-top>
       <Paginator
         v-if="notifications"
@@ -383,7 +383,9 @@ const destroyAll = () =>
 .admin-notifications__badge {
   padding: 0 6px;
   color: $gray-black;
-  font-size: 0.8em;
+  // Absolute rather than an em: `mobile-icon-only` collapses the label by
+  // setting the button's font-size to 0, and the count would go with it.
+  font-size: 12px;
   font-weight: bold;
   background-color: var(--color-primary, #{$primary});
   border-radius: 10px;


### PR DESCRIPTION
The notification center was built for the two-pane layout and had not been looked at below it. Two things were broken on a phone and one was in the wrong place.

## The archive switch moves back to the left

Inbox and Archive sat in the toolbar's right group next to the paginator, which on a 390px screen pushed the Archive tab off the viewport. The switch moves to the left group, where it reads before the controls that modify the list it chooses, and the paginator has the right group to itself.

Three label-bearing controls still do not fit a 390px row, so the tabs and the sort button go icon-only below 992px — the same call the page's own header actions (Mark all as read, Delete all) already make. The unread badge needs an absolute `font-size` to survive that: `mobile-icon-only` collapses the label by setting the button's font-size to 0, and an `em` would take the count with it.

Toolbar, 390px: `[filter] [inbox 4 | archive] [sort] … [1 of 1]`, on one row.

## The reading pane fits a phone

The header put the back button, the icon, the title and up to four actions in one row that never wrapped. On a phone the title was squeezed into a column two words wide, the date broke one word per line, and the delete button ran off the panel.

The header wraps now, and the heading carries a `min-width` — that is what the line break is measured against, so the actions drop to a row of their own once the title would fall below it. No breakpoint is involved: at 768px and in the two-pane layout the header renders exactly as before, and the stack engages under roughly 620px of viewport.

## One scroll region, not two

The pane capped itself at `calc(100vh - 60px)` and scrolled its own content at every width. That cap belongs to the sticky two-pane layout; alone on the page it only nested a second scroll region inside one that already scrolled, which cut off the end of a report. It moves into the two-pane media query.

Rows also give back what padding they can on a phone: without hover their archive/delete buttons are permanently visible and take that width off the title.

## Verification

Checked against the running app at 390 / 500 / 620 / 768 / 900 / 1440px, logging in and opening a notification with a long body — the toolbar fits, the report renders in full, and the desktop two-pane layout is unchanged. `vue-tsc`, eslint and prettier are clean.

`AdminNotifications.spec.ts` is **not** run: the local Docker daemon is wedged, so the test database is unreachable and every Rails request hangs. The change is CSS plus moving the tab group between two `FilteredList` slots, and the `data-test` ids are untouched, but CI should be the judge.

🤖