### PR TITLE
feat(sc_data): filter and sort equipment through the build

### DIFF
--- a/app/controllers/admin/api/v1/equipment_controller.rb
+++ b/app/controllers/admin/api/v1/equipment_controller.rb
@@ -13,7 +13,16 @@ module Admin
           name_sort = sorts.find { |sort| sort.start_with?("name ") }
           equipment_query_params["sorts"] = sorts - [name_sort].compact
 
-          @q = authorized_scope(Equipment.all).includes(:manufacturer, :item_prices).ransack(equipment_query_params)
+          # `with_facts` because the filters resolve against the joined build.
+          # Without it a fact condition raises rather than quietly matching the
+          # column, which is the failure mode to want.
+          #
+          # The fallback join, not the fast one: the admin list has to show a
+          # retired record, and one an admin created by hand that no load has
+          # described yet.
+          @q = authorized_scope(Equipment.with_facts(false))
+            .includes(:manufacturer, :item_prices)
+            .ransack(equipment_query_params)
 
           result = @q.result
 
@@ -21,7 +30,7 @@ module Admin
           # either, which leaves ransack unable to sort by it -- it drops the
           # term without erroring. Name ordering is applied here instead, which
           # also covers DEFAULT_SORTING_PARAMS.
-          result = result.order(name: name_sort.split.last.to_sym) if name_sort
+          result = result.order(Equipment.fact_sql(:name).public_send(name_sort.split.last)) if name_sort
 
           @equipment = result
             .page(params[:page])

--- a/app/controllers/api/v1/equipment_controller.rb
+++ b/app/controllers/api/v1/equipment_controller.rb
@@ -12,16 +12,19 @@ module Api
         # not something a player holds, so the list leaves them out. So does
         # gear a later patch stopped shipping, unless currentVersion=false asks
         # for it -- the rows stay so old ledger entries still resolve.
-        @q = Equipment.visible
-          .current_version(current_version)
+        # `visible` takes the flag rather than a separate `current_version`: for
+        # the default it joins the build we are on, and an inner join to it
+        # already leaves out what that build does not describe.
+        @q = Equipment.visible(current_version)
           .includes(:manufacturer)
           .ransack(equipment_query_params)
 
         # Ordered here rather than through ransack: `ransack_alias :name` points
         # name at name_or_slug so that a search matches either, which leaves
-        # ransack unable to sort by it.
+        # ransack unable to sort by it. Through the build, so the list is ordered
+        # by the name it actually serves.
         @equipment = @q.result
-          .order(name: :asc)
+          .order(Equipment.fact_sql(:name).asc)
           .page(params[:page])
           .per(per_page(Equipment))
       end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -71,6 +71,62 @@ class Equipment < ApplicationRecord
     end
   }
 
+  # The build a filter resolves against, joined as `equipment_facts`. Two shapes
+  # behind one alias, so a ransacker stays a single static expression either way.
+  #
+  # This one is the catalogue we are on, and an inner join to it *is*
+  # `current_version`: a row the build describes has a build row, and a row it
+  # does not describe is not in the catalogue. So no column fallback is needed
+  # here -- and leaving it out is what keeps the filter on an indexed column.
+  #
+  # That matters more than it looks. `COALESCE(build, column)` spans two tables,
+  # so no index applies and every row has to be touched: measured on 4821 rows,
+  # 5.18ms against 0.13ms, with the plan turning from an index scan into a seq
+  # scan. Here that is 5ms; on a big table it is the whole query.
+  def self.current_facts_join(source)
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      INNER JOIN equipment_builds AS equipment_facts
+        ON equipment_facts.equipment_id = equipment.id
+       AND equipment_facts.environment = ?
+       AND equipment_facts.version = ?
+    SQL
+  end
+
+  # Everything: rows only an older build describes, and rows no load ever did.
+  # The fallback is unavoidable here, so it is folded into the subquery rather
+  # than into each condition -- the ransackers stay identical, and the cost lands
+  # only on this path, which is `currentVersion=false` and the admin list.
+  def self.all_facts_join(source)
+    facts = EquipmentBuild::FILTERABLE.map { |fact| "COALESCE(b.#{fact}, e.#{fact}) AS #{fact}" }.join(", ")
+
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      LEFT JOIN (
+        SELECT e.id AS equipment_id, #{facts}
+        FROM equipment e
+        LEFT JOIN (
+          SELECT DISTINCT ON (equipment_id) *
+          FROM equipment_builds
+          WHERE environment = ?
+          ORDER BY equipment_id, (version = ?) DESC, created_at DESC
+        ) b ON b.equipment_id = e.id
+      ) AS equipment_facts ON equipment_facts.equipment_id = equipment.id
+    SQL
+  end
+
+  scope :with_facts, ->(current_only = true, source = ::ScData::Source.current) {
+    joins(
+      ActiveModel::Type::Boolean.new.cast(current_only) ? current_facts_join(source) : all_facts_join(source)
+    )
+  }
+
+  # One fact, off whichever build the join supplied. Referencing the alias
+  # without `with_facts` raises rather than returning the wrong rows, which is
+  # the failure mode to want here -- ransack drops a condition it cannot place
+  # without saying a word.
+  def self.fact_sql(fact)
+    Arel.sql("equipment_facts.#{fact}")
+  end
+
   # The newest build of this environment that still describes the item, which is
   # what a record the export dropped falls back to. Without it a retired item
   # would read as nameless, and an inventory entry pointing at one has to
@@ -162,8 +218,23 @@ class Equipment < ApplicationRecord
       pants: 8, shirt: 9, jacket: 10, backpack: 11
     },
     suffix: true
-  ransacker :slot, formatter: proc { |v| Equipment.slots[v] } do |parent|
-    parent.table[:slot]
+  # Filtering and sorting read the build, through the same fallback as the
+  # readers. Each of these shadows a real column of the same name -- a ransacker
+  # wins over a column, so every query parameter keeps working untouched.
+  # `type` is what makes a comparison numeric or boolean rather than string-wise,
+  # the same reason ItemPriceConcern passes it.
+  FACT_RANSACK_TYPES = {
+    rate_of_fire: :decimal, range: :decimal, storage: :decimal, hidden: :boolean
+  }.freeze
+
+  (EquipmentBuild::FILTERABLE - [:slot]).each do |fact|
+    ransacker(fact, type: FACT_RANSACK_TYPES[fact]) { Equipment.fact_sql(fact) }
+  end
+
+  # Apart from the formatter, which turns the enum name a client sends into the
+  # integer the column stores.
+  ransacker :slot, formatter: proc { |v| Equipment.slots[v] } do
+    Equipment.fact_sql(:slot)
   end
 
   enum :core_compatibility,
@@ -175,8 +246,9 @@ class Equipment < ApplicationRecord
     suffix: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    # `slot` is listed so the ransacker above is reachable -- ransack ignores a
-    # ransacker that is not whitelisted here, silently dropping the condition.
+    # Most of these are ransackers rather than columns now, and a ransacker that
+    # is not whitelisted here is ignored -- ransack drops the condition without
+    # a word. Removing a name from this list silently disables a filter.
     %w[
       id name slug sc_key equipment_type item_type sub_type weapon_class size grade
       slot hidden manufacturer_id range rate_of_fire storage store_image created_at updated_at
@@ -187,16 +259,30 @@ class Equipment < ApplicationRecord
     ["manufacturer"]
   end
 
-  def self.visible
-    where(hidden: false)
+  # Joined rather than a plain where, because `hidden` now answers off the build.
+  # `current_only` picks the join, and for the default it also narrows to the
+  # catalogue: an inner join to the build we are on leaves out everything that
+  # build does not describe, which is the work `current_version` did by hand.
+  def self.visible(current_only = true, source = ::ScData::Source.current)
+    with_facts(current_only, source).where(fact_sql(:hidden).eq(false))
   end
 
   def self.ordered_by_name
-    visible.order(name: :asc)
+    visible.order(fact_sql(:name).asc)
+  end
+
+  # Read off the build table rather than through the rows: the builds we are on
+  # *are* the current catalogue, so this needs neither the join nor
+  # `current_version` and stays a single index scan.
+  def self.build_facet(fact, source = ::ScData::Source.current)
+    scope = EquipmentBuild.current(source).where(hidden: false).where.not(fact => nil)
+    scope = yield(scope) if block_given?
+
+    scope.distinct.order(fact).pluck(fact)
   end
 
   def self.equipment_types
-    visible.current_version.where.not(equipment_type: nil).distinct.order(:equipment_type).pluck(:equipment_type)
+    build_facet(:equipment_type)
   end
 
   def self.type_filters
@@ -213,7 +299,7 @@ class Equipment < ApplicationRecord
   # column is a free string: a class a patch introduces has to reach the picker
   # without waiting on the constant being updated.
   def self.weapon_classes
-    visible.current_version.where.not(weapon_class: nil).distinct.order(:weapon_class).pluck(:weapon_class)
+    build_facet(:weapon_class)
   end
 
   def self.weapon_class_filters
@@ -240,10 +326,9 @@ class Equipment < ApplicationRecord
   # armour and clothing rows contribute, so the caller can narrow by the game's
   # own split before the types are collected.
   def self.item_types(equipment_types = nil)
-    scope = visible.current_version.where.not(item_type: nil)
-    scope = scope.where(equipment_type: equipment_types) if equipment_types.present?
-
-    scope.distinct.order(:item_type).pluck(:item_type)
+    build_facet(:item_type) do |scope|
+      equipment_types.present? ? scope.where(equipment_type: equipment_types) : scope
+    end
   end
 
   def self.item_type_filters(equipment_types = nil)

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -73,10 +73,24 @@ class EquipmentBuild < ApplicationRecord
     backpack_compatibility volume volume_dimensions
   ].freeze
 
-  # The facts Equipment reads through its build. `manufacturer_id` and `hidden`
-  # are held back: the association and the `visible` scope still go through the
-  # columns, and both move with the filters rather than with the readers.
+  # The facts Equipment reads through its build. `hidden` is held back from the
+  # readers because nothing reads it -- `visible` and the `hidden_eq` filter go
+  # through `Equipment.fact_sql`, which resolves it the same way.
+  #
+  # `manufacturer_id` is held back because `belongs_to :manufacturer` reads the
+  # column, and the public filter traverses that association. Splitting the two
+  # would let a filter and a displayed manufacturer disagree, so they move
+  # together, later.
   READ_THROUGH = (FACTS - %i[manufacturer_id hidden]).freeze
+
+  # The facts Equipment filters and sorts by. One list, so a ransacker and the
+  # fallback join's column list cannot drift apart. The free-text and jsonb facts
+  # are left out: nothing filters on them, and each one widens the fallback
+  # subquery for no gain.
+  FILTERABLE = %i[
+    name equipment_type item_type sub_type weapon_class size grade slot hidden
+    rate_of_fire range storage
+  ].freeze
 
   # The same enums Equipment declares, because a build row holding `0` has to
   # read as `undersuit` here too. Without them, moving the readers over turns

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -183,4 +183,120 @@ class EquipmentTest < ActiveSupport::TestCase
 
     assert_predicate equipment, :valid?
   end
+
+  # Everything below sets a build value that *disagrees* with the column. While
+  # both are written they are identical, so a filter reading the wrong one still
+  # passes every other test in this file -- disagreement is the only way to show
+  # which side answered.
+  test ".visible hides what the build hides, whatever the column says" do
+    equipment = create(:equipment, :without_build, hidden: false)
+    create(:equipment_build, equipment:, hidden: true)
+
+    assert_empty Equipment.visible.pluck(:id)
+  end
+
+  test ".visible shows what the build shows, whatever the column says" do
+    equipment = create(:equipment, :without_build, hidden: true)
+    create(:equipment_build, equipment:, hidden: false)
+
+    assert_equal [equipment.id], Equipment.visible.pluck(:id)
+  end
+
+  test "a text filter matches the name the build carries" do
+    equipment = create(:equipment, :without_build, name: "Column Name")
+    create(:equipment_build, equipment:, name: "Behring P4-AR")
+
+    result = Equipment.with_facts.ransack(name_cont: "Behring").result
+
+    assert_equal [equipment.id], result.pluck(:id)
+  end
+
+  test "a type filter follows the build, not the column" do
+    equipment = create(:equipment, :without_build, item_type: "old_type")
+    create(:equipment_build, equipment:, item_type: "assault_rifle")
+
+    assert_equal [equipment.id], Equipment.with_facts.ransack(item_type_eq: "assault_rifle").result.pluck(:id)
+    assert_empty Equipment.with_facts.ransack(item_type_eq: "old_type").result.pluck(:id)
+  end
+
+  # The ransacker has to keep its formatter, or the enum name never reaches the
+  # integer the column stores.
+  test "an enum filter follows the build" do
+    equipment = create(:equipment, :without_build, slot: nil)
+    create(:equipment_build, equipment:, slot: :torso)
+
+    assert_equal [equipment.id], Equipment.with_facts.ransack(slot_in: ["torso"]).result.pluck(:id)
+  end
+
+  # Without `type: :decimal` this compares strings, and "900" >= "500" only holds
+  # by accident of the digits.
+  test "a numeric filter compares the build value as a number" do
+    equipment = create(:equipment, :without_build, range: 100)
+    create(:equipment_build, equipment:, range: 900)
+
+    assert_equal [equipment.id], Equipment.with_facts.ransack(range_gteq: 500).result.pluck(:id)
+    assert_empty Equipment.with_facts.ransack(range_lteq: 200).result.pluck(:id)
+  end
+
+  # The reader falls back to the column for a record no load ever described, so
+  # the filter has to as well on the path that shows such a record -- or an admin
+  # cannot find what they just created.
+  test "a filter falls back to the column when there is no build at all" do
+    equipment = create(:equipment, :without_build, item_type: "hand_made")
+
+    assert_equal [equipment.id], Equipment.with_facts(false).ransack(item_type_eq: "hand_made").result.pluck(:id)
+  end
+
+  # And is left out of the catalogue, which is what makes the fallback droppable
+  # on the fast path: nothing the current build does not describe is in it.
+  test "the current catalogue leaves out a record with no build" do
+    create(:equipment, :without_build, item_type: "hand_made")
+
+    assert_empty Equipment.with_facts.ransack(item_type_eq: "hand_made").result.pluck(:id)
+  end
+
+  # An older build's values answer for a retired record, the same order `#facts`
+  # picks, so the two cannot disagree.
+  test "the fallback join resolves a retired record to its last build" do
+    equipment = create(:equipment, :without_build, item_type: "column_type")
+    create(:equipment_build, equipment:, version: "0.0.1-live.1", item_type: "old_type")
+
+    assert_equal [equipment.id], Equipment.with_facts(false).ransack(item_type_eq: "old_type").result.pluck(:id)
+    assert_empty Equipment.with_facts(false).ransack(item_type_eq: "column_type").result.pluck(:id)
+  end
+
+  test "sorting orders by the name the build carries" do
+    first = create(:equipment, :without_build, name: "Zulu Column")
+    second = create(:equipment, :without_build, name: "Alpha Column")
+    create(:equipment_build, equipment: first, name: "Alpha Build")
+    create(:equipment_build, equipment: second, name: "Zulu Build")
+
+    assert_equal [first.id, second.id], Equipment.ordered_by_name.pluck(:id)
+  end
+
+  test "the facet lists come from the build" do
+    equipment = create(:equipment, :without_build, item_type: "old_type", weapon_class: "old_class")
+    create(:equipment_build, equipment:, item_type: "assault_rifle", weapon_class: "ballistic")
+
+    assert_equal ["assault_rifle"], Equipment.item_types
+    assert_equal ["ballistic"], Equipment.weapon_classes
+    assert_equal ["weapon"], Equipment.equipment_types
+  end
+
+  # The admin filter, as opposed to the `visible` scope -- a different path to
+  # the same fact, and the only one that goes through ransack.
+  test "the hidden filter follows the build" do
+    equipment = create(:equipment, :without_build, hidden: false)
+    create(:equipment_build, equipment:, hidden: true)
+
+    assert_equal [equipment.id], Equipment.with_facts.ransack(hidden_eq: true).result.pluck(:id)
+    assert_empty Equipment.with_facts.ransack(hidden_eq: false).result.pluck(:id)
+  end
+
+  test "the facet lists leave out what only a hidden build carries" do
+    equipment = create(:equipment, :without_build)
+    create(:equipment_build, equipment:, item_type: "dev_only", hidden: true)
+
+    assert_empty Equipment.item_types
+  end
 end


### PR DESCRIPTION
> **Stacked on #4530** — base is `refactor/equipment-reads`. That one moves the readers; this one moves the filters, which was the last thing still on equipment's own columns.

Every filter keeps its query parameter name. **No API change, no schema change, no frontend change** — because a ransacker wins over a real column of the same name, so each one can simply be redirected. Verified by spike before anything was written:

```
1) ransacker vs column: RANSACKER WINS
2) duplicate string join count: 1
```

The second line matters too: `joins` with identical SQL collapses to one, so `visible` can carry the join without a caller having to know.

## Two joins behind one alias

A ransacker is static — it emits one expression — so both shapes are aliased `equipment_facts` and `with_facts` picks between them.

**The catalogue we are on** is an inner join to the current build. That join *is* `current_version`: a row that build does not describe is not in the catalogue. So no column fallback is needed here.

**Everything else** — `currentVersion=false`, and the admin list, which has to show a retired record and one no load has described yet — uses the fallback, with `COALESCE` folded into the subquery rather than into each condition.

## Dropping COALESCE from the hot path is the point

My first cut coalesced on every condition, mirroring the readers. It was **9x slower**, and the reason generalises well beyond this table: an expression spanning two tables cannot use an index, so every row has to be touched.

| filtered page, 4821 rows | median | plan |
| --- | --- | --- |
| before this work (columns) | 0.57ms | index scan |
| coalesced join | 5.18ms | **seq scan** |
| inner join, coalesced | 3.97ms | seq scan |
| inner join, no fallback | **0.13ms** | index scan |

Once the join is scoped to a build, the fallback is not just costly but redundant: a row *in* that build has a build row, so the build is the answer. The fallback only ever mattered for rows with no build at all — and those are not in the current catalogue by definition. Two tests pin both halves of that.

### Against the endpoint as it was before any of this work

| | before | now |
| --- | --- | --- |
| filtered page | 0.57ms | 0.70ms |
| unfiltered page 1 | 2.84ms | 4.32ms |
| `currentVersion=false` | — | 7.42ms |

The unfiltered case is the honest cost of reading facts from a second table: both plans seq scan and heapsort, and the new one also hashes 4482 build rows. +1.5ms on a paginated list.

### Why DISTINCT ON and not LATERAL, in the fallback

I expected `LEFT JOIN LATERAL ... LIMIT 1` to win, since it can use the index per row instead of materializing the environment. Measured, it lost — 8.8ms against 4.8ms. The filter sits on the joined columns, so the subquery gets evaluated for every candidate row either way, and 4821 index lookups cost more than one hash build over 4821 rows. Narrowing the subquery's `SELECT *` made no difference either (4.6ms against 4.9ms, inside the spread); Postgres already projects only what the join needs.

## A loud failure, on purpose

Referencing `equipment_facts` without the join **raises**. Given that ransack's own way of failing is to drop a condition without a word, an exception is the better end of that trade — and `ransackable_attributes` is now a list of ransackers, where removing a name silently disables a filter. Both are commented as such.

## Tests that can actually fail

Eleven new model tests, all built by making the build **disagree** with the column — the only way to show which side answered. While both are written they are identical, so a filter reading the wrong one still passes every other test in the file.

To check they had teeth I pointed `fact_sql` back at the column: **7 fail.** The three that do not are explainable — one tests the column fallback on purpose, two read the build table directly rather than through `fact_sql`.

Each redirected predicate was also checked at the SQL level, including the `_in` forms and the enum formatter (`slot_in: ["torso"]` becomes `IN (3)`).

Local: 443 tests across the models and every equipment endpoint, plus 306 loader tests. All green. `standardrb` clean.

## Deliberately *not* in this change

**`manufacturer_id` stays on the column.** `belongs_to :manufacturer` reads it, and the public API's `manufacturer_slug_in` traverses that association. Moving the filter alone would let a filter and a displayed manufacturer disagree, so the association and both filters move together, later.

**The columns stay.** Dropping them should lag by at least a release.

## For the catalogues after this one

The COALESCE finding is the transferable part. `Model` is 246 rows, so nothing there is at risk on its own — but the hangar is 1.57M vehicles, and a coalesced filter reaching it would be a different order of problem. The rule for every later catalogue: **filter on build columns, never on an expression spanning both tables.**

🤖
