### PR TITLE
fix(deps): pin the pnpm version for Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fleetyards",
   "private": true,
   "version": "7.2.0",
+  "packageManager": "pnpm@10.31.0",
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Why

#4518 moved `overrides` / `patchedDependencies` into `pnpm-workspace.yaml`, and that half worked: the recreated #4503 lockfile **applied** the overrides — 2539 packages, matching main, down from the broken 2551.

But `js-setup` still failed, with the error now on `patchedDependencies` rather than `overrides`:

```yaml
# main — written by pnpm 10.31.0
patchedDependencies:
  '@tresjs/core@5.8.1':
    hash: 51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2
    path: patches/@tresjs__core@5.8.1.patch

# Dependabot's lockfile
patchedDependencies:
  '@tresjs/core@5.8.1': 51b209e656692a4745230325ad9388969f6657b9a9f8dba55dc7d6bebbe0b8d2
```

Identical hash, **older serialization format**. Dependabot runs an earlier pnpm 10.x than the 10.31.0 that `js-setup-action` installs, and the two write this block differently — so a frozen install rejects the lockfile the other produced.

That also retro-explains the original symptom. Early pnpm 10 already ignores the `pnpm` key in `package.json` for these settings, which is why relocating them to `pnpm-workspace.yaml` fixed the overrides half. The root cause was never the config layout — it was two different pnpm versions, and the layout change only papered over the part of it that `overrides` touched.

## What

Adds `"packageManager": "pnpm@10.31.0"`. Dependabot and corepack both honour it, so both ends resolve the same pnpm and generate the same lockfile format.

One line. The lockfile is unchanged.

## Verification

With pnpm 10.31.0:

- Regenerating produces a **byte-identical `pnpm-lock.yaml`**
- `CI=1 pnpm install --frozen-lockfile` passes
- Passes **with a simulated `vendor/bundle` gem `package.json` present** — the case that broke `ruby-tests`, `api-schema-check` and both e2e shards on the first cut of #4518, and which a bare local check cannot reproduce

## Honest status

This is the fourth PR on this problem and the first three each looked right and weren't:

| | | |
|---|---|---|
| #4511 | consolidate `resolutions` into `pnpm.overrides` | inert — wrong theory |
| #4515 | prune 10 dead overrides | real cleanup, not a fix |
| #4518 | move settings to `pnpm-workspace.yaml` | fixed the overrides half only |
| this | pin the pnpm version | addresses the actual cause |

The difference here is that the evidence is a direct version-fingerprint — two known serialization formats of the same hash — rather than an inference about how Dependabot reads config. But the proof is still the same recreate test: merge this, `@dependabot recreate` on **#4503 only**, and `js-setup` either passes or it doesn't.

If it fails again, I'd stop patching config and read Dependabot's job logs for its actual pnpm invocation, which is where I should have gone two PRs ago.

🤖