### PR TITLE
refactor(sc_data): route every loader write through one seam

### DIFF
--- a/app/controllers/api/v1/components_controller.rb
+++ b/app/controllers/api/v1/components_controller.rb
@@ -27,7 +27,7 @@ module Api
           .where(
             category: "weapons",
             component_sub_type: "Gun",
-            version: Rails.configuration.sc_data[:version]
+            version: ::ScData::Source.version
           )
           .where.not(type_data: nil)
           .where("sc_key IS NULL OR sc_key !~ ?", WEAPON_VARIANT_KEYS)

--- a/app/jobs/loaders/sc_data/all_job.rb
+++ b/app/jobs/loaders/sc_data/all_job.rb
@@ -4,7 +4,7 @@ module Loaders
   module ScData
     class AllJob < ::Loaders::BaseJob
       def perform(version = nil, admin_user_id = nil)
-        version ||= Rails.configuration.sc_data[:version]
+        version ||= ::ScData::Source.version
 
         import = Imports::ScData::AllImport.create(version:, admin_user_id:)
 

--- a/app/jobs/loaders/sc_data/all_job.rb
+++ b/app/jobs/loaders/sc_data/all_job.rb
@@ -10,7 +10,10 @@ module Loaders
 
         import.start!
 
-        ::ScData::Loader::BaseLoader.all
+        # Kept on the import so the admin view of a load says what it did.
+        # Otherwise the only record of a build that rewrote the catalogue, versus
+        # one that changed nothing, is a log line nobody goes looking for.
+        import.update!(output: ::ScData::Loader::BaseLoader.all)
 
         import.finish!
       rescue => e

--- a/app/jobs/loaders/sc_data/model_job.rb
+++ b/app/jobs/loaders/sc_data/model_job.rb
@@ -12,6 +12,8 @@ module Loaders
 
         loader.one(Model.find(model_id))
 
+        import.update!(output: {"ModelsLoader" => loader.stats})
+
         import.finish!
       rescue => e
         import.fail!

--- a/app/jobs/loaders/sc_data/models_job.rb
+++ b/app/jobs/loaders/sc_data/models_job.rb
@@ -14,6 +14,8 @@ module Loaders
 
         loader.all
 
+        import.update!(output: {"ModelsLoader" => loader.stats})
+
         import.finish!
       rescue => e
         import.fail!

--- a/app/jobs/loaders/sc_data/models_job.rb
+++ b/app/jobs/loaders/sc_data/models_job.rb
@@ -4,7 +4,7 @@ module Loaders
   module ScData
     class ModelsJob < ::Loaders::BaseJob
       def perform
-        version = Rails.configuration.sc_data[:version]
+        version = ::ScData::Source.version
 
         import = Imports::ScData::ModelsImport.create(version:)
 

--- a/app/jobs/sc_data/check_job.rb
+++ b/app/jobs/sc_data/check_job.rb
@@ -15,7 +15,7 @@ module ScData
     MAX_IMPORTS_PER_VERSION = 2
 
     def perform
-      new_version = Rails.configuration.sc_data[:version]
+      new_version = ::ScData::Source.version
 
       return if new_version.blank?
       return if loaded?(new_version)

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -15,9 +15,11 @@ module ScData
       end
 
       def initialize(base_folder: DEFAULT_BASE_FOLDER)
+        source = ::ScData::Source.current
+
         self.base_folder = base_folder
-        self.sc_version = Rails.configuration.sc_data[:version]
-        self.sc_environment = Rails.configuration.sc_data[:environment]
+        self.sc_version = source.version
+        self.sc_environment = source.environment
       end
 
       # Read on every call rather than built in the constructor: callers set

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -5,13 +5,27 @@ module ScData
 
       attr_accessor :sc_version, :sc_environment, :base_folder
 
+      # Listed inside the method rather than in a constant: every one of these
+      # subclasses BaseLoader, so resolving them while this class body is still
+      # being evaluated would be a circular load.
+      #
+      # Order matters -- items resolve their manufacturer, models resolve the
+      # components a loadout names, and modules hang off models.
       def self.all
-        ::ScData::Loader::ManufacturersLoader.new.all
-        ::ScData::Loader::ItemsLoader.new.all
-        ::ScData::Loader::ModelsLoader.new.all
-        ::ScData::Loader::ModelModulesLoader.new.all
-        ::ScData::Loader::CommoditiesLoader.new.all
-        ::ScData::Loader::EquipmentLoader.new.all
+        [
+          ::ScData::Loader::ManufacturersLoader,
+          ::ScData::Loader::ItemsLoader,
+          ::ScData::Loader::ModelsLoader,
+          ::ScData::Loader::ModelModulesLoader,
+          ::ScData::Loader::CommoditiesLoader,
+          ::ScData::Loader::EquipmentLoader
+        ].each do |loader_class|
+          loader = loader_class.new
+
+          loader.all
+
+          Rails.logger.info("[sc_data] #{loader_class.name.demodulize}: #{loader.stats_summary}")
+        end
       end
 
       def initialize(base_folder: DEFAULT_BASE_FOLDER)
@@ -27,6 +41,59 @@ module ScData
       # preview tree is the same loader pointed somewhere else.
       def export_path
         Pathname(base_folder).join("parsed", sc_environment.to_s)
+      end
+
+      # What this run actually did, per model class. `update!` on its own cannot
+      # tell a row it rewrote from a row it left alone, so a load that changed
+      # nothing and a load that rewrote the catalogue look identical in the logs
+      # -- which is exactly what you want to know when a build lands badly.
+      def stats
+        @stats ||= Hash.new { |all, name| all[name] = {created: 0, updated: 0, unchanged: 0} }
+      end
+
+      def stats_summary
+        return "nothing written" if stats.empty?
+
+        stats.sort.map { |name, counts|
+          "#{name} #{counts.map { |bucket, count| "#{bucket}=#{count}" }.join(" ")}"
+        }.join(", ")
+      end
+
+      # The one write path a load takes. Assigning before saving is what makes
+      # the three outcomes distinguishable; `update!` would collapse them.
+      def apply(record, params)
+        created = record.new_record?
+
+        record.assign_attributes(params)
+        changed = record.changed?
+
+        record.save!
+
+        count(record, outcome(created:, changed:))
+
+        record
+      end
+
+      # Validations and callbacks are skipped on purpose where this is used: it
+      # sweeps every Model on every load, and the in-game flag is not something
+      # a validation or a stored version has an opinion about.
+      def apply_columns(record, params)
+        record.update_columns(params)
+
+        count(record, :updated)
+
+        record
+      end
+
+      private def outcome(created:, changed:)
+        return :created if created
+        return :updated if changed
+
+        :unchanged
+      end
+
+      private def count(record, bucket)
+        stats[record.class.name][bucket] += 1
       end
 
       def load_item(path)
@@ -230,20 +297,20 @@ module ScData
 
               hardpoint_ids += update_loadout(parent, hardpoint_data, cleanup: false) if hardpoint_data["loadout"].present?
             else
-              hardpoint.update!(
+              apply(hardpoint, {
                 source: :game_files,
                 component: component,
                 min_size: component.size,
                 max_size: component.size
-              )
+              })
 
               hardpoint_ids << hardpoint.id
             end
           else
-            hardpoint.update!(
+            apply(hardpoint, {
               source: :game_files,
               component: nil
-            )
+            })
           end
 
           if item["loadout"].present? || item["default_loadout"].present?

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -5,9 +5,12 @@ module ScData
 
       attr_accessor :sc_version, :sc_environment, :base_folder
 
-      # Listed inside the method rather than in a constant: every one of these
-      # subclasses BaseLoader, so resolving them while this class body is still
-      # being evaluated would be a circular load.
+      # Returns what each loader did, so the job that ran it can keep the counts
+      # on its import rather than leaving them only in the log.
+      #
+      # The classes are listed inside the method rather than in a constant: every
+      # one of them subclasses BaseLoader, so resolving them while this class
+      # body is still being evaluated would be a circular load.
       #
       # Order matters -- items resolve their manufacturer, models resolve the
       # components a loadout names, and modules hang off models.
@@ -19,12 +22,14 @@ module ScData
           ::ScData::Loader::ModelModulesLoader,
           ::ScData::Loader::CommoditiesLoader,
           ::ScData::Loader::EquipmentLoader
-        ].each do |loader_class|
+        ].to_h do |loader_class|
           loader = loader_class.new
 
           loader.all
 
           Rails.logger.info("[sc_data] #{loader_class.name.demodulize}: #{loader.stats_summary}")
+
+          [loader_class.name.demodulize, loader.stats]
         end
       end
 

--- a/app/lib/sc_data/loader/commodities_loader.rb
+++ b/app/lib/sc_data/loader/commodities_loader.rb
@@ -14,7 +14,7 @@ module ScData
         commodity ||= Commodity.find_by(name: commodity_data["name"], sc_key: nil)
         commodity ||= Commodity.new(sc_key: commodity_data["sc_key"])
 
-        commodity.update!(update_params(commodity_data))
+        apply(commodity, update_params(commodity_data))
 
         # Filled in only while empty, the same way the manufacturer logo is:
         # `store_image` is curated -- an admin uploads it -- so following the

--- a/app/lib/sc_data/loader/equipment_loader.rb
+++ b/app/lib/sc_data/loader/equipment_loader.rb
@@ -13,7 +13,7 @@ module ScData
         equipment = Equipment.find_by(sc_key: equipment_data["key"])
         equipment ||= Equipment.new(sc_key: equipment_data["key"])
 
-        equipment.update!(update_params(equipment_data))
+        apply(equipment, update_params(equipment_data))
 
         equipment
       end

--- a/app/lib/sc_data/loader/items_loader.rb
+++ b/app/lib/sc_data/loader/items_loader.rb
@@ -70,7 +70,7 @@ module ScData
           # builds now, so this is what records the build it was last seen in.
           update_params[:version] = sc_version
 
-          component.update!(update_params)
+          apply(component, update_params)
 
           if item["icon"].present?
             attach_icon(component, :icon, item["icon"])
@@ -139,8 +139,10 @@ module ScData
 
           next if loadout_name_blacklisted?(loadout["name"], default_loadout)
 
-          hardpoint = component.hardpoints.find_or_create_by!(sc_name: loadout["name"].downcase)
-          hardpoint_ids << hardpoint.id
+          # Initialized rather than created, so a new hardpoint is one insert
+          # with its attributes rather than an insert followed by an update. The
+          # id is collected after the save for that reason.
+          hardpoint = component.hardpoints.find_or_initialize_by(sc_name: loadout["name"].downcase)
 
           update_params = {
             source: :game_files,
@@ -157,7 +159,9 @@ module ScData
             )
           end
 
-          hardpoint.update!(update_params)
+          apply(hardpoint, update_params)
+
+          hardpoint_ids << hardpoint.id
         end
 
         component.hardpoints.where.not(id: hardpoint_ids).destroy_all
@@ -193,7 +197,7 @@ module ScData
 
         component = find_component(normalized_key, key, ref, name)
 
-        component = Component.create!(sc_key: normalized_key, sc_ref: ref, version: sc_version) if component.blank?
+        component = apply(Component.new, {sc_key: normalized_key, sc_ref: ref, version: sc_version}) if component.blank?
 
         component
       end

--- a/app/lib/sc_data/loader/manufacturers_loader.rb
+++ b/app/lib/sc_data/loader/manufacturers_loader.rb
@@ -54,7 +54,7 @@ module ScData
               update_params[:code] = manufacturer_data["code"]
             end
 
-            manufacturer.update!(update_params)
+            apply(manufacturer, update_params)
 
             # Onto `icon`, never onto `logo`: the logo is curated -- an admin
             # uploads it, and RSI's own artwork lands there -- and writing the
@@ -71,13 +71,13 @@ module ScData
 
             manufacturer
           elsif name.present?
-            created = Manufacturer.create!(
+            created = apply(Manufacturer.new, {
               sc_ref: manufacturer_data["ref"],
               name:,
               code: manufacturer_data["code"],
               description: manufacturer_data["description"],
               icon_path: manufacturer_data["icon"]
-            )
+            })
 
             attach_icon(created, :icon, manufacturer_data["icon"])
 

--- a/app/lib/sc_data/loader/model_modules_loader.rb
+++ b/app/lib/sc_data/loader/model_modules_loader.rb
@@ -25,7 +25,7 @@ module ScData
         update_params = update_metrics(module_data, update_params)
         update_params = update_cargo_holds(model_module.hardpoints.game_files, update_params)
 
-        model_module.update!(update_params.merge(update_reason: :sc_loader))
+        apply(model_module, update_params.merge(update_reason: :sc_loader))
       end
 
       private def load_module_data(sc_key)

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -45,7 +45,7 @@ module ScData
         update_params = update_speeds(hardpoints, update_params)
         update_params = update_ground_speeds(model_data, update_params)
 
-        model.update!(update_params.merge(update_reason: :sc_data_loader))
+        apply(model, update_params.merge(update_reason: :sc_data_loader))
       end
 
       private def update_in_game_flags
@@ -61,9 +61,9 @@ module ScData
         )
 
         if file_exists && !model.in_game?
-          model.update_columns(in_game: true, production_status: "flight-ready")
+          apply_columns(model, {in_game: true, production_status: "flight-ready"})
         elsif !file_exists && model.in_game?
-          model.update_columns(in_game: false)
+          apply_columns(model, {in_game: false})
         end
       end
 

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ScData
+  # Which build of the game data the application is reading: the version that
+  # marks a catalogue row as current, and the parsed tree a loader reads from.
+  #
+  # Both come from `config/app/sc_data.yml`, rewritten by `bin/scdata parse`.
+  # Asking here rather than reaching into `Rails.configuration` from a model or a
+  # job keeps that to one place -- which is what makes it possible to answer the
+  # question per request, or per job, once more than one build is available at a
+  # time.
+  #
+  # Deliberately not memoized. The value is a config read, and a process that
+  # reparses mid-run (`bin/scdata`) has to see the version it just wrote.
+  class Source
+    class << self
+      def current
+        config = Rails.configuration.sc_data
+
+        new(version: config[:version], environment: config[:environment])
+      end
+
+      delegate :version, :environment, to: :current
+    end
+
+    attr_reader :version, :environment
+
+    def initialize(version:, environment:)
+      @version = version
+      @environment = environment
+    end
+
+    def ==(other)
+      other.is_a?(self.class) && other.version == version && other.environment == environment
+    end
+    alias_method :eql?, :==
+
+    def hash
+      [version, environment].hash
+    end
+
+    def to_s
+      "#{version} (#{environment})"
+    end
+  end
+end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -27,6 +27,7 @@
 class Commodity < ApplicationRecord
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 60
 
@@ -51,18 +52,6 @@ class Commodity < ApplicationRecord
     medical_supply metal military_supply mineral natural nonmetals plasma_fuel
     processed_goods quantum_fuel rmc scrap vice waste
   ].freeze
-
-  # Commodities of past patches stay in the table -- a ledger entry made last
-  # patch still has to resolve its item -- so anything meant for a picker
-  # narrows to the version the game currently ships. Component and Equipment
-  # keep the same scope.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   DEFAULT_SORTING_PARAMS = ["name asc"]
   ALLOWED_SORTING_PARAMS = [

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -41,6 +41,7 @@ class Component < ApplicationRecord
   include ActiveStorageVariants
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 50
   max_paginates_per 240
@@ -87,16 +88,6 @@ class Component < ApplicationRecord
   serialize :heat_connection, coder: YAML
   serialize :ammunition, coder: YAML
   serialize :inventory_consumption, coder: YAML
-
-  # Components of past patches stay in the table, so anything meant for a
-  # picker has to narrow down to the version the game currently ships.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   DEFAULT_SORTING_PARAMS = ["name asc", "created_at asc"]
   ALLOWED_SORTING_PARAMS = [

--- a/app/models/concerns/inventory_ledger_entry.rb
+++ b/app/models/concerns/inventory_ledger_entry.rb
@@ -126,7 +126,7 @@ module InventoryLedgerEntry
     return true unless referenced_item?
     return true unless item.respond_to?(:version)
 
-    item.version == Rails.configuration.sc_data[:version]
+    item.version == ScData::Source.version
   end
 
   # What one piece costs a cargo grid, in SCU. Bulk cargo is already counted in

--- a/app/models/concerns/sc_data_versioned.rb
+++ b/app/models/concerns/sc_data_versioned.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# A catalogue whose rows carry the build they were last seen in.
+#
+# Rows of past patches stay in the table -- a ledger entry or a loadout made
+# against one still has to resolve -- so anything meant for a picker narrows to
+# the version the game currently ships. `ScData::Loader::BaseLoader#retire_absent`
+# is the other half: it clears the version off a row the export stopped naming.
+#
+# Note that this only supplies the scope. `ransackable_scopes` is left to each
+# model, because only Component exposes it through ransack -- the commodity and
+# equipment controllers take the parameter off the query and pass it to the scope
+# themselves.
+module ScDataVersioned
+  extend ActiveSupport::Concern
+
+  included do
+    # The flag arrives from a query parameter, so it is cast rather than
+    # trusted: what reaches here is the string "false", which is truthy.
+    scope :current_version, ->(flag = true) {
+      if ActiveModel::Type::Boolean.new.cast(flag)
+        where(version: ScData::Source.version)
+      else
+        all
+      end
+    }
+  end
+end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -46,6 +46,7 @@
 class Equipment < ApplicationRecord
   include AttachmentRansackers
   include ItemPriceConcern
+  include ScDataVersioned
 
   paginates_per 50
 
@@ -115,17 +116,6 @@ class Equipment < ApplicationRecord
   def self.ransackable_associations(_auth_object = nil)
     ["manufacturer"]
   end
-
-  # Gear from past patches stays in the table -- a ledger entry made last patch
-  # still has to resolve its item -- so anything meant for a picker narrows to
-  # the version the game currently ships. Component keeps the same scope.
-  scope :current_version, ->(flag = true) {
-    if ActiveModel::Type::Boolean.new.cast(flag)
-      where(version: Rails.configuration.sc_data[:version])
-    else
-      all
-    end
-  }
 
   def self.visible
     where(hidden: false)

--- a/app/tasks/maintenance/move_export_logos_to_icon_task.rb
+++ b/app/tasks/maintenance/move_export_logos_to_icon_task.rb
@@ -71,7 +71,7 @@ module Maintenance
     end
 
     private def sc_environment
-      Rails.configuration.sc_data[:environment]
+      ::ScData::Source.environment
     end
 
     # The task's log is its output in the UI, which is stdout for this engine.

--- a/bin/scdata
+++ b/bin/scdata
@@ -29,8 +29,7 @@ def boot_rails
 end
 
 def config_info
-  config = Rails.configuration.sc_data
-  "version: #{config[:version]} (#{config[:environment]})"
+  "version: #{ScData::Source.current}"
 end
 
 def latest_version(export_folder, sc_environment)
@@ -97,7 +96,7 @@ when "parse"
     [true, ""]
   }
 
-  sc_environment = args.shift || Rails.configuration.sc_data[:environment]
+  sc_environment = args.shift || ScData::Source.environment
   sc_version = latest_version(EXPORT_FOLDER, sc_environment)
 
   CliHelpers.run_step("Parsing SC Data #{sc_version} (#{sc_environment})") do

--- a/test/jobs/loaders/sc_data/all_job_test.rb
+++ b/test/jobs/loaders/sc_data/all_job_test.rb
@@ -19,6 +19,23 @@ module Loaders
         assert_equal "finished", import.aasm_state
       end
 
+      # The counts are the record of what a load did. A log line is not enough:
+      # the admin view of an import is where somebody looks after a build lands
+      # badly, and "changed nothing" has to be distinguishable there from
+      # "rewrote the catalogue".
+      test "#perform keeps what each loader did on the import" do
+        ::ScData::Loader::BaseLoader.expects(:all).returns({
+          "EquipmentLoader" => {"Equipment" => {created: 2, updated: 1, unchanged: 4818}}
+        })
+
+        ::Loaders::ScData::AllJob.new.perform
+
+        output = Imports::ScData::AllImport.last.output
+
+        assert_equal({"created" => 2, "updated" => 1, "unchanged" => 4818},
+          output.dig("EquipmentLoader", "Equipment"))
+      end
+
       test "#perform marks import as failed on error" do
         ::ScData::Loader::BaseLoader.stubs(:all).raises(StandardError, "sc data error")
 

--- a/test/jobs/loaders/sc_data/model_job_test.rb
+++ b/test/jobs/loaders/sc_data/model_job_test.rb
@@ -8,6 +8,7 @@ module Loaders
       test "#perform creates an import, runs the loader, and finishes the import" do
         model = create(:model)
         loader = mock("ScData::Loader::ModelsLoader")
+        loader.stubs(:stats).returns({})
         loader.expects(:one).with(model)
         ::ScData::Loader::ModelsLoader.stubs(:new).returns(loader)
 
@@ -21,6 +22,7 @@ module Loaders
       test "#perform marks import as failed on error" do
         model = create(:model)
         loader = mock("ScData::Loader::ModelsLoader")
+        loader.stubs(:stats).returns({})
         loader.stubs(:one).raises(StandardError, "sc data error")
         ::ScData::Loader::ModelsLoader.stubs(:new).returns(loader)
 

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ScData
+  class SourceTest < ActiveSupport::TestCase
+    # Mocha undoes this on teardown, so nothing here leaks into another test.
+    private def with_config(version:, environment:)
+      Rails.configuration.stubs(:sc_data).returns({version:, environment:})
+
+      yield
+    end
+
+    test ".current reads the build and environment out of the configuration" do
+      with_config(version: "4.9.0-live.1", environment: "live") do
+        source = ::ScData::Source.current
+
+        assert_equal "4.9.0-live.1", source.version
+        assert_equal "live", source.environment
+      end
+    end
+
+    test ".version and .environment delegate to the current source" do
+      with_config(version: "4.10.0-ptu.2", environment: "ptu") do
+        assert_equal "4.10.0-ptu.2", ::ScData::Source.version
+        assert_equal "ptu", ::ScData::Source.environment
+      end
+    end
+
+    # Not memoized on purpose: `bin/scdata parse` rewrites the config and then
+    # goes on to load in the same process, so a cached value would have it
+    # loading the build it replaced.
+    test ".current follows a configuration change rather than caching the first read" do
+      first = with_config(version: "4.9.0-live.1", environment: "live") { ::ScData::Source.version }
+      second = with_config(version: "4.10.0-ptu.2", environment: "ptu") { ::ScData::Source.version }
+
+      assert_equal "4.9.0-live.1", first
+      assert_equal "4.10.0-ptu.2", second
+    end
+
+    # Two sources are the same when they name the same build, so a caller can
+    # compare them without reaching for the strings inside.
+    test "sources naming the same build are equal and hash alike" do
+      one = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+      same = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+      other = ::ScData::Source.new(version: "4.9.0-live.1", environment: "ptu")
+
+      assert_equal one, same
+      assert_equal one.hash, same.hash
+      refute_equal one, other
+      assert_equal 1, [one, same].uniq.size
+    end
+
+    test "#to_s names the build and the environment it came from" do
+      source = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+
+      assert_equal "4.9.0-live.1 (live)", source.to_s
+    end
+  end
+end

--- a/test/loaders/sc_data/base_loader_apply_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The write seam every loader goes through. Its value is telling the three
+# outcomes apart -- `update!` reports a row it rewrote and a row it left alone
+# identically, which is what made a badly landed build indistinguishable from a
+# no-op in the logs.
+module ScData
+  module Loader
+    class BaseLoaderApplyTest < ActiveSupport::TestCase
+      setup do
+        @loader = ::ScData::Loader::BaseLoader.new
+      end
+
+      test "#apply saves a new record and counts it as created" do
+        commodity = @loader.apply(Commodity.new, {name: "Agricium", sc_key: "agricium"})
+
+        assert_predicate commodity, :persisted?
+        assert_equal "Agricium", commodity.name
+        assert_equal({created: 1, updated: 0, unchanged: 0}, @loader.stats["Commodity"])
+      end
+
+      test "#apply counts a record whose attributes moved as updated" do
+        commodity = create(:commodity, name: "Old")
+
+        @loader.apply(commodity, {name: "New"})
+
+        assert_equal "New", commodity.reload.name
+        assert_equal({created: 0, updated: 1, unchanged: 0}, @loader.stats["Commodity"])
+      end
+
+      # The distinction the seam exists for: assigning the values a row already
+      # holds is not a write, and a run of those should not read as one.
+      test "#apply counts a record assigned its own values as unchanged" do
+        commodity = create(:commodity, name: "Same")
+
+        @loader.apply(commodity, {name: "Same"})
+
+        assert_equal({created: 0, updated: 0, unchanged: 1}, @loader.stats["Commodity"])
+      end
+
+      test "#apply returns the record so a caller can keep using it" do
+        commodity = create(:commodity)
+
+        assert_equal commodity, @loader.apply(commodity, {name: "Whatever"})
+      end
+
+      test "#apply raises rather than saving an invalid record" do
+        assert_raises(ActiveRecord::RecordInvalid) { @loader.apply(Commodity.new, {name: nil}) }
+      end
+
+      # Counted separately from `apply` because it deliberately skips
+      # validations and callbacks, so `changed?` is never consulted.
+      test "#apply_columns writes the columns and counts an update" do
+        model = create(:model, in_game: false)
+
+        @loader.apply_columns(model, {in_game: true})
+
+        assert_predicate model.reload, :in_game?
+        assert_equal({created: 0, updated: 1, unchanged: 0}, @loader.stats["Model"])
+      end
+
+      test "counts are kept per model class" do
+        @loader.apply(Commodity.new, {name: "Agricium", sc_key: "agricium"})
+        @loader.apply(Commodity.new, {name: "Aluminium", sc_key: "aluminium"})
+        @loader.apply_columns(create(:model), {in_game: true})
+
+        assert_equal 2, @loader.stats["Commodity"][:created]
+        assert_equal 1, @loader.stats["Model"][:updated]
+      end
+
+      test "#stats_summary says so plainly when a run wrote nothing" do
+        assert_equal "nothing written", @loader.stats_summary
+      end
+
+      test "#stats_summary names each class and its counts" do
+        @loader.apply(Commodity.new, {name: "Agricium", sc_key: "agricium"})
+
+        assert_equal "Commodity created=1 updated=0 unchanged=0", @loader.stats_summary
+      end
+    end
+  end
+end

--- a/test/support/import_wrapping_job_tests.rb
+++ b/test/support/import_wrapping_job_tests.rb
@@ -35,6 +35,9 @@ module ImportWrappingJobTests
   def assert_import_wrapping_job_success(job_class:, import_class:, loader_class:, loader_method:, perform_args: [], loader_args: [], before_perform: nil)
     loader = mock("loader")
     loader_class.stubs(:new).returns(loader)
+    # Loaders that keep counts have them read off afterwards and stored on the
+    # import; the ones that do not never ask.
+    loader.stubs(:stats).returns({})
     if loader_args.empty?
       loader.expects(loader_method)
     else
@@ -53,6 +56,7 @@ module ImportWrappingJobTests
   def assert_import_wrapping_job_failure(job_class:, import_class:, loader_class:, loader_method:, perform_args: [], before_perform: nil)
     loader = mock("loader")
     loader_class.stubs(:new).returns(loader)
+    loader.stubs(:stats).returns({})
     loader.stubs(loader_method).raises(StandardError, "loader error")
 
     instance_exec(&before_perform) if before_perform


### PR DESCRIPTION
> **Stacked on #4512** — base is `refactor/sc-data-source`, not `main`. Review that one first; this diff is only the loader writes.

All fourteen writes a load makes had their own `update!`, `create!` or `update_columns` call. They now go through `BaseLoader#apply`.

```
$ grep -rn "\.update!\|\.update_columns\|find_or_create_by!\|\.create!" app/lib/sc_data/loader/
app/lib/sc_data/loader/base_loader.rb:67:        record.update_columns(params)
```

The only raw write left is the one inside `apply_columns`.

## Why, concretely

`apply` assigns before saving, which is what lets it tell three outcomes apart — created, updated, **unchanged**. `update!` cannot: it reports a row it rewrote and a row it left alone identically. So today a load that changed nothing and a load that rewrote the whole catalogue look the same, which is precisely the question you want answered when a build lands badly or a re-parse quietly retires records.

`BaseLoader.all` now logs a summary per loader:

```
[sc_data] ItemsLoader: Component created=12 updated=340 unchanged=7460, Hardpoint created=0 updated=88 unchanged=51203
```

Beyond the diagnostics, this is the choke point a later change needs: writing a build's facts somewhere other than straight onto the row.

## `apply_columns`

Separate on purpose, for the two `update_columns` sites in `models_loader`. Those skip validations and callbacks deliberately — they sweep every `Model` on every load, and the in-game flag is not something a validation or a stored version has an opinion about. Keeping them out of `apply` avoids implying `changed?` was consulted.

## One behaviour change, not a pure refactor

The items loader did `find_or_create_by!` and then `update!` on the same hardpoint — an INSERT followed immediately by an UPDATE, for every hardpoint on every component. It now uses `find_or_initialize_by` and applies once, so a new hardpoint is a single insert carrying its attributes, and the id is collected after the save because that is where it now exists.

The consequence worth naming: a hardpoint whose attributes fail validation is no longer left behind as a bare row. That seems strictly better, but it is a change, not a no-op.

## A circular load, avoided

The six loader classes are listed **inside** `self.all` rather than in a constant. Each subclasses `BaseLoader`, so resolving them while its class body is still being evaluated is a circular autoload — it would have failed at boot rather than in a test.

## Verification

- `test/loaders/sc_data/` + `test/jobs/loaders/sc_data/`: **111 tests, 271 assertions, 0 failures.** These are contract tests over the real export, so they exercise every converted site with live data.
- New `base_loader_apply_test.rb`: 9 tests covering created / updated / unchanged, per-class counts, the invalid-record path, and both summary forms.
- `standardrb` clean.

🤖
