### PR TITLE
fix(fleets): rank promote and demote against one ordering

### DIFF
--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -369,19 +369,24 @@ class FleetMembership < ApplicationRecord
   end
 
   def next_fleet_role
-    return if fleet_role.nil?
+    ranked_roles, index = ranked_roles_and_index
+    return if index.nil? || index - 1 < 0
 
-    index = fleet.fleet_roles.ranked.index(fleet_role)
-
-    return if index - 1 < 0
-
-    fleet.fleet_roles[index - 1]
+    ranked_roles[index - 1]
   end
 
   def prev_fleet_role
-    return if fleet_role.nil?
+    ranked_roles, index = ranked_roles_and_index
+    return if index.nil?
 
-    index = fleet.fleet_roles.ranked.index(fleet_role)
-    fleet.fleet_roles[index + 1]
+    ranked_roles[index + 1]
+  end
+
+  private def ranked_roles_and_index
+    return [nil, nil] if fleet_role.nil?
+
+    ranked_roles = fleet.fleet_roles.ranked.to_a
+
+    [ranked_roles, ranked_roles.index(fleet_role)]
   end
 end

--- a/test/models/fleet_membership_test.rb
+++ b/test/models/fleet_membership_test.rb
@@ -104,4 +104,45 @@ class FleetMembershipTest < ActiveSupport::TestCase
       new_membership.destroy
     end
   end
+
+  test "#next_fleet_role and #prev_fleet_role follow the ranked order after a reorder" do
+    officer_user = create(:user)
+    officer_role = @fleet.fleet_roles.ranked.second
+    officer_membership = @fleet.fleet_memberships.create!(user: officer_user, fleet_role: officer_role, aasm_state: :accepted)
+
+    recruit_role = @fleet.fleet_roles.create!(name: "Recruit", resource_access: FleetRole.preset_privileges[:member])
+    recruit_role.move_to(1)
+    @fleet.reload
+
+    assert_equal recruit_role, officer_membership.next_fleet_role
+    assert_equal @fleet.fleet_roles.ranked.last, officer_membership.prev_fleet_role
+  end
+
+  test "#demote moves the member down the ranked order after a reorder" do
+    officer_user = create(:user)
+    officer_role = @fleet.fleet_roles.ranked.second
+    officer_membership = @fleet.fleet_memberships.create!(user: officer_user, fleet_role: officer_role, aasm_state: :accepted)
+
+    recruit_role = @fleet.fleet_roles.create!(name: "Recruit", resource_access: FleetRole.preset_privileges[:member])
+    recruit_role.move_to(1)
+    @fleet.reload
+
+    member_role = @fleet.fleet_roles.ranked.last
+
+    assert officer_membership.demote
+    assert_equal member_role, officer_membership.reload.fleet_role
+  end
+
+  test "#promote moves the member up the ranked order after a reorder" do
+    officer_user = create(:user)
+    officer_role = @fleet.fleet_roles.ranked.second
+    officer_membership = @fleet.fleet_memberships.create!(user: officer_user, fleet_role: officer_role, aasm_state: :accepted)
+
+    recruit_role = @fleet.fleet_roles.create!(name: "Recruit", resource_access: FleetRole.preset_privileges[:member])
+    recruit_role.move_to(1)
+    @fleet.reload
+
+    assert officer_membership.promote
+    assert_equal recruit_role, officer_membership.reload.fleet_role
+  end
 end


### PR DESCRIPTION
Fixes the flaky `FleetsMembersDemoteTest#test_...demotes_the_officer` failure — expected 200, got 400 `You can't demote the last Member of a permanent Fleet Role`. It last showed up on the release PR #4513, which carries no code change, so it is a pre-existing flake on main (2 of the last 20 runs were red, the other one for an unrelated reason).

## Cause

The rendered message points at the wrong branch. `next_fleet_role` and `prev_fleet_role` took their index from `fleet.fleet_roles.ranked` and then read it back out of `fleet.fleet_roles`:

```ruby
index = fleet.fleet_roles.ranked.index(fleet_role)
fleet.fleet_roles[index + 1]
```

`ranked` is lexorank's `where.not(rank: nil).order(rank: :asc)` over a text column; the `has_many` declares no order at all. The two agree only while rank order happens to match insertion order, which is true for a freshly created fleet — hence green almost everywhere. Once they diverge the lookup returns the membership's own role, `promote`/`demote` return nil, and the controller renders 400.

## Reproduction

Adding a fourth role and `move_to(1)`-ing it makes it deterministic:

```
ranked:    [["Admin", "0"], ["Recruit", "00U"], ["Officer", "10"], ["Member", "20"]]
unordered: ["Admin", "Officer", "Member", "Recruit"]
next_fleet_role for Officer: "Officer"   # its own role
```

## Change

Materialise the ranked list once and index only that. Three regression tests cover `next`/`prev`, `promote` and `demote` after a reorder — all three fail without the model change and pass with it.

One caveat: I could not trigger the CI flake itself locally, not even running 70 fleet tests across 4 workers. The ordering bug is proven and sits exactly on the path that produced the 400, so it is very likely the cause of that run, but that part is not proven.

🤖