### PR TITLE
fix(cargo-holds): keep a curated offset on the hold it was set on

### DIFF
--- a/app/models/concerns/derived_cargo_holds.rb
+++ b/app/models/concerns/derived_cargo_holds.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# A parent whose `cargo_holds` YAML column -- written by the sc_data loader out
+# of the game files -- is projected into CargoHold rows so a hold can be queried,
+# and so it can carry placement an admin set by hand.
+#
+# The geometry is rewritten on every load. The placement columns
+# (`offset_x/y/z`, `rotation`) are never written here at all, which is what keeps
+# a curated offset on the hold it was set on.
+module DerivedCargoHolds
+  extend ActiveSupport::Concern
+
+  def cargo_holds_with_offsets
+    db_records = cargo_holds_db.where.not(offset_x: nil)
+      .or(cargo_holds_db.where.not(offset_y: nil))
+      .or(cargo_holds_db.where.not(offset_z: nil))
+      .or(cargo_holds_db.where.not(rotation: nil))
+      .index_by(&:position)
+
+    return cargo_holds if db_records.empty?
+
+    cargo_holds.each_with_index.map do |hold_data, index|
+      db_record = db_records[index]
+
+      next hold_data if db_record.blank?
+
+      extra = {
+        "offset" => {
+          "x" => db_record.offset_x&.to_f || 0.0,
+          "y" => db_record.offset_y&.to_f || 0.0,
+          "z" => db_record.offset_z&.to_f || 0.0
+        }
+      }
+      extra["rotation"] = db_record.rotation if db_record.rotation.present?
+
+      hold_data.merge(extra)
+    end
+  end
+
+  # Holds are matched to their existing row and updated in place. They used to be
+  # destroyed and rebuilt, with the placement columns copied back onto whatever
+  # row landed at the same array index -- so adding, dropping or reordering a
+  # hold in the game files moved a curated offset onto a different hold, quietly.
+  def update_cargo_holds_db
+    holds = (cargo_holds || []).reject { |hold| hold.blank? || hold["dimensions"].blank? }
+    keys = cargo_hold_keys(holds.map { |hold| hold["name"] })
+
+    existing = cargo_holds_db.order(:position).to_a
+    by_key = cargo_hold_keys(existing.map(&:name)).zip(existing).to_h
+
+    kept = holds.each_with_index.map do |hold_data, index|
+      record = by_key[keys[index]] || cargo_holds_db.new
+
+      record.assign_attributes(derived_cargo_hold_attributes(hold_data).merge(position: index))
+      record.save!
+
+      record.calculate_container_capacities!
+
+      record.id
+    end
+
+    # `where.not(id: [])` is `1=1`, which is wanted here: a parent the export
+    # stopped giving holds should be left with none.
+    cargo_holds_db.where.not(id: kept).destroy_all
+  end
+
+  # Matched on the name the hardpoint carries, not on `position` -- position is
+  # only the index in the array the loader wrote, and it moves with the build.
+  #
+  # Names are not quite unique in practice (a couple of models repeat one, and a
+  # few holds carry none at all), so the ordinal among holds sharing a name is
+  # part of the key. An unnamed hold falls back to its ordinal among the unnamed,
+  # which is no worse than what it had before.
+  private def cargo_hold_keys(names)
+    seen = Hash.new(0)
+
+    names.map do |raw_name|
+      name = raw_name.presence
+      key = [name, seen[name]]
+
+      seen[name] += 1
+
+      key
+    end
+  end
+
+  private def derived_cargo_hold_attributes(hold_data)
+    {
+      name: hold_data["name"],
+      dimension_x: hold_data["dimensions"]["x"],
+      dimension_y: hold_data["dimensions"]["y"],
+      dimension_z: hold_data["dimensions"]["z"],
+      capacity_scu: hold_data["capacity"],
+      max_container_size_scu: hold_data.dig("max_container_size", "size"),
+      max_container_dimension_x: hold_data.dig("max_container_size", "dimensions", "x"),
+      max_container_dimension_y: hold_data.dig("max_container_size", "dimensions", "y"),
+      max_container_dimension_z: hold_data.dig("max_container_size", "dimensions", "z"),
+      min_container_size_scu: hold_data.dig("limits", "min", "capacity"),
+      min_container_dimension_x: hold_data.dig("limits", "min", "dimensions", "x"),
+      min_container_dimension_y: hold_data.dig("limits", "min", "dimensions", "y"),
+      min_container_dimension_z: hold_data.dig("limits", "min", "dimensions", "z")
+    }
+  end
+end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -130,6 +130,7 @@
 class Model < ApplicationRecord
   include ActionView::Helpers::NumberHelper
   include RoutingConcern
+  include DerivedCargoHolds
   include ActiveStorageVariants
   include AttachmentRansackers
 
@@ -416,77 +417,6 @@ class Model < ApplicationRecord
     end
 
     update_cargo_holds_db
-  end
-
-  def cargo_holds_with_offsets
-    db_records = cargo_holds_db.where.not(offset_x: nil)
-      .or(cargo_holds_db.where.not(offset_y: nil))
-      .or(cargo_holds_db.where.not(offset_z: nil))
-      .or(cargo_holds_db.where.not(rotation: nil))
-      .index_by(&:position)
-
-    return cargo_holds if db_records.empty?
-
-    cargo_holds.each_with_index.map do |hold_data, index|
-      db_record = db_records[index]
-      if db_record
-        extra = {
-          "offset" => {
-            "x" => db_record.offset_x&.to_f || 0.0,
-            "y" => db_record.offset_y&.to_f || 0.0,
-            "z" => db_record.offset_z&.to_f || 0.0
-          }
-        }
-        extra["rotation"] = db_record.rotation if db_record.rotation.present?
-        hold_data.merge(extra)
-      else
-        hold_data
-      end
-    end
-  end
-
-  def update_cargo_holds_db
-    # Preserve manually-set offsets before recreating
-    existing_offsets = cargo_holds_db.where.not(offset_x: nil).or(
-      cargo_holds_db.where.not(offset_y: nil)
-    ).or(
-      cargo_holds_db.where.not(offset_z: nil)
-    ).or(
-      cargo_holds_db.where.not(rotation: nil)
-    ).index_by(&:position)
-
-    cargo_holds_db.destroy_all
-
-    cargo_holds.each_with_index do |hold_data, index|
-      next if hold_data.blank? || hold_data["dimensions"].blank?
-
-      # Restore offsets from previous record if they existed (match by position)
-      previous = existing_offsets[index]
-
-      cargo_hold = cargo_holds_db.create!(
-        name: hold_data["name"],
-        dimension_x: hold_data["dimensions"]["x"],
-        dimension_y: hold_data["dimensions"]["y"],
-        dimension_z: hold_data["dimensions"]["z"],
-        capacity_scu: hold_data["capacity"],
-        max_container_size_scu: hold_data.dig("max_container_size", "size"),
-        max_container_dimension_x: hold_data.dig("max_container_size", "dimensions", "x"),
-        max_container_dimension_y: hold_data.dig("max_container_size", "dimensions", "y"),
-        max_container_dimension_z: hold_data.dig("max_container_size", "dimensions", "z"),
-        min_container_size_scu: hold_data.dig("limits", "min", "capacity"),
-        min_container_dimension_x: hold_data.dig("limits", "min", "dimensions", "x"),
-        min_container_dimension_y: hold_data.dig("limits", "min", "dimensions", "y"),
-        min_container_dimension_z: hold_data.dig("limits", "min", "dimensions", "z"),
-        position: index,
-        offset_x: previous&.offset_x,
-        offset_y: previous&.offset_y,
-        offset_z: previous&.offset_z,
-        rotation: previous&.rotation
-      )
-
-      # Calculate container capacities
-      cargo_hold.calculate_container_capacities!
-    end
   end
 
   def set_quantum_fuel_from_hardpoints

--- a/app/models/model_module.rb
+++ b/app/models/model_module.rb
@@ -22,6 +22,7 @@
 #
 class ModelModule < ApplicationRecord
   include ActiveStorageVariants
+  include DerivedCargoHolds
 
   paginates_per 30
 
@@ -107,74 +108,6 @@ class ModelModule < ApplicationRecord
     end
 
     update_cargo_holds_db
-  end
-
-  def cargo_holds_with_offsets
-    db_records = cargo_holds_db.where.not(offset_x: nil)
-      .or(cargo_holds_db.where.not(offset_y: nil))
-      .or(cargo_holds_db.where.not(offset_z: nil))
-      .or(cargo_holds_db.where.not(rotation: nil))
-      .index_by(&:position)
-
-    return cargo_holds if db_records.empty?
-
-    cargo_holds.each_with_index.map do |hold_data, index|
-      db_record = db_records[index]
-      if db_record
-        extra = {
-          "offset" => {
-            "x" => db_record.offset_x&.to_f || 0.0,
-            "y" => db_record.offset_y&.to_f || 0.0,
-            "z" => db_record.offset_z&.to_f || 0.0
-          }
-        }
-        extra["rotation"] = db_record.rotation if db_record.rotation.present?
-        hold_data.merge(extra)
-      else
-        hold_data
-      end
-    end
-  end
-
-  def update_cargo_holds_db
-    existing_offsets = cargo_holds_db.where.not(offset_x: nil).or(
-      cargo_holds_db.where.not(offset_y: nil)
-    ).or(
-      cargo_holds_db.where.not(offset_z: nil)
-    ).or(
-      cargo_holds_db.where.not(rotation: nil)
-    ).index_by(&:position)
-
-    cargo_holds_db.destroy_all
-
-    cargo_holds.each_with_index do |hold_data, index|
-      next if hold_data.blank? || hold_data["dimensions"].blank?
-
-      previous = existing_offsets[index]
-
-      cargo_hold = cargo_holds_db.create!(
-        name: hold_data["name"],
-        dimension_x: hold_data["dimensions"]["x"],
-        dimension_y: hold_data["dimensions"]["y"],
-        dimension_z: hold_data["dimensions"]["z"],
-        capacity_scu: hold_data["capacity"],
-        max_container_size_scu: hold_data.dig("max_container_size", "size"),
-        max_container_dimension_x: hold_data.dig("max_container_size", "dimensions", "x"),
-        max_container_dimension_y: hold_data.dig("max_container_size", "dimensions", "y"),
-        max_container_dimension_z: hold_data.dig("max_container_size", "dimensions", "z"),
-        min_container_size_scu: hold_data.dig("limits", "min", "capacity"),
-        min_container_dimension_x: hold_data.dig("limits", "min", "dimensions", "x"),
-        min_container_dimension_y: hold_data.dig("limits", "min", "dimensions", "y"),
-        min_container_dimension_z: hold_data.dig("limits", "min", "dimensions", "z"),
-        position: index,
-        offset_x: previous&.offset_x,
-        offset_y: previous&.offset_y,
-        offset_z: previous&.offset_z,
-        rotation: previous&.rotation
-      )
-
-      cargo_hold.calculate_container_capacities!
-    end
   end
 
   private def touch_models

--- a/test/models/concerns/derived_cargo_holds_test.rb
+++ b/test/models/concerns/derived_cargo_holds_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DerivedCargoHoldsTest < ActiveSupport::TestCase
+  private def hold(name, capacity: 32, size: 2.5)
+    {
+      "name" => name,
+      "capacity" => capacity,
+      "dimensions" => {"x" => size, "y" => size, "z" => size},
+      "max_container_size" => {"size" => 2, "dimensions" => {"x" => 2.5, "y" => 1.25, "z" => 1.25}}
+    }
+  end
+
+  private def build_holds(model, holds)
+    model.update!(cargo_holds: holds, cargo: 0)
+    model.update_cargo_holds_db
+    model.cargo_holds_db.reload.order(:position)
+  end
+
+  setup do
+    @model = create(:model, cargo: 0)
+  end
+
+  test "projects each hold in the column into a row, in order" do
+    rows = build_holds(@model, [hold("hold_a"), hold("hold_b")])
+
+    assert_equal %w[hold_a hold_b], rows.map(&:name)
+    assert_equal [0, 1], rows.map(&:position)
+    assert_equal [32, 32], rows.map { |row| row.capacity_scu.to_i }
+  end
+
+  test "skips an entry with no dimensions rather than failing on it" do
+    rows = build_holds(@model, [hold("hold_a"), {"name" => "broken", "capacity" => 1}])
+
+    assert_equal %w[hold_a], rows.map(&:name)
+  end
+
+  # The bug this concern exists for. A build that inserts a hold ahead of a
+  # curated one used to shift every offset onto its neighbour, because the rows
+  # were destroyed and the offsets copied back by array index.
+  test "keeps a curated offset on its own hold when a hold is inserted ahead of it" do
+    build_holds(@model, [hold("hold_a"), hold("hold_b")])
+    @model.cargo_holds_db.find_by(name: "hold_b").update!(offset_x: 5, offset_y: 6, offset_z: 7, rotation: 90)
+
+    rows = build_holds(@model, [hold("hold_new"), hold("hold_a"), hold("hold_b")])
+
+    placed = rows.find { |row| row.name == "hold_b" }
+    assert_equal [5, 6, 7], [placed.offset_x.to_i, placed.offset_y.to_i, placed.offset_z.to_i]
+    assert_equal 90, placed.rotation
+    assert_equal 2, placed.position, "position still tracks the new order"
+
+    assert_nil rows.find { |row| row.name == "hold_new" }.offset_x
+    assert_nil rows.find { |row| row.name == "hold_a" }.offset_x
+  end
+
+  test "keeps a curated offset when the holds are reordered" do
+    build_holds(@model, [hold("hold_a"), hold("hold_b")])
+    @model.cargo_holds_db.find_by(name: "hold_a").update!(offset_x: 3)
+
+    rows = build_holds(@model, [hold("hold_b"), hold("hold_a")])
+
+    assert_equal 3, rows.find { |row| row.name == "hold_a" }.offset_x.to_i
+    assert_nil rows.find { |row| row.name == "hold_b" }.offset_x
+  end
+
+  # Updated in place rather than rebuilt, so anything hanging off the row -- and
+  # the row a curated offset was set on -- survives a reload.
+  test "reuses the existing row instead of replacing it" do
+    original_id = build_holds(@model, [hold("hold_a")]).first.id
+
+    rows = build_holds(@model, [hold("hold_a", capacity: 64)])
+
+    assert_equal original_id, rows.first.id
+    assert_equal 64, rows.first.capacity_scu.to_i
+  end
+
+  test "drops a hold the column stopped carrying" do
+    build_holds(@model, [hold("hold_a"), hold("hold_b")])
+
+    rows = build_holds(@model, [hold("hold_a")])
+
+    assert_equal %w[hold_a], rows.map(&:name)
+  end
+
+  test "leaves no holds behind when the column empties" do
+    build_holds(@model, [hold("hold_a")])
+
+    assert_empty build_holds(@model, [])
+  end
+
+  # Names are not unique in the export, so the ordinal among holds sharing one
+  # is part of the key. Two same-named holds must not collapse into one row.
+  test "keeps holds that share a name apart" do
+    rows = build_holds(@model, [hold("bay"), hold("bay", capacity: 64)])
+
+    assert_equal 2, rows.size
+    assert_equal [32, 64], rows.map { |row| row.capacity_scu.to_i }
+  end
+
+  test "keeps holds with no name at all apart" do
+    rows = build_holds(@model, [hold(nil), hold(nil, capacity: 64)])
+
+    assert_equal 2, rows.size
+    assert_equal [32, 64], rows.map { |row| row.capacity_scu.to_i }
+  end
+
+  test "recalculates container capacities for a hold it updated" do
+    build_holds(@model, [hold("hold_a", size: 2.5)])
+
+    rows = build_holds(@model, [hold("hold_a", size: 5.0)])
+
+    assert_predicate rows.first.cargo_hold_container_capacities.count, :positive?
+  end
+
+  # ModelModule carries the same column and used to carry its own copy of this.
+  test "works the same for a model module" do
+    model_module = create(:model_module)
+
+    model_module.update!(cargo_holds: [hold("module_bay")], cargo: 0)
+    model_module.update_cargo_holds_db
+
+    assert_equal %w[module_bay], model_module.cargo_holds_db.reload.map(&:name)
+  end
+end


### PR DESCRIPTION
A curated cargo-hold offset could silently move to a different hold. This fixes that, and de-duplicates the code it lived in.

## The bug

`update_cargo_holds_db` destroyed every `CargoHold` row and rebuilt it from the `cargo_holds` column, copying the placement columns (`offset_x/y/z`, `rotation`) back onto **whatever row landed at the same array index**:

```ruby
existing_offsets = cargo_holds_db.where.not(offset_x: nil)…index_by(&:position)

cargo_holds_db.destroy_all

cargo_holds.each_with_index do |hold_data, index|
  previous = existing_offsets[index]      # ← matched by array index
```

`position` is only the index in the array the sc_data loader wrote. So any build that inserted, dropped or reordered a hold shifted every offset after it onto a neighbouring hold — no error, no log line, just a hand-placed offset now describing the wrong hold.

It was duplicated verbatim in `model.rb` and `model_module.rb`, both with the same flaw.

## The fix

Holds are matched to their existing row and **updated in place**. `destroy_all` is gone, and the placement columns are never assigned here at all — which is what keeps an offset on the hold it was set on. Rows whose hold disappeared are destroyed; an emptied column leaves none.

Both copies move to a `DerivedCargoHolds` concern.

## Why the key is what it is

Matched on the hardpoint `name`, not `position`. `name` comes from the game files and survives a reordering; `position` does not.

Names are *not* quite unique, which I checked against real data rather than assuming — of **99 models carrying holds, 4 have a hold with no name and 2 repeat a name**. So the key is `[name, ordinal-among-holds-sharing-that-name]`. An unnamed hold falls back to its ordinal among the unnamed, which is no worse than the behaviour it has today.

## Two side effects, both good

- **Container capacities stop churning.** They used to be destroyed with their parent every load. `calculate_container_capacities!` already upserts per container size, so a hold that keeps its row keeps them.
- **Rows keep their identity across loads**, which is what a later change re-parenting holds onto a build will need.

## What this deliberately does not do

The placement columns stay on `cargo_holds` rather than moving to a table of their own. Offsets are edited directly on the record through `admin/api/v1/cargo_holds_controller.rb`, so splitting them would change that API surface for no gain here. The curated/derived split is still worth doing when holds re-parent onto a build; nothing here blocks it.

## Verification

**11 tests, 23 assertions, 0 failures**, covering the insert-ahead and reorder cases, row reuse, deletion, an emptied column, same-named holds, unnamed holds, and the `ModelModule` path.

They were checked by mutation, not just by passing — reverting `cargo_hold_keys` to position-based matching fails exactly the two bug tests:

```
FAIL keeps_a_curated_offset_when_the_holds_are_reordered
FAIL keeps_a_curated_offset_on_its_own_hold_when_a_hold_is_inserted_ahead_of_it
```

Full suite: 3150 tests, 0 failures. Two errors remain in `users_resend_confirmation_test.rb`; I verified those fail identically with this branch fully reverted, so they are a local worktree gap (no dev server for the mailer's asset fetch), not this change. `standardrb` clean.

🤖
