### PR TITLE
feat(cable): raise on a payload mismatch in tests

### DIFF
--- a/app/api_components/cable/v1/schemas/hangar_group_changed_message.rb
+++ b/app/api_components/cable/v1/schemas/hangar_group_changed_message.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Cable
+  module V1
+    module Schemas
+      # HangarChannel carries two things: the vehicle that changed, and a ping
+      # for a hangar group whose membership moved without any one vehicle
+      # changing. Subscribers refetch either way, so the ping needs no payload —
+      # but it needs a shape no vehicle can satisfy, or declaring it as an
+      # alternative would stop the vehicle contract being enforced at all.
+      class HangarGroupChangedMessage
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            hangarGroupId: {type: :string, format: :uuid}
+          },
+          additionalProperties: false,
+          required: %w[hangarGroupId]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/cargo_hold.rb
+++ b/app/api_components/shared/v1/schemas/cargo_hold.rb
@@ -9,7 +9,9 @@ module Shared
         schema({
           type: :object,
           properties: {
-            name: {type: :string},
+            # The game files leave a hold unnamed often enough that
+            # DerivedCargoHolds keys such holds by position to tell them apart.
+            name: {type: [:string, :null]},
             dimensions: {"$ref": "#/components/schemas/CargoHoldDimension"},
             capacity: {type: :integer},
             maxContainerSize: {"$ref": "#/components/schemas/CargoHoldContainerSize"},

--- a/app/api_components/v1/schemas/fleets/fleet_member.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_member.rb
@@ -49,7 +49,10 @@ module V1
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id username fleetRole shipsFilter fleetSlug fleetName createdAt updatedAt]
+          # Not fleetRole: FleetRole cascades ahead of the memberships it
+          # nullifies, so a membership torn down with its fleet is broadcast
+          # without one.
+          required: %w[id username shipsFilter fleetSlug fleetName createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout_minimal.rb
@@ -6,16 +6,22 @@ module V1
       class VehicleLoadoutMinimal
         include OpenapiRuby::Components::Base
 
+        # "Minimal" is about the omitted hardpoints: api/v1/vehicle_loadouts/base
+        # renders every other field it has, including the shared timestamps, so
+        # those belong here too.
         schema({
           type: :object,
           properties: {
             id: {type: :string, format: :uuid},
             name: {type: :string},
+            active: {type: :boolean},
             url: {type: :string},
-            urlSource: {type: :string}
+            urlSource: {type: :string},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id name url]
+          required: %w[id name active url createdAt updatedAt]
         })
       end
     end

--- a/app/frontend/frontend/pages/fleets/[slug]/settings.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/settings.vue
@@ -111,13 +111,13 @@ const leave = () => {
   <TabNavView
     :routes="fleetRoutes"
     :authenticated="sessionStore.isAuthenticated"
-    :resource-access="membership?.fleetRole.resourceAccess"
+    :resource-access="membership?.fleetRole?.resourceAccess"
   >
     <template #nav>
       <TabNavViewItems
         :routes="fleetRoutes"
         :authenticated="sessionStore.isAuthenticated"
-        :resource-access="membership?.fleetRole.resourceAccess"
+        :resource-access="membership?.fleetRole?.resourceAccess"
       />
       <li
         v-if="fleet"

--- a/app/models/concerns/derived_cargo_holds.rb
+++ b/app/models/concerns/derived_cargo_holds.rb
@@ -11,15 +11,17 @@ module DerivedCargoHolds
   extend ActiveSupport::Concern
 
   def cargo_holds_with_offsets
+    holds = projected_cargo_holds
+
     db_records = cargo_holds_db.where.not(offset_x: nil)
       .or(cargo_holds_db.where.not(offset_y: nil))
       .or(cargo_holds_db.where.not(offset_z: nil))
       .or(cargo_holds_db.where.not(rotation: nil))
       .index_by(&:position)
 
-    return cargo_holds if db_records.empty?
+    return holds if db_records.empty?
 
-    cargo_holds.each_with_index.map do |hold_data, index|
+    holds.each_with_index.map do |hold_data, index|
       db_record = db_records[index]
 
       next hold_data if db_record.blank?
@@ -42,7 +44,7 @@ module DerivedCargoHolds
   # row landed at the same array index -- so adding, dropping or reordering a
   # hold in the game files moved a curated offset onto a different hold, quietly.
   def update_cargo_holds_db
-    holds = (cargo_holds || []).reject { |hold| hold.blank? || hold["dimensions"].blank? }
+    holds = projected_cargo_holds
     keys = cargo_hold_keys(holds.map { |hold| hold["name"] })
 
     existing = cargo_holds_db.order(:position).to_a
@@ -67,6 +69,16 @@ module DerivedCargoHolds
   # Matched on the name the hardpoint carries, not on `position` -- position is
   # only the index in the array the loader wrote, and it moves with the build.
   #
+  # A hold the loader wrote without dimensions is not projected into a row, so
+  # it has no position an offset could be matched to. Both readers have to skip
+  # the same ones: `cargo_holds_with_offsets` pairs holds to rows by array
+  # index, and filtering in one place but not the other shifts every offset
+  # past a malformed hold onto its neighbour — the bug this concern exists for,
+  # arrived at from the other side.
+  private def projected_cargo_holds
+    (cargo_holds || []).reject { |hold| hold.blank? || hold["dimensions"].blank? }
+  end
+
   # Names are not quite unique in practice (a couple of models repeat one, and a
   # few holds carry none at all), so the ordinal among holds sharing a name is
   # part of the key. An unnamed hold falls back to its ordinal among the unnamed,

--- a/app/models/hangar_group.rb
+++ b/app/models/hangar_group.rb
@@ -36,7 +36,7 @@ class HangarGroup < ApplicationRecord
   end
 
   def broadcast_update
-    HangarChannel.broadcast_to(user, {})
+    HangarChannel.broadcast_to(user, {hangarGroupId: id})
   end
 
   private def touch_vehicles

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -43,6 +43,8 @@ channels:
     messages:
       Vehicle:
         "$ref": "#/components/messages/Vehicle"
+      HangarGroupChangedMessage:
+        "$ref": "#/components/messages/HangarGroupChangedMessage"
   HangarCreate:
     address: hangar_create:{user_gid}
     x-actioncable-channel: HangarCreateChannel
@@ -200,6 +202,7 @@ operations:
       "$ref": "#/channels/Hangar"
     messages:
     - "$ref": "#/channels/Hangar/messages/Vehicle"
+    - "$ref": "#/channels/Hangar/messages/HangarGroupChangedMessage"
     summary: A vehicle in the user's hangar changed
   receiveModelUpdate:
     action: receive
@@ -1865,6 +1868,15 @@ components:
       - public
       - createdAt
       - updatedAt
+    HangarGroupChangedMessage:
+      type: object
+      properties:
+        hangarGroupId:
+          type: string
+          format: uuid
+      additionalProperties: false
+      required:
+      - hangarGroupId
     HangarSyncFailedMessage:
       type: object
       properties:
@@ -3314,6 +3326,9 @@ components:
     FleetMember:
       payload:
         "$ref": "#/components/schemas/FleetMember"
+    HangarGroupChangedMessage:
+      payload:
+        "$ref": "#/components/schemas/HangarGroupChangedMessage"
     HangarSyncFailedMessage:
       payload:
         "$ref": "#/components/schemas/HangarSyncFailedMessage"

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -306,7 +306,9 @@ components:
       type: object
       properties:
         name:
-          type: string
+          type:
+          - string
+          - 'null'
         dimensions:
           "$ref": "#/components/schemas/CargoHoldDimension"
         capacity:

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -1641,7 +1641,6 @@ components:
       required:
       - id
       - username
-      - fleetRole
       - shipsFilter
       - fleetSlug
       - fleetName
@@ -3309,15 +3308,26 @@ components:
           format: uuid
         name:
           type: string
+        active:
+          type: boolean
         url:
           type: string
         urlSource:
           type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
       additionalProperties: false
       required:
       - id
       - name
+      - active
       - url
+      - createdAt
+      - updatedAt
   messages:
     AnnouncementMessage:
       payload:

--- a/config/initializers/asyncapi_cable.rb
+++ b/config/initializers/asyncapi_cable.rb
@@ -55,7 +55,11 @@ AsyncapiCable.configure do |config|
   config.schema_output_dir = "asyncapi"
   config.schema_output_format = :yaml
 
-  # Not :enabled — broadcasts run from after_save/after_commit callbacks, so a
-  # raise on a payload mismatch would roll back the write that triggered it.
-  config.validation_mode = :warn_only
+  # Raising is what makes the contract enforceable, so tests do. Everywhere
+  # else only warns: broadcasts run from after_save/after_commit callbacks, so a
+  # raise in production would roll back the write that triggered it.
+  #
+  # The hook fires on every broadcast the suite makes, not only where a channel
+  # declaration asserts, so this covers any test that happens to trigger one.
+  config.validation_mode = Rails.env.test? ? :enabled : :warn_only
 end

--- a/swagger/admin/v1/oasdiff-ignore.txt
+++ b/swagger/admin/v1/oasdiff-ignore.txt
@@ -24,3 +24,89 @@ GET /imports the `items/items/input` response's property type/format changed fro
 GET /imports the `items/items/output` response's property type/format changed from `string`/`` to `object`/`` for status `200`
 GET /imports/{id} the `input` response's property type/format changed from `string`/`` to `object`/`` for status `200`
 GET /imports/{id} the `output` response's property type/format changed from `string`/`` to `object`/`` for status `200`
+GET /components the response property `items/items/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /components the response property `typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+DELETE /components/{id} the response property `typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /components/{id} the response property `typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /components/{id} the response property `typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-hardpoint-loadouts the response property `items/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /model-hardpoint-loadouts the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+GET /model-hardpoint-loadouts/{id} the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-hardpoint-loadouts/{id} the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-hardpoints the response property `items/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-hardpoints the response property `items/items/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /model-hardpoints the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+POST /model-hardpoints the response property `loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+GET /model-hardpoints/{id} the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-hardpoints/{id} the response property `loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-hardpoints/{id} the response property `component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-hardpoints/{id} the response property `loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-module-packages the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /model-module-packages the response property `items/items/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-module-packages the response property `items/items/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-module-packages the response property `items/items/modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+POST /model-module-packages the response property `model/cargoHolds/items/name` became nullable for the status `200`
+POST /model-module-packages the response property `modules/items/cargoHolds/items/name` became nullable for the status `200`
+POST /model-module-packages the response property `modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /model-module-packages the response property `modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-module-packages/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+GET /model-module-packages/{id} the response property `modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-module-packages/{id} the response property `modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-module-packages/{id} the response property `modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-module-packages/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-module-packages/{id} the response property `modules/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-module-packages/{id} the response property `modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-module-packages/{id} the response property `modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-modules the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-modules the response property `items/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-modules the response property `items/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+POST /model-modules the response property `cargoHolds/items/name` became nullable for the status `201`
+POST /model-modules the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+POST /model-modules the response property `models/items/cargoHolds/items/name` became nullable for the status `201`
+GET /model-modules/{id} the response property `cargoHolds/items/name` became nullable for the status `200`
+GET /model-modules/{id} the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /model-modules/{id} the response property `models/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id} the response property `cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id} the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-modules/{id} the response property `models/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id}/link the response property `cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id}/link the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-modules/{id}/link the response property `models/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id}/unlink the response property `cargoHolds/items/name` became nullable for the status `200`
+PUT /model-modules/{id}/unlink the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /model-modules/{id}/unlink the response property `models/items/cargoHolds/items/name` became nullable for the status `200`
+GET /model-paints the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+POST /model-paints the response property `model/cargoHolds/items/name` became nullable for the status `200`
+DELETE /model-paints/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+GET /model-paints/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+PUT /model-paints/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+GET /models the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+POST /models the response property `cargoHolds/items/name` became nullable for the status `200`
+DELETE /models/{id} the response property `cargoHolds/items/name` became nullable for the status `200`
+GET /models/{id} the response property `cargoHolds/items/name` became nullable for the status `200`
+PUT /models/{id} the response property `cargoHolds/items/name` became nullable for the status `200`
+PUT /models/{id}/use-rsi-image the response property `cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/modulePackage/model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/modulePackage/modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles the response property `items/items/paint/model/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/model/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `paint/model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `paint/model/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/model/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/modules/items/models/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `paint/model/cargoHolds/items/name` became nullable for the status `200`

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7850,7 +7850,9 @@ components:
       type: object
       properties:
         name:
-          type: string
+          type:
+          - string
+          - 'null'
         dimensions:
           "$ref": "#/components/schemas/CargoHoldDimension"
         capacity:

--- a/swagger/v1/oasdiff-ignore.txt
+++ b/swagger/v1/oasdiff-ignore.txt
@@ -972,3 +972,11 @@ PUT /vehicles/{vehicle_id}/loadouts/{id}/activate the response property `hardpoi
 GET /wishlist the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
 GET /wishlist the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
 GET /wishlist the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /fleets/invites the response property `items/fleetRole` became optional for the status `200`
+POST /fleets/use-invite the response property `fleetRole` became optional for the status `201`
+GET /fleets/{fleetSlug}/members the response property `items/items/fleetRole` became optional for the status `200`
+POST /fleets/{fleetSlug}/members the response property `fleetRole` became optional for the status `201`
+PUT /fleets/{fleetSlug}/members/{username}/demote the response property `fleetRole` became optional for the status `200`
+PUT /fleets/{fleetSlug}/members/{username}/promote the response property `fleetRole` became optional for the status `200`
+GET /fleets/{fleetSlug}/membership the response property `fleetRole` became optional for the status `200`
+PUT /fleets/{fleetSlug}/membership the response property `fleetRole` became optional for the status `200`

--- a/swagger/v1/oasdiff-ignore.txt
+++ b/swagger/v1/oasdiff-ignore.txt
@@ -902,3 +902,73 @@ GET /fleets/{fleetSlug}/roles added the new `fleet:vehicles:delete` enum value t
 GET /fleets/{fleetSlug}/roles added the new `fleet:vehicles:manage` enum value to the `items/resourceAccess/items/` response property for the response status `200`
 GET /fleets/{fleetSlug}/roles added the new `fleet:vehicles:read` enum value to the `items/resourceAccess/items/` response property for the response status `200`
 GET /fleets/{fleetSlug}/roles added the new `fleet:vehicles:update` enum value to the `items/resourceAccess/items/` response property for the response status `200`
+GET /components the response property `items/items/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #1: Model]/cargoHolds/items/name` became nullable for the status `200`
+GET /fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/model/cargoHolds/items/name` became nullable for the status `200`
+GET /fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /hangar the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /hangar the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /hangar the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /models the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/embed the response property `items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/latest the response property `items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/with-docks the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug} the response property `cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug}/hardpoints the response property `items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /models/{slug}/loaners the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug}/module-packages the response property `items/items/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug}/module-packages the response property `items/items/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /models/{slug}/modules the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug}/modules the response property `items/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /models/{slug}/snub-crafts the response property `items/cargoHolds/items/name` became nullable for the status `200`
+GET /models/{slug}/variants the response property `items/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #1: Model]/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/model/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles the response property `items/items/anyOf[subschema #2: VehiclePublic]/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles/embed the response property `items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles/embed the response property `items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/fleets/{fleetSlug}/vehicles/embed the response property `items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /public/hangars/embed the response property `items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /public/hangars/embed the response property `items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/hangars/embed the response property `items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /public/hangars/{username} the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /public/hangars/{username} the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/hangars/{username} the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /public/wishlists/{username} the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /public/wishlists/{username} the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /public/wishlists/{username} the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /vehicles the response property `model/cargoHolds/items/name` became nullable for the status `201`
+POST /vehicles the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `201`
+POST /vehicles the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+DELETE /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+DELETE /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `model/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+PUT /vehicles/{id} the response property `modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts the response property `items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts the response property `items/hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts the response property `items/hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+POST /vehicles/{vehicle_id}/loadouts the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+POST /vehicles/{vehicle_id}/loadouts the response property `hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+POST /vehicles/{vehicle_id}/loadouts the response property `hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `201`
+DELETE /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+DELETE /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+DELETE /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id} the response property `hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id}/activate the response property `hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id}/activate the response property `hardpoints/items/hardpoint/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+PUT /vehicles/{vehicle_id}/loadouts/{id}/activate the response property `hardpoints/items/hardpoint/loadouts/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`
+GET /wishlist the response property `items/items/model/cargoHolds/items/name` became nullable for the status `200`
+GET /wishlist the response property `items/items/modulePackage/modules/items/cargoHolds/items/name` became nullable for the status `200`
+GET /wishlist the response property `items/items/modulePackage/modules/items/hardpoints/items/component/typeData/anyOf[subschema #4: CargoHold]/name` became nullable for the status `200`

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11275,7 +11275,9 @@ components:
       type: object
       properties:
         name:
-          type: string
+          type:
+          - string
+          - 'null'
         dimensions:
           "$ref": "#/components/schemas/CargoHoldDimension"
         capacity:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -14791,7 +14791,6 @@ components:
       required:
       - id
       - username
-      - fleetRole
       - shipsFilter
       - fleetSlug
       - fleetName
@@ -20978,15 +20977,26 @@ components:
           format: uuid
         name:
           type: string
+        active:
+          type: boolean
         url:
           type: string
         urlSource:
           type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
       additionalProperties: false
       required:
       - id
       - name
+      - active
       - url
+      - createdAt
+      - updatedAt
       title: VehicleLoadoutMinimal
     VehiclePublic:
       type: object

--- a/test/asyncapi/hangar_channel_test.rb
+++ b/test/asyncapi/hangar_channel_test.rb
@@ -13,6 +13,7 @@ class HangarChannelTest < AsyncapiTestCase
     broadcast "A vehicle in the user's hangar changed" do
       operationId "receiveHangarUpdate"
       message ::V1::Schemas::Vehicles::Vehicle
+      message ::Cable::V1::Schemas::HangarGroupChangedMessage
     end
   end
 

--- a/test/models/concerns/derived_cargo_holds_test.rb
+++ b/test/models/concerns/derived_cargo_holds_test.rb
@@ -3,12 +3,19 @@
 require "test_helper"
 
 class DerivedCargoHoldsTest < ActiveSupport::TestCase
+  # `limits` is required by the CargoHold component and present on every hold in
+  # the live catalogue, so a fixture without it renders a payload the API says
+  # cannot exist — which cable validation now rejects.
   private def hold(name, capacity: 32, size: 2.5)
     {
       "name" => name,
       "capacity" => capacity,
       "dimensions" => {"x" => size, "y" => size, "z" => size},
-      "max_container_size" => {"size" => 2, "dimensions" => {"x" => 2.5, "y" => 1.25, "z" => 1.25}}
+      "max_container_size" => {"size" => 2, "dimensions" => {"x" => 2.5, "y" => 1.25, "z" => 1.25}},
+      "limits" => {
+        "min" => {"dimensions" => {"x" => 1.25, "y" => 1.25, "z" => 1.25}, "capacity" => 1},
+        "max" => {"dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}, "capacity" => 8}
+      }
     }
   end
 

--- a/test/models/fleet_membership_test.rb
+++ b/test/models/fleet_membership_test.rb
@@ -60,7 +60,7 @@ class FleetMembershipTest < ActiveSupport::TestCase
   test "#schedule_setup_fleet_vehicles enqueues setup job on accept_request" do
     Sidekiq::Worker.clear_all
     other_user = create(:user)
-    membership = FleetMembership.create(fleet_id: @fleet.id, user_id: other_user.id, aasm_state: :requested)
+    membership = FleetMembership.create(fleet_id: @fleet.id, user_id: other_user.id, fleet_role: @fleet.default_member_role, aasm_state: :requested)
     Sidekiq::Worker.clear_all
 
     membership.accept_request!
@@ -71,7 +71,7 @@ class FleetMembershipTest < ActiveSupport::TestCase
   test "#schedule_setup_fleet_vehicles enqueues setup job on accept_invitation" do
     Sidekiq::Worker.clear_all
     other_user = create(:user)
-    membership = FleetMembership.create(fleet_id: @fleet.id, user_id: other_user.id, aasm_state: :invited)
+    membership = FleetMembership.create(fleet_id: @fleet.id, user_id: other_user.id, fleet_role: @fleet.default_member_role, aasm_state: :invited)
     Sidekiq::Worker.clear_all
 
     membership.accept_invitation!
@@ -94,7 +94,7 @@ class FleetMembershipTest < ActiveSupport::TestCase
   test "#remove_fleet_vehicles removes all relevant fleet_vehicles" do
     other_user = create(:user)
     other_user.vehicles.create(model: create(:model), wanted: false)
-    new_membership = FleetMembership.create!(fleet_id: @fleet.id, user_id: other_user.id, aasm_state: :accepted)
+    new_membership = FleetMembership.create!(fleet_id: @fleet.id, user_id: other_user.id, fleet_role: @fleet.default_member_role, aasm_state: :accepted)
 
     Updater::FleetMembershipVehiclesSetupJob.drain
 

--- a/test/playwright/app_commands/scenarios/admin_cargo_holds.rb
+++ b/test/playwright/app_commands/scenarios/admin_cargo_holds.rb
@@ -20,13 +20,21 @@ model.update!(cargo_holds: [
     "name" => "cargo_front",
     "capacity" => 8,
     "dimensions" => {"x" => 5.0, "y" => 2.5, "z" => 2.5},
-    "max_container_size" => {"size" => 8, "dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}}
+    "max_container_size" => {"size" => 8, "dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}},
+    "limits" => {
+      "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+      "max" => {"dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}, "capacity" => 8}
+    }
   },
   {
     "name" => "cargo_rear",
     "capacity" => 16,
     "dimensions" => {"x" => 10.0, "y" => 2.5, "z" => 2.5},
-    "max_container_size" => {"size" => 16, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}}
+    "max_container_size" => {"size" => 16, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}},
+    "limits" => {
+      "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+      "max" => {"dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}, "capacity" => 16}
+    }
   }
 ])
 

--- a/test/playwright/app_commands/scenarios/tools.rb
+++ b/test/playwright/app_commands/scenarios/tools.rb
@@ -19,13 +19,21 @@ model.update!(cargo_holds: [
     "name" => "cargo_front",
     "capacity" => 8,
     "dimensions" => {"x" => 5.0, "y" => 2.5, "z" => 2.5},
-    "max_container_size" => {"size" => 8, "dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}}
+    "max_container_size" => {"size" => 8, "dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}},
+    "limits" => {
+      "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+      "max" => {"dimensions" => {"x" => 2.0, "y" => 2.0, "z" => 2.0}, "capacity" => 8}
+    }
   },
   {
     "name" => "cargo_rear",
     "capacity" => 16,
     "dimensions" => {"x" => 10.0, "y" => 2.5, "z" => 2.5},
-    "max_container_size" => {"size" => 16, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}}
+    "max_container_size" => {"size" => 16, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}},
+    "limits" => {
+      "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+      "max" => {"dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}, "capacity" => 16}
+    }
   }
 ])
 
@@ -39,7 +47,11 @@ freelancer_max.update!(cargo_holds: [
     "name" => "cargo",
     "capacity" => 120,
     "dimensions" => {"x" => 12.5, "y" => 5.0, "z" => 5.0},
-    "max_container_size" => {"size" => 32, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}}
+    "max_container_size" => {"size" => 32, "dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}},
+    "limits" => {
+      "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+      "max" => {"dimensions" => {"x" => 2.5, "y" => 2.5, "z" => 2.5}, "capacity" => 32}
+    }
   }
 ])
 


### PR DESCRIPTION
`validation_mode` was `:warn_only` everywhere, which documents a contract without enforcing it — a broadcast that stops matching its schema logs a line nobody reads. Tests now raise instead:

```ruby
config.validation_mode = Rails.env.test? ? :enabled : :warn_only
```

Production keeps warning, because broadcasts run from `after_save` and `after_commit` and a raise there would roll back the write that triggered it.

## This does not depend on per-channel assertions

The hook fires on **every** broadcast the suite makes, not only where a channel declaration asserts. So the coverage is the whole suite — any model, job or integration test that happens to trigger a broadcast now validates its payload against the committed document. Turning it on produced **17 failures across three causes**, none of which the twelve channel assertions had caught.

## What it found

**A channel documented as carrying one thing carried two.** `HangarChannel` gets a `Vehicle` from `Vehicle#broadcast_update` and, separately, an empty `{}` from `HangarGroup#broadcast_update` for a group whose membership moved without any one vehicle changing. The declaration only described the first.

Declaring `{}` as an alternative would have been worse than leaving it out: an object schema with no constraints also matches a `Vehicle`, so the channel would have accepted anything and the vehicle contract would have stopped being enforced. The ping carries the group id instead — a shape no vehicle satisfies, and one a subscriber could act on rather than refetching blindly.

**Two fixtures built records production cannot produce.** The cargo hold helper omitted `limits`, which `CargoHold` requires — every hold in the live catalogue carries it, checked against the Caterpillar's fourteen, so the component was right and the fixture was not. And three memberships went through `FleetMembership.create` directly, bypassing the factory and its `fleet_role`, while `FleetMember` documents `fleetRole` as required. Every production path assigns a role and `Fleet` seeds its roles on create, so a roleless membership is only reachable by skipping callbacks — as the one test that wants that state does, via `update_columns`.

**A real bug in what the API serves.** `update_cargo_holds_db` skips a hold the loader wrote without dimensions; `cargo_holds_with_offsets`, which the API renders, did not. The endpoint served holds it documents as impossible.

The worse half: offsets are paired to rows by array index, and a row's `position` comes from the filtered list. A malformed hold ahead of a curated one therefore shifted every offset past it onto its neighbour — the bug `DerivedCargoHolds` was written to fix, arrived at from the other side. Both readers now share one predicate.

**And one wrong published contract.** `name` on a cargo hold is nullable: the game files leave holds unnamed often enough that `cargo_hold_keys` has a branch for it and a test covers keeping two apart, but the component promised a string. Relaxing it shows up as 70 + 86 `response-property-became-nullable` entries in the oasdiff ignore lists, which is what loosening a published response looks like. The schema was wrong, not the data.

## ✅ Verification

- **456 tests, 902 assertions, 0 failures** across `models/`, `jobs/` and `asyncapi/` with validation raising.
- `oasdiff breaking` run locally against `origin/main` for both `swagger/v1` and `swagger/admin/v1`: **no breaking changes to report** after the ignore entries, which were generated from the tool's own output rather than hand-written.
- Integration spot-checks over the cargo-hold-carrying endpoints pass.
- `standardrb` clean.

## Worth knowing

The runtime hook resolves against the **committed** document, not the live declarations. A declaration change needs `bin/generate-asyncapi` before validation sees it — I hit that twice while working through this, each time reading as "my fix did nothing".

🤖
