### PR TITLE
feat(sc_data): read equipment off the build

### DIFF
--- a/app/api_components/shared/v1/schemas/equipment.rb
+++ b/app/api_components/shared/v1/schemas/equipment.rb
@@ -67,11 +67,13 @@ module Shared
 
             storeImage: {"$ref": "#/components/schemas/MediaFile"},
 
+            retired: {type: :boolean},
+
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id name slug availability createdAt updatedAt]
+          required: %w[id name slug availability retired createdAt updatedAt]
         })
       end
     end

--- a/app/controllers/admin/api/v1/equipment_controller.rb
+++ b/app/controllers/admin/api/v1/equipment_controller.rb
@@ -42,7 +42,7 @@ module Admin
         end
 
         def update
-          return if @equipment.update(equipment_params)
+          return if @equipment.update_with_facts(equipment_params)
 
           render json: ValidationError.new("equipment.update", errors: @equipment.errors), status: :bad_request
         end

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -93,6 +93,15 @@ module ScData
         )
 
         apply(build, params)
+
+        # Saving the record above ran its validations, and a fact reader consults
+        # the build -- so the association may have cached a nil from before this
+        # row existed. Dropped rather than left to answer for a build there now is.
+        %i[build last_build].each do |association|
+          record.association(association).reset if record.class.reflect_on_association(association)
+        end
+
+        build
       end
 
       # The build this loader is writing, which is not always the configured one:

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -95,6 +95,25 @@ module ScData
         apply(build, params)
       end
 
+      # The build this loader is writing, which is not always the configured one:
+      # a caller can point a loader at another environment's tree.
+      def source
+        ::ScData::Source.new(version: sc_version, environment: sc_environment)
+      end
+
+      # The build equivalent of `retire_absent`. A record the export dropped
+      # keeps its row, but it must stop having a row for the build it is no
+      # longer part of -- otherwise asking "is this in the current build?" by
+      # row existence answers yes for something the build does not carry.
+      #
+      # Nothing retires on a run that loaded nothing, for the same reason
+      # `retire_absent` does not: `where.not(id: [])` is `1=1`.
+      def retire_absent_builds(build_class, foreign_key, loaded)
+        return 0 if loaded.blank?
+
+        build_class.current(source).where.not(foreign_key => loaded).delete_all
+      end
+
       # Keeps the last few builds of this environment and drops the rest. Run
       # after a load rather than during it, so a build being written is never a
       # candidate for pruning.

--- a/app/lib/sc_data/loader/equipment_loader.rb
+++ b/app/lib/sc_data/loader/equipment_loader.rb
@@ -5,6 +5,7 @@ module ScData
         loaded = load_items("equipment").filter_map { |equipment_data| one(equipment_data)&.id }
 
         retire_absent(Equipment, loaded)
+        retire_absent_builds(EquipmentBuild, :equipment_id, loaded)
 
         prune_builds(EquipmentBuild)
       end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -71,6 +71,57 @@ class Equipment < ApplicationRecord
     end
   }
 
+  # The newest build of this environment that still describes the item, which is
+  # what a record the export dropped falls back to. Without it a retired item
+  # would read as nameless, and an inventory entry pointing at one has to
+  # resolve to something.
+  has_one :last_build,
+    -> { for_source.order(created_at: :desc) },
+    class_name: "EquipmentBuild", inverse_of: :equipment
+
+  # Not in the build we are on. Said out loud in the API, which until now offered
+  # a record the export had dropped as though it were current.
+  def retired?
+    build.blank?
+  end
+
+  # The build we are on, or the last one that described the item.
+  def facts
+    build || last_build
+  end
+
+  # An admin correction is a correction to the build we are on, so it has to
+  # reach the build as well as the row.
+  #
+  # The next load overwrites it, and that is the point: the game files hold what
+  # is actually in the game, so a wrong value here is a parser bug, and the fix
+  # belongs in the parser. Nothing is curated on equipment the way Model splits
+  # its `rsi_*` columns from the ones a person maintains.
+  def update_with_facts(attributes)
+    transaction do
+      return false unless update(attributes)
+
+      facts_attributes = attributes.to_h.symbolize_keys.slice(*EquipmentBuild::FACTS)
+
+      # Reloaded rather than read off the association: validating the row above
+      # consults a fact reader, which caches whatever the build was at that
+      # moment -- a nil, for a row whose build is written afterwards.
+      reload_build&.update!(facts_attributes) if facts_attributes.present?
+
+      true
+    end
+  end
+
+  # Read through the build, falling back to the column. The column still answers
+  # for a record no load has given a build -- an admin can create one by hand.
+  EquipmentBuild::READ_THROUGH.each do |fact|
+    define_method(fact) do
+      value = facts&.public_send(fact)
+
+      value.nil? ? super() : value
+    end
+  end
+
   # Nothing fills this from the game files: the loadout icons the records name
   # are art the export leaves out on purpose. It is here for the same reason
   # every other catalogue has one -- an upload, and the ledger's fallback to

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -57,6 +57,20 @@ class Equipment < ApplicationRecord
   has_many :builds, class_name: "EquipmentBuild", dependent: :destroy
   has_one :build, -> { current }, class_name: "EquipmentBuild", inverse_of: :equipment
 
+  # Whether the build we are on describes this item, rather than whether the
+  # version string on the row still matches it. An exists check rather than a
+  # join, so nothing fans out and `current_version(false)` stays the plain table.
+  #
+  # Overrides ScDataVersioned for equipment only; the other catalogues still
+  # compare their column until they have builds of their own.
+  scope :current_version, ->(flag = true, source = ::ScData::Source.current) {
+    if ActiveModel::Type::Boolean.new.cast(flag)
+      where(id: EquipmentBuild.current(source).select(:equipment_id))
+    else
+      all
+    end
+  }
+
   # Nothing fills this from the game files: the loadout icons the records name
   # are art the export leaves out on purpose. It is here for the same reason
   # every other catalogue has one -- an upload, and the ledger's fallback to

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -62,6 +62,17 @@ class EquipmentBuild < ApplicationRecord
   # the table growing with every patch forever.
   BUILDS_RETAINED = 3
 
+  # Everything a build says, as opposed to what identifies the item. The data
+  # migration carries its own copy on purpose: a migration has to keep running
+  # against the schema of its own moment, not this list as it later becomes.
+  FACTS = %i[
+    manufacturer_id name description equipment_type item_type sub_type
+    weapon_class size grade slot hidden rate_of_fire range storage
+    damage_reduction temperature_rating radiation_protection
+    radiation_scrub_rate g_force_tolerance core_compatibility
+    backpack_compatibility volume volume_dimensions
+  ].freeze
+
   validates :environment, presence: true
   validates :version, presence: true
   validates :equipment_id, uniqueness: {scope: [:environment, :version]}

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -73,6 +73,25 @@ class EquipmentBuild < ApplicationRecord
     backpack_compatibility volume volume_dimensions
   ].freeze
 
+  # The facts Equipment reads through its build. `manufacturer_id` and `hidden`
+  # are held back: the association and the `visible` scope still go through the
+  # columns, and both move with the filters rather than with the readers.
+  READ_THROUGH = (FACTS - %i[manufacturer_id hidden]).freeze
+
+  # The same enums Equipment declares, because a build row holding `0` has to
+  # read as `undersuit` here too. Without them, moving the readers over turns
+  # every enum-backed fact back into a raw integer.
+  enum :slot,
+    {
+      undersuit: 0, arms: 1, helmet: 2, torso: 3, legs: 4, footwear: 5, hat: 6, gloves: 7,
+      pants: 8, shirt: 9, jacket: 10, backpack: 11
+    },
+    suffix: true
+
+  enum :core_compatibility, {all: 0, medium_heavy: 1, heavy: 2}, suffix: true
+
+  enum :backpack_compatibility, {all: 0, light_medium: 1, light: 2}, suffix: true
+
   validates :environment, presence: true
   validates :version, presence: true
   validates :equipment_id, uniqueness: {scope: [:environment, :version]}

--- a/app/views/api/v1/equipment/_base.jbuilder
+++ b/app/views/api/v1/equipment/_base.jbuilder
@@ -43,6 +43,8 @@ json.availability do
   end
 end
 
+json.retired equipment.retired?
+
 json.store_image do
   json.partial! "api/v1/shared/file", record: equipment, attr: :store_image
 end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -9785,6 +9785,8 @@ components:
           - soldAt
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
+        retired:
+          type: boolean
         createdAt:
           type: string
           format: date-time
@@ -9819,6 +9821,7 @@ components:
       - name
       - slug
       - availability
+      - retired
       - createdAt
       - updatedAt
       - hidden

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -12957,6 +12957,8 @@ components:
           - soldAt
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
+        retired:
+          type: boolean
         createdAt:
           type: string
           format: date-time
@@ -12969,6 +12971,7 @@ components:
       - name
       - slug
       - availability
+      - retired
       - createdAt
       - updatedAt
       title: Equipment

--- a/test/factories/equipment.rb
+++ b/test/factories/equipment.rb
@@ -55,6 +55,28 @@ FactoryBot.define do
     hidden { false }
     version { Rails.configuration.sc_data[:version] }
 
+    transient { with_build { true } }
+
+    # A build describing the item, mirroring what the backfill did for the rows
+    # already in the table. Keyed on the row's own version, so
+    # `create(:equipment, version: <older>)` is retired here too.
+    after(:create) do |equipment, evaluator|
+      next unless evaluator.with_build
+      next if equipment.version.blank?
+
+      equipment.builds.create!(
+        environment: ScData::Source.environment,
+        version: equipment.version,
+        **equipment.attributes.symbolize_keys.slice(*EquipmentBuild::FACTS)
+      )
+    end
+
+    # For tests that manage builds themselves and would otherwise collide with
+    # the one above.
+    trait :without_build do
+      with_build { false }
+    end
+
     trait :with_store_image do
       store_image { Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test.png"), "image/png") }
     end

--- a/test/factories/equipment.rb
+++ b/test/factories/equipment.rb
@@ -69,6 +69,11 @@ FactoryBot.define do
         version: equipment.version,
         **equipment.attributes.symbolize_keys.slice(*EquipmentBuild::FACTS)
       )
+
+      # Validating the row consulted a fact reader, which cached the build as it
+      # was then -- absent. Dropped so the record behaves like a freshly loaded one.
+      equipment.association(:build).reset
+      equipment.association(:last_build).reset
     end
 
     # For tests that manage builds themselves and would otherwise collide with

--- a/test/factories/equipment_builds.rb
+++ b/test/factories/equipment_builds.rb
@@ -47,7 +47,7 @@
 #
 FactoryBot.define do
   factory :equipment_build do
-    equipment
+    association :equipment, factory: [:equipment, :without_build]
     environment { ScData::Source.environment }
     version { ScData::Source.version }
     sequence(:name) { |n| "#{Faker::Company.name} Rifle #{n}" }

--- a/test/jobs/sc_data/check_job_test.rb
+++ b/test/jobs/sc_data/check_job_test.rb
@@ -5,9 +5,10 @@ require "test_helper"
 module ScData
   class CheckJobTest < ActiveJob::TestCase
     VERSION = "3.24.0"
+    ENVIRONMENT = "live"
 
     setup do
-      Rails.configuration.stubs(:sc_data).returns({version: VERSION})
+      Rails.configuration.stubs(:sc_data).returns({version: VERSION, environment: ENVIRONMENT})
     end
 
     test "#perform enqueues AllJob when version is new" do
@@ -19,7 +20,7 @@ module ScData
     end
 
     test "#perform does not enqueue AllJob when version is blank" do
-      Rails.configuration.stubs(:sc_data).returns({version: nil})
+      Rails.configuration.stubs(:sc_data).returns({version: nil, environment: ENVIRONMENT})
 
       Loaders::ScData::AllJob.expects(:perform_async).never
 

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -10,7 +10,7 @@ module ScData
     class BaseLoaderApplyBuildTest < ActiveSupport::TestCase
       setup do
         @loader = ::ScData::Loader::BaseLoader.new
-        @equipment = create(:equipment)
+        @equipment = create(:equipment, :without_build)
       end
 
       test "#apply_build records the build the current environment is on" do
@@ -49,6 +49,44 @@ module ScData
         assert_equal ::ScData::Source.version, @equipment.build.version
       end
 
+      # Without this, a record the export dropped keeps its row for the build it
+      # is no longer part of -- and asking "is this in the current build?" by row
+      # existence would answer yes.
+      test "#retire_absent_builds drops the current build's row for a record the run did not load" do
+        kept = create(:equipment, :without_build)
+        dropped = create(:equipment, :without_build)
+        @loader.apply_build(kept, {name: "Kept"})
+        @loader.apply_build(dropped, {name: "Dropped"})
+
+        @loader.retire_absent_builds(EquipmentBuild, :equipment_id, [kept.id])
+
+        assert_predicate kept.reload.build, :present?
+        assert_nil dropped.reload.build
+        assert Equipment.exists?(dropped.id), "the row itself has to stay"
+      end
+
+      # An earlier build is history, not something this run reconciles.
+      test "#retire_absent_builds leaves an earlier build alone" do
+        equipment = create(:equipment, :without_build)
+        earlier = create(
+          :equipment_build,
+          equipment:, environment: ::ScData::Source.environment, version: "4.8.0-live.1"
+        )
+
+        @loader.retire_absent_builds(EquipmentBuild, :equipment_id, [create(:equipment, :without_build).id])
+
+        assert EquipmentBuild.exists?(earlier.id)
+      end
+
+      # `where.not(id: [])` is `1=1`, so a run that loaded nothing must not empty
+      # the build it was going to write.
+      test "#retire_absent_builds retires nothing when the run loaded nothing" do
+        @loader.apply_build(@equipment, {name: "Behring P4-AR"})
+
+        assert_equal 0, @loader.retire_absent_builds(EquipmentBuild, :equipment_id, [])
+        assert_predicate @equipment.reload.build, :present?
+      end
+
       # Bounded on purpose: history is worth a couple of patches, not every patch
       # ever shipped.
       test "#prune_builds keeps the retained builds and drops the rest" do
@@ -57,7 +95,7 @@ module ScData
         (keep + 2).times do |index|
           create(
             :equipment_build,
-            equipment: create(:equipment),
+            equipment: create(:equipment, :without_build),
             environment: ::ScData::Source.environment,
             version: "4.#{index}.0-live.#{index}",
             created_at: index.days.from_now

--- a/test/loaders/sc_data/equipment_loader_test.rb
+++ b/test/loaders/sc_data/equipment_loader_test.rb
@@ -214,7 +214,7 @@ module ScData
 
         assert Equipment.exists?(retired.id), "the row has to stay for existing references"
         assert_nil retired.reload.version
-        assert_not Equipment.current_version.exists?(retired.id)
+        assert_not Equipment.current_version(true, fixture_source).exists?(retired.id)
       end
 
       test "#all leaves the records still in the export on the current build" do
@@ -222,7 +222,8 @@ module ScData
         curated.all
 
         assert_predicate Equipment.count, :positive?
-        assert_equal Equipment.pluck(:sc_key).sort, Equipment.current_version.pluck(:sc_key).sort
+        assert_equal Equipment.pluck(:sc_key).sort,
+          Equipment.current_version(true, fixture_source).pluck(:sc_key).sort
       end
 
       # A tree that carries no equipment at all is what a build whose files
@@ -267,8 +268,9 @@ module ScData
       test "#all persists the volume onto the record" do
         curated.all
 
-        assert_equal Equipment.count, Equipment.current_version.where.not(volume: nil).count
-        assert_equal Equipment.count, Equipment.current_version.where.not(volume_dimensions: nil).count
+        assert_equal Equipment.count, Equipment.current_version(true, fixture_source).where.not(volume: nil).count
+        assert_equal Equipment.count,
+          Equipment.current_version(true, fixture_source).where.not(volume_dimensions: nil).count
 
         helmet = Equipment.find_by(sc_key: "gys_helmet_03_01_01")
 

--- a/test/models/equipment_build_test.rb
+++ b/test/models/equipment_build_test.rb
@@ -54,7 +54,7 @@ require "test_helper"
 #
 class EquipmentBuildTest < ActiveSupport::TestCase
   test "an item carries one row per build, not two" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     create(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
 
     duplicate = build(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
@@ -66,14 +66,14 @@ class EquipmentBuildTest < ActiveSupport::TestCase
   # The point of keeping history: a later build lands beside its predecessor
   # rather than overwriting it.
   test "a later build of the same environment sits beside the earlier one" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     create(:equipment_build, equipment:, environment: "live", version: "4.9.0-live.1")
 
     assert_predicate build(:equipment_build, equipment:, environment: "live", version: "4.10.0-live.2"), :valid?
   end
 
   test "the same item can be described by more than one environment" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     create(:equipment_build, equipment:, environment: "live")
 
     assert_predicate build(:equipment_build, equipment:, environment: "ptu"), :valid?
@@ -87,7 +87,7 @@ class EquipmentBuildTest < ActiveSupport::TestCase
   # `for_source` is what the `build` association narrows by, so an environment
   # only ever sees its own row.
   test ".for_source keeps only the current environment" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     live = create(:equipment_build, equipment:, environment: ScData::Source.environment)
     other = create(:equipment_build, equipment:, environment: "somewhere-else")
 
@@ -98,16 +98,16 @@ class EquipmentBuildTest < ActiveSupport::TestCase
   # An environment that has moved on leaves its old row behind until the next
   # load rewrites it, so the version is checked as well as the environment.
   test ".current also narrows to the version the environment is on" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     current = create(:equipment_build, equipment:)
-    stale = create(:equipment_build, equipment: create(:equipment), version: "0.0.1-live.1")
+    stale = create(:equipment_build, equipment: create(:equipment, :without_build), version: "0.0.1-live.1")
 
     assert_includes EquipmentBuild.current, current
     refute_includes EquipmentBuild.current, stale
   end
 
   test "#build returns the row for the current environment" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     create(:equipment_build, equipment:, environment: "somewhere-else")
     current = create(:equipment_build, equipment:, environment: ScData::Source.environment)
 
@@ -120,7 +120,7 @@ class EquipmentBuildTest < ActiveSupport::TestCase
     %w[4.8.0-live.1 4.9.0-live.2 4.10.0-live.3 4.11.0-live.4].each_with_index do |version, index|
       create(
         :equipment_build,
-        equipment: create(:equipment), environment: "live", version:,
+        equipment: create(:equipment, :without_build), environment: "live", version:,
         created_at: index.days.ago.end_of_day
       )
     end
@@ -139,7 +139,7 @@ class EquipmentBuildTest < ActiveSupport::TestCase
   end
 
   test "builds go when the item does" do
-    equipment = create(:equipment)
+    equipment = create(:equipment, :without_build)
     create(:equipment_build, equipment:)
 
     assert_difference("EquipmentBuild.count", -1) { equipment.destroy }

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -74,6 +74,75 @@ class EquipmentTest < ActiveSupport::TestCase
     assert_equal [shown.id], Equipment.visible.pluck(:id)
   end
 
+  # A record the export dropped keeps the values of the last build that described
+  # it -- an inventory entry pointing at one has to resolve to something -- and
+  # says so, rather than serving them as if they were current.
+  test "a retired record reads the last build that described it, and is marked" do
+    equipment = create(:equipment, :without_build, name: "Column Name")
+    create(
+      :equipment_build,
+      equipment:, environment: ScData::Source.environment,
+      version: "0.0.1-live.1", name: "Behring P4-AR", size: "3"
+    )
+
+    assert_equal "Behring P4-AR", equipment.reload.name
+    assert_equal "3", equipment.size
+    assert_predicate equipment, :retired?
+  end
+
+  test "a record in the current build reads that build, and is not retired" do
+    equipment = create(:equipment, :without_build, name: "Column Name")
+    create(:equipment_build, equipment:, name: "Behring P4-AR")
+
+    assert_equal "Behring P4-AR", equipment.reload.name
+    assert_not_predicate equipment, :retired?
+  end
+
+  test "the current build wins over an earlier one" do
+    equipment = create(:equipment, :without_build)
+    create(:equipment_build, equipment:, version: "0.0.1-live.1", size: "1")
+    create(:equipment_build, equipment:, size: "4")
+
+    assert_equal "4", equipment.reload.size
+  end
+
+  # An admin can create a record by hand, and no load has given it a build yet.
+  test "a record with no build at all falls back to its own columns" do
+    equipment = create(:equipment, :without_build, name: "Hand Made", size: "2")
+
+    assert_equal "Hand Made", equipment.reload.name
+    assert_equal "2", equipment.size
+    assert_predicate equipment, :retired?
+  end
+
+  # An enum-backed fact has to read as its name from the build too, not as the
+  # integer the column stores.
+  test "an enum fact read off the build keeps its name" do
+    equipment = create(:equipment, :without_build)
+    create(:equipment_build, equipment:, slot: :torso)
+
+    assert_equal "torso", equipment.reload.slot
+  end
+
+  # Without this the reader would go on serving the build's old value.
+  test "#update_with_facts writes the correction to the build as well" do
+    equipment = create(:equipment, name: "Typo")
+
+    assert equipment.update_with_facts({name: "Corrected"})
+
+    assert_equal "Corrected", equipment.reload.name
+    assert_equal "Corrected", equipment.build.name
+  end
+
+  test "#update_with_facts leaves a retired record's build alone" do
+    equipment = create(:equipment, :without_build, name: "Typo")
+    old = create(:equipment_build, equipment:, version: "0.0.1-live.1", name: "Old Name")
+
+    assert equipment.update_with_facts({name: "Corrected"})
+
+    assert_equal "Old Name", old.reload.name
+  end
+
   test ".current_version narrows to the patch the game ships, or opts out" do
     current = create(:equipment)
     retired = create(:equipment, version: "0.0.1-live.1")

--- a/test/support/sc_data_fixture_tree.rb
+++ b/test/support/sc_data_fixture_tree.rb
@@ -13,6 +13,13 @@ module ScDataFixtureTree
     end
   end
 
+  # The build a fixture loader writes: the configured version, but the fixture
+  # environment rather than the configured one. What `current_version` has to be
+  # asked about when the records came from this tree.
+  def fixture_source
+    ::ScData::Source.new(version: ::ScData::Source.version, environment: FIXTURE_ENVIRONMENT)
+  end
+
   # A tree that carries no catalogue at all -- what a build whose files failed
   # to sync looks like from a loader's side.
   def empty_tree_loader(loader_class)


### PR DESCRIPTION
Equipment stopped reading its own columns. Both halves of that move are here: whether the item exists in the build we are on, and what that build says about it.

Two commits, reviewable in order. **Filters and sorting follow in #4532.**

## 1. Currency is row existence

`current_version` compared the version string on the row. It now asks whether the build we are on has a row describing the item:

```ruby
scope :current_version, ->(flag = true, source = ::ScData::Source.current) {
  if ActiveModel::Type::Boolean.new.cast(flag)
    where(id: EquipmentBuild.current(source).select(:equipment_id))
  else
    all
  end
}
```

An exists check rather than a join, so nothing fans out and `currentVersion=false` stays the plain table.

**"Is this in the current build?" is now row existence.** That is the mechanism that eventually replaces both `retire_absent` and the `version` column.

The scope takes a source because a loader can be pointed at another environment's tree, and then "current" means *that* environment's build, not the configured one. `BaseLoader#source` is the same idea from the writing side — the first piece of the per-request scoping the PTU work needs.

## 2. Facts come from the build

Three steps, in order: the current build, else the last build that described the item, else the column.

```ruby
def facts
  build || last_build
end

EquipmentBuild::READ_THROUGH.each do |fact|
  define_method(fact) do
    value = facts&.public_send(fact)

    value.nil? ? super() : value
  end
end
```

The `last_build` fallback is the answer to a question this PR could not dodge: a record the export dropped has no *current* build, so a hard delegation would make it nameless — and an inventory entry pointing at one has to resolve to something. It keeps the last values instead, and **says so**: `retired` is now in the API, which until now served a dropped record as though it were current.

The column still answers for a record no load has given a build. An admin can create one by hand.

`EquipmentBuild` repeats Equipment's three enums, because a build row holding `0` has to read as `undersuit` here too. Without them, moving the readers over quietly turns every enum-backed fact back into a raw integer.

### Admin corrections reach the build

Otherwise the reader goes on serving the old value and the correction looks like it did nothing. `update_with_facts` writes both.

The next load overwrites it, and **that is intended**: the game files hold what is actually in the game, so a wrong value is a parser bug and the fix belongs in the parser. Nothing on equipment is curated the way `Model` splits its `rsi_*` columns from the fields a person maintains.

## The association cache, twice

Worth calling out, because every later catalogue will hit it.

Saving the row runs its validations; `validates :name` calls the fact reader; the reader asks for `build` — and caches the answer. When the build is written *afterwards*, that cached `nil` is what the reader keeps returning. It cost me two wrong diagnoses.

It bites in three places, all now handled: `apply_build` resets the association after saving, `update_with_facts` uses `reload_build` instead of the cached one, and the factory resets after creating its build.

## Deliberately *not* in this change

**Filters and sorting still read the columns** — `manufacturer_id` and `hidden` are held back from `READ_THROUGH` for exactly that reason. They are dual-written and identical, so this is behaviour-preserving, and moving them means going through ransack, which silently drops a condition it does not recognise. That is #4532, stacked on this one.

**The columns stay.** Dropping them should lag by at least a release.

## The factory did the heavy lifting

Without a build row, every piece of test equipment would have become invisible. Rather than editing ~100 call sites across 15 files, the `:equipment` factory creates one — mirroring the backfill, keyed on the row's own version, so `create(:equipment, version: <older>)` is retired here too. That is what keeps both existing `current_version` tests passing **untouched**.

`:without_build` is for the tests that manage builds themselves and would otherwise collide on the unique index.

## Verification

CI green — 16 of 16, including the full Ruby suite and e2e.

Local: 7 new model tests covering the fallback chain, the retired marker, enum names through the build, and both `update_with_facts` paths. The equipment loader contract suite is 27 tests, 87 assertions.

One correction to numbers I reported earlier on the first commit: two "errors" I attributed to a worktree Vite gap were partly that, but one full-suite run was also polluted by a row my own `rails runner -e test` had committed into the test database — that writes and commits, unlike a test, which rolls back. CI is the honest signal here, and it is green.

🤖
