### PR TITLE
refactor(api): name every request and response body

### DIFF
--- a/.cursor/rules/backend/api-components.mdc
+++ b/.cursor/rules/backend/api-components.mdc
@@ -1,0 +1,75 @@
+---
+description:
+globs: app/api_components/**/*.rb,test/integration/**/*_test.rb
+alwaysApply: true
+---
+
+# API Components
+
+The OpenAPI schema is generated from the integration tests, so the tests decide
+what the schema looks like. Keep the shapes out of them.
+
+## Never define request or response types inline
+
+Every request body and every response body is a `$ref` to a component class
+under `app/api_components/`. The test declares the reference, never the shape.
+
+```ruby
+# Good
+request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
+
+response(200, "successful") do
+  schema "$ref": "#/components/schemas/MessageResponse"
+end
+
+# Bad
+request_body required: true, schema: {
+  type: :object,
+  properties: {modelId: {type: :string, format: :uuid}},
+  required: [:modelId]
+}
+```
+
+An inline body has no name, so Orval invents one from the operation
+(`UnlinkModelModuleBody`, `ReloadLoaners200`). Endpoints sharing a payload end
+up with unrelated TypeScript types that drift, and the frontend has nothing
+stable to import.
+
+## Placement
+
+- Request bodies → `<scope>/v1/schemas/inputs/<name>_input.rb`
+- Response bodies → `<scope>/v1/schemas/<name>.rb`
+- Used by both the public and the admin schema → `shared/v1/`
+- Enums → their own component in `shared/v1/schemas/enums/`, referenced by
+  `$ref`; never inline an `enum:` into a property
+
+Scopes come from `config.component_scope_paths` in
+`config/initializers/openapi_ruby.rb` — `v1`, `admin/v1`, `oauth/v1`,
+`cable/v1`, and `shared/v1` (registered into both `v1` and `admin`).
+
+## Reuse first
+
+Check for an existing component before adding one. `SortInput`,
+`StandardError`, `SuccessResponse`, `MessageResponse` and the
+`BaseList` / `Meta` pair cover most small payloads.
+
+## The one inline exception
+
+The `q` deepObject query parameter needs a literal `type: :object` alongside
+`style: :deepObject`, and carries its `$ref` to a `<Name>Query` component:
+
+```ruby
+parameter name: "q", in: :query,
+  schema: {type: :object, "$ref": "#/components/schemas/ModelQuery"},
+  style: :deepObject, explode: true, required: false
+```
+
+## After changing components
+
+```bash
+bundle exec standardrb --fix
+./bin/generate-schema          # regenerates swagger/*.yaml and the Orval clients
+pnpm lint:ts
+```
+
+Never edit `swagger/*.yaml` by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,49 @@ When adding new API endpoints, follow this order:
 8. **Generate schema**: `./bin/generate-schema`
 9. **Run tests**: `bin/rails test`
 
+### Never define request or response types inline
+
+Every request body and every response body must be a `$ref` to an explicit
+component class under `app/api_components/`. The integration test declares the
+reference, never the shape:
+
+```ruby
+# Good
+request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
+
+response(200, "successful") do
+  schema "$ref": "#/components/schemas/MessageResponse"
+end
+
+# Bad — the shape lives in the test
+request_body required: true, schema: {
+  type: :object,
+  properties: {modelId: {type: :string, format: :uuid}},
+  required: [:modelId]
+}
+```
+
+Why: an inline body has no name, so Orval invents one from the operation —
+`UnlinkModelModuleBody`, `ReloadLoaners200`, `FleetCalendar200`. Four endpoints
+sharing one payload get four unrelated TypeScript types that drift
+independently, and the frontend has nothing stable to import.
+
+Naming and placement follow the existing tree:
+
+- Request bodies → `<scope>/v1/schemas/inputs/<name>_input.rb`
+- Response bodies → `<scope>/v1/schemas/<name>.rb`
+- Reused by both the public and the admin schema → `shared/v1/`
+- Enums get their own component under `shared/v1/schemas/enums/`, referenced by
+  `$ref` — don't inline an `enum:` into a property
+
+Before adding a component, check whether one already fits: `SortInput`,
+`StandardError`, `SuccessResponse`, `MessageResponse` and the `BaseList` /
+`Meta` pair cover most small payloads.
+
+The `q` deepObject query parameter is the one exception to "no inline object":
+it needs a literal `type: :object` next to `style: :deepObject`, and carries its
+`$ref` to a `<Name>Query` component alongside.
+
 ## Feature Flags
 
 Flags are declared in **`config/feature_flags.yml`** — the single source of truth.
@@ -298,6 +341,7 @@ For deeper guidance on specific topics, refer to:
 - `.cursor/rules/project-structure.mdc` — Project structure details
 - `.cursor/rules/backend.mdc` — Backend development rules
 - `.cursor/rules/backend/linting-and-formatting.mdc` — Ruby formatting
+- `.cursor/rules/backend/api-components.mdc` — OpenAPI component placement and the no-inline-schema rule
 - `.cursor/rules/frontend.mdc` — Frontend development rules
 - `.cursor/rules/frontend/linting-and-formatting.mdc` — Frontend formatting
 - `.cursor/rules/frontend/styling.mdc` — SCSS/styling rules

--- a/app/api_components/admin/v1/schemas/inputs/model_link_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_link_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ModelLinkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              modelId: {type: :string, format: :uuid}
+            },
+            required: [:modelId]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/message_response.rb
+++ b/app/api_components/admin/v1/schemas/message_response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class MessageResponse
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            message: {type: :string}
+          },
+          required: [:message]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/feature_names_list.rb
+++ b/app/api_components/v1/schemas/feature_names_list.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # Plain strings on purpose. Referencing FeatureFlagName here would put its
+    # enum on a response, and every added flag then trips
+    # response-property-enum-value-added in the breaking-change check.
+    class FeatureNamesList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {type: :string}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_calendar.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_calendar.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetCalendar
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              items: {
+                type: :array,
+                items: {"$ref": "#/components/schemas/FleetEvent"}
+              }
+            },
+            required: %w[items]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_notification_discord_status.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_notification_discord_status.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetNotificationDiscordStatus
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            ok: {type: :boolean},
+            code: {type: :string},
+            message: {type: :string},
+            guildId: {type: :string},
+            guildName: {type: :string},
+            status: {type: :integer},
+            installUrl: {type: :string}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/hangar_items_list.rb
+++ b/app/api_components/v1/schemas/hangar/hangar_items_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Hangar
+      class HangarItemsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {type: :string}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_occurrence_date_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_occurrence_date_input.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventOccurrenceDateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {date: {type: :string, format: :date}},
+          required: %w[date]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_occurrence_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_occurrence_update_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventOccurrenceUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            date: {type: :string, format: :date},
+            title: {type: [:string, :null]},
+            description: {type: [:string, :null]},
+            briefing: {type: [:string, :null]},
+            location: {type: [:string, :null]},
+            meetupLocation: {type: [:string, :null]},
+            scenario: {type: [:string, :null]},
+            coverImagePreset: {type: [:string, :null]}
+          },
+          required: %w[date]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_ship_expand_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_ship_expand_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventShipExpandInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            modelId: {type: :string, format: :uuid},
+            positionIds: {type: :array, items: {type: :string, format: :uuid}}
+          },
+          required: %w[modelId]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_event_slot_sort_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_event_slot_sort_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetEventSlotSortInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slottableType: {type: :string, enum: %w[FleetEventTeam FleetEventShip]},
+            slottableId: {type: :string, format: :uuid},
+            sorting: {type: :array, items: {type: :string, format: :uuid}}
+          },
+          required: %w[slottableType slottableId sorting]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/fleet_notification_setting_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_notification_setting_update_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetNotificationSettingUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            discordGuildId: {type: [:string, :null]},
+            discordChannelId: {type: [:string, :null]},
+            discordWebhookUrl: {type: [:string, :null]},
+            enabledInAppEvents: {type: :array, items: {type: :string}}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/notification_preference_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/notification_preference_update_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class NotificationPreferenceUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            app: {type: :boolean},
+            mail: {type: :boolean},
+            push: {type: :boolean}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/success_response.rb
+++ b/app/api_components/v1/schemas/success_response.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SuccessResponse
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          success: {type: :boolean}
+        }
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/wishlist_items_list.rb
+++ b/app/api_components/v1/schemas/wishlist_items_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class WishlistItemsList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {type: :string}
+      })
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -4132,13 +4132,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                  format: uuid
-              required:
-              - modelId
+              "$ref": "#/components/schemas/ModelLinkInput"
       responses:
         '200':
           description: successful
@@ -4178,13 +4172,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                  format: uuid
-              required:
-              - modelId
+              "$ref": "#/components/schemas/ModelLinkInput"
       responses:
         '200':
           description: successful
@@ -5000,13 +4988,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                  format: uuid
-              required:
-              - modelId
+              "$ref": "#/components/schemas/ModelLinkInput"
       responses:
         '200':
           description: successful
@@ -5046,13 +5028,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                  format: uuid
-              required:
-              - modelId
+              "$ref": "#/components/schemas/ModelLinkInput"
       responses:
         '200':
           description: successful
@@ -5189,12 +5165,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -5219,12 +5190,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -5249,12 +5215,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -5279,12 +5240,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -5309,12 +5265,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -5458,12 +5409,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '404':
           description: not found
           content:
@@ -5504,12 +5450,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '404':
           description: not found
           content:
@@ -5550,12 +5491,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '404':
           description: not found
           content:
@@ -6458,12 +6394,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                - message
+                "$ref": "#/components/schemas/MessageResponse"
         '403':
           description: forbidden
           content:
@@ -11671,6 +11602,14 @@ components:
       - size
       - url
       title: MediaFile
+    MessageResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+      - message
+      title: MessageResponse
     Meta:
       type: object
       properties:
@@ -12905,6 +12844,15 @@ components:
       - meta
       - items
       title: ModelHardpoints
+    ModelLinkInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+      required:
+      - modelId
+      title: ModelLinkInput
     ModelLoaner:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -173,9 +173,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                "$ref": "#/components/schemas/FeatureNamesList"
   "/filters/commodities/types":
     get:
       summary: Commodity Types Filters
@@ -602,25 +600,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                slottableType:
-                  type: string
-                  enum:
-                  - FleetEventTeam
-                  - FleetEventShip
-                slottableId:
-                  type: string
-                  format: uuid
-                sorting:
-                  type: array
-                  items:
-                    type: string
-                    format: uuid
-              required:
-              - slottableType
-              - slottableId
-              - sorting
+              "$ref": "#/components/schemas/FleetEventSlotSortInput"
       responses:
         '200':
           description: successful
@@ -1053,14 +1033,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  items:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/FleetEvent"
-                required:
-                - items
+                "$ref": "#/components/schemas/FleetCalendar"
         '401':
           description: unauthorized
           content:
@@ -1358,15 +1331,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                sorting:
-                  type: array
-                  items:
-                    type: string
-                    format: uuid
-              required:
-              - sorting
+              "$ref": "#/components/schemas/SortInput"
       responses:
         '200':
           description: successful
@@ -1464,15 +1429,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                sorting:
-                  type: array
-                  items:
-                    type: string
-                    format: uuid
-              required:
-              - sorting
+              "$ref": "#/components/schemas/SortInput"
       responses:
         '200':
           description: successful
@@ -1604,18 +1561,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                  format: uuid
-                positionIds:
-                  type: array
-                  items:
-                    type: string
-                    format: uuid
-              required:
-              - modelId
+              "$ref": "#/components/schemas/FleetEventShipExpandInput"
       responses:
         '200':
           description: successful
@@ -2051,13 +1997,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                date:
-                  type: string
-                  format: date
-              required:
-              - date
+              "$ref": "#/components/schemas/FleetEventOccurrenceDateInput"
       responses:
         '200':
           description: successful
@@ -2227,13 +2167,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                date:
-                  type: string
-                  format: date
-              required:
-              - date
+              "$ref": "#/components/schemas/FleetEventOccurrenceDateInput"
       responses:
         '200':
           description: successful
@@ -2453,41 +2387,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                date:
-                  type: string
-                  format: date
-                title:
-                  type:
-                  - string
-                  - 'null'
-                description:
-                  type:
-                  - string
-                  - 'null'
-                briefing:
-                  type:
-                  - string
-                  - 'null'
-                location:
-                  type:
-                  - string
-                  - 'null'
-                meetupLocation:
-                  type:
-                  - string
-                  - 'null'
-                scenario:
-                  type:
-                  - string
-                  - 'null'
-                coverImagePreset:
-                  type:
-                  - string
-                  - 'null'
-              required:
-              - date
+              "$ref": "#/components/schemas/FleetEventOccurrenceUpdateInput"
       responses:
         '200':
           description: successful
@@ -4259,10 +4159,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
+                "$ref": "#/components/schemas/SuccessResponse"
         '401':
           description: unauthorized
           content:
@@ -4443,10 +4340,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
+                "$ref": "#/components/schemas/SuccessResponse"
         '401':
           description: unauthorized
           content:
@@ -4788,24 +4682,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                discordGuildId:
-                  type:
-                  - string
-                  - 'null'
-                discordChannelId:
-                  type:
-                  - string
-                  - 'null'
-                discordWebhookUrl:
-                  type:
-                  - string
-                  - 'null'
-                enabledInAppEvents:
-                  type: array
-                  items:
-                    type: string
+              "$ref": "#/components/schemas/FleetNotificationSettingUpdateInput"
       responses:
         '200':
           description: successful
@@ -4847,22 +4724,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                  code:
-                    type: string
-                  message:
-                    type: string
-                  guildId:
-                    type: string
-                  guildName:
-                    type: string
-                  status:
-                    type: integer
-                  installUrl:
-                    type: string
+                "$ref": "#/components/schemas/FleetNotificationDiscordStatus"
         '401':
           description: unauthorized
           content:
@@ -5797,10 +5659,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
+                "$ref": "#/components/schemas/SuccessResponse"
         '401':
           description: unauthorized
           content:
@@ -6610,9 +6469,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                "$ref": "#/components/schemas/HangarItemsList"
         '401':
           description: unauthorized
           content:
@@ -7146,10 +7003,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
+                "$ref": "#/components/schemas/SuccessResponse"
         '401':
           description: unauthorized
           content:
@@ -7957,14 +7811,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                app:
-                  type: boolean
-                mail:
-                  type: boolean
-                push:
-                  type: boolean
+              "$ref": "#/components/schemas/NotificationPreferenceUpdateInput"
       responses:
         '200':
           description: successful
@@ -9702,12 +9549,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  code:
-                    type: string
-                  message:
-                    type: string
+                "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/user-features/{id}/enable":
@@ -9747,12 +9589,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  code:
-                    type: string
-                  message:
-                    type: string
+                "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/users/account":
@@ -11109,9 +10946,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                "$ref": "#/components/schemas/WishlistItemsList"
         '401':
           description: unauthorized
           content:
@@ -13112,6 +12947,11 @@ components:
       - TOOLS_CARGO_GRIDS
       - TOOLS_TRAVEL_TIMES
       title: FeatureFlagName
+    FeatureNamesList:
+      type: array
+      items:
+        type: string
+      title: FeatureNamesList
     FieldError:
       type: object
       properties:
@@ -13215,6 +13055,16 @@ components:
       - createdAt
       - updatedAt
       title: Fleet
+    FleetCalendar:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetEvent"
+      required:
+      - items
+      title: FleetCalendar
     FleetCheckInput:
       type: object
       properties:
@@ -13608,6 +13458,15 @@ components:
         - teams
         - unassignedSignups
       title: FleetEventExtended
+    FleetEventOccurrenceDateInput:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+      required:
+      - date
+      title: FleetEventOccurrenceDateInput
     FleetEventOccurrenceState:
       type: object
       properties:
@@ -13657,6 +13516,43 @@ components:
       - fleetEventId
       - occurrenceDate
       title: FleetEventOccurrenceState
+    FleetEventOccurrenceUpdateInput:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        title:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        briefing:
+          type:
+          - string
+          - 'null'
+        location:
+          type:
+          - string
+          - 'null'
+        meetupLocation:
+          type:
+          - string
+          - 'null'
+        scenario:
+          type:
+          - string
+          - 'null'
+        coverImagePreset:
+          type:
+          - string
+          - 'null'
+      required:
+      - date
+      title: FleetEventOccurrenceUpdateInput
     FleetEventShip:
       type: object
       properties:
@@ -13764,6 +13660,20 @@ components:
             format: uuid
       additionalProperties: false
       title: FleetEventShipCreateInput
+    FleetEventShipExpandInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+        positionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+      - modelId
+      title: FleetEventShipExpandInput
     FleetEventShipUpdateInput:
       type: object
       properties:
@@ -14049,6 +13959,27 @@ components:
       - title
       additionalProperties: false
       title: FleetEventSlotCreateInput
+    FleetEventSlotSortInput:
+      type: object
+      properties:
+        slottableType:
+          type: string
+          enum:
+          - FleetEventTeam
+          - FleetEventShip
+        slottableId:
+          type: string
+          format: uuid
+        sorting:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+      - slottableType
+      - slottableId
+      - sorting
+      title: FleetEventSlotSortInput
     FleetEventSlotUpdateInput:
       type: object
       properties:
@@ -15033,6 +14964,24 @@ components:
       required:
       - modelCounts
       title: FleetModelCountsStats
+    FleetNotificationDiscordStatus:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        code:
+          type: string
+        message:
+          type: string
+        guildId:
+          type: string
+        guildName:
+          type: string
+        status:
+          type: integer
+        installUrl:
+          type: string
+      title: FleetNotificationDiscordStatus
     FleetNotificationSetting:
       type: object
       properties:
@@ -15065,6 +15014,26 @@ components:
       - enabledInAppEvents
       - discordWebhookConfigured
       title: FleetNotificationSetting
+    FleetNotificationSettingUpdateInput:
+      type: object
+      properties:
+        discordGuildId:
+          type:
+          - string
+          - 'null'
+        discordChannelId:
+          type:
+          - string
+          - 'null'
+        discordWebhookUrl:
+          type:
+          - string
+          - 'null'
+        enabledInAppEvents:
+          type: array
+          items:
+            type: string
+      title: FleetNotificationSettingUpdateInput
     FleetPublicVehicles:
       type: object
       properties:
@@ -16095,6 +16064,11 @@ components:
           - 'null'
       additionalProperties: false
       title: HangarInventoryUpdateInput
+    HangarItemsList:
+      type: array
+      items:
+        type: string
+      title: HangarItemsList
     HangarMetrics:
       type: object
       properties:
@@ -19735,6 +19709,16 @@ components:
       - mailAvailable
       - pushAvailable
       title: NotificationPreference
+    NotificationPreferenceUpdateInput:
+      type: object
+      properties:
+        app:
+          type: boolean
+        mail:
+          type: boolean
+        push:
+          type: boolean
+      title: NotificationPreferenceUpdateInput
     NotificationTypeEnum:
       type: string
       enum:
@@ -20175,6 +20159,12 @@ components:
       - wishlistsCount
       - shipOfTheMonthCount
       title: Stats
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+      title: SuccessResponse
     SupportProgress:
       type: object
       properties:
@@ -21344,6 +21334,11 @@ components:
       - name
       - damagePerShot
       title: WeaponIndexItem
+    WishlistItemsList:
+      type: array
+      items:
+        type: string
+      title: WishlistItemsList
   securitySchemes:
     BearerAuth:
       type: http

--- a/test/integration/admin/api/v1/model_modules_link_test.rb
+++ b/test/integration/admin/api/v1/model_modules_link_test.rb
@@ -15,13 +15,7 @@ class Admin::Api::V1::ModelModulesLinkTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: :id, in: :path, required: true, schema: {type: :string, format: :uuid}
-      request_body required: true, schema: {
-        type: :object,
-        properties: {
-          modelId: {type: :string, format: :uuid}
-        },
-        required: [:modelId]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/ModelModule"

--- a/test/integration/admin/api/v1/model_modules_unlink_test.rb
+++ b/test/integration/admin/api/v1/model_modules_unlink_test.rb
@@ -15,13 +15,7 @@ class Admin::Api::V1::ModelModulesUnlinkTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: :id, in: :path, required: true, schema: {type: :string, format: :uuid}
-      request_body required: true, schema: {
-        type: :object,
-        properties: {
-          modelId: {type: :string, format: :uuid}
-        },
-        required: [:modelId]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/ModelModule"

--- a/test/integration/admin/api/v1/model_upgrades_link_test.rb
+++ b/test/integration/admin/api/v1/model_upgrades_link_test.rb
@@ -15,13 +15,7 @@ class Admin::Api::V1::ModelUpgradesLinkTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: :id, in: :path, required: true, schema: {type: :string, format: :uuid}
-      request_body required: true, schema: {
-        type: :object,
-        properties: {
-          modelId: {type: :string, format: :uuid}
-        },
-        required: [:modelId]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/ModelUpgrade"

--- a/test/integration/admin/api/v1/model_upgrades_unlink_test.rb
+++ b/test/integration/admin/api/v1/model_upgrades_unlink_test.rb
@@ -15,13 +15,7 @@ class Admin::Api::V1::ModelUpgradesUnlinkTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: :id, in: :path, required: true, schema: {type: :string, format: :uuid}
-      request_body required: true, schema: {
-        type: :object,
-        properties: {
-          modelId: {type: :string, format: :uuid}
-        },
-        required: [:modelId]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/ModelLinkInput"}
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/ModelUpgrade"

--- a/test/integration/admin/api/v1/models_reload_loaners_test.rb
+++ b/test/integration/admin/api/v1/models_reload_loaners_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsReloadLoanersTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/models_reload_matrix_test.rb
+++ b/test/integration/admin/api/v1/models_reload_matrix_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsReloadMatrixTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/models_reload_modules_test.rb
+++ b/test/integration/admin/api/v1/models_reload_modules_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsReloadModulesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/models_reload_one_matrix_test.rb
+++ b/test/integration/admin/api/v1/models_reload_one_matrix_test.rb
@@ -16,7 +16,7 @@ class Admin::Api::V1::ModelsReloadOneMatrixTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(404, "not found") do

--- a/test/integration/admin/api/v1/models_reload_one_scdata_test.rb
+++ b/test/integration/admin/api/v1/models_reload_one_scdata_test.rb
@@ -16,7 +16,7 @@ class Admin::Api::V1::ModelsReloadOneScdataTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(404, "not found") do

--- a/test/integration/admin/api/v1/models_reload_one_test.rb
+++ b/test/integration/admin/api/v1/models_reload_one_test.rb
@@ -16,7 +16,7 @@ class Admin::Api::V1::ModelsReloadOneTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(404, "not found") do

--- a/test/integration/admin/api/v1/models_reload_paints_test.rb
+++ b/test/integration/admin/api/v1/models_reload_paints_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsReloadPaintsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/models_reload_scdata_test.rb
+++ b/test/integration/admin/api/v1/models_reload_scdata_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsReloadScdataTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/supporter_contributions_sync_patreon_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_sync_patreon_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::SupporterContributionsSyncPatreonTest < ActionDispatch::In
       produces "application/json"
 
       response(202, "accepted") do
-        schema type: :object, properties: {message: {type: :string}}, required: [:message]
+        schema "$ref": "#/components/schemas/MessageResponse"
       end
 
       response(403, "forbidden") do

--- a/test/integration/api/v1/features_test.rb
+++ b/test/integration/api/v1/features_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FeaturesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {type: :string}
+        schema "$ref": "#/components/schemas/FeatureNamesList"
       end
     end
   end

--- a/test/integration/api/v1/fleet_event_slots_sort_test.rb
+++ b/test/integration/api/v1/fleet_event_slots_sort_test.rb
@@ -14,15 +14,7 @@ class Api::V1::FleetEventSlotsSortTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body schema: {
-        type: :object,
-        properties: {
-          slottableType: {type: :string, enum: %w[FleetEventTeam FleetEventShip]},
-          slottableId: {type: :string, format: :uuid},
-          sorting: {type: :array, items: {type: :string, format: :uuid}}
-        },
-        required: %w[slottableType slottableId sorting]
-      }, required: true
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventSlotSortInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_calendar_show_test.rb
+++ b/test/integration/api/v1/fleets_calendar_show_test.rb
@@ -25,9 +25,7 @@ class Api::V1::FleetsCalendarShowTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :object, properties: {
-          items: {type: :array, items: {"$ref": "#/components/schemas/FleetEvent"}}
-        }, required: %w[items]
+        schema "$ref": "#/components/schemas/FleetCalendar"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_events_end_series_test.rb
+++ b/test/integration/api/v1/fleets_events_end_series_test.rb
@@ -17,11 +17,7 @@ class Api::V1::FleetsEventsEndSeriesTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body schema: {
-        type: :object,
-        properties: {date: {type: :string, format: :date}},
-        required: %w[date]
-      }, required: true
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventOccurrenceDateInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_events_recurrence_test.rb
+++ b/test/integration/api/v1/fleets_events_recurrence_test.rb
@@ -17,11 +17,7 @@ class Api::V1::FleetsEventsRecurrenceTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body schema: {
-        type: :object,
-        properties: {date: {type: :string, format: :date}},
-        required: %w[date]
-      }, required: true
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventOccurrenceDateInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_events_teams_ships_expand_from_model_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_expand_from_model_test.rb
@@ -19,14 +19,7 @@ class Api::V1::FleetsEventsTeamsShipsExpandFromModelTest < ActionDispatch::Integ
       consumes "application/json"
       produces "application/json"
 
-      request_body required: true, schema: {
-        type: :object,
-        properties: {
-          modelId: {type: :string, format: :uuid},
-          positionIds: {type: :array, items: {type: :string, format: :uuid}}
-        },
-        required: %w[modelId]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventShipExpandInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_events_teams_ships_sort_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_ships_sort_test.rb
@@ -18,11 +18,7 @@ class Api::V1::FleetsEventsTeamsShipsSortTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body required: true, schema: {
-        type: :object,
-        properties: {sorting: {type: :array, items: {type: :string, format: :uuid}}},
-        required: %w[sorting]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/SortInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_events_teams_sort_test.rb
+++ b/test/integration/api/v1/fleets_events_teams_sort_test.rb
@@ -17,11 +17,7 @@ class Api::V1::FleetsEventsTeamsSortTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body required: true, schema: {
-        type: :object,
-        properties: {sorting: {type: :array, items: {type: :string, format: :uuid}}},
-        required: %w[sorting]
-      }
+      request_body required: true, schema: {"$ref": "#/components/schemas/SortInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_events_update_occurrence_swagger_test.rb
+++ b/test/integration/api/v1/fleets_events_update_occurrence_swagger_test.rb
@@ -17,20 +17,7 @@ class Api::V1::FleetsEventsUpdateOccurrenceSwaggerTest < ActionDispatch::Integra
       consumes "application/json"
       produces "application/json"
 
-      request_body schema: {
-        type: :object,
-        properties: {
-          date: {type: :string, format: :date},
-          title: {type: [:string, :null]},
-          description: {type: [:string, :null]},
-          briefing: {type: [:string, :null]},
-          location: {type: [:string, :null]},
-          meetupLocation: {type: [:string, :null]},
-          scenario: {type: [:string, :null]},
-          coverImagePreset: {type: [:string, :null]}
-        },
-        required: %w[date]
-      }, required: true
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetEventOccurrenceUpdateInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/fleets_mission_teams_ships_sort_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_sort_test.rb
@@ -27,7 +27,7 @@ class Api::V1::FleetsMissionTeamsShipsSortTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :object, properties: {success: {type: :boolean}}
+        schema "$ref": "#/components/schemas/SuccessResponse"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_mission_teams_sort_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_sort_test.rb
@@ -26,7 +26,7 @@ class Api::V1::FleetsMissionTeamsSortTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :object, properties: {success: {type: :boolean}}
+        schema "$ref": "#/components/schemas/SuccessResponse"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_notifications_discord_status_test.rb
+++ b/test/integration/api/v1/fleets_notifications_discord_status_test.rb
@@ -22,16 +22,7 @@ class Api::V1::FleetsNotificationsDiscordStatusTest < ActionDispatch::Integratio
       ]
 
       response(200, "successful") do
-        schema type: :object,
-          properties: {
-            ok: {type: :boolean},
-            code: {type: :string},
-            message: {type: :string},
-            guildId: {type: :string},
-            guildName: {type: :string},
-            status: {type: :integer},
-            installUrl: {type: :string}
-          }
+        schema "$ref": "#/components/schemas/FleetNotificationDiscordStatus"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_notifications_update_test.rb
+++ b/test/integration/api/v1/fleets_notifications_update_test.rb
@@ -16,15 +16,7 @@ class Api::V1::FleetsNotificationsUpdateTest < ActionDispatch::IntegrationTest
       consumes "application/json"
       produces "application/json"
 
-      request_body schema: {
-        type: :object,
-        properties: {
-          discordGuildId: {type: [:string, :null]},
-          discordChannelId: {type: [:string, :null]},
-          discordWebhookUrl: {type: [:string, :null]},
-          enabledInAppEvents: {type: :array, items: {type: :string}}
-        }
-      }, required: true
+      request_body required: true, schema: {"$ref": "#/components/schemas/FleetNotificationSettingUpdateInput"}
 
       security [
         {SessionCookie: []},

--- a/test/integration/api/v1/hangar_groups_test.rb
+++ b/test/integration/api/v1/hangar_groups_test.rb
@@ -68,7 +68,7 @@ class Api::V1::HangarGroupsTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :object, properties: {success: {type: :boolean}}
+        schema "$ref": "#/components/schemas/SuccessResponse"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_items_test.rb
+++ b/test/integration/api/v1/hangar_items_test.rb
@@ -20,7 +20,7 @@ class Api::V1::HangarItemsTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {type: :string}
+        schema "$ref": "#/components/schemas/HangarItemsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/mission_slots_sort_test.rb
+++ b/test/integration/api/v1/mission_slots_sort_test.rb
@@ -23,7 +23,7 @@ class Api::V1::MissionSlotsSortTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :object, properties: {success: {type: :boolean}}
+        schema "$ref": "#/components/schemas/SuccessResponse"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/notification_preferences_test.rb
+++ b/test/integration/api/v1/notification_preferences_test.rb
@@ -44,14 +44,7 @@ class Api::V1::NotificationPreferencesTest < ActionDispatch::IntegrationTest
         {OpenId: ["notifications", "notifications:write"]}
       ]
 
-      request_body schema: {
-        type: :object,
-        properties: {
-          app: {type: :boolean},
-          mail: {type: :boolean},
-          push: {type: :boolean}
-        }
-      }
+      request_body schema: {"$ref": "#/components/schemas/NotificationPreferenceUpdateInput"}
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/NotificationPreference"

--- a/test/integration/api/v1/user_features_disable_test.rb
+++ b/test/integration/api/v1/user_features_disable_test.rb
@@ -30,7 +30,7 @@ class Api::V1::UserFeaturesDisableTest < ActionDispatch::IntegrationTest
       end
 
       response(403, "forbidden") do
-        schema type: :object, properties: {code: {type: :string}, message: {type: :string}}
+        schema "$ref": "#/components/schemas/StandardError"
       end
     end
   end

--- a/test/integration/api/v1/user_features_enable_test.rb
+++ b/test/integration/api/v1/user_features_enable_test.rb
@@ -30,7 +30,7 @@ class Api::V1::UserFeaturesEnableTest < ActionDispatch::IntegrationTest
       end
 
       response(403, "forbidden") do
-        schema type: :object, properties: {code: {type: :string}, message: {type: :string}}
+        schema "$ref": "#/components/schemas/StandardError"
       end
     end
   end

--- a/test/integration/api/v1/wishlist_items_test.rb
+++ b/test/integration/api/v1/wishlist_items_test.rb
@@ -20,7 +20,7 @@ class Api::V1::WishlistItemsTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {type: :string}
+        schema "$ref": "#/components/schemas/WishlistItemsList"
       end
 
       response(401, "unauthorized") do


### PR DESCRIPTION
## Why

`AGENTS.md` had exactly one rule about the API schema — "add OpenAPI components in `app/api_components/`, never edit `swagger/*.yaml` directly". Nothing said the bodies themselves had to be components, so thirty request and response bodies had been declared inline in the integration tests.

An inline body has no name, so Orval invents one from the operation: `UnlinkModelModuleBody`, `ReloadLoaners200`, `FleetCalendar200`. Four endpoints sharing the same `{modelId}` payload each got their own unrelated TypeScript type, and the frontend had nothing stable to import.

## What

**Fourteen new components**, replacing inline bodies with `$ref`:

| Component | Replaces |
| --- | --- |
| `Admin::V1::Schemas::MessageResponse` | 9× `{message}` (models-reload variants, sync-patreon) |
| `Admin::V1::Schemas::Inputs::ModelLinkInput` | 4× `{modelId}` (module/upgrade link + unlink) |
| `V1::Schemas::SuccessResponse` | 4× `{success}` (mission + hangar-group sorts) |
| `V1::Schemas::Fleets::Events::FleetCalendar` | `{items: [FleetEvent]}` |
| `V1::Schemas::Fleets::FleetNotificationDiscordStatus` | the 7-property Discord status object |
| `V1::Schemas::Inputs::FleetEventShipExpandInput` | expand-from-model body |
| `V1::Schemas::Inputs::FleetEventSlotSortInput` | slot-sort body |
| `V1::Schemas::Inputs::FleetEventOccurrenceDateInput` | 2× `{date}` (recurrence, end-series) |
| `V1::Schemas::Inputs::FleetEventOccurrenceUpdateInput` | update-occurrence body |
| `V1::Schemas::Inputs::FleetNotificationSettingUpdateInput` | notifications-update body |
| `V1::Schemas::Inputs::NotificationPreferenceUpdateInput` | preference-update body |
| `FeatureNamesList`, `Hangar::HangarItemsList`, `WishlistItemsList` | 3× bare `array of string` |

**Existing components reused** rather than duplicated: `SortInput` for the two event sorts (identical shape, already referenced by the mission sorts) and `StandardError` for the two `user-features` 403s.

All 30 anonymous Orval types are gone — 13 `*Body.ts` and 17 `*<Status>.ts`. No app file imported them, so there are no call-site changes.

**The rule, written down** in `AGENTS.md` and a new `.cursor/rules/backend/api-components.mdc`: every request and response body is a `$ref` to a component class, request bodies go to `<scope>/v1/schemas/inputs/`, response bodies to `<scope>/v1/schemas/`, shapes used by both schemas to `shared/v1/`. The `q` deepObject parameter is documented as the one place a literal `type: :object` is correct.

## Verification

- `oasdiff breaking` against the pre-change schemas: **no breaking changes**, public and admin. The extracted shapes are byte-identical to the inline ones and oasdiff dereferences `$ref`, so the schema diff is purely structural.
- `validate-schema` / `validate-admin-schema` valid; 67 warnings before and after, all pre-existing `security-scopes-defined`.
- `pnpm lint:ts` clean, `standardrb` clean.
- The 33 touched integration tests: 121 tests, 0 failures.

## Deliberately out of scope

**90 responses declared as an inline `type: :array` around a `$ref`** (`schema type: :array, items: {"$ref": ".../FilterOption"}`). Only the cardinality is inline there — the item type is already named, and Orval emits `FilterOption[]` rather than an anonymous type, so nothing drifts. Extracting them means 90 new `*List` files; worth deciding separately. The 3 arrays with no named item type are extracted here.

**Two endpoints with an untyped `q`** — `notifications_test.rb:26` has `schema: {type: :object}` with no Query component, and `filters_equipment_item_types_test.rb:18` declares its filter properties inline instead of via a `<Name>Query`. Both are additions rather than refactors (the real Ransack filters need checking), so they are reported, not changed.

**91 inline `enum:` declarations** across `app/api_components/` remain, next to 52 real enum components — including one this PR carries over verbatim in `FleetEventSlotSortInput` to keep the shape identical. The rule now covers them; the cleanup does not.

🤖
