### PR TITLE
chore(ci): install pnpm from packageManager and fix the JS cache

### DIFF
--- a/.github/workflows/js-setup-action/action.yml
+++ b/.github/workflows/js-setup-action/action.yml
@@ -3,18 +3,17 @@ description: JS Setup Tasks
 runs:
   using: "composite"
   steps:
+    # No version input: pnpm/action-setup reads it from packageManager in
+    # package.json, so the version is declared in exactly one place.
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
         node-version: "lts/*"
-    - name: Install pnpm
-      run: npm install -g pnpm@10.31.0
-      shell: bash
-    - uses: actions/cache@v5
-      with:
-        path: |
-          "**/node_modules"
-          "~/.pnpm-store"
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-    - run: pnpm install
+        cache: "pnpm"
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -53,19 +53,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
-      - name: Install pnpm
-        run: npm install -g pnpm@10.31.0
-      - uses: actions/cache@v6
-        with:
-          path: |
-            "**/node_modules"
-            "~/.pnpm-store"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - run: pnpm install
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
       - name: Build email assets
         run: bin/build-email-assets
       - run: mkdir -p log


### PR DESCRIPTION
Follows #4519. Adopts the setup pnpm documents for this, which avoids the version drift described below.

## The drift that caused all of this

The pnpm version was hardcoded in **two** workflow files, independent of `package.json`:

- `.github/workflows/js-setup-action/action.yml`
- `.github/workflows/ruby-tests.job.yml`

Dependabot never sees those files. With no `packageManager` declared it resolved its own pnpm, and the two versions serialize `patchedDependencies` differently, so each rejected the other's lockfile — the `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` that blocked every npm PR. #4519 added `packageManager` to stop that, but left the hardcodes in place, so they could silently drift apart again.

`pnpm/action-setup` with **no version input** reads the version from `packageManager`:

```yaml
- name: Install pnpm
  uses: pnpm/action-setup@v6
```

One declaration, resolved identically by CI, local dev and Dependabot.

| | before | after |
|---|---|---|
| `js-setup-action` | `npm install -g pnpm@10.31.0` | reads `packageManager` |
| `ruby-tests.job.yml` | `npm install -g pnpm@10.31.0` | reads `packageManager` |
| `package.json` | `packageManager` (added in #4519) | unchanged, now authoritative |

## The JS cache has never worked

Both files hand-rolled an `actions/cache` block with quoted paths:

```yaml
path: |
  "**/node_modules"
  "~/.pnpm-store"
```

The quotes are literal, so the paths never matched. Every run logged it:

```
Cache not found for input keys: Linux-modules-...
[warning]Path Validation Error: Path(s) specified in the action for caching
do(es) not exist, hence no cache is being saved.
```

Every JS job has been installing from scratch. Replaced with `actions/setup-node`'s `cache: "pnpm"`, which keys off the lockfile and knows where the pnpm store lives. Note `pnpm/action-setup` has to run **before** `setup-node` for that to resolve.

Unrelated to the Dependabot bug, but it's free CI time and the same two files.

## Also

`pnpm install` is now explicitly `--frozen-lockfile`. No behaviour change — pnpm already defaults to frozen when `CI` is set — but it states the intent.

## Verification

- `actionlint` reports **no new findings**: 2 pre-existing `js-setup-action` syntax-check warnings (it reads the composite action as a workflow, since the file sits under `.github/workflows/`) and 3 pre-existing `deploy.job.yml` shellcheck warnings, identical counts before and after
- No `pnpm@` or `install -g pnpm` hardcodes left anywhere in `.github/workflows/`

The real test is CI on this PR, since it changes how every JS job installs. Expect the first run to be no faster — the cache has to populate once before it helps.

## Known remaining duplication

pnpm is still declared twice overall: `package.json` for CI/Dependabot, and `.tool-versions` (`pnpm 10.31.0`) for mise-based local dev. Removing it from `.tool-versions` would break local setup, so **those two need to be bumped together**.

Worth considering separately: `node-version` is hardcoded `"lts/*"` in both files while `.tool-versions` says `nodejs lts`. `setup-node` supports `node-version-file: ".tool-versions"` instead. I left it alone rather than risk `setup-node` not parsing the bare `lts` value.

🤖
