### PR TITLE
chore(deps): move pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,18 +152,6 @@
     "workbox-window": "^7.4.1"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "json5": ">=2.2.2",
-      "semver": ">=7.5.2",
-      "picomatch": ">=4.0.4",
-      "serialize-javascript": ">=7.0.5"
-    },
-    "patchedDependencies": {
-      "@tresjs/core@5.8.1": "patches/@tresjs__core@5.8.1.patch"
-    },
     "peerDependencyRules": {
       "allowedVersions": {
         "vite-plugin-pwa>vite": "8"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+onlyBuiltDependencies:
+  - esbuild
+overrides:
+  json5: '>=2.2.2'
+  semver: '>=7.5.2'
+  picomatch: '>=4.0.4'
+  serialize-javascript: '>=7.0.5'
+patchedDependencies:
+  '@tresjs/core@5.8.1': patches/@tresjs__core@5.8.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '.'
 onlyBuiltDependencies:
   - esbuild
 overrides:


### PR DESCRIPTION
## Why

Every Dependabot npm PR fails `js-setup` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. #4511 and #4515 did **not** fix this — I consolidated the override keys on the theory that the `resolutions` / `pnpm.overrides` split confused Dependabot's updater, and an `@dependabot recreate` on #4503–#4506 afterwards still produced lockfiles with no `overrides:` block. That theory is dead; those two PRs stand only as config cleanups.

The measurement that actually points somewhere: the recreated lockfiles carry **2551 packages against main's 2539**. The twelve extra are duplicate older copies of `json5`, `semver`, `picomatch` and `serialize-javascript` — precisely what resolving *without* those overrides produces (verified separately by deleting them locally and counting).

So Dependabot isn't stripping the overrides from its output. **It never applied them during resolution.** It resolved as though they weren't declared.

Also worth noting explicitly: a `@dependabot rebase` can never fix this. It replays Dependabot's original lockfile commit — the broken artifact — leaving main's corrected `package.json` against a stale lockfile.

## What

Both settings lived under the `pnpm` key in `package.json`. pnpm's canonical location for them is `pnpm-workspace.yaml`, which this repo didn't have. This moves `overrides`, `patchedDependencies` and `onlyBuiltDependencies` there.

`peerDependencyRules` stays in `package.json` — it doesn't appear in the lockfile and can't cause the mismatch, so there's no reason to touch it.

## Verification

With pnpm 10.31.0, the exact version `js-setup-action` installs:

- Regenerating the lockfile after the move produces a **byte-identical `pnpm-lock.yaml`** (`git diff pnpm-lock.yaml` empty)
- `overrides:` and `patchedDependencies:` blocks both retained; **2539 packages**, matching main
- `CI=1 pnpm install --frozen-lockfile` passes

So this is a no-op for our own tooling — the resolved dependency tree is unchanged.

## Second commit: scoping the workspace

The first version of this PR broke `ruby-tests`, `api-schema-check` and both e2e shards with:

```
ERR_PNPM_OUTDATED_LOCKFILE ... not up to date with
<ROOT>/vendor/bundle/ruby/4.0.0/gems/actiontext-8.1.3.1/package.json
* 4 dependencies were added: rollup, rollup-plugin-terser, trix, @rails/activestorage
```

Adding `pnpm-workspace.yaml` makes pnpm treat the repo as a workspace and glob for member packages. It picks up the `package.json` that the **actiontext gem ships** inside `vendor/bundle` and tries to reconcile its JS dependencies against our lockfile.

`js-setup` passed the whole time because it never installs gems, so `vendor/bundle` does not exist in that job — which is also why this did not reproduce locally until the vendored gem was simulated. Note an empty `package.json` is *not* enough to reproduce it; the fixture needs real dependencies before pnpm reports a specifier mismatch.

`packages: ['.']` scopes the workspace to the root package. Verified with the vendored gem present: frozen install passes, lockfile identical to main, one importer, 2539 packages.

**Anyone adding a `pnpm-workspace.yaml` to a Rails repo that vendors gems needs this scoping.**

## What is NOT proven

I have no direct evidence of which pnpm version Dependabot runs, or that it reads `pnpm-workspace.yaml`. Having already been wrong once on this exact problem, I'm not claiming this is the fix.

What's different is that the mechanism is now *measured* (the 12-package delta) rather than inferred from how the config looks, and there's a clean kill criterion: merge this, run `@dependabot recreate` on **#4503 only**, and check whether its lockfile keeps the `overrides:` block:

```
gh api "repos/fleetyards/fleetyards/contents/pnpm-lock.yaml?ref=<branch>" \
  --jq .content | base64 -d | grep -c '^overrides:'
```

If that returns 0 again, this angle is also wrong and the next step is inspecting Dependabot's own job logs for the pnpm invocation rather than guessing from repo config.

Deliberately not relaxing `--frozen-lockfile` for Dependabot branches. pnpm works fine with Dependabot in other repos, so the fault is repo-specific and weakening the gate would hide it rather than fix it.

🤖

