### PR TITLE
fix(admin-api): type the import payloads as the objects they are

### DIFF
--- a/app/api_components/admin/v1/schemas/import.rb
+++ b/app/api_components/admin/v1/schemas/import.rb
@@ -16,8 +16,8 @@ module Admin
             info: {type: :string},
             version: {type: :string},
 
-            input: {type: :string},
-            output: {type: :string},
+            input: {type: :object, additionalProperties: true},
+            output: {type: :object, additionalProperties: true},
             import: {type: :string},
             importData: {type: :string},
 

--- a/app/frontend/admin/pages/maintenance/imports/[id].vue
+++ b/app/frontend/admin/pages/maintenance/imports/[id].vue
@@ -58,8 +58,11 @@ const statusVariant = (status: ImportStatusEnum): `${PillVariantsEnum}` => {
   }
 };
 
-const formatPayload = (value: string | undefined | null): string | null => {
+const formatPayload = (value: unknown): string | null => {
   if (value === undefined || value === null || value === "") return null;
+
+  if (typeof value !== "string") return JSON.stringify(value, null, 2);
+
   try {
     return JSON.stringify(JSON.parse(value), null, 2);
   } catch {

--- a/asyncapi/cable/admin/v1/schema.yaml
+++ b/asyncapi/cable/admin/v1/schema.yaml
@@ -148,9 +148,11 @@ components:
         version:
           type: string
         input:
-          type: string
+          type: object
+          additionalProperties: true
         output:
-          type: string
+          type: object
+          additionalProperties: true
         import:
           type: string
         importData:

--- a/swagger/admin/v1/oasdiff-ignore.txt
+++ b/swagger/admin/v1/oasdiff-ignore.txt
@@ -20,3 +20,7 @@ PUT /features/{id}/enable-percentage-of-time removed the required property `self
 PUT /features/{id}/toggle-self-service api path removed without deprecation
 POST /admin_users request property `resourceAccess/items/` was restricted to a list of enum values
 PUT /admin_users/{id} request property `resourceAccess/items/` was restricted to a list of enum values
+GET /imports the `items/items/input` response's property type/format changed from `string`/`` to `object`/`` for status `200`
+GET /imports the `items/items/output` response's property type/format changed from `string`/`` to `object`/`` for status `200`
+GET /imports/{id} the `input` response's property type/format changed from `string`/`` to `object`/`` for status `200`
+GET /imports/{id} the `output` response's property type/format changed from `string`/`` to `object`/`` for status `200`

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -11083,9 +11083,11 @@ components:
         version:
           type: string
         input:
-          type: string
+          type: object
+          additionalProperties: true
         output:
-          type: string
+          type: object
+          additionalProperties: true
         import:
           type: string
         importData:


### PR DESCRIPTION
`input` and `output` on the admin import schema were typed `string`. Both are jsonb columns, and `_base.jbuilder` renders them raw — so the API has always returned objects there.

```diff
-            input: {type: :string},
-            output: {type: :string},
+            input: {type: :object, additionalProperties: true},
+            output: {type: :object, additionalProperties: true},
```

## Why it went unnoticed

No test asserts either field. But the generated client typed both as `string`, so anything reading them had to lie to TypeScript. After this, orval produces:

```ts
export type ImportOutput = { [key: string]: unknown };
```

Free-form is the honest type: what these hold depends on the import. A model import names its model, a UEX price sync counts what it changed, an sc_data load reports per loader.

Not required, and empty imports simply omit the key — `Jbuilder.ignore_nil` is on globally, so there is nothing to guard in the serializer.

## The oasdiff entries

A response property type change is an **error**, and the admin check runs `--fail-on ERR`. Verified locally:

```
4 changes: 4 error, 0 warning, 0 info
error [response-property-type-changed] the `output` response's property `type` changed from `string` to `object`
```

Four entries added to `swagger/admin/v1/oasdiff-ignore.txt`, and re-running with the ignore file gives `No breaking changes to report`. Suppressing is right here: **the response shape is not changing, only the description of it.** Consumers were already receiving objects.

## Verification

- `oasdiff breaking … --fail-on ERR --err-ignore …` → clean
- `test/integration/admin/api/v1/imports_test.rb` → 11 tests, 29 assertions, 0 failures
- `standardrb` clean
- Generated clients are gitignored, so only the component and the two swagger files are committed

🤖
