### PR TITLE
refactor(sc_data): resolve the build through one object

### DIFF
--- a/app/controllers/api/v1/components_controller.rb
+++ b/app/controllers/api/v1/components_controller.rb
@@ -27,7 +27,7 @@ module Api
           .where(
             category: "weapons",
             component_sub_type: "Gun",
-            version: Rails.configuration.sc_data[:version]
+            version: ::ScData::Source.version
           )
           .where.not(type_data: nil)
           .where("sc_key IS NULL OR sc_key !~ ?", WEAPON_VARIANT_KEYS)

--- a/app/jobs/loaders/sc_data/all_job.rb
+++ b/app/jobs/loaders/sc_data/all_job.rb
@@ -4,7 +4,7 @@ module Loaders
   module ScData
     class AllJob < ::Loaders::BaseJob
       def perform(version = nil, admin_user_id = nil)
-        version ||= Rails.configuration.sc_data[:version]
+        version ||= ::ScData::Source.version
 
         import = Imports::ScData::AllImport.create(version:, admin_user_id:)
 

--- a/app/jobs/loaders/sc_data/models_job.rb
+++ b/app/jobs/loaders/sc_data/models_job.rb
@@ -4,7 +4,7 @@ module Loaders
   module ScData
     class ModelsJob < ::Loaders::BaseJob
       def perform
-        version = Rails.configuration.sc_data[:version]
+        version = ::ScData::Source.version
 
         import = Imports::ScData::ModelsImport.create(version:)
 

--- a/app/jobs/sc_data/check_job.rb
+++ b/app/jobs/sc_data/check_job.rb
@@ -15,7 +15,7 @@ module ScData
     MAX_IMPORTS_PER_VERSION = 2
 
     def perform
-      new_version = Rails.configuration.sc_data[:version]
+      new_version = ::ScData::Source.version
 
       return if new_version.blank?
       return if loaded?(new_version)

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -15,9 +15,11 @@ module ScData
       end
 
       def initialize(base_folder: DEFAULT_BASE_FOLDER)
+        source = ::ScData::Source.current
+
         self.base_folder = base_folder
-        self.sc_version = Rails.configuration.sc_data[:version]
-        self.sc_environment = Rails.configuration.sc_data[:environment]
+        self.sc_version = source.version
+        self.sc_environment = source.environment
       end
 
       # Read on every call rather than built in the constructor: callers set

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ScData
+  # Which build of the game data the application is reading: the version that
+  # marks a catalogue row as current, and the parsed tree a loader reads from.
+  #
+  # Both come from `config/app/sc_data.yml`, rewritten by `bin/scdata parse`.
+  # Asking here rather than reaching into `Rails.configuration` from a model or a
+  # job keeps that to one place -- which is what makes it possible to answer the
+  # question per request, or per job, once more than one build is available at a
+  # time.
+  #
+  # Deliberately not memoized. The value is a config read, and a process that
+  # reparses mid-run (`bin/scdata`) has to see the version it just wrote.
+  class Source
+    class << self
+      def current
+        config = Rails.configuration.sc_data
+
+        new(version: config[:version], environment: config[:environment])
+      end
+
+      delegate :version, :environment, to: :current
+    end
+
+    attr_reader :version, :environment
+
+    def initialize(version:, environment:)
+      @version = version
+      @environment = environment
+    end
+
+    def ==(other)
+      other.is_a?(self.class) && other.version == version && other.environment == environment
+    end
+    alias_method :eql?, :==
+
+    def hash
+      [version, environment].hash
+    end
+
+    def to_s
+      "#{version} (#{environment})"
+    end
+  end
+end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -27,6 +27,7 @@
 class Commodity < ApplicationRecord
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 60
 
@@ -51,18 +52,6 @@ class Commodity < ApplicationRecord
     medical_supply metal military_supply mineral natural nonmetals plasma_fuel
     processed_goods quantum_fuel rmc scrap vice waste
   ].freeze
-
-  # Commodities of past patches stay in the table -- a ledger entry made last
-  # patch still has to resolve its item -- so anything meant for a picker
-  # narrows to the version the game currently ships. Component and Equipment
-  # keep the same scope.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   DEFAULT_SORTING_PARAMS = ["name asc"]
   ALLOWED_SORTING_PARAMS = [

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -41,6 +41,7 @@ class Component < ApplicationRecord
   include ActiveStorageVariants
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 50
   max_paginates_per 240
@@ -87,16 +88,6 @@ class Component < ApplicationRecord
   serialize :heat_connection, coder: YAML
   serialize :ammunition, coder: YAML
   serialize :inventory_consumption, coder: YAML
-
-  # Components of past patches stay in the table, so anything meant for a
-  # picker has to narrow down to the version the game currently ships.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   DEFAULT_SORTING_PARAMS = ["name asc", "created_at asc"]
   ALLOWED_SORTING_PARAMS = [

--- a/app/models/concerns/inventory_ledger_entry.rb
+++ b/app/models/concerns/inventory_ledger_entry.rb
@@ -126,7 +126,7 @@ module InventoryLedgerEntry
     return true unless referenced_item?
     return true unless item.respond_to?(:version)
 
-    item.version == Rails.configuration.sc_data[:version]
+    item.version == ScData::Source.version
   end
 
   # What one piece costs a cargo grid, in SCU. Bulk cargo is already counted in

--- a/app/models/concerns/sc_data_versioned.rb
+++ b/app/models/concerns/sc_data_versioned.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# A catalogue whose rows carry the build they were last seen in.
+#
+# Rows of past patches stay in the table -- a ledger entry or a loadout made
+# against one still has to resolve -- so anything meant for a picker narrows to
+# the version the game currently ships. `ScData::Loader::BaseLoader#retire_absent`
+# is the other half: it clears the version off a row the export stopped naming.
+#
+# Note that this only supplies the scope. `ransackable_scopes` is left to each
+# model, because only Component exposes it through ransack -- the commodity and
+# equipment controllers take the parameter off the query and pass it to the scope
+# themselves.
+module ScDataVersioned
+  extend ActiveSupport::Concern
+
+  included do
+    # The flag arrives from a query parameter, so it is cast rather than
+    # trusted: what reaches here is the string "false", which is truthy.
+    scope :current_version, ->(flag = true) {
+      if ActiveModel::Type::Boolean.new.cast(flag)
+        where(version: ScData::Source.version)
+      else
+        all
+      end
+    }
+  end
+end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -46,6 +46,7 @@
 class Equipment < ApplicationRecord
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 50
 
@@ -115,17 +116,6 @@ class Equipment < ApplicationRecord
   def self.ransackable_associations(_auth_object = nil)
     ["manufacturer"]
   end
-
-  # Gear from past patches stays in the table -- a ledger entry made last patch
-  # still has to resolve its item -- so anything meant for a picker narrows to
-  # the version the game currently ships. Component keeps the same scope.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   def self.visible
     where(hidden: false)

--- a/app/tasks/maintenance/move_export_logos_to_icon_task.rb
+++ b/app/tasks/maintenance/move_export_logos_to_icon_task.rb
@@ -71,7 +71,7 @@ module Maintenance
     end
 
     private def sc_environment
-      Rails.configuration.sc_data[:environment]
+      ::ScData::Source.environment
     end
 
     # The task's log is its output in the UI, which is stdout for this engine.

--- a/bin/scdata
+++ b/bin/scdata
@@ -29,8 +29,7 @@ def boot_rails
 end
 
 def config_info
-  config = Rails.configuration.sc_data
-  "version: #{config[:version]} (#{config[:environment]})"
+  "version: #{ScData::Source.current}"
 end
 
 def latest_version(export_folder, sc_environment)
@@ -97,7 +96,7 @@ when "parse"
     [true, ""]
   }
 
-  sc_environment = args.shift || Rails.configuration.sc_data[:environment]
+  sc_environment = args.shift || ScData::Source.environment
   sc_version = latest_version(EXPORT_FOLDER, sc_environment)
 
   CliHelpers.run_step("Parsing SC Data #{sc_version} (#{sc_environment})") do

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ScData
+  class SourceTest < ActiveSupport::TestCase
+    # Mocha undoes this on teardown, so nothing here leaks into another test.
+    private def with_config(version:, environment:)
+      Rails.configuration.stubs(:sc_data).returns({version:, environment:})
+
+      yield
+    end
+
+    test ".current reads the build and environment out of the configuration" do
+      with_config(version: "4.9.0-live.1", environment: "live") do
+        source = ::ScData::Source.current
+
+        assert_equal "4.9.0-live.1", source.version
+        assert_equal "live", source.environment
+      end
+    end
+
+    test ".version and .environment delegate to the current source" do
+      with_config(version: "4.10.0-ptu.2", environment: "ptu") do
+        assert_equal "4.10.0-ptu.2", ::ScData::Source.version
+        assert_equal "ptu", ::ScData::Source.environment
+      end
+    end
+
+    # Not memoized on purpose: `bin/scdata parse` rewrites the config and then
+    # goes on to load in the same process, so a cached value would have it
+    # loading the build it replaced.
+    test ".current follows a configuration change rather than caching the first read" do
+      first = with_config(version: "4.9.0-live.1", environment: "live") { ::ScData::Source.version }
+      second = with_config(version: "4.10.0-ptu.2", environment: "ptu") { ::ScData::Source.version }
+
+      assert_equal "4.9.0-live.1", first
+      assert_equal "4.10.0-ptu.2", second
+    end
+
+    # Two sources are the same when they name the same build, so a caller can
+    # compare them without reaching for the strings inside.
+    test "sources naming the same build are equal and hash alike" do
+      one = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+      same = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+      other = ::ScData::Source.new(version: "4.9.0-live.1", environment: "ptu")
+
+      assert_equal one, same
+      assert_equal one.hash, same.hash
+      refute_equal one, other
+      assert_equal 1, [one, same].uniq.size
+    end
+
+    test "#to_s names the build and the environment it came from" do
+      source = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+
+      assert_equal "4.9.0-live.1 (live)", source.to_s
+    end
+  end
+end


### PR DESCRIPTION
Eleven places read `Rails.configuration.sc_data` to answer one of two questions: which version marks a catalogue row as current, and which parsed tree a loader reads from. `ScData::Source` answers both, and is now the only reader of that config.

```
$ grep -rn "Rails.configuration.sc_data" app bin lib
app/lib/sc_data/source.rb:18:        config = Rails.configuration.sc_data
```

## Why

Groundwork. The eventual goal is more than one build being readable at once — a PTU catalogue alongside live — which means the question "which build am I reading?" has to be answerable per request or per job rather than from a process-wide constant. That is only tractable if there is one place that answers it.

It also gets `Rails.configuration` reach-ins out of model scopes, which is worth something on its own.

## The scope came with it

`current_version` was duplicated **byte for byte** across `Component`, `Commodity` and `Equipment`. Three copies reading a resolver is no better than three copies reading the config, so it moves to `ScDataVersioned`.

`ransackable_scopes` deliberately **stays on `Component`**. It is the only model that exposes the scope through ransack — the commodity and equipment controllers take the parameter off the query and pass it to the scope themselves (`commodities_controller.rb:25`, `equipment_controller.rb:31`). Hoisting it would have widened those two models' query surface for no reason. The concern says so, in case the asymmetry reads as an oversight later.

## Deliberately not memoized

`bin/scdata parse` rewrites `config/app/sc_data.yml` and then loads in the same process. A cached version would have it loading the build it just replaced.

## A bug this turned up

Referenced as `::ScData::Source` from anything under `Loaders::ScData`, because a bare `ScData` there resolves to `Loaders::ScData` and the constant is not found.

`ModelsJob` failed outright. `AllJob` hid it behind `version ||= …`, which short-circuits whenever a version is passed — and the nightly `ScData::CheckJob` always passes one. The path that breaks is `Loaders::ScData::AllJob.perform_async` with no arguments, which is the manual reload used to fill a catalogue by hand. It would have raised `NoMethodError: undefined method 'fail!' for nil`, with the rescue masking the cause.

Found by the existing `all_job_test`, which already calls `perform` with no arguments — no new test needed for it.

## Verification

Full suite: **3117 tests, 7545 assertions, 0 failures, 0 errors.** `standardrb` clean.

New `test/lib/sc_data/source_test.rb` covers the config read, the delegation, the not-memoized behaviour, and value equality. The scope's existing coverage in `commodity_test.rb:84-90` and `equipment_test.rb` already pinned the behaviour that moved, so the extraction is protected by tests that predate it.

Net: **14 insertions, 43 deletions** across 10 files, plus two small new files.

🤖
