### PR TITLE
chore(deps): drop overrides that no longer affect resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,20 +156,10 @@
       "esbuild"
     ],
     "overrides": {
-      "form-data": ">=4.0.4",
-      "async": ">=3.2.2",
-      "follow-redirects": ">=1.14.8",
       "json5": ">=2.2.2",
-      "node-fetch": ">=3.2.10",
-      "node-forge": ">=1.3.0",
-      "qs": ">=6.5.3",
       "semver": ">=7.5.2",
-      "flatted": ">=3.4.2",
-      "js-cookie": ">=3.0.7",
-      "lodash": ">=4.18.1",
       "picomatch": ">=4.0.4",
-      "serialize-javascript": ">=7.0.5",
-      "vite": ">=7.3.2"
+      "serialize-javascript": ">=7.0.5"
     },
     "patchedDependencies": {
       "@tresjs/core@5.8.1": "patches/@tresjs__core@5.8.1.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,20 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  form-data: '>=4.0.4'
-  async: '>=3.2.2'
-  follow-redirects: '>=1.14.8'
   json5: '>=2.2.2'
-  node-fetch: '>=3.2.10'
-  node-forge: '>=1.3.0'
-  qs: '>=6.5.3'
   semver: '>=7.5.2'
-  flatted: '>=3.4.2'
-  js-cookie: '>=3.0.7'
-  lodash: '>=4.18.1'
   picomatch: '>=4.0.4'
   serialize-javascript: '>=7.0.5'
-  vite: '>=7.3.2'
 
 patchedDependencies:
   '@tresjs/core@5.8.1':
@@ -144,7 +134,7 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       qs:
-        specifier: '>=6.5.3'
+        specifier: ^6.15.3
         version: 6.15.3
       sortablejs:
         specifier: ^1.15.7
@@ -361,7 +351,7 @@ importers:
         specifier: ^32.1.0
         version: 32.1.0(vue@3.5.41(typescript@6.0.3))
       vite:
-        specifier: '>=7.3.2'
+        specifier: 8.2.2
         version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.2)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: 1.3.0
@@ -2254,7 +2244,7 @@ packages:
   '@tailwindcss/vite@4.3.3':
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
-      vite: '>=7.3.2'
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tanstack/eslint-plugin-query@5.101.4':
     resolution: {integrity: sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==}
@@ -2651,7 +2641,7 @@ packages:
     resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: '>=7.3.2'
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
   '@vitest/expect@4.1.11':
@@ -2661,7 +2651,7 @@ packages:
     resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=7.3.2'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -5724,7 +5714,7 @@ packages:
       rolldown: '*'
       rollup: '*'
       unloader: '*'
-      vite: '>=7.3.2'
+      vite: '*'
       webpack: '*'
     peerDependenciesMeta:
       '@farmfe/core':
@@ -5784,7 +5774,7 @@ packages:
   vite-plugin-environment@1.1.3:
     resolution: {integrity: sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==}
     peerDependencies:
-      vite: '>=7.3.2'
+      vite: '>= 2.7'
 
   vite-plugin-full-reload@1.2.0:
     resolution: {integrity: sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==}
@@ -5797,7 +5787,7 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@vite-pwa/assets-generator': ^1.0.0
-      vite: '>=7.3.2'
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       workbox-build: ^7.4.1
       workbox-window: ^7.4.1
     peerDependenciesMeta:
@@ -5807,12 +5797,12 @@ packages:
   vite-plugin-rails@0.6.0:
     resolution: {integrity: sha512-4Ze5Up+RD0QwF03WauEYtAaJU1SKWDHnojsDbyEQk4GZfp0alRuPWipOphFEla69VKrhw2adz5xmfRzr5wHb+A==}
     peerDependencies:
-      vite: '>=7.3.2'
+      vite: '>=5.0.0'
 
   vite-plugin-ruby@5.1.3:
     resolution: {integrity: sha512-vpTOKbR6AmnupmXvQccRcr/jIY+oobNuCbNJHUzkT8oQ2BBQSlp22Xec3zszBBc7GjwDGn2+E+IQoNRXdEY7Ig==}
     peerDependencies:
-      vite: '>=7.3.2'
+      vite: '>=5.0.0'
 
   vite-plugin-stimulus-hmr@3.0.0:
     resolution: {integrity: sha512-KElOiZOlaG4XilQQHrzK8M1u5UfK4EFfADJKQYbnmsUMifDOnPR6anVYgHAN95QyWJ67Q/rYWe5BB9M5OxocfQ==}
@@ -5876,7 +5866,7 @@ packages:
       '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=7.3.2'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -5953,7 +5943,7 @@ packages:
       '@pinia/colada': '>=0.21.2'
       '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
       pinia: ^3.0.4 || ^4.0.2
-      vite: '>=7.3.2'
+      vite: ^7.3.0 || ^8.0.0
       vue: ^3.5.34 || ^4.0.0
     peerDependenciesMeta:
       '@pinia/colada':


### PR DESCRIPTION
> #4511 has merged, so this now targets `main` directly and is no longer stacked. It was rebased onto the squashed commit (`fdf673655`) to clear the resulting conflict — a single commit, `+13/-33` in 2 files.

## Why

Follow-up to #4511. With the override set consolidated into a single key it became easy to audit, and most of it turned out to be inert.

## Method

Removed all 14 overrides, regenerated the lockfile, and compared resolved versions against the baseline. That separates "resolves above the floor anyway" from "the floor is what's holding it there".

| Override | Resolves to | Without it | Verdict |
|---|---|---|---|
| `node-fetch` `>=3.2.10` | — | — | **dead** — not in the graph |
| `node-forge` `>=1.3.0` | — | — | **dead** — not in the graph |
| `form-data` `>=4.0.4` | 4.0.6 | 4.0.6 | no-op |
| `async` `>=3.2.2` | 3.2.6 | 3.2.6 | no-op |
| `follow-redirects` `>=1.14.8` | 1.16.0 | 1.16.0 | no-op |
| `qs` `>=6.5.3` | 6.15.3 | 6.15.3 | no-op |
| `flatted` `>=3.4.2` | 3.4.4 | 3.4.4 | no-op |
| `js-cookie` `>=3.0.7` | 3.0.8 | 3.0.8 | no-op |
| `lodash` `>=4.18.1` | 4.18.1 | 4.18.1 | no-op |
| `vite` `>=7.3.2` | 8.2.2 | 8.2.2 | no-op |
| `json5` `>=2.2.2` | 2.2.3 | +1.0.2 | kept |
| `semver` `>=7.5.2` | 7.7.4, 7.8.5 | +6.3.1 | kept |
| `picomatch` `>=4.0.4` | 4.0.4, 4.0.5 | +2.3.2 | kept |
| `serialize-javascript` `>=7.0.5` | 7.1.0 | +6.0.2 | **kept — security** |

## What

Drops the ten no-ops. Keeps the four that still change the tree.

`serialize-javascript` is the one with a live security reason: without the floor a 6.0.2 copy enters the tree, and 6.0.2 is vulnerable under `<= 7.0.2` (patched 7.0.3) and `>= 5.0.0, < 7.0.5` (patched 7.0.5).

`json5`, `semver` and `picomatch` are kept on the conservative side. Their fallbacks (1.0.2, 6.3.1, 2.3.2) are each *the patched release* of their own major, so those three are a dedupe/bundle-size concern rather than a vulnerability. Happy to drop them too if you'd rather have the smaller config — say so and I'll amend.

## Verification

- Resolved tree is **identical**: 1957 packages before and after, same version set (`diff` of all `packages:` keys is empty).
- Lockfile diff is only the ten removed declarations plus `specifier:` fields reverting to each package's own declared range. No resolved `version:` changes.
- `CI=1 pnpm install --frozen-lockfile` passes; `patchedDependencies` intact.

## Trade-off worth naming

A version floor is also a ratchet. These ten are no-ops *today*, but they'd catch a future transitive downgrade below the vulnerable threshold. Removing them trades that passive insurance for a config that reflects reality — reasonable given Dependabot alerts cover the same ground, but it is a trade rather than a pure win, so it's your call.

Separately: none of these overrides relate to the 7 open Dependabot alerts on `main` (`css_parser`, `fast-uri`, `postcss` ×2, `@babel/core`). That's untouched by both PRs.

🤖
