### PR TITLE
fix(ci): copy pnpm-workspace.yaml into the build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ RUN bundle install --jobs 4 && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Install Node dependencies (skip postinstall, orval runs after full copy)
-# patches/ comes along because package.json's patchedDependencies reads from it
-COPY package.json pnpm-lock.yaml ./
+# patches/ comes along because pnpm-workspace.yaml's patchedDependencies reads from it
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches
 RUN pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
Main has been red since #4518 — every push fails on `build / build`, and only that job.

#4518 moved `overrides`, `patchedDependencies` and `onlyBuiltDependencies` out of `package.json` into `pnpm-workspace.yaml`. The Dockerfile still copies only `package.json` and `pnpm-lock.yaml`, so inside the image pnpm sees no overrides while the lockfile still records them:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

The buildx error only names the `RUN` step, so the cause is a few lines further up in the log. The other CI jobs stayed green because they check out the whole repo.

## Verification

Built a throwaway image with just `corepack prepare pnpm@10.31.0`, the two `COPY` lines and `pnpm install --frozen-lockfile --ignore-scripts` — passes (`Done in 2m 17s using pnpm v10.31.0`). Without `pnpm-workspace.yaml` it reproduces the failure above.

🤖