### PR TITLE
feat(sc_data): give equipment a row per build

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -79,6 +79,38 @@ module ScData
         record
       end
 
+      # The same values, written to what this build says about the record as well
+      # as onto the record itself. Dual-writing is what lets reads move to the
+      # build one catalogue at a time instead of in one cut.
+      #
+      # Keyed on the build, so re-loading one updates it in place while a new
+      # build lands beside its predecessor. What that leaves behind is bounded by
+      # `prune_builds`.
+      def apply_build(record, params)
+        build = record.builds.find_or_initialize_by(
+          environment: sc_environment,
+          version: sc_version
+        )
+
+        apply(build, params)
+      end
+
+      # Keeps the last few builds of this environment and drops the rest. Run
+      # after a load rather than during it, so a build being written is never a
+      # candidate for pruning.
+      #
+      # Deleted rather than destroyed: these rows describe a build, nothing hangs
+      # off them, and a load writes thousands at a time.
+      def prune_builds(build_class)
+        retained = build_class.retained_versions(sc_environment)
+
+        # `where.not(version: [])` is `1=1`. An environment with nothing retained
+        # has nothing loaded either, and must not have its history swept.
+        return 0 if retained.blank?
+
+        build_class.where(environment: sc_environment).where.not(version: retained).delete_all
+      end
+
       # Validations and callbacks are skipped on purpose where this is used: it
       # sweeps every Model on every load, and the in-game flag is not something
       # a validation or a stored version has an opinion about.

--- a/app/lib/sc_data/loader/equipment_loader.rb
+++ b/app/lib/sc_data/loader/equipment_loader.rb
@@ -5,6 +5,8 @@ module ScData
         loaded = load_items("equipment").filter_map { |equipment_data| one(equipment_data)&.id }
 
         retire_absent(Equipment, loaded)
+
+        prune_builds(EquipmentBuild)
       end
 
       def one(equipment_data)
@@ -13,7 +15,13 @@ module ScData
         equipment = Equipment.find_by(sc_key: equipment_data["key"])
         equipment ||= Equipment.new(sc_key: equipment_data["key"])
 
-        apply(equipment, update_params(equipment_data))
+        update_params = update_params(equipment_data)
+
+        apply(equipment, update_params)
+
+        # `sc_key` and `sc_ref` identify the item rather than describing a build,
+        # so they stay on the row and are not repeated here.
+        apply_build(equipment, update_params.except(:sc_key, :sc_ref, :version))
 
         equipment
       end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -52,6 +52,11 @@ class Equipment < ApplicationRecord
 
   belongs_to :manufacturer, optional: true
 
+  # What each build of the game says about this item. Written alongside the
+  # columns for now, so reads can move over a catalogue at a time.
+  has_many :builds, class_name: "EquipmentBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "EquipmentBuild", inverse_of: :equipment
+
   # Nothing fills this from the game files: the loadout icons the records name
   # are art the export leaves out on purpose. It is here for the same reason
   # every other catalogue has one -- an upload, and the ledger's fallback to

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: equipment_builds
+#
+#  id                     :uuid             not null, primary key
+#  backpack_compatibility :integer
+#  core_compatibility     :integer
+#  damage_reduction       :decimal(15, 2)
+#  description            :text
+#  environment            :string           not null
+#  equipment_type         :string
+#  g_force_tolerance      :decimal(15, 2)
+#  grade                  :string
+#  hidden                 :boolean          default(FALSE)
+#  item_type              :string
+#  name                   :string
+#  radiation_protection   :decimal(15, 2)
+#  radiation_scrub_rate   :decimal(15, 2)
+#  range                  :decimal(15, 2)
+#  rate_of_fire           :decimal(15, 2)
+#  size                   :string
+#  slot                   :integer
+#  storage                :decimal(15, 2)
+#  sub_type               :string
+#  temperature_rating     :string
+#  version                :string           not null
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
+#  weapon_class           :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  equipment_id           :uuid             not null
+#  manufacturer_id        :uuid
+#
+# Indexes
+#
+#  index_equipment_builds_on_environment_and_equipment_type  (environment,equipment_type)
+#  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
+#  index_equipment_builds_on_environment_and_version         (environment,version)
+#  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
+#  index_equipment_builds_on_equipment_id                    (equipment_id)
+#  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (equipment_id => equipment.id) ON DELETE => cascade
+#
+# What one build of the game says about a piece of equipment.
+#
+# The columns here are exactly the ones `ScData::Loader::EquipmentLoader` writes.
+# Everything that identifies the item, or that a person set by hand, stays on
+# Equipment -- so a load can rewrite a build without touching the row a ledger
+# entry or an uploaded image hangs off.
+class EquipmentBuild < ApplicationRecord
+  belongs_to :equipment
+  belongs_to :manufacturer, optional: true
+
+  # How many builds of one environment are kept. Enough to diff a patch against
+  # the one before it, and to compare a bad load with what it replaced, without
+  # the table growing with every patch forever.
+  BUILDS_RETAINED = 3
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :equipment_id, uniqueness: {scope: [:environment, :version]}
+
+  # Every build this environment still has, newest first.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on. `ScData::Source` names the version
+  # exactly, so this needs no ordering or subselect.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared. Re-loading a build updates its rows in place, so `created_at` is
+  # when that build first landed rather than when it was last touched.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/app/services/manufacturers/deduplicator.rb
+++ b/app/services/manufacturers/deduplicator.rb
@@ -14,7 +14,7 @@ module Manufacturers
     # Tables carrying `manufacturer_id`. Checked against the schema on the way in
     # so a table added later fails loudly here rather than quietly orphaning its
     # rows.
-    ASSOCIATED_MODELS = [Model, Component, Equipment, ModelModule].freeze
+    ASSOCIATED_MODELS = [Model, Component, Equipment, EquipmentBuild, ModelModule].freeze
 
     Result = Struct.new(:renamed, :dropped, :merged)
 

--- a/db/data/20260825120100_backfill_equipment_builds.rb
+++ b/db/data/20260825120100_backfill_equipment_builds.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Seeds a build row from what each equipment row already says, so the new table
+# is populated before anything reads from it -- rather than staying empty until
+# the next sc_data load.
+#
+# Rows whose version is nil are skipped: the export stopped naming them, so there
+# is no build they describe.
+class BackfillEquipmentBuilds < ActiveRecord::Migration[8.1]
+  FACTS = %i[
+    manufacturer_id name description equipment_type item_type sub_type
+    weapon_class size grade slot hidden rate_of_fire range storage
+    damage_reduction temperature_rating radiation_protection
+    radiation_scrub_rate g_force_tolerance core_compatibility
+    backpack_compatibility volume volume_dimensions
+  ].freeze
+
+  def up
+    environment = ScData::Source.environment
+
+    Equipment.where.not(version: nil).find_each do |equipment|
+      build = equipment.builds.find_or_initialize_by(environment:)
+
+      build.update!(FACTS.index_with { |fact| equipment.public_send(fact) }.merge(version: equipment.version))
+    end
+  end
+
+  def down
+    EquipmentBuild.delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_12_100000)
+DataMigrate::Data.define(version: 2026_08_25_120100)

--- a/db/migrate/20260825120000_create_equipment_builds.rb
+++ b/db/migrate/20260825120000_create_equipment_builds.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# The first catalogue to separate what a thing *is* from what a build *says about
+# it*. `equipment` keeps its identity -- the row a ledger entry points at, its
+# sc_key, its slug, its uploaded image -- and everything the sc_data loader
+# writes moves here.
+#
+# Equipment is the pilot because nothing references it: no child table carries an
+# `equipment_id`, so the split is columns only.
+#
+# One row per item per build, so a patch can be diffed against the one before it
+# and a bad load can be compared with what it replaced. Kept to the last few
+# builds per environment rather than forever -- see BUILDS_RETAINED.
+class CreateEquipmentBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :equipment_builds, id: :uuid do |t|
+      # Cascade: a build says something about an item, and says nothing at all
+      # once the item is gone.
+      t.references :equipment, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      t.uuid :manufacturer_id
+      t.string :name
+      t.text :description
+      t.string :equipment_type
+      t.string :item_type
+      t.string :sub_type
+      t.string :weapon_class
+      t.string :size
+      t.string :grade
+      t.integer :slot
+      t.boolean :hidden, default: false
+      t.decimal :rate_of_fire, precision: 15, scale: 2
+      t.decimal :range, precision: 15, scale: 2
+      t.decimal :storage, precision: 15, scale: 2
+      t.decimal :damage_reduction, precision: 15, scale: 2
+      t.string :temperature_rating
+      t.decimal :radiation_protection, precision: 15, scale: 2
+      t.decimal :radiation_scrub_rate, precision: 15, scale: 2
+      t.decimal :g_force_tolerance, precision: 15, scale: 2
+      t.integer :core_compatibility
+      t.integer :backpack_compatibility
+      t.decimal :volume, precision: 15, scale: 6
+      t.jsonb :volume_dimensions
+
+      t.timestamps
+    end
+
+    # One row per item per build. Re-loading the same build updates it in place;
+    # a new build adds a row beside it.
+    add_index :equipment_builds, [:equipment_id, :environment, :version],
+      unique: true, name: "index_equipment_builds_on_equipment_and_build"
+
+    # The filters a browsable catalogue needs, so narrowing to one build stays a
+    # join rather than a scan. Every read names an environment and a version,
+    # because that pair is what `ScData::Source` hands out.
+    add_index :equipment_builds, [:environment, :version]
+    add_index :equipment_builds, [:environment, :equipment_type]
+    add_index :equipment_builds, [:environment, :item_type]
+    add_index :equipment_builds, :manufacturer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -302,6 +302,43 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_140000) do
     t.index ["manufacturer_id"], name: "index_equipment_on_manufacturer_id"
     t.index ["sc_key"], name: "index_equipment_on_sc_key", unique: true
     t.index ["slot"], name: "index_equipment_on_slot"
+  end
+
+  create_table "equipment_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "backpack_compatibility"
+    t.integer "core_compatibility"
+    t.datetime "created_at", null: false
+    t.decimal "damage_reduction", precision: 15, scale: 2
+    t.text "description"
+    t.string "environment", null: false
+    t.uuid "equipment_id", null: false
+    t.string "equipment_type"
+    t.decimal "g_force_tolerance", precision: 15, scale: 2
+    t.string "grade"
+    t.boolean "hidden", default: false
+    t.string "item_type"
+    t.uuid "manufacturer_id"
+    t.string "name"
+    t.decimal "radiation_protection", precision: 15, scale: 2
+    t.decimal "radiation_scrub_rate", precision: 15, scale: 2
+    t.decimal "range", precision: 15, scale: 2
+    t.decimal "rate_of_fire", precision: 15, scale: 2
+    t.string "size"
+    t.integer "slot"
+    t.decimal "storage", precision: 15, scale: 2
+    t.string "sub_type"
+    t.string "temperature_rating"
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.decimal "volume", precision: 15, scale: 6
+    t.jsonb "volume_dimensions"
+    t.string "weapon_class"
+    t.index ["environment", "equipment_type"], name: "index_equipment_builds_on_environment_and_equipment_type"
+    t.index ["environment", "item_type"], name: "index_equipment_builds_on_environment_and_item_type"
+    t.index ["environment", "version"], name: "index_equipment_builds_on_environment_and_version"
+    t.index ["equipment_id", "environment", "version"], name: "index_equipment_builds_on_equipment_and_build", unique: true
+    t.index ["equipment_id"], name: "index_equipment_builds_on_equipment_id"
+    t.index ["manufacturer_id"], name: "index_equipment_builds_on_manufacturer_id"
   end
 
   create_table "exchange_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1485,6 +1522,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_140000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_notifications", "admin_users", on_delete: :cascade
   add_foreign_key "cargo_hold_container_capacities", "cargo_holds"
+  add_foreign_key "equipment_builds", "equipment", on_delete: :cascade
   add_foreign_key "fleet_event_admins", "fleet_events"
   add_foreign_key "fleet_event_admins", "users"
   add_foreign_key "fleet_event_occurrence_states", "fleet_events"

--- a/test/factories/equipment_builds.rb
+++ b/test/factories/equipment_builds.rb
@@ -1,0 +1,59 @@
+# == Schema Information
+#
+# Table name: equipment_builds
+#
+#  id                     :uuid             not null, primary key
+#  backpack_compatibility :integer
+#  core_compatibility     :integer
+#  damage_reduction       :decimal(15, 2)
+#  description            :text
+#  environment            :string           not null
+#  equipment_type         :string
+#  g_force_tolerance      :decimal(15, 2)
+#  grade                  :string
+#  hidden                 :boolean          default(FALSE)
+#  item_type              :string
+#  name                   :string
+#  radiation_protection   :decimal(15, 2)
+#  radiation_scrub_rate   :decimal(15, 2)
+#  range                  :decimal(15, 2)
+#  rate_of_fire           :decimal(15, 2)
+#  size                   :string
+#  slot                   :integer
+#  storage                :decimal(15, 2)
+#  sub_type               :string
+#  temperature_rating     :string
+#  version                :string           not null
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
+#  weapon_class           :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  equipment_id           :uuid             not null
+#  manufacturer_id        :uuid
+#
+# Indexes
+#
+#  index_equipment_builds_on_environment_and_equipment_type  (environment,equipment_type)
+#  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
+#  index_equipment_builds_on_environment_and_version         (environment,version)
+#  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
+#  index_equipment_builds_on_equipment_id                    (equipment_id)
+#  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (equipment_id => equipment.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :equipment_build do
+    equipment
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+    sequence(:name) { |n| "#{Faker::Company.name} Rifle #{n}" }
+    equipment_type { "weapon" }
+    item_type { "assault_rifle" }
+    size { "2" }
+    hidden { false }
+  end
+end

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Dual-writing: the loader puts its values on the row and on what this build says
+# about the row, so reads can move to the build one catalogue at a time rather
+# than in a single cut.
+module ScData
+  module Loader
+    class BaseLoaderApplyBuildTest < ActiveSupport::TestCase
+      setup do
+        @loader = ::ScData::Loader::BaseLoader.new
+        @equipment = create(:equipment)
+      end
+
+      test "#apply_build records the build the current environment is on" do
+        @loader.apply_build(@equipment, {name: "Behring P4-AR"})
+
+        build = @equipment.reload.build
+        assert_equal "Behring P4-AR", build.name
+        assert_equal ::ScData::Source.environment, build.environment
+        assert_equal ::ScData::Source.version, build.version
+      end
+
+      # Keyed on the build, so re-loading the one we are on updates it in place
+      # rather than piling up rows.
+      test "#apply_build updates the build in place when it is reloaded" do
+        @loader.apply_build(@equipment, {name: "First"})
+
+        assert_difference("EquipmentBuild.count", 0) do
+          @loader.apply_build(@equipment, {name: "Second"})
+        end
+
+        assert_equal "Second", @equipment.reload.build.name
+      end
+
+      # A new build lands beside its predecessor -- which is what makes a patch
+      # diffable against the one before it.
+      test "#apply_build leaves the previous build standing" do
+        previous = create(
+          :equipment_build,
+          equipment: @equipment, environment: ::ScData::Source.environment, version: "4.8.0-live.1"
+        )
+
+        @loader.apply_build(@equipment, {name: "Behring P4-AR"})
+
+        assert EquipmentBuild.exists?(previous.id)
+        assert_equal 2, @equipment.reload.builds.count
+        assert_equal ::ScData::Source.version, @equipment.build.version
+      end
+
+      # Bounded on purpose: history is worth a couple of patches, not every patch
+      # ever shipped.
+      test "#prune_builds keeps the retained builds and drops the rest" do
+        keep = EquipmentBuild::BUILDS_RETAINED
+
+        (keep + 2).times do |index|
+          create(
+            :equipment_build,
+            equipment: create(:equipment),
+            environment: ::ScData::Source.environment,
+            version: "4.#{index}.0-live.#{index}",
+            created_at: index.days.from_now
+          )
+        end
+
+        @loader.prune_builds(EquipmentBuild)
+
+        assert_equal keep, EquipmentBuild.distinct.count(:version)
+      end
+
+      # `where.not(version: [])` is `1=1`, so an environment with nothing loaded
+      # must not have its history swept.
+      test "#prune_builds leaves another environment's history alone" do
+        create(:equipment_build, environment: "somewhere-else", version: "4.9.0-else.1")
+
+        @loader.prune_builds(EquipmentBuild)
+
+        assert_equal 1, EquipmentBuild.where(environment: "somewhere-else").count
+      end
+
+      test "#apply_build counts through the same stats as any other write" do
+        @loader.apply_build(@equipment, {name: "Behring P4-AR"})
+
+        assert_equal 1, @loader.stats["EquipmentBuild"][:created]
+      end
+
+      # The loader writes both, and they agree.
+      test "the equipment loader writes the row and the build together" do
+        data = {
+          "key" => "behr_rifle_ballistic_01",
+          "name" => "Behring P4-AR",
+          "equipment_type" => "weapon",
+          "item_type" => "assault_rifle",
+          "size" => "2"
+        }
+
+        equipment = ::ScData::Loader::EquipmentLoader.new.one(data)
+
+        assert_equal "Behring P4-AR", equipment.name
+        assert_equal "Behring P4-AR", equipment.build.name
+        assert_equal "weapon", equipment.build.equipment_type
+        assert_equal ::ScData::Source.version, equipment.build.version
+      end
+
+      # sc_key identifies the item rather than describing a build, so it is not
+      # repeated onto the build row.
+      test "identity stays off the build" do
+        equipment = ::ScData::Loader::EquipmentLoader.new.one({
+          "key" => "behr_rifle_ballistic_01", "name" => "Behring P4-AR"
+        })
+
+        assert_equal "behr_rifle_ballistic_01", equipment.sc_key
+        refute EquipmentBuild.column_names.include?("sc_key")
+      end
+    end
+  end
+end

--- a/test/models/equipment_build_test.rb
+++ b/test/models/equipment_build_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The first catalogue to say what a build claims about an item separately from
+# what the item is. Equipment keeps its identity and anything a person set; the
+# loader's values live here, one row per environment.
+# == Schema Information
+#
+# Table name: equipment_builds
+#
+#  id                     :uuid             not null, primary key
+#  backpack_compatibility :integer
+#  core_compatibility     :integer
+#  damage_reduction       :decimal(15, 2)
+#  description            :text
+#  environment            :string           not null
+#  equipment_type         :string
+#  g_force_tolerance      :decimal(15, 2)
+#  grade                  :string
+#  hidden                 :boolean          default(FALSE)
+#  item_type              :string
+#  name                   :string
+#  radiation_protection   :decimal(15, 2)
+#  radiation_scrub_rate   :decimal(15, 2)
+#  range                  :decimal(15, 2)
+#  rate_of_fire           :decimal(15, 2)
+#  size                   :string
+#  slot                   :integer
+#  storage                :decimal(15, 2)
+#  sub_type               :string
+#  temperature_rating     :string
+#  version                :string           not null
+#  volume                 :decimal(15, 6)
+#  volume_dimensions      :jsonb
+#  weapon_class           :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  equipment_id           :uuid             not null
+#  manufacturer_id        :uuid
+#
+# Indexes
+#
+#  index_equipment_builds_on_environment_and_equipment_type  (environment,equipment_type)
+#  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
+#  index_equipment_builds_on_environment_and_version         (environment,version)
+#  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
+#  index_equipment_builds_on_equipment_id                    (equipment_id)
+#  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (equipment_id => equipment.id) ON DELETE => cascade
+#
+class EquipmentBuildTest < ActiveSupport::TestCase
+  test "an item carries one row per build, not two" do
+    equipment = create(:equipment)
+    create(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
+
+    duplicate = build(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
+
+    refute_predicate duplicate, :valid?
+    assert_includes duplicate.errors.attribute_names, :equipment_id
+  end
+
+  # The point of keeping history: a later build lands beside its predecessor
+  # rather than overwriting it.
+  test "a later build of the same environment sits beside the earlier one" do
+    equipment = create(:equipment)
+    create(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
+
+    assert_predicate build(:equipment_build, equipment:, environment: "live", version: "4.10.0-live.2"), :valid?
+  end
+
+  test "the same item can be described by more than one environment" do
+    equipment = create(:equipment)
+    create(:equipment_build, equipment:, environment: "live")
+
+    assert_predicate build(:equipment_build, equipment:, environment: "ptu"), :valid?
+  end
+
+  test "requires the build it describes" do
+    refute_predicate build(:equipment_build, version: nil), :valid?
+    refute_predicate build(:equipment_build, environment: nil), :valid?
+  end
+
+  # `for_source` is what the `build` association narrows by, so an environment
+  # only ever sees its own row.
+  test ".for_source keeps only the current environment" do
+    equipment = create(:equipment)
+    live = create(:equipment_build, equipment:, environment: ScData::Source.environment)
+    other = create(:equipment_build, equipment:, environment: "somewhere-else")
+
+    assert_includes EquipmentBuild.for_source, live
+    refute_includes EquipmentBuild.for_source, other
+  end
+
+  # An environment that has moved on leaves its old row behind until the next
+  # load rewrites it, so the version is checked as well as the environment.
+  test ".current also narrows to the version the environment is on" do
+    equipment = create(:equipment)
+    current = create(:equipment_build, equipment:)
+    stale = create(:equipment_build, equipment: create(:equipment), version: "0.0.1-live.1")
+
+    assert_includes EquipmentBuild.current, current
+    refute_includes EquipmentBuild.current, stale
+  end
+
+  test "#build returns the row for the current environment" do
+    equipment = create(:equipment)
+    create(:equipment_build, equipment:, environment: "somewhere-else")
+    current = create(:equipment_build, equipment:, environment: ScData::Source.environment)
+
+    assert_equal current, equipment.reload.build
+  end
+
+  # Ordered by when a build first appeared, so re-loading an old build does not
+  # promote it past the ones that came after.
+  test ".retained_versions keeps the newest builds of an environment" do
+    %w[4.8.0-live.1 4.9.0-live.2 4.10.0-live.3 4.11.0-live.4].each_with_index do |version, index|
+      create(
+        :equipment_build,
+        equipment: create(:equipment), environment: "live", version:,
+        created_at: index.days.ago.end_of_day
+      )
+    end
+
+    retained = EquipmentBuild.retained_versions("live", keep: 3)
+
+    assert_equal %w[4.10.0-live.3 4.9.0-live.2 4.8.0-live.1].sort, retained.sort
+    refute_includes retained, "4.11.0-live.4", "the oldest by first-seen falls out"
+  end
+
+  test ".retained_versions looks at one environment at a time" do
+    create(:equipment_build, environment: "live", version: "4.9.0-live.1")
+    create(:equipment_build, environment: "ptu", version: "4.10.0-ptu.2")
+
+    assert_equal ["4.9.0-live.1"], EquipmentBuild.retained_versions("live")
+  end
+
+  test "builds go when the item does" do
+    equipment = create(:equipment)
+    create(:equipment_build, equipment:)
+
+    assert_difference("EquipmentBuild.count", -1) { equipment.destroy }
+  end
+end

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -71,12 +71,14 @@ module Manufacturers
 
       component = create(:component, manufacturer: drop)
       equipment = create(:equipment, manufacturer: drop)
+      equipment_build = create(:equipment_build, manufacturer: drop)
       model = create(:model, manufacturer: drop)
 
       ::Manufacturers::Deduplicator.new.call
 
       assert_equal keep, component.reload.manufacturer
       assert_equal keep, equipment.reload.manufacturer
+      assert_equal keep, equipment_build.reload.manufacturer
       assert_equal keep, model.reload.manufacturer
     end
 


### PR DESCRIPTION
> **Stacked on #4520** — base is `refactor/loadout-resolution`, which sits on #4514 → #4512 → `main`. Review those first; this diff is only the build table.

The first step of separating what a catalogue item **is** from what a build of the game **says about it**. Equipment keeps its identity — the row a ledger entry points at, its `sc_key`, its slug, its uploaded image — and the columns the loader writes get a row of their own per build.

## Why equipment first

Nothing references it. No child table carries an `equipment_id`, so the split is columns only. `Component`, `Commodity` and `Model` each bring child tables (`hardpoints`, `cargo_holds`, `docks`, `model_positions`) and follow once the shape is settled here.

That also means this is the cheapest moment to disagree with the shape — three more catalogues will copy it.

## The shape

```
(equipment_id, environment, version) UNIQUE
```

One row per item **per build**. Re-loading the build we are on updates it in place; a new build lands beside its predecessor. That is what makes a patch diffable against the one before it, and lets a bad load be compared with what it replaced — which matters because PTU support is, in substance, a diff feature.

**Bounded rather than kept forever.** `EquipmentBuild::BUILDS_RETAINED = 3`, and `prune_builds` drops the rest after a load. Ordered by when a build *first* appeared, so re-loading an old build does not promote it past the ones that came after it.

Every read names an environment and a version, because that pair is exactly what `ScData::Source` hands out — so `current` needs no ordering and no subselect.

## Expand phase only

The rows are written **alongside** the existing columns and nothing reads them yet. This is inert until the read switch, which is what lets the catalogues move over one at a time instead of in a single cut. Nothing here changes behaviour.

`apply_build` goes through the same seam as every other loader write (#4514), so a build row turns up in the run's stats like anything else:

```
[sc_data] EquipmentLoader: Equipment created=0 updated=12 unchanged=4809, EquipmentBuild created=4821 …
```

## Backfill

Seeds a build from what each row already says — **4,821 rows**, verified as one build each at the current version. Rows whose `version` is nil are skipped: the export stopped naming them, so there is no build they describe.

## Two things worth a second look

**`prune_builds` is guarded against `where.not(version: [])`**, which is `1=1` — an environment with nothing retained would otherwise have its whole history swept. Same trap the comment on `retire_absent` warns about.

**Admins can edit the columns the loader writes** (`name`, `size`, `grade`, `description` via `admin/api/v1/equipment_controller.rb`). That is already true today — the loader overwrites admin edits on the next load — but when reads move to the build, the admin write path has to target the build row too. Not addressed here; flagging it so it is not discovered later.

## Verification

| | |
| --- | --- |
| `equipment_build_test` + `base_loader_apply_build_test` | 18 tests, 45 assertions, 0 failures |
| Loader contract suite + equipment model / API / admin | **175 tests, 443 assertions, 0 failures** |

The second row is the one that counts — contract tests over the real export, so the dual-write ran across all 4,821 items with live data.

`standardrb` clean.

🤖
