### PR TITLE
refactor(api): give the last two q parameters a Query component

### DIFF
--- a/app/api_components/shared/v1/schemas/sorts/notification_sort_enum.rb
+++ b/app/api_components/shared/v1/schemas/sorts/notification_sort_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      module Sorts
+        class NotificationSortEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::Notification::ALLOWED_SORTING_PARAMS,
+            "x-enumNames": ::Notification::ALLOWED_SORTING_PARAMS.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/equipment_item_type_filter_query.rb
+++ b/app/api_components/v1/schemas/queries/equipment_item_type_filter_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Queries
+      class EquipmentItemTypeFilterQuery
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            equipmentTypeIn: {type: :array, items: {type: :string}}
+          },
+          additionalProperties: false,
+          example: {}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/notification_query.rb
+++ b/app/api_components/v1/schemas/queries/notification_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Queries
+      class NotificationQuery
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            notificationTypeEq: {"$ref": "#/components/schemas/NotificationTypeEnum"},
+            readAtNull: {type: :boolean},
+            sorts: {anyOf: [{
+              type: :array, items: {"$ref": "#/components/schemas/NotificationSortEnum"}
+            }, {
+              "$ref": "#/components/schemas/NotificationSortEnum"
+            }]}
+          },
+          additionalProperties: false,
+          example: {}
+        })
+      end
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -14427,6 +14427,15 @@ components:
       - meta
       - items
       title: Models
+    NotificationSortEnum:
+      type: string
+      enum:
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: NotificationSortEnum
     NotificationTypeEnum:
       type: string
       enum:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -268,12 +268,7 @@ paths:
         in: query
         schema:
           type: object
-          properties:
-            equipmentTypeIn:
-              type: array
-              items:
-                type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/EquipmentItemTypeFilterQuery"
         style: deepObject
         explode: true
         required: false
@@ -7852,6 +7847,7 @@ paths:
         in: query
         schema:
           type: object
+          "$ref": "#/components/schemas/NotificationQuery"
         style: deepObject
         explode: true
         required: false
@@ -12807,6 +12803,16 @@ components:
       - createdAt
       - updatedAt
       title: Equipment
+    EquipmentItemTypeFilterQuery:
+      type: object
+      properties:
+        equipmentTypeIn:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      example: {}
+      title: EquipmentItemTypeFilterQuery
     EquipmentQuery:
       type: object
       properties:
@@ -19719,6 +19725,31 @@ components:
         push:
           type: boolean
       title: NotificationPreferenceUpdateInput
+    NotificationQuery:
+      type: object
+      properties:
+        notificationTypeEq:
+          "$ref": "#/components/schemas/NotificationTypeEnum"
+        readAtNull:
+          type: boolean
+        sorts:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/NotificationSortEnum"
+          - "$ref": "#/components/schemas/NotificationSortEnum"
+      additionalProperties: false
+      example: {}
+      title: NotificationQuery
+    NotificationSortEnum:
+      type: string
+      enum:
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: NotificationSortEnum
     NotificationTypeEnum:
       type: string
       enum:

--- a/test/integration/api/v1/filters_equipment_item_types_test.rb
+++ b/test/integration/api/v1/filters_equipment_item_types_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FiltersEquipmentItemTypesTest < ActionDispatch::IntegrationTest
       parameter name: "q", in: :query,
         schema: {
           type: :object,
-          properties: {
-            equipmentTypeIn: {type: :array, items: {type: :string}}
-          },
-          additionalProperties: false
+          "$ref": "#/components/schemas/EquipmentItemTypeFilterQuery"
         },
         style: :deepObject,
         explode: true,

--- a/test/integration/api/v1/notifications_test.rb
+++ b/test/integration/api/v1/notifications_test.rb
@@ -25,7 +25,8 @@ class Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
       }, required: false
       parameter name: "q", in: :query,
         schema: {
-          type: :object
+          type: :object,
+          "$ref": "#/components/schemas/NotificationQuery"
         },
         style: :deepObject,
         explode: true,
@@ -139,11 +140,11 @@ class Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "GET /notifications filters by notification_type_eq" do
+  test "GET /notifications filters by notificationTypeEq" do
     create_list(:notification, 3, user: @user)
     sign_in @user
 
-    assert_api_response :get, 200, params: {q: {"notification_type_eq" => "hangar_create"}} do
+    assert_api_response :get, 200, params: {q: {"notificationTypeEq" => "hangar_create"}} do
       assert_equal 3, parsed_body["items"].count
     end
   end


### PR DESCRIPTION
Stacked on #4531 — review that one first.

## Why

Those were the last two `q` parameters without a Query component. `/notifications` declared `schema: {type: :object}` with no properties at all, and `/filters/equipment/item-types` spelled its filter out inline. Neither endpoint documented what it accepts, and the notifications one accepted anything.

## What

**`NotificationQuery`** mirrors what `Api::V1::NotificationsController#notification_query_params` permits — `notificationTypeEq`, `readAtNull`, `sorts` — and pulls in the existing `NotificationTypeEnum` plus a new **`NotificationSortEnum`** built from `Notification::ALLOWED_SORTING_PARAMS`. Same shape as the admin `AdminNotificationQuery` next to it.

**`EquipmentItemTypeFilterQuery`** moves the `equipmentTypeIn` shape as it stood. Deliberately still `items: {type: :string}` rather than an enum `$ref`, matching the sibling `EquipmentQuery` — the controller already intersects with `Equipment::EQUIPMENT_TYPES`, and tightening the documented type is a separate decision.

## Behaviour change worth a look

`GET /notifications` now **rejects snake_case `q` keys with a 400**. `request_validation` is enabled, and with `additionalProperties: false` on the new component, `q[notification_type_eq]` no longer validates — `q[notificationTypeEq]` does.

Snake_case worked only because there was no schema to check against: the `TransformParameters` middleware decamelizes every key, so both spellings reached Ransack. camelCase is what the API documents everywhere else, and every other filterable endpoint already 400s on anything outside its Query component, so this makes `/notifications` consistent rather than stricter than its peers. The integration test was filtering with the snake_case spelling and is updated.

If that is not wanted, the alternative is dropping `additionalProperties: false` from `NotificationQuery` alone — say the word and I will.

## Verification

- `oasdiff breaking` against both the parent branch and main: no breaking changes on any of the three specs. It cannot see request-validation behaviour, hence the note above.
- `validate-schema` valid, 67 warnings before and after.
- `pnpm lint:ts` clean, `standardrb` clean.
- `notifications_test.rb` + `filters_equipment_item_types_test.rb`: 21 tests, 0 failures.

🤖
