### PR TITLE
chore(deps): consolidate resolutions into pnpm.overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,21 +151,19 @@
     "workbox-build": "^7.4.1",
     "workbox-window": "^7.4.1"
   },
-  "resolutions": {
-    "form-data": ">=4.0.4",
-    "async": ">=3.2.2",
-    "follow-redirects": ">=1.14.8",
-    "json5": ">=2.2.2",
-    "node-fetch": ">=3.2.10",
-    "node-forge": ">=1.3.0",
-    "qs": ">=6.5.3",
-    "semver": ">=7.5.2"
-  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
     ],
     "overrides": {
+      "form-data": ">=4.0.4",
+      "async": ">=3.2.2",
+      "follow-redirects": ">=1.14.8",
+      "json5": ">=2.2.2",
+      "node-fetch": ">=3.2.10",
+      "node-forge": ">=1.3.0",
+      "qs": ">=6.5.3",
+      "semver": ">=7.5.2",
       "flatted": ">=3.4.2",
       "js-cookie": ">=3.0.7",
       "lodash": ">=4.18.1",


### PR DESCRIPTION
## Why

Every open Dependabot **npm** PR is failing `js-setup` (and the downstream `ruby-tests`) with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
Cannot proceed with the frozen installation. The current "overrides"
configuration doesn't match the value found in the lockfile
```

The bumps themselves are fine — #4503 changes exactly one line of `package.json`. The problem is that Dependabot regenerates `pnpm-lock.yaml` from scratch and drops **both** the `overrides:` block (all 14 entries) and `patchedDependencies:` (the `@tresjs/core@5.8.1` patch), while `package.json` still declares them.

The likely trigger is that the override set was split across two keys:

- `resolutions` — 8 entries (`form-data`, `async`, `follow-redirects`, `json5`, `node-fetch`, `node-forge`, `qs`, `semver`)
- `pnpm.overrides` — 6 entries (`flatted`, `js-cookie`, `lodash`, `picomatch`, `serialize-javascript`, `vite`)

pnpm honours both and records the union (14) in the lockfile, which is why `main` is internally consistent and green — but it also makes the config harder for the updater to round-trip.

## What

Folds the 8 `resolutions` entries into `pnpm.overrides` and removes the `resolutions` key, leaving a single canonical source. Entry order matches how pnpm already serialised them into the lockfile.

## Verification

- Regenerating the lockfile against the consolidated key (`pnpm install --lockfile-only`, pnpm 10.31.0 — same version as `js-setup-action`) produces a **byte-identical** `pnpm-lock.yaml`. `git diff pnpm-lock.yaml` is empty, so the resolved dependency tree is unchanged and this carries no runtime risk.
- `CI=1 pnpm install --frozen-lockfile` — CI's exact gate — passes, with `patchedDependencies` intact.

Only `package.json` changes.

## Follow-up

Once this is on `main`, the four blocked npm PRs (#4503, #4504, #4505, #4506) need `@dependabot recreate` to pick up clean lockfiles. Re-running their CI alone won't help — the lockfile on those branches is the problem.

Note that the single-canonical-key theory is the plausible cause rather than a confirmed one; whether Dependabot then round-trips the config correctly will only be provable from the recreated PRs.

🤖