### PR TITLE
fix: six errors from AppSignal production triage

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -20,8 +20,7 @@ module Admin
     add_flash_types :error, :warning
 
     rescue_from ActionController::InvalidAuthenticityToken do
-      @action_name = "unprocessable_entity"
-      render "errors/error", status: :unprocessable_entity
+      render "admin/index", status: :unprocessable_entity
     end
 
     private def unauthorized_controllers

--- a/app/controllers/api/v1/fleet_notification_settings_controller.rb
+++ b/app/controllers/api/v1/fleet_notification_settings_controller.rb
@@ -79,11 +79,13 @@ module Api
         authorize! @fleet, to: :show?
       end
 
+      # Concurrent requests for the same fleet both miss the association, so the
+      # insert has to tolerate losing the race against the unique index.
       private def set_setting
         @setting = @fleet.fleet_notification_setting ||
-          @fleet.create_fleet_notification_setting!(
-            enabled_in_app_events: FleetNotificationSetting::DEFAULT_IN_APP_EVENTS
-          )
+          FleetNotificationSetting.create_or_find_by!(fleet: @fleet) do |setting|
+            setting.enabled_in_app_events = FleetNotificationSetting::DEFAULT_IN_APP_EVENTS
+          end
       end
     end
   end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -4,7 +4,9 @@ class DocsController < ActionController::Base
   def index
     respond_to do |format|
       format.html
-      format.all { head :not_acceptable }
+      # Plain text, not the requested format: an empty JavaScript-typed response
+      # to a cross-origin <script> tag trips Rails' same-origin verification.
+      format.all { head :not_acceptable, content_type: "text/plain" }
     end
   end
 end

--- a/app/frontend/admin/pages/fleets/[id].vue
+++ b/app/frontend/admin/pages/fleets/[id].vue
@@ -2,6 +2,7 @@
 import { useFleet as useFleetQuery } from "@/services/fyAdminApi";
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import { routes as fleetChildRoutes } from "./[id]/routes";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -13,7 +14,7 @@ const { data: fleet, ...asyncStatus } = useFleetQuery(
   route.params.id as string,
 );
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "admin-fleets", hash: fleet.value ? `#${fleet.value.id}` : "" },
     label: t("nav.admin.fleets.index"),

--- a/app/frontend/admin/pages/fleets/destroyed/index.vue
+++ b/app/frontend/admin/pages/fleets/destroyed/index.vue
@@ -8,6 +8,7 @@ export default {
 import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Panel from "@/shared/components/base/Panel/index.vue";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
@@ -30,7 +31,7 @@ import DestroyedFleetActions from "@/admin/components/DestroyedFleets/Actions/in
 
 const { t, l } = useI18n();
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "admin-fleets" },
     label: t("nav.admin.fleets.index"),

--- a/app/frontend/admin/pages/users/[id].vue
+++ b/app/frontend/admin/pages/users/[id].vue
@@ -2,6 +2,7 @@
 import { useUser as useUserQuery } from "@/services/fyAdminApi";
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import { routes as userChildRoutes } from "./[id]/routes";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -11,7 +12,7 @@ const { t } = useI18n();
 
 const { data: user, ...asyncStatus } = useUserQuery(route.params.id as string);
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "admin-users", hash: user.value ? `#${user.value.id}` : "" },
     label: t("nav.admin.users.index"),

--- a/app/frontend/frontend/pages/fleets/[slug]/events/[event].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/[event].vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import Panel from "@/shared/components/base/Panel/index.vue";
@@ -410,7 +411,7 @@ onUnmounted(() => {
   fleetEventChildrenChangedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/events/[event]/edit.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/[event]/edit.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import TabNavViewItems from "@/shared/components/TabNavView/Items/index.vue";
 import { routes as editRoutes } from "@/frontend/pages/fleets/[slug]/events/[event]/edit/routes";
@@ -49,7 +50,7 @@ onUnmounted(() => {
   fleetEventChildrenChangedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
@@ -219,7 +220,7 @@ onUnmounted(() => {
   fleetEventUpdatedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/events/new.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/new.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import EventForm from "@/frontend/components/Fleets/Events/EventForm/index.vue";
 import {
@@ -54,7 +55,7 @@ const cancel = () => {
   });
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
@@ -156,7 +157,7 @@ onUnmounted(() => {
   inventoryItemCreatedComlink.value();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
@@ -8,6 +8,7 @@ export default {
 import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
@@ -201,7 +202,7 @@ onMounted(() => {
   comlink.on("fleet-inventory-updated", () => void refetchInventory());
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory]/[item].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory]/[item].vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
@@ -186,7 +187,7 @@ const destroyStockItem = () => {
   });
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
@@ -10,6 +10,7 @@ import debounce from "lodash.debounce";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
@@ -130,7 +131,7 @@ useSubscription({
   received: () => debounce(fetch, 500),
 });
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   return [
     {
       to: {

--- a/app/frontend/frontend/pages/fleets/[slug]/members/invites.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/invites.vue
@@ -10,6 +10,7 @@ import debounce from "lodash.debounce";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
@@ -123,7 +124,7 @@ useSubscription({
   received: () => debounce(fetch, 500),
 });
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   return [
     {
       to: {

--- a/app/frontend/frontend/pages/fleets/[slug]/members/starmap.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/starmap.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
@@ -48,7 +49,7 @@ const membersWithSystem = computed(() =>
   memberItems.value.filter((member) => member.currentSystemCode != null),
 );
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: {
       name: "fleet",

--- a/app/frontend/frontend/pages/fleets/[slug]/members/worldmap.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/worldmap.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import MembersWorldMap from "@/frontend/components/Fleets/MembersWorldMap/index.vue";
@@ -47,7 +48,7 @@ const membersWithLocation = computed(() =>
   ),
 );
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: {
       name: "fleet",

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/[mission].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/[mission].vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Panel from "@/shared/components/base/Panel/index.vue";
 import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
@@ -107,7 +108,7 @@ onUnmounted(() => {
   missionChildrenChangedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/[mission]/edit.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/[mission]/edit.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import TabNavViewItems from "@/shared/components/TabNavView/Items/index.vue";
 import { routes as editRoutes } from "@/frontend/pages/fleets/[slug]/missions/[mission]/edit/routes";
@@ -53,7 +54,7 @@ onUnmounted(() => {
   missionChildrenChangedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
@@ -85,7 +86,7 @@ onUnmounted(() => {
   fleetMissionUpdatedComlink.value?.();
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/new.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/new.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import MissionForm from "@/frontend/components/Fleets/Missions/MissionForm/index.vue";
 import { type Fleet, type FleetMember } from "@/services/fyApi";
@@ -30,7 +31,7 @@ const cancel = () => {
   });
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "fleet", params: { slug: props.fleet.slug } },
     label: props.fleet.name,

--- a/app/frontend/frontend/pages/fleets/[slug]/settings.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import TabNavViewItems from "@/shared/components/TabNavView/Items/index.vue";
@@ -34,7 +35,7 @@ const props = defineProps<Props>();
 
 const route = useRoute();
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   return [
     {
       to: {

--- a/app/frontend/frontend/pages/fleets/[slug]/stats.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/stats.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import FleetStats from "@/frontend/components/Fleets/FleetStats/index.vue";
 import PublicFleetStats from "@/frontend/components/Fleets/PublicFleetStats/index.vue";
@@ -23,7 +24,7 @@ const { t } = useI18n();
 
 const route = useRoute();
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   if (!props.fleet) {
     return [];
   }

--- a/app/frontend/frontend/pages/hangar/[id].vue
+++ b/app/frontend/frontend/pages/hangar/[id].vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import TabNavView from "@/shared/components/TabNavView/index.vue";
 import { useShowVehicle } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -45,7 +46,7 @@ const vehicleName = computed(() => {
   return nameParts.join(" ");
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "hangar" },
     label: t("nav.hangar.index"),

--- a/app/frontend/frontend/pages/hangar/[id]/cargo/[item].vue
+++ b/app/frontend/frontend/pages/hangar/[id]/cargo/[item].vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
@@ -167,7 +168,7 @@ const destroyStockItem = () => {
   });
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "hangar" },
     label: t("nav.hangar.index"),

--- a/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
@@ -159,7 +160,7 @@ onMounted(() => {
   comlink.on("hangar-inventory-updated", () => void refetchInventory());
 });
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "hangar" },
     label: t("nav.hangar.index"),

--- a/app/frontend/frontend/pages/hangar/inventories/[inventory]/[item].vue
+++ b/app/frontend/frontend/pages/hangar/inventories/[inventory]/[item].vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import AsyncData from "@/shared/components/AsyncData.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
@@ -160,7 +161,7 @@ const destroyStockItem = () => {
   });
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "hangar" },
     label: t("nav.hangar.index"),

--- a/app/frontend/frontend/pages/settings/calendar.vue
+++ b/app/frontend/frontend/pages/settings/calendar.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
@@ -99,7 +100,7 @@ const copyFeedUrl = async () => {
   }
 };
 
-const crumbs = computed(() => [
+const crumbs = computed<Crumb[]>(() => [
   {
     to: { name: "settings-profile" },
     label: t("nav.settings.index"),

--- a/app/frontend/frontend/pages/ships/[slug]/images.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/images.vue
@@ -8,6 +8,7 @@ export default {
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import { useGallery } from "@/shared/composables/useGallery";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -58,7 +59,7 @@ const metaImage = computed(() => {
 
 const route = useRoute();
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   if (!props.model) {
     return [];
   }

--- a/app/frontend/frontend/pages/ships/[slug]/images.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/images.vue
@@ -72,7 +72,7 @@ const crumbs = computed(() => {
       label: t("nav.ships.index"),
     },
     {
-      to: { name: "ship", param: { slug: route.params.slug } },
+      to: { name: "ship", params: { slug: route.params.slug } },
       label: props.model.name,
     },
   ];

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -24,6 +24,7 @@ import FleetchartImages from "@/frontend/components/Models/FleetchartImages/inde
 import ModelBaseMetrics from "@/frontend/components/Models/BaseMetrics/index.vue";
 import ModelCrewMetrics from "@/frontend/components/Models/CrewMetrics/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import HoloViewer from "@/shared/components/HoloViewer/index.vue";
 import ShareBtn from "@/frontend/components/ShareBtn/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -154,7 +155,9 @@ const metaImage = computed(() => {
   return props.model.media.storeImage?.largeUrl;
 });
 
-const crumbs = computed(() => {
+// Undefined rather than empty: the breadcrumb bar stays hidden until the model
+// arrives instead of flashing a lone home crumb.
+const crumbs = computed<Crumb[] | undefined>(() => {
   if (!props.model) {
     return undefined;
   }

--- a/app/frontend/frontend/pages/ships/[slug]/videos.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/videos.vue
@@ -8,6 +8,7 @@ export default {
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
 import VideoEmbed from "@/shared/components/Video/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useMetaInfo } from "@/shared/composables/useMetaInfo";
@@ -52,7 +53,7 @@ const metaImage = computed(() => {
 
 const route = useRoute();
 
-const crumbs = computed(() => {
+const crumbs = computed<Crumb[]>(() => {
   if (!props.model) {
     return [];
   }

--- a/app/frontend/frontend/pages/ships/[slug]/videos.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/videos.vue
@@ -66,7 +66,7 @@ const crumbs = computed(() => {
       label: t("nav.ships.index"),
     },
     {
-      to: { name: "ship", param: { slug: route.params.slug } },
+      to: { name: "ship", params: { slug: route.params.slug } },
       label: props.model.name,
     },
   ];

--- a/app/jobs/notifications/admin_job.rb
+++ b/app/jobs/notifications/admin_job.rb
@@ -5,8 +5,10 @@ module Notifications
     def perform
       report = AdminWeeklyReport.build
 
+      # Delivered inline: the report carries Struct values that ActiveJob cannot
+      # serialize, and this job is already running in the background.
       AdminUser.where(super_admin: true).find_each do |admin_user|
-        AdminMailer.weekly(admin_user, report).deliver_later
+        AdminMailer.weekly(admin_user, report).deliver_now
       end
 
       AdminNotification.notify!(

--- a/app/models/compare_image.rb
+++ b/app/models/compare_image.rb
@@ -36,7 +36,11 @@ class CompareImage < ApplicationRecord
     slug_set = "#{STYLE_VERSION}-#{models_with_images.map(&:slug).sort.join("-")}"
     record = find_or_initialize_by(slug_set: slug_set)
     record.generate!(models_with_images) unless record.image.attached?
-    record
+    return record if record.persisted?
+
+    # A lost race leaves this instance unsaved with an in-memory attachment that
+    # has no signed_id yet, so hand back the row the winner persisted.
+    find_by(slug_set: slug_set) || record
   end
 
   def self.find_or_create_for_share(slugs)

--- a/test/integration/admin/invalid_authenticity_token_test.rb
+++ b/test/integration/admin/invalid_authenticity_token_test.rb
@@ -8,6 +8,10 @@ require "test_helper"
 class Admin::InvalidAuthenticityTokenTest < ActionDispatch::IntegrationTest
   setup do
     ActionController::Base.allow_forgery_protection = true
+    # The admin shell resolves its assets through Vite, and CI has neither a
+    # built manifest nor a dev server. Pretending the dev server is up makes
+    # every lookup resolve to a path instead of raising.
+    ViteRuby.instance.stubs(:dev_server_running?).returns(true)
   end
 
   teardown do

--- a/test/integration/admin/invalid_authenticity_token_test.rb
+++ b/test/integration/admin/invalid_authenticity_token_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The admin catch-all funnels every verb into base#index, so a stale token or a
+# mismatched Origin reaches the CSRF rescue. That rescue used to render a
+# template removed in the Vue 3 migration, which raised MissingTemplate.
+class Admin::InvalidAuthenticityTokenTest < ActionDispatch::IntegrationTest
+  setup do
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  test "a mismatched origin renders the admin shell instead of raising" do
+    post "/admin/dashboard", headers: {"HTTP_ORIGIN" => "https://admin.example.test/old"}
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/integration/docs_cross_origin_test.rb
+++ b/test/integration/docs_cross_origin_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The docs catch-all answers every verb and format. A 406 that kept the
+# requested JavaScript content type made Rails' same-origin verification raise
+# InvalidCrossOriginRequest, turning a refused embed into a reported error.
+class DocsCrossOriginTest < ActionDispatch::IntegrationTest
+  test "a cross-origin script request is refused as plain text" do
+    get "/docs/api.js", headers: {"HTTP_ORIGIN" => "https://embedder.test"}
+
+    assert_response :not_acceptable
+    assert_equal "text/plain", response.media_type
+  end
+end

--- a/test/integration/fleet_notification_settings_race_test.rb
+++ b/test/integration/fleet_notification_settings_race_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Lives outside test/integration/api/v1 on purpose: it asserts behaviour under a
+# concurrent insert rather than a documented response, so it must not contribute
+# to the generated OpenAPI schema.
+class FleetNotificationSettingsRaceTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @fleet = create(:fleet, admins: [@user])
+    sign_in @user
+  end
+
+  test "a settings row created by a concurrent request is reused" do
+    FleetNotificationSetting.create!(fleet: @fleet)
+    # Both requests miss the association and both try to insert; only one wins
+    # against the unique index on fleet_id.
+    Fleet.any_instance.stubs(:fleet_notification_setting).returns(nil)
+
+    get "/api/v1/fleets/#{@fleet.slug}/notifications/discord-status"
+
+    assert_response :success
+    assert_equal 1, FleetNotificationSetting.where(fleet: @fleet).count
+  end
+end

--- a/test/jobs/notifications/admin_job_test.rb
+++ b/test/jobs/notifications/admin_job_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 module Notifications
   class AdminJobTest < ActiveJob::TestCase
+    include ActionMailer::TestHelper
+
     setup do
       AdminNotificationsChannel.stubs(:broadcast_to)
     end
@@ -17,7 +19,7 @@ module Notifications
       AdminMailer.stubs(:weekly).with do |admin_user, _report|
         recipients << admin_user
         true
-      end.returns(stub(deliver_later: true))
+      end.returns(stub(deliver_now: true))
 
       ::Notifications::AdminJob.new.perform
 
@@ -31,7 +33,7 @@ module Notifications
       AdminMailer.stubs(:weekly).with do |_admin_user, report|
         captured = report
         true
-      end.returns(stub(deliver_later: true))
+      end.returns(stub(deliver_now: true))
 
       ::Notifications::AdminJob.new.perform
 
@@ -39,9 +41,22 @@ module Notifications
       assert_includes captured[:sections].first.metrics.map(&:key), :wishes
     end
 
+    # The report carries Struct values, so an ActiveJob hand-off raises
+    # SerializationError and no digest ever reaches an inbox.
+    test "#perform delivers the digest without an ActiveJob hand-off" do
+      create(:admin_user, :super_admin)
+      # The CSS inliner runs as a delivery interceptor and would fetch the
+      # stylesheet over HTTP, which no test can reach.
+      Premailer::Rails::Hook.stubs(:delivering_email)
+
+      assert_emails 1 do
+        ::Notifications::AdminJob.new.perform
+      end
+    end
+
     test "#perform records the report as an admin notification" do
       admin_user = create(:admin_user, resource_access: [:stats])
-      AdminMailer.stubs(:weekly).returns(stub(deliver_later: true))
+      AdminMailer.stubs(:weekly).returns(stub(deliver_now: true))
 
       ::Notifications::AdminJob.new.perform
 

--- a/test/models/compare_image_test.rb
+++ b/test/models/compare_image_test.rb
@@ -106,6 +106,21 @@ class CompareImageTest < ActiveSupport::TestCase
     assert_not record.image.attached?
   end
 
+  # The unsaved loser keeps its composite in memory, and an in-memory
+  # attachment has no signed_id, so callers raise on rails_blob_url.
+  test "hands back the persisted row when the insert loses the race" do
+    first = create_model_with_store_image("rsi-constellation-andromeda")
+    second = create_model_with_store_image("aegs-gladius")
+    slug_set = "#{CompareImage::STYLE_VERSION}-aegs-gladius-rsi-constellation-andromeda"
+    winner = CompareImage.create!(slug_set: slug_set)
+    CompareImage.stubs(:find_or_initialize_by).returns(CompareImage.new(slug_set: slug_set))
+
+    record = CompareImage.for([first, second])
+
+    assert_equal winner.id, record.id
+    assert record.persisted?
+  end
+
   private
 
   def create_model_with_slug(slug, legacy_slug: nil)


### PR DESCRIPTION
Triage of the open exception incidents in AppSignal (Fleetyards/production). Six of them turned out to be real code bugs; each commit is one fix plus a test that reproduces the production error.

## Fixes

| Incident | Error | Cause |
| --- | --- | --- |
| [#17054](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17054) | `ActionView::MissingTemplate` (1,519×) | The admin CSRF rescue rendered `errors/error`, a template removed in the Vue 3 migration (#2655), so every mismatched Origin became a 500 instead of a 422. |
| [#17364](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17364) | `InvalidCrossOriginRequest` (4,003×) | The docs catch-all answered `*.js` with an empty 406 that kept the JavaScript content type, which trips Rails' same-origin verification. |
| [#17852](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17852) | `ActiveJob::SerializationError` | `AdminWeeklyReport` returns Structs, which `deliver_later` cannot serialize — the weekly admin digest had not gone out since Aug 23. |
| [#17859](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17859) | `ActiveRecord::RecordNotUnique` | `discord_status` did read-then-create on a `has_one` behind a unique index, so concurrent polling from the settings page collided. |
| [#17675](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17675) | `Cannot get a signed_id for a new record` | `CompareImage#generate!` swallows the loser's `RecordNotUnique`, leaving an unsaved record holding an in-memory attachment that has no signed id. |
| [#17080](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/17080) | `Missing required param "slug"` (4,886×) | The ship breadcrumb on the images and videos pages spelled the key `param` instead of `params`, so vue-router resolved the `ship` route without its required slug. |

## Verification

Every new test was run against the unfixed code first and reproduces the exact production error (`Missing template errors/error`, `duplicate key value violates unique constraint "index_fleet_notification_settings_on_fleet_id"`, and so on). The existing `AdminJob` tests stubbed the mailer wholesale, which is why the serialization bug was invisible to them.

`bin/rails test` on the touched files and `pnpm lint:ts` are green.

## Note on the last commit

`refactor(breadcrumbs): type the crumbs computeds` annotates all 28 `crumbs` computeds. It does **not** prevent the `param`/`params` typo from recurring — I verified that `vue-tsc` still passes with the typo reintroduced. `RouteLocationRaw` is built as a mapped type over `RouteMapGeneric` (`Record<string, …>`), and the resulting index signature disables TypeScript's excess property checking. The annotation does catch wrong property types and wrong return types, and it surfaced one real inconsistency: `ships/[slug]/index.vue` returned `undefined` where its sibling pages return `[]` (kept as-is, since it deliberately hides the bar instead of flashing a lone home crumb).

Closing that gap properly needs vue-router typed routes (`TypesConfig` / `RouteNamedMap`), which is its own piece of work. Happy to drop this commit if the 28-file diff is more review noise than it is worth.

## Not fixed

Infrastructure rather than code (`ActiveStorage::FileNotFoundError`, `Aws::S3::Errors::Http504Error`, `RedisClient::ReadTimeoutError`), client-side WebGL failures, scanner noise, and the 16 `Gem::LoadError` incidents that all stop on Aug 12 and look like one bad deploy image. Several loud frontend incidents (#17508, #17800, #17493, #17799, together 800+ occurrences) stop on Aug 11 at 17:08 and appear to have been fixed by a deploy already.

🤖
