### PR TITLE
refactor(sc_data): separate resolving a loadout from writing it

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -240,94 +240,154 @@ module ScData
         end.flatten
       end
 
+      # One hardpoint the loadout says should exist: resolved, but unwritten.
+      # This is the handover between working out what a loadout means and making
+      # rows match it -- two jobs that used to be one recursive method that wrote
+      # as it walked, which is why the rules could not be exercised without a
+      # database and why the destructive cleanup sat in the middle of them.
+      Slot = Struct.new(:name, :component, :children, :retain_only)
+
       private def update_loadout(parent, loadout, cleanup: true)
-        hardpoint_ids = []
+        # The module-key derivation below only applies to a ship. A module's own
+        # loadout, and every nested level, resolves without it.
+        slots = resolve_loadout(loadout, model: (parent if parent.is_a?(Model)))
 
-        (loadout["loadout"] || loadout["default_loadout"]).each do |item|
-          default_loadout = loadout["default_loadout"]&.find { |dl| dl["name"] == item["name"] }
+        persist_loadout(parent, slots, cleanup:)
+      end
 
-          next if loadout_name_blacklisted?(item["name"], default_loadout)
+      # Nothing past here writes: the only database access is what it takes to
+      # turn a key or a ref into a component.
+      private def resolve_loadout(loadout, model: nil)
+        entries = loadout["loadout"] || loadout["default_loadout"]
 
-          hardpoint = parent.hardpoints.find_or_initialize_by(sc_name: item["name"].downcase)
+        entries.flat_map { |item| resolve_item(loadout, item, model:) }
+      end
 
-          if item["key"].blank? && default_loadout.present?
-            item["key"] = default_loadout["key"]
-            item["ref"] = default_loadout["ref"]
-            item["default_loadout"] = default_loadout["default_loadout"] if default_loadout["default_loadout"].present?
-          end
+      private def resolve_item(loadout, item, model:)
+        default_loadout = loadout["default_loadout"]&.find { |dl| dl["name"] == item["name"] }
 
-          if item["key"].blank? && item["ref"].blank? && parent.is_a?(Model) && item["name"]&.end_with?("_module")
-            derived_key = "#{parent.sc_data_identifier}_module"
-            item["key"] = derived_key if Component.exists?(sc_key: derived_key)
-          end
+        return [] if loadout_name_blacklisted?(item["name"], default_loadout)
 
-          # Resolved by key alone: a component is one row now, and `version`
-          # says which build it was last seen in rather than which row to use.
-          component = if item["key"].present?
-            Component.find_by(sc_key: item["key"]&.downcase)
-          elsif item["ref"].present?
-            Component.find_by(sc_ref: item["ref"])
-          end
+        item = adopt_default_loadout(item, default_loadout)
+        item = derive_module_key(item, model)
 
-          if component.present?
-            if component.hidden?
-              # Build flattened hardpoints from the component's sub-hardpoints.
-              # Use model loadout data to fill in component references that
-              # the items loader couldn't resolve (e.g. Door → CargoGrid).
-              nested_loadout = item["loadout"] || item["default_loadout"]
-              hardpoint_data = {
-                "loadout" => component.hardpoints.filter_map do |hp|
-                               sub_component = hp.component
+        component = resolve_component(item)
 
-                               if sub_component.blank? && nested_loadout.present?
-                                 nested = nested_loadout.find { |nl| nl["name"]&.downcase == hp.sc_name }
-                                 if nested.present?
-                                   sub_component = if nested["key"].present?
-                                     Component.find_by(sc_key: nested["key"]&.downcase)
-                                   elsif nested["ref"].present?
-                                     Component.find_by(sc_ref: nested["ref"])
-                                   end
-                                 end
-                               end
+        return flatten_hidden(item, component) if component&.hidden?
 
-                               next if sub_component.blank?
-                               next if loadout_name_blacklisted?(sub_component.sc_key)
+        [Slot.new(name: item["name"].downcase, component:, children: nested_slots(item))]
+      end
 
-                               {
-                                 "name" => "#{item["name"]}-#{hp.sc_name}",
-                                 "key" => sub_component.sc_key
-                               }
-                             end
-              }
+      # A hidden component is a container the game files ship as an item -- a
+      # door that holds a cargo grid. It gets no hardpoint of its own; its
+      # sub-hardpoints are promoted onto this level under a compound name.
+      private def flatten_hidden(item, component)
+        nested_loadout = item["loadout"] || item["default_loadout"]
 
-              hardpoint_ids += update_loadout(parent, hardpoint_data, cleanup: false) if hardpoint_data["loadout"].present?
-            else
-              apply(hardpoint, {
-                source: :game_files,
-                component: component,
-                min_size: component.size,
-                max_size: component.size
-              })
+        promoted = component.hardpoints.filter_map do |sub_hardpoint|
+          sub_component = sub_hardpoint.component ||
+            nested_component(nested_loadout, sub_hardpoint)
 
-              hardpoint_ids << hardpoint.id
-            end
-          else
-            apply(hardpoint, {
-              source: :game_files,
-              component: nil
-            })
-          end
+          next if sub_component.blank?
+          next if loadout_name_blacklisted?(sub_component.sc_key)
 
-          if item["loadout"].present? || item["default_loadout"].present?
-            update_loadout(hardpoint, item) if hardpoint.persisted?
-          end
-
-          hardpoint_ids << hardpoint.id if hardpoint.persisted?
+          Slot.new(
+            name: "#{item["name"]}-#{sub_hardpoint.sc_name}".downcase,
+            component: sub_component,
+            children: []
+          )
         end
+
+        # Carried over deliberately: the hardpoint under the hidden component's
+        # own name used to be looked up before the code knew the component was
+        # hidden, and the id that collected protected the row from cleanup. So a
+        # row left from a build where the component was not hidden survives,
+        # still naming the component the flattening was meant to replace.
+        promoted + [Slot.new(name: item["name"].downcase, retain_only: true, children: [])]
+      end
+
+      # The items loader cannot always resolve a hidden component's own
+      # sub-hardpoints, so the loadout being walked is consulted to fill the gap.
+      private def nested_component(nested_loadout, sub_hardpoint)
+        return if nested_loadout.blank?
+
+        nested = nested_loadout.find { |entry| entry["name"]&.downcase == sub_hardpoint.sc_name }
+
+        return if nested.blank?
+
+        resolve_component(nested)
+      end
+
+      # Resolved by key alone when a key is present: a component is one row now,
+      # and `version` says which build it was last seen in rather than which row
+      # to use. A key that fails to resolve does not fall through to the ref.
+      private def resolve_component(item)
+        if item["key"].present?
+          Component.find_by(sc_key: item["key"]&.downcase)
+        elsif item["ref"].present?
+          Component.find_by(sc_ref: item["ref"])
+        end
+      end
+
+      # Matched on the raw name, case-sensitively, while the row is keyed on the
+      # downcased one -- so a default whose capitalisation differs is not
+      # applied. Merged rather than assigned into: the parsed hash belongs to
+      # the caller, and a nested level reads the adopted default off the copy.
+      private def adopt_default_loadout(item, default_loadout)
+        return item if item["key"].present? || default_loadout.blank?
+
+        adopted = item.merge("key" => default_loadout["key"], "ref" => default_loadout["ref"])
+
+        return adopted if default_loadout["default_loadout"].blank?
+
+        adopted.merge("default_loadout" => default_loadout["default_loadout"])
+      end
+
+      # A module hardpoint the export names but does not key, whose component is
+      # named after the ship carrying it.
+      private def derive_module_key(item, model)
+        return item if model.blank?
+        return item if item["key"].present? || item["ref"].present?
+        return item unless item["name"]&.end_with?("_module")
+
+        derived_key = "#{model.sc_data_identifier}_module"
+
+        return item unless Component.exists?(sc_key: derived_key)
+
+        item.merge("key" => derived_key)
+      end
+
+      private def nested_slots(item)
+        return [] if item["loadout"].blank? && item["default_loadout"].blank?
+
+        resolve_loadout(item)
+      end
+
+      private def persist_loadout(parent, slots, cleanup: true)
+        hardpoint_ids = slots.filter_map { |slot| persist_slot(parent, slot) }
 
         parent.hardpoints.where(source: :game_files).where.not(id: hardpoint_ids).destroy_all if cleanup
 
         hardpoint_ids
+      end
+
+      private def persist_slot(parent, slot)
+        hardpoint = parent.hardpoints.find_or_initialize_by(sc_name: slot.name)
+
+        return hardpoint.persisted? ? hardpoint.id : nil if slot.retain_only
+
+        update_params = {source: :game_files, component: slot.component}
+
+        if slot.component.present?
+          update_params[:min_size] = slot.component.size
+          update_params[:max_size] = slot.component.size
+        end
+
+        apply(hardpoint, update_params)
+
+        persist_loadout(hardpoint, slot.children) if slot.children.present?
+
+        hardpoint.id
       end
 
       private def loadout_name_blacklisted?(name, default_loadout = nil)

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -317,20 +317,19 @@ module ScData
 
       # --- Return value -----------------------------------------------------
 
-      # QUIRK: a resolved, non-hidden entry pushes its id twice -- once in the
-      # resolved branch and once by the unconditional push at the end of the
-      # loop. Harmless for the `where.not(id: ...)` cleanup this feeds, but the
-      # array is not the distinct id list it reads as.
-      test "returns the touched hardpoint ids, with resolved entries duplicated" do
+      # This used to come back with the id twice for a resolved entry -- once
+      # from the branch that wrote it and once from an unconditional push at the
+      # end of the loop. Splitting resolution from persistence left one push per
+      # slot, so the list is now what it always read as. Safe because the only
+      # consumer is the `where.not(id: ...)` cleanup, which does not care.
+      test "returns one id per hardpoint it touched" do
         create(:component, sc_key: "kept_component")
 
         ids = update_loadout(@model, {"loadout" => [{"name" => "kept", "key" => "kept_component"}]})
 
-        hardpoint = game_files_hardpoints(@model).sole
-        assert_equal [hardpoint.id, hardpoint.id], ids
+        assert_equal [game_files_hardpoints(@model).sole.id], ids
       end
 
-      # An entry that resolved to nothing is pushed once, by the tail push only.
       test "returns a single id for an entry that resolved to no component" do
         ids = update_loadout(@model, {"loadout" => [{"name" => "mystery", "key" => "absent"}]})
 

--- a/test/loaders/sc_data/base_loader_resolution_test.rb
+++ b/test/loaders/sc_data/base_loader_resolution_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Resolution on its own: what a loadout says should exist, without a single row
+# being written. That is the point of splitting it out of `update_loadout` --
+# the rules used to be reachable only by running the writes, so every assertion
+# about them had to go through hardpoint rows and the cleanup that follows.
+module ScData
+  module Loader
+    class BaseLoaderResolutionTest < ActiveSupport::TestCase
+      setup do
+        @loader = ::ScData::Loader::BaseLoader.new
+        @model = create(:model, sc_key: "drak_caterpillar")
+      end
+
+      private def resolve(loadout, model: nil)
+        @loader.send(:resolve_loadout, loadout, model:)
+      end
+
+      test "resolving writes nothing" do
+        create(:component, sc_key: "power_plant_s2")
+
+        assert_no_difference("Hardpoint.count") do
+          resolve({"loadout" => [{"name" => "hardpoint_power", "key" => "power_plant_s2"}]})
+        end
+      end
+
+      test "names the slot by the lowered hardpoint name and resolves its component" do
+        component = create(:component, sc_key: "power_plant_s2")
+
+        slots = resolve({"loadout" => [{"name" => "Hardpoint_POWER", "key" => "Power_Plant_S2"}]})
+
+        assert_equal ["hardpoint_power"], slots.map(&:name)
+        assert_equal [component], slots.map(&:component)
+      end
+
+      test "leaves the component nil when nothing resolves" do
+        slots = resolve({"loadout" => [{"name" => "hardpoint_mystery", "key" => "absent"}]})
+
+        assert_nil slots.sole.component
+      end
+
+      test "carries a nested loadout as the slot's children" do
+        create(:component, sc_key: "turret_s4")
+        gun = create(:component, sc_key: "gun_s2")
+
+        slots = resolve({
+          "loadout" => [{
+            "name" => "hardpoint_turret",
+            "key" => "turret_s4",
+            "loadout" => [{"name" => "hardpoint_gun", "key" => "gun_s2"}]
+          }]
+        })
+
+        assert_equal [gun], slots.sole.children.map(&:component)
+      end
+
+      test "omits a blacklisted entry entirely" do
+        slots = resolve({"loadout" => [
+          {"name" => "hardpoint_fuelpod_2_console"},
+          {"name" => "aegs_retaliator_door_cap_rear"}
+        ]})
+
+        assert_empty slots
+      end
+
+      # The hidden component contributes its sub-hardpoints as siblings at this
+      # level, plus the retain-only slot that keeps an existing row of its own
+      # name from being cleaned up.
+      test "flattens a hidden component into sibling slots" do
+        cargo_grid = create(:component, sc_key: "cargo_grid_s4")
+        door = create(:component, :hidden, sc_key: "cargo_door")
+        create(:hardpoint, parent: door, sc_name: "grid", component: cargo_grid, source: :game_files)
+
+        slots = resolve({"loadout" => [{"name" => "hardpoint_door", "key" => "cargo_door"}]})
+
+        assert_equal ["hardpoint_door-grid", "hardpoint_door"], slots.map(&:name)
+        assert_equal [cargo_grid, nil], slots.map(&:component)
+        assert_equal [nil, true], slots.map(&:retain_only)
+      end
+
+      # Derived only for a ship. A module's own loadout, and every nested level,
+      # resolves without it -- which is why the model is passed rather than read
+      # off whatever happens to be the parent.
+      test "derives the module key only when given a model" do
+        component = create(:component, sc_key: "drak_caterpillar_module")
+
+        with_model = resolve({"loadout" => [{"name" => "cargo_module"}]}, model: @model)
+        without_model = resolve({"loadout" => [{"name" => "cargo_module"}]})
+
+        assert_equal component, with_model.sole.component
+        assert_nil without_model.sole.component
+      end
+
+      test "adopts a default without altering the loadout it was handed" do
+        create(:component, sc_key: "default_gun")
+        loadout = {
+          "loadout" => [{"name" => "hardpoint_gun"}],
+          "default_loadout" => [{"name" => "hardpoint_gun", "key" => "default_gun"}]
+        }
+
+        resolve(loadout)
+
+        assert_nil loadout["loadout"].sole["key"], "the parsed hash belongs to the caller"
+      end
+    end
+  end
+end


### PR DESCRIPTION
> **Stacked on #4514** — base is `refactor/sc-data-loader-writes`, which is itself based on #4512. Review those first; this diff is only the loadout split. It needs `apply` from #4514, and the characterization tests it is measured against came from the already-merged #4467.

`update_loadout` was one 89-line recursive method that wrote as it walked. So the rules it encodes could not be exercised without a database, and the destructive cleanup sat in the middle of them.

```ruby
private def update_loadout(parent, loadout, cleanup: true)
  slots = resolve_loadout(loadout, model: (parent if parent.is_a?(Model)))

  persist_loadout(parent, slots, cleanup:)
end
```

`resolve_loadout` returns `Slot` structs and writes nothing. `persist_loadout` makes the rows match and then cleans up. The pieces that were tangled into the walk came out named: `adopt_default_loadout`, `derive_module_key`, `resolve_component`, `flatten_hidden`, `nested_component`.

## Why

It is the prerequisite for writing a build's loadout somewhere other than straight onto rows — the thing a per-build catalogue needs. But it stands on its own: the resolution rules are the most consequential logic in the ingest path, and until now the only way to assert anything about them was to run the writes and inspect hardpoint rows.

The new test does what was impossible before:

```ruby
assert_no_difference("Hardpoint.count") do
  resolve({"loadout" => [{"name" => "hardpoint_power", "key" => "power_plant_s2"}]})
end
```

## Two things fixed structurally, not cosmetically

**The model is passed explicitly.** `parent.is_a?(Model)` worked by accident — `ModelModule` is also a caller of this method, and the rule "only a ship derives a module key" was expressed as a type check on whatever the parent happened to be. It is now an argument, stated where it applies, and nested levels resolve without it by construction.

**`flatten_hidden` returns its siblings directly** instead of re-entering the whole method with `cleanup: false`. That was the only path where a cleanup could be skipped; it no longer exists.

## What the characterization tests decided

**25 of the 26 passed unchanged.** The single failure was the duplicate-id quirk they were written to pin:

```
-["79a8c8f8-…", "79a8c8f8-…"]
+["79a8c8f8-…"]
```

An id used to be pushed twice for a resolved entry — once by the branch that wrote it, once by an unconditional push at the end of the loop. There is one push per slot now. The only consumer is the `where.not(id: …)` cleanup, which cannot tell the difference. That test is updated, and *why* is written into its comment rather than the test being quietly dropped.

The other five quirks are carried over **deliberately**, including the `retain_only` slot that keeps a stale hardpoint alive when its component turns hidden. That one is a real bug — it leaves a hardpoint naming the component the flattening was meant to replace — but fixing it changes behaviour and belongs in its own change with its own test update, not smuggled into a refactor. The code says so where it happens.

## Verification

| | |
| --- | --- |
| Characterization tests (`base_loader_loadout_test`) | 26 tests, 40 assertions, 0 failures |
| New resolution tests (`base_loader_resolution_test`) | 8 tests, 14 assertions, 0 failures |
| Loader + job contract suites | **119 tests, 285 assertions, 0 failures** |

The last row is the one that counts: those are contract tests over the real export, so the rewrite was walked across all 1,129 models with live data rather than fixtures.

`standardrb` clean.

🤖
