### PR TITLE
refactor(api): name every array response

### DIFF
--- a/.cursor/rules/backend/api-components.mdc
+++ b/.cursor/rules/backend/api-components.mdc
@@ -35,6 +35,23 @@ An inline body has no name, so Orval invents one from the operation
 up with unrelated TypeScript types that drift, and the frontend has nothing
 stable to import.
 
+An array-only response counts too — it gets a `<Plural>List` component instead
+of an inline `type: :array` around the item `$ref`:
+
+```ruby
+# Good
+schema "$ref": "#/components/schemas/FilterOptionsList"
+
+# Bad
+schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+```
+
+One list component per item type, reused by every endpoint returning it. When
+the plural already names the paginated collection (`Models`, `Images`,
+`FleetMembersList`), the bare array takes the `List` suffix or a name from the
+endpoint — `ModelsList`, `ImagesList`, `FleetInvitesList` — and says so in a
+comment.
+
 ## Placement
 
 - Request bodies → `<scope>/v1/schemas/inputs/<name>_input.rb`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,10 +253,31 @@ Why: an inline body has no name, so Orval invents one from the operation —
 sharing one payload get four unrelated TypeScript types that drift
 independently, and the frontend has nothing stable to import.
 
+That includes a response that is only an array. Give it a `<Plural>List`
+component rather than wrapping the item `$ref` in the test:
+
+```ruby
+# Good
+response(200, "successful") do
+  schema "$ref": "#/components/schemas/FilterOptionsList"
+end
+
+# Bad — the cardinality lives in the test
+response(200, "successful") do
+  schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+end
+```
+
+One component per item type, shared by every endpoint returning that array.
+Where the plural is already taken by the paginated collection (`Models`,
+`Images`, `FleetMembersList`), the bare array gets the `List` suffix or a name
+from what it returns — `ModelsList`, `ImagesList`, `FleetInvitesList`.
+
 Naming and placement follow the existing tree:
 
 - Request bodies → `<scope>/v1/schemas/inputs/<name>_input.rb`
 - Response bodies → `<scope>/v1/schemas/<name>.rb`
+- Array-only responses → `<scope>/v1/schemas/<name>_list.rb`
 - Reused by both the public and the admin schema → `shared/v1/`
 - Enums → `<scope>/v1/schemas/enums/<name>_enum.rb`, referenced by `$ref` —
   don't inline an `enum:` into a property

--- a/app/api_components/admin/v1/schemas/admin_resource_access_groups_list.rb
+++ b/app/api_components/admin/v1/schemas/admin_resource_access_groups_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminResourceAccessGroupsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/AdminResourceAccessGroup"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/features_list.rb
+++ b/app/api_components/admin/v1/schemas/features_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FeaturesList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/Feature"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/bar_chart_stats_list.rb
+++ b/app/api_components/shared/v1/schemas/bar_chart_stats_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class BarChartStatsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/BarChartStats"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/filter_options_list.rb
+++ b/app/api_components/shared/v1/schemas/filter_options_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class FilterOptionsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FilterOption"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleet_features_list.rb
+++ b/app/api_components/v1/schemas/fleet_features_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class FleetFeaturesList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/FleetFeature"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/extended_fleet_roles_list.rb
+++ b/app/api_components/v1/schemas/fleets/extended_fleet_roles_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class ExtendedFleetRolesList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetRoleExtended"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_invite_urls_list.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_invite_urls_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetInviteUrlsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetInviteUrl"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_invites_list.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_invites_list.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetInvitesList
+        include OpenapiRuby::Components::Base
+
+        # FleetMembersList is the paginated collection; GET /fleets/invites returns a
+        # bare array of the same member records.
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetMember"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_resource_access_groups_list.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_resource_access_groups_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetResourceAccessGroupsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetResourceAccessGroup"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_vehicle_exports_list.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_vehicle_exports_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetVehicleExportsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetVehicleExport"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleets_list.rb
+++ b/app/api_components/v1/schemas/fleets/fleets_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/Fleet"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_stock_items_list.rb
+++ b/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_stock_items_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Logistics
+        class FleetInventoryStockItemsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/FleetInventoryStockItem"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/groups/hangar_groups_list.rb
+++ b/app/api_components/v1/schemas/hangar/groups/hangar_groups_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Hangar
+      module Groups
+        class HangarGroupsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/HangarGroup"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/groups/public_hangar_groups_list.rb
+++ b/app/api_components/v1/schemas/hangar/groups/public_hangar_groups_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Hangar
+      module Groups
+        class PublicHangarGroupsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/HangarGroupPublic"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_stock_items_list.rb
+++ b/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_stock_items_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Hangar
+      module Logistics
+        class HangarInventoryStockItemsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/HangarInventoryStockItem"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/images_list.rb
+++ b/app/api_components/v1/schemas/images_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class ImagesList
+      include OpenapiRuby::Components::Base
+
+      # Images is the paginated collection; GET /images/random returns a bare array.
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/Image"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inventory_stock_positions_list.rb
+++ b/app/api_components/v1/schemas/inventory_stock_positions_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class InventoryStockPositionsList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/InventoryStockPosition"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/fleetchart_views_list.rb
+++ b/app/api_components/v1/schemas/models/fleetchart_views_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      class FleetchartViewsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/FleetchartView"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/hardpoints/hardpoints_list.rb
+++ b/app/api_components/v1/schemas/models/hardpoints/hardpoints_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Hardpoints
+        class HardpointsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/Hardpoint"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/models_list.rb
+++ b/app/api_components/v1/schemas/models/models_list.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      class ModelsList
+        include OpenapiRuby::Components::Base
+
+        # Models is the paginated collection; this is the bare array the embed,
+        # latest and snub-craft endpoints return.
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/Model"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/paints/model_paints_list.rb
+++ b/app/api_components/v1/schemas/models/paints/model_paints_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Paints
+        class ModelPaintsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/ModelPaint"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/positions/model_positions_list.rb
+++ b/app/api_components/v1/schemas/models/positions/model_positions_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Positions
+        class ModelPositionsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/ModelPosition"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/upgrades/model_upgrades_list.rb
+++ b/app/api_components/v1/schemas/models/upgrades/model_upgrades_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Upgrades
+        class ModelUpgradesList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/ModelUpgrade"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/notification_preferences_list.rb
+++ b/app/api_components/v1/schemas/notification_preferences_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class NotificationPreferencesList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/NotificationPreference"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/oauth_applications_list.rb
+++ b/app/api_components/v1/schemas/oauth_applications_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class OauthApplicationsList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/OauthApplication"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/pie_chart_stats_list.rb
+++ b/app/api_components/v1/schemas/pie_chart_stats_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class PieChartStatsList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/PieChartStats"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/user_features_list.rb
+++ b/app/api_components/v1/schemas/user_features_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class UserFeaturesList
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :array,
+        items: {"$ref": "#/components/schemas/UserFeature"}
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/public_vehicles_list.rb
+++ b/app/api_components/v1/schemas/vehicles/public_vehicles_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class PublicVehiclesList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/VehiclePublic"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_exports_list.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_exports_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class VehicleExportsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/VehicleExport"}
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadouts_list.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadouts_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class VehicleLoadoutsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/VehicleLoadout"}
+        })
+      end
+    end
+  end
+end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -384,9 +384,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -603,9 +601,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -630,9 +626,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -1130,9 +1124,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -1157,9 +1149,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -1184,9 +1174,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -1211,9 +1199,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -1349,9 +1335,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Feature"
+                "$ref": "#/components/schemas/FeaturesList"
         '403':
           description: forbidden
           content:
@@ -5132,9 +5116,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '403':
           description: forbidden
           content:
@@ -5997,9 +5979,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/AdminResourceAccessGroup"
+                "$ref": "#/components/schemas/AdminResourceAccessGroupsList"
         '401':
           description: unauthorized
           content:
@@ -6133,9 +6113,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6173,9 +6151,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6194,9 +6170,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6215,9 +6189,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -7563,6 +7535,11 @@ components:
       - key
       - privileges
       title: AdminResourceAccessGroup
+    AdminResourceAccessGroupsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/AdminResourceAccessGroup"
+      title: AdminResourceAccessGroupsList
     AdminUser:
       type: object
       properties:
@@ -7753,6 +7730,11 @@ components:
       - count
       - tooltip
       title: BarChartStats
+    BarChartStatsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/BarChartStats"
+      title: BarChartStatsList
     BaseList:
       type: object
       properties:
@@ -10094,6 +10076,11 @@ components:
       required:
       - percentage
       title: FeaturePercentageInput
+    FeaturesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Feature"
+      title: FeaturesList
     FieldError:
       type: object
       properties:
@@ -10133,6 +10120,11 @@ components:
       - label
       - value
       title: FilterOption
+    FilterOptionsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FilterOption"
+      title: FilterOptionsList
     Fleet:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -186,9 +186,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/components/categories":
     get:
       summary: Components Categories Filters
@@ -201,9 +199,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/components/classes":
     get:
       summary: Components Classes Filters
@@ -216,9 +212,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/components/item-types":
     get:
       summary: Components Item Types Filters
@@ -231,9 +225,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/components/sub-types":
     get:
       summary: Components Sub Type Filters
@@ -252,9 +244,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/filters/equipment/item-types":
@@ -278,9 +268,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/filters/manufacturers/options":
@@ -331,9 +319,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/models/classifications":
     get:
       summary: Model classifications Filters
@@ -346,9 +332,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/models/dock-sizes":
     get:
       summary: Model Dock Sizes Filters
@@ -361,9 +345,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/models/focus":
     get:
       summary: Model focus Filters
@@ -383,9 +365,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/filters/models/options":
@@ -436,9 +416,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/models/sizes":
     get:
       summary: Model Sizes Filters
@@ -451,9 +429,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/vehicles/bought-via":
     get:
       summary: Vehicles Bought Via Filters
@@ -466,9 +442,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FilterOption"
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/fleet-event-signups/{id}":
     parameters:
     - name: id
@@ -897,9 +871,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetMember"
+                "$ref": "#/components/schemas/FleetInvitesList"
         '401':
           description: unauthorized
           content:
@@ -926,9 +898,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Fleet"
+                "$ref": "#/components/schemas/FleetsList"
         '401':
           description: unauthorized
           content:
@@ -947,9 +917,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetResourceAccessGroup"
+                "$ref": "#/components/schemas/FleetResourceAccessGroupsList"
   "/fleets/use-invite":
     post:
       summary: Create Fleet Membership by Invite
@@ -2419,9 +2387,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetFeature"
+                "$ref": "#/components/schemas/FleetFeaturesList"
         '401':
           description: unauthorized
           content:
@@ -2875,9 +2841,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetInventoryStockItem"
+                "$ref": "#/components/schemas/FleetInventoryStockItemsList"
         '401':
           description: unauthorized
           content:
@@ -3228,9 +3192,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetInventoryStockItem"
+                "$ref": "#/components/schemas/FleetInventoryStockItemsList"
         '401':
           description: unauthorized
           content:
@@ -3329,9 +3291,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetInviteUrl"
+                "$ref": "#/components/schemas/FleetInviteUrlsList"
         '401':
           description: unauthorized
           content:
@@ -4755,9 +4715,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetRoleExtended"
+                "$ref": "#/components/schemas/ExtendedFleetRolesList"
         '401':
           description: unauthorized
           content:
@@ -4895,9 +4853,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -4933,9 +4889,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -4971,9 +4925,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -5009,9 +4961,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -5089,9 +5039,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -5209,9 +5157,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetVehicleExport"
+                "$ref": "#/components/schemas/FleetVehicleExportsList"
         '401':
           description: unauthorized
           content:
@@ -5262,9 +5208,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetVehicleExport"
+                "$ref": "#/components/schemas/FleetVehicleExportsList"
         '401':
           description: unauthorized
           content:
@@ -5514,9 +5458,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehicleExport"
+                "$ref": "#/components/schemas/VehicleExportsList"
         '401':
           description: unauthorized
           content:
@@ -5554,9 +5496,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehicleExport"
+                "$ref": "#/components/schemas/VehicleExportsList"
         '401':
           description: unauthorized
           content:
@@ -5619,9 +5559,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/HangarGroup"
+                "$ref": "#/components/schemas/HangarGroupsList"
         '401':
           description: unauthorized
           content:
@@ -6103,9 +6041,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/HangarInventoryStockItem"
+                "$ref": "#/components/schemas/HangarInventoryStockItemsList"
         '401':
           description: unauthorized
           content:
@@ -6433,9 +6369,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/HangarInventoryStockItem"
+                "$ref": "#/components/schemas/HangarInventoryStockItemsList"
         '401':
           description: unauthorized
           content:
@@ -6552,9 +6486,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6581,9 +6513,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6610,9 +6540,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6639,9 +6567,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '401':
           description: unauthorized
           content:
@@ -6777,9 +6703,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Image"
+                "$ref": "#/components/schemas/ImagesList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/manufacturers":
@@ -7105,9 +7029,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/ModelPaint"
+                "$ref": "#/components/schemas/ModelPaintsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/models":
@@ -7182,9 +7104,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Model"
+                "$ref": "#/components/schemas/ModelsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/models/fleetchart-views":
@@ -7225,9 +7145,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Model"
+                "$ref": "#/components/schemas/ModelsList"
   "/models/slugs":
     get:
       summary: Available Model-Slugs
@@ -7383,9 +7301,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Hardpoint"
+                "$ref": "#/components/schemas/HardpointsList"
         '404':
           description: not found
           content:
@@ -7577,9 +7493,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/ModelPaint"
+                "$ref": "#/components/schemas/ModelPaintsList"
         '404':
           description: not found
           content:
@@ -7607,9 +7521,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/ModelPosition"
+                "$ref": "#/components/schemas/ModelPositionsList"
         '404':
           description: not found
           content:
@@ -7637,9 +7549,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Model"
+                "$ref": "#/components/schemas/ModelsList"
         '404':
           description: not found
           content:
@@ -7686,9 +7596,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/ModelUpgrade"
+                "$ref": "#/components/schemas/ModelUpgradesList"
         '404':
           description: not found
           content:
@@ -7799,9 +7707,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/NotificationPreference"
+                "$ref": "#/components/schemas/NotificationPreferencesList"
         '401':
           description: unauthorized
           content:
@@ -8062,9 +7968,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/OauthApplication"
+                "$ref": "#/components/schemas/OauthApplicationsList"
         '401':
           description: unauthorized
           content:
@@ -8579,9 +8483,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -8609,9 +8511,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -8639,9 +8539,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -8669,9 +8567,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -8727,9 +8623,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
         '404':
           description: not found
           content:
@@ -8825,9 +8719,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehiclePublic"
+                "$ref": "#/components/schemas/PublicVehiclesList"
         '404':
           description: not found
           content:
@@ -8884,9 +8776,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehiclePublic"
+                "$ref": "#/components/schemas/PublicVehiclesList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/public/hangars/{username}":
@@ -8956,9 +8846,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/HangarGroupPublic"
+                "$ref": "#/components/schemas/PublicHangarGroupsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/public/hangars/{username}/stats":
@@ -9017,9 +8905,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -9047,9 +8933,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -9077,9 +8961,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -9107,9 +8989,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
         '404':
           description: not found
           content:
@@ -9358,9 +9238,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
   "/stats/models-by-classification":
     get:
       summary: Stats Models by Classification
@@ -9373,9 +9251,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
   "/stats/models-by-manufacturer":
     get:
       summary: Stats Models by Manufacturer
@@ -9388,9 +9264,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
   "/stats/models-by-production-status":
     get:
       summary: Stats Models by Production-Status
@@ -9403,9 +9277,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
   "/stats/models-by-size":
     get:
       summary: Stats Models by Size
@@ -9418,9 +9290,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/PieChartStats"
+                "$ref": "#/components/schemas/PieChartStatsList"
   "/stats/models-per-month":
     get:
       summary: Stats Models per Month
@@ -9433,9 +9303,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/stats/quick-stats":
     get:
       summary: Stats
@@ -9461,9 +9329,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/stats/vehicles-by-model":
     get:
       summary: Stats Vehicles by Model
@@ -9476,9 +9342,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/stats/vehicles-per-month":
     get:
       summary: Stats Vehicles per Month
@@ -9491,9 +9355,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/BarChartStats"
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/supporters/progress":
     get:
       summary: Public Supporters Progress
@@ -9525,9 +9387,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/UserFeature"
+                "$ref": "#/components/schemas/UserFeaturesList"
         '401':
           description: unauthorized
           content:
@@ -10439,9 +10299,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/InventoryStockPosition"
+                "$ref": "#/components/schemas/InventoryStockPositionsList"
         '401':
           description: unauthorized
           content:
@@ -10645,9 +10503,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehicleLoadout"
+                "$ref": "#/components/schemas/VehicleLoadoutsList"
         '401':
           description: unauthorized
           content:
@@ -10939,9 +10795,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/VehicleExport"
+                "$ref": "#/components/schemas/VehicleExportsList"
         '401':
           description: unauthorized
           content:
@@ -11097,6 +10951,11 @@ components:
       - count
       - tooltip
       title: BarChartStats
+    BarChartStatsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/BarChartStats"
+      title: BarChartStatsList
     BaseList:
       type: object
       properties:
@@ -12934,6 +12793,11 @@ components:
       - meta
       - items
       title: Equipments
+    ExtendedFleetRolesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetRoleExtended"
+      title: ExtendedFleetRolesList
     ExternalFuelTank:
       type: object
       properties:
@@ -13026,6 +12890,11 @@ components:
       - label
       - value
       title: FilterOption
+    FilterOptionsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FilterOption"
+      title: FilterOptionsList
     Fleet:
       type: object
       properties:
@@ -14182,6 +14051,11 @@ components:
       - toggleable
       - groups
       title: FleetFeature
+    FleetFeaturesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetFeature"
+      title: FleetFeaturesList
     FleetInventoriesList:
       type: object
       properties:
@@ -14485,6 +14359,11 @@ components:
       - unit
       - netQuantity
       title: FleetInventoryStockItem
+    FleetInventoryStockItemsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetInventoryStockItem"
+      title: FleetInventoryStockItemsList
     FleetInventoryUpdateInput:
       type: object
       properties:
@@ -14568,6 +14447,16 @@ components:
           - 'null'
       additionalProperties: false
       title: FleetInviteUrlCreateInput
+    FleetInviteUrlsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetInviteUrl"
+      title: FleetInviteUrlsList
+    FleetInvitesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetMember"
+      title: FleetInvitesList
     FleetMember:
       type: object
       properties:
@@ -15018,6 +14907,11 @@ components:
       - key
       - privileges
       title: FleetResourceAccessGroup
+    FleetResourceAccessGroupsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetResourceAccessGroup"
+      title: FleetResourceAccessGroupsList
     FleetRole:
       type: object
       properties:
@@ -15295,6 +15189,11 @@ components:
       - modules
       - upgrades
       title: FleetVehicleExport
+    FleetVehicleExportsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetVehicleExport"
+      title: FleetVehicleExportsList
     FleetVehicleQuery:
       type: object
       properties:
@@ -15485,6 +15384,11 @@ components:
           items:
             type: string
       title: FleetchartViewQuery
+    FleetsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Fleet"
+      title: FleetsList
     FuelTank:
       type: object
       properties:
@@ -15705,6 +15609,11 @@ components:
           type: boolean
       additionalProperties: false
       title: HangarGroupUpdateInput
+    HangarGroupsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/HangarGroup"
+      title: HangarGroupsList
     HangarImportResult:
       type: object
       properties:
@@ -15996,6 +15905,11 @@ components:
       - unit
       - netQuantity
       title: HangarInventoryStockItem
+    HangarInventoryStockItemsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/HangarInventoryStockItem"
+      title: HangarInventoryStockItemsList
     HangarInventoryUpdateInput:
       type: object
       properties:
@@ -16568,6 +16482,11 @@ components:
       - SHIP_MATRIX
       - GAME_FILES
       title: HardpointSourceEnum
+    HardpointsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Hardpoint"
+      title: HardpointsList
     Image:
       type: object
       properties:
@@ -16675,6 +16594,11 @@ components:
       - meta
       - items
       title: Images
+    ImagesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Image"
+      title: ImagesList
     ImportInput:
       type: object
       properties:
@@ -17039,6 +16963,11 @@ components:
           "$ref": "#/components/schemas/InventoryUnitEnum"
       additionalProperties: false
       title: InventoryStockPositionInput
+    InventoryStockPositionsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/InventoryStockPosition"
+      title: InventoryStockPositionsList
     InventoryStockQuery:
       type: object
       properties:
@@ -19285,6 +19214,11 @@ components:
       - MODEL_SLUG_ASC
       - MODEL_SLUG_DESC
       title: ModelPaintSortEnum
+    ModelPaintsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/ModelPaint"
+      title: ModelPaintsList
     ModelPosition:
       type: object
       properties:
@@ -19347,6 +19281,11 @@ components:
       - OPERATOR
       - CUSTOM
       title: ModelPositionTypeEnum
+    ModelPositionsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/ModelPosition"
+      title: ModelPositionsList
     ModelProductionStatusEnum:
       type: string
       enum:
@@ -19584,6 +19523,11 @@ components:
       - createdAt
       - updatedAt
       title: ModelUpgrade
+    ModelUpgradesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/ModelUpgrade"
+      title: ModelUpgradesList
     Models:
       type: object
       properties:
@@ -19598,6 +19542,11 @@ components:
       - meta
       - items
       title: Models
+    ModelsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Model"
+      title: ModelsList
     Notification:
       type: object
       properties:
@@ -19672,6 +19621,11 @@ components:
         push:
           type: boolean
       title: NotificationPreferenceUpdateInput
+    NotificationPreferencesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/NotificationPreference"
+      title: NotificationPreferencesList
     NotificationQuery:
       type: object
       properties:
@@ -19917,6 +19871,11 @@ components:
       - createdAt
       - updatedAt
       title: OauthApplicationWithSecret
+    OauthApplicationsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/OauthApplication"
+      title: OauthApplicationsList
     OrderDirectionEnum:
       type: string
       enum:
@@ -20000,6 +19959,21 @@ components:
       - selected
       - sliced
       title: PieChartStats
+    PieChartStatsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/PieChartStats"
+      title: PieChartStatsList
+    PublicHangarGroupsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/HangarGroupPublic"
+      title: PublicHangarGroupsList
+    PublicVehiclesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/VehiclePublic"
+      title: PublicVehiclesList
     RefuelBoom:
       type: object
       properties:
@@ -20499,6 +20473,11 @@ components:
       - USER
       - FLEET
       title: UserFeatureScopeEnum
+    UserFeaturesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/UserFeature"
+      title: UserFeaturesList
     UserPublic:
       type: object
       properties:
@@ -20916,6 +20895,11 @@ components:
       - modules
       - upgrades
       title: VehicleExport
+    VehicleExportsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/VehicleExport"
+      title: VehicleExportsList
     VehicleLoadout:
       type: object
       properties:
@@ -21020,6 +21004,11 @@ components:
       - createdAt
       - updatedAt
       title: VehicleLoadoutMinimal
+    VehicleLoadoutsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/VehicleLoadout"
+      title: VehicleLoadoutsList
     VehiclePublic:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7128,9 +7128,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/FleetchartView"
+                "$ref": "#/components/schemas/FleetchartViewsList"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
   "/models/latest":
@@ -15384,6 +15382,11 @@ components:
           items:
             type: string
       title: FleetchartViewQuery
+    FleetchartViewsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/FleetchartView"
+      title: FleetchartViewsList
     FleetsList:
       type: array
       items:

--- a/test/integration/admin/api/v1/commodity_types_test.rb
+++ b/test/integration/admin/api/v1/commodity_types_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::CommodityTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/component_classes_test.rb
+++ b/test/integration/admin/api/v1/component_classes_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ComponentClassesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/component_item_types_test.rb
+++ b/test/integration/admin/api/v1/component_item_types_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ComponentItemTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/equipment_item_types_test.rb
+++ b/test/integration/admin/api/v1/equipment_item_types_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::EquipmentItemTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/equipment_slots_test.rb
+++ b/test/integration/admin/api/v1/equipment_slots_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::EquipmentSlotsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/equipment_types_test.rb
+++ b/test/integration/admin/api/v1/equipment_types_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::EquipmentTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/equipment_weapon_classes_test.rb
+++ b/test/integration/admin/api/v1/equipment_weapon_classes_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::EquipmentWeaponClassesTest < ActionDispatch::IntegrationTe
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/features_test.rb
+++ b/test/integration/admin/api/v1/features_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::FeaturesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/Feature"}
+        schema "$ref": "#/components/schemas/FeaturesList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/models_production_states_test.rb
+++ b/test/integration/admin/api/v1/models_production_states_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ModelsProductionStatesTest < ActionDispatch::IntegrationTe
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
 
       response(403, "forbidden") do

--- a/test/integration/admin/api/v1/resource_access_catalog_test.rb
+++ b/test/integration/admin/api/v1/resource_access_catalog_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ResourceAccessCatalogTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/AdminResourceAccessGroup"}
+        schema "$ref": "#/components/schemas/AdminResourceAccessGroupsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/admin/api/v1/stats_most_viewed_pages_test.rb
+++ b/test/integration/admin/api/v1/stats_most_viewed_pages_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::StatsMostViewedPagesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/admin/api/v1/stats_registrations_per_month_test.rb
+++ b/test/integration/admin/api/v1/stats_registrations_per_month_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::StatsRegistrationsPerMonthTest < ActionDispatch::Integrati
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/admin/api/v1/stats_visits_per_day_test.rb
+++ b/test/integration/admin/api/v1/stats_visits_per_day_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::StatsVisitsPerDayTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/admin/api/v1/stats_visits_per_month_test.rb
+++ b/test/integration/admin/api/v1/stats_visits_per_month_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::StatsVisitsPerMonthTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/filters_commodities_types_test.rb
+++ b/test/integration/api/v1/filters_commodities_types_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersCommoditiesTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_components_categories_test.rb
+++ b/test/integration/api/v1/filters_components_categories_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersComponentsCategoriesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_components_classes_test.rb
+++ b/test/integration/api/v1/filters_components_classes_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersComponentsClassesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_components_item_types_test.rb
+++ b/test/integration/api/v1/filters_components_item_types_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersComponentsItemTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_components_sub_types_test.rb
+++ b/test/integration/api/v1/filters_components_sub_types_test.rb
@@ -16,7 +16,7 @@ class Api::V1::FiltersComponentsSubTypesTest < ActionDispatch::IntegrationTest
       parameter name: "category", in: :query, schema: {type: :string}, required: false
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_equipment_item_types_test.rb
+++ b/test/integration/api/v1/filters_equipment_item_types_test.rb
@@ -23,7 +23,7 @@ class Api::V1::FiltersEquipmentItemTypesTest < ActionDispatch::IntegrationTest
         required: false
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_classifications_test.rb
+++ b/test/integration/api/v1/filters_models_classifications_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersModelsClassificationsTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_dock_sizes_test.rb
+++ b/test/integration/api/v1/filters_models_dock_sizes_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersModelsDockSizesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_focus_test.rb
+++ b/test/integration/api/v1/filters_models_focus_test.rb
@@ -17,7 +17,7 @@ class Api::V1::FiltersModelsFocusTest < ActionDispatch::IntegrationTest
         description: "Restrict the result to focuses of models with this classification"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_models_test.rb
+++ b/test/integration/api/v1/filters_models_models_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersModelsModelsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_production_states_test.rb
+++ b/test/integration/api/v1/filters_models_production_states_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersModelsProductionStatesTest < ActionDispatch::IntegrationTe
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_models_sizes_test.rb
+++ b/test/integration/api/v1/filters_models_sizes_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersModelsSizesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/filters_vehicles_bought_via_test.rb
+++ b/test/integration/api/v1/filters_vehicles_bought_via_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FiltersVehiclesBoughtViaTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FilterOption"}
+        schema "$ref": "#/components/schemas/FilterOptionsList"
       end
     end
   end

--- a/test/integration/api/v1/fleet_resource_access_catalog_test.rb
+++ b/test/integration/api/v1/fleet_resource_access_catalog_test.rb
@@ -14,7 +14,7 @@ class Api::V1::FleetResourceAccessCatalogTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetResourceAccessGroup"}
+        schema "$ref": "#/components/schemas/FleetResourceAccessGroupsList"
       end
     end
   end

--- a/test/integration/api/v1/fleets_all_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/fleets_all_inventory_stock_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsAllInventoryStockIndexTest < ActionDispatch::IntegrationTes
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetInventoryStockItem"}
+        schema "$ref": "#/components/schemas/FleetInventoryStockItemsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_features_index_test.rb
+++ b/test/integration/api/v1/fleets_features_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsFeaturesIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetFeature"}
+        schema "$ref": "#/components/schemas/FleetFeaturesList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/fleets_inventory_stock_index_test.rb
@@ -23,7 +23,7 @@ class Api::V1::FleetsInventoryStockIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetInventoryStockItem"}
+        schema "$ref": "#/components/schemas/FleetInventoryStockItemsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_invite_urls_index_test.rb
+++ b/test/integration/api/v1/fleets_invite_urls_index_test.rb
@@ -25,7 +25,7 @@ class Api::V1::FleetsInviteUrlsIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetInviteUrl"}
+        schema "$ref": "#/components/schemas/FleetInviteUrlsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_invites_test.rb
+++ b/test/integration/api/v1/fleets_invites_test.rb
@@ -20,7 +20,7 @@ class Api::V1::FleetsInvitesTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetMember"}
+        schema "$ref": "#/components/schemas/FleetInvitesList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_my_test.rb
+++ b/test/integration/api/v1/fleets_my_test.rb
@@ -20,7 +20,7 @@ class Api::V1::FleetsMyTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/Fleet"}
+        schema "$ref": "#/components/schemas/FleetsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_roles_index_test.rb
+++ b/test/integration/api/v1/fleets_roles_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsRolesIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetRoleExtended"}
+        schema "$ref": "#/components/schemas/ExtendedFleetRolesList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_stats_models_by_classification_test.rb
+++ b/test/integration/api/v1/fleets_stats_models_by_classification_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsStatsModelsByClassificationTest < ActionDispatch::Integrati
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_stats_models_by_manufacturer_test.rb
+++ b/test/integration/api/v1/fleets_stats_models_by_manufacturer_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsStatsModelsByManufacturerTest < ActionDispatch::Integration
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_stats_models_by_production_status_test.rb
+++ b/test/integration/api/v1/fleets_stats_models_by_production_status_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsStatsModelsByProductionStatusTest < ActionDispatch::Integra
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_stats_models_by_size_test.rb
+++ b/test/integration/api/v1/fleets_stats_models_by_size_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsStatsModelsBySizeTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_stats_vehicles_by_model_test.rb
+++ b/test/integration/api/v1/fleets_stats_vehicles_by_model_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FleetsStatsVehiclesByModelTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_vehicles_export_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_export_test.rb
@@ -31,7 +31,7 @@ class Api::V1::FleetsVehiclesExportTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetVehicleExport"}
+        schema "$ref": "#/components/schemas/FleetVehicleExportsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/fleets_vehicles_hangar_link_export_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_hangar_link_export_test.rb
@@ -31,7 +31,7 @@ class Api::V1::FleetsVehiclesHangarLinkExportTest < ActionDispatch::IntegrationT
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetVehicleExport"}
+        schema "$ref": "#/components/schemas/FleetVehicleExportsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_all_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/hangar_all_inventory_stock_index_test.rb
@@ -29,7 +29,7 @@ class Api::V1::HangarAllInventoryStockIndexTest < ActionDispatch::IntegrationTes
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/HangarInventoryStockItem"}
+        schema "$ref": "#/components/schemas/HangarInventoryStockItemsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_export_test.rb
+++ b/test/integration/api/v1/hangar_export_test.rb
@@ -29,7 +29,7 @@ class Api::V1::HangarExportTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehicleExport"}
+        schema "$ref": "#/components/schemas/VehicleExportsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_groups_test.rb
+++ b/test/integration/api/v1/hangar_groups_test.rb
@@ -43,7 +43,7 @@ class Api::V1::HangarGroupsTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/HangarGroup"}
+        schema "$ref": "#/components/schemas/HangarGroupsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/hangar_inventory_stock_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::HangarInventoryStockIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/HangarInventoryStockItem"}
+        schema "$ref": "#/components/schemas/HangarInventoryStockItemsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_link_export_test.rb
+++ b/test/integration/api/v1/hangar_link_export_test.rb
@@ -29,7 +29,7 @@ class Api::V1::HangarLinkExportTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehicleExport"}
+        schema "$ref": "#/components/schemas/VehicleExportsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_stats_models_by_classification_test.rb
+++ b/test/integration/api/v1/hangar_stats_models_by_classification_test.rb
@@ -20,7 +20,7 @@ class Api::V1::HangarStatsModelsByClassificationTest < ActionDispatch::Integrati
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_stats_models_by_manufacturer_test.rb
+++ b/test/integration/api/v1/hangar_stats_models_by_manufacturer_test.rb
@@ -20,7 +20,7 @@ class Api::V1::HangarStatsModelsByManufacturerTest < ActionDispatch::Integration
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_stats_models_by_production_status_test.rb
+++ b/test/integration/api/v1/hangar_stats_models_by_production_status_test.rb
@@ -20,7 +20,7 @@ class Api::V1::HangarStatsModelsByProductionStatusTest < ActionDispatch::Integra
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/hangar_stats_models_by_size_test.rb
+++ b/test/integration/api/v1/hangar_stats_models_by_size_test.rb
@@ -20,7 +20,7 @@ class Api::V1::HangarStatsModelsBySizeTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/images_random_test.rb
+++ b/test/integration/api/v1/images_random_test.rb
@@ -22,8 +22,7 @@ class Api::V1::ImagesRandomTest < ActionDispatch::IntegrationTest
       }, required: false
 
       response(200, "successful") do
-        schema type: :array,
-          items: {"$ref" => "#/components/schemas/Image"}
+        schema "$ref": "#/components/schemas/ImagesList"
       end
     end
   end

--- a/test/integration/api/v1/model_paints_test.rb
+++ b/test/integration/api/v1/model_paints_test.rb
@@ -25,8 +25,7 @@ class Api::V1::ModelPaintsTest < ActionDispatch::IntegrationTest
         required: false
 
       response(200, "successful") do
-        schema type: :array,
-          items: {"$ref": "#/components/schemas/ModelPaint"}
+        schema "$ref": "#/components/schemas/ModelPaintsList"
       end
     end
   end

--- a/test/integration/api/v1/models_embed_test.rb
+++ b/test/integration/api/v1/models_embed_test.rb
@@ -16,7 +16,7 @@ class Api::V1::ModelsEmbedTest < ActionDispatch::IntegrationTest
       parameter name: :models, in: :query, schema: {type: :array, items: {type: :string}}, style: :form, explode: true, required: true
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/Model"}
+        schema "$ref": "#/components/schemas/ModelsList"
       end
     end
   end

--- a/test/integration/api/v1/models_fleetchart_views_test.rb
+++ b/test/integration/api/v1/models_fleetchart_views_test.rb
@@ -23,7 +23,7 @@ class Api::V1::ModelsFleetchartViewsTest < ActionDispatch::IntegrationTest
         required: false
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/FleetchartView"}
+        schema "$ref": "#/components/schemas/FleetchartViewsList"
       end
     end
   end

--- a/test/integration/api/v1/models_hardpoints_test.rb
+++ b/test/integration/api/v1/models_hardpoints_test.rb
@@ -19,8 +19,7 @@ class Api::V1::ModelsHardpointsTest < ActionDispatch::IntegrationTest
         schema: {"$ref": "#/components/schemas/HardpointSourceEnum"}, required: false
 
       response(200, "successful") do
-        schema type: :array,
-          items: {"$ref": "#/components/schemas/Hardpoint"}
+        schema "$ref": "#/components/schemas/HardpointsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/models_latest_test.rb
+++ b/test/integration/api/v1/models_latest_test.rb
@@ -14,7 +14,7 @@ class Api::V1::ModelsLatestTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/Model"}
+        schema "$ref": "#/components/schemas/ModelsList"
       end
     end
   end

--- a/test/integration/api/v1/models_paints_test.rb
+++ b/test/integration/api/v1/models_paints_test.rb
@@ -16,7 +16,7 @@ class Api::V1::ModelsPaintsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/ModelPaint"}
+        schema "$ref": "#/components/schemas/ModelPaintsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/models_positions_test.rb
+++ b/test/integration/api/v1/models_positions_test.rb
@@ -16,7 +16,7 @@ class Api::V1::ModelsPositionsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/ModelPosition"}
+        schema "$ref": "#/components/schemas/ModelPositionsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/models_snub_crafts_test.rb
+++ b/test/integration/api/v1/models_snub_crafts_test.rb
@@ -16,7 +16,7 @@ class Api::V1::ModelsSnubCraftsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/Model"}
+        schema "$ref": "#/components/schemas/ModelsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/models_upgrades_test.rb
+++ b/test/integration/api/v1/models_upgrades_test.rb
@@ -16,7 +16,7 @@ class Api::V1::ModelsUpgradesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/ModelUpgrade"}
+        schema "$ref": "#/components/schemas/ModelUpgradesList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/notification_preferences_test.rb
+++ b/test/integration/api/v1/notification_preferences_test.rb
@@ -20,7 +20,7 @@ class Api::V1::NotificationPreferencesTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/NotificationPreference"}
+        schema "$ref": "#/components/schemas/NotificationPreferencesList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/oauth_applications_test.rb
+++ b/test/integration/api/v1/oauth_applications_test.rb
@@ -47,7 +47,7 @@ class Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/OauthApplication"}
+        schema "$ref": "#/components/schemas/OauthApplicationsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/public_fleets_stats_models_by_classification_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_models_by_classification_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicFleetsStatsModelsByClassificationTest < ActionDispatch::Int
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_fleets_stats_models_by_manufacturer_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_models_by_manufacturer_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicFleetsStatsModelsByManufacturerTest < ActionDispatch::Integ
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_fleets_stats_models_by_production_status_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_models_by_production_status_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicFleetsStatsModelsByProductionStatusTest < ActionDispatch::I
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_fleets_stats_models_by_size_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_models_by_size_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicFleetsStatsModelsBySizeTest < ActionDispatch::IntegrationTe
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_fleets_stats_vehicles_by_model_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_vehicles_by_model_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicFleetsStatsVehiclesByModelTest < ActionDispatch::Integratio
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_fleets_vehicles_embed_test.rb
+++ b/test/integration/api/v1/public_fleets_vehicles_embed_test.rb
@@ -25,7 +25,7 @@ class Api::V1::PublicFleetsVehiclesEmbedTest < ActionDispatch::IntegrationTest
         required: false
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehiclePublic"}
+        schema "$ref": "#/components/schemas/PublicVehiclesList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_hangars_embed_test.rb
+++ b/test/integration/api/v1/public_hangars_embed_test.rb
@@ -20,7 +20,7 @@ class Api::V1::PublicHangarsEmbedTest < ActionDispatch::IntegrationTest
         required: true
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehiclePublic"}
+        schema "$ref": "#/components/schemas/PublicVehiclesList"
       end
     end
   end

--- a/test/integration/api/v1/public_hangars_groups_test.rb
+++ b/test/integration/api/v1/public_hangars_groups_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicHangarsGroupsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/HangarGroupPublic"}
+        schema "$ref": "#/components/schemas/PublicHangarGroupsList"
       end
     end
   end

--- a/test/integration/api/v1/public_hangars_stats_models_by_classification_test.rb
+++ b/test/integration/api/v1/public_hangars_stats_models_by_classification_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicHangarsStatsModelsByClassificationTest < ActionDispatch::In
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_hangars_stats_models_by_manufacturer_test.rb
+++ b/test/integration/api/v1/public_hangars_stats_models_by_manufacturer_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicHangarsStatsModelsByManufacturerTest < ActionDispatch::Inte
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_hangars_stats_models_by_production_status_test.rb
+++ b/test/integration/api/v1/public_hangars_stats_models_by_production_status_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicHangarsStatsModelsByProductionStatusTest < ActionDispatch::
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/public_hangars_stats_models_by_size_test.rb
+++ b/test/integration/api/v1/public_hangars_stats_models_by_size_test.rb
@@ -16,7 +16,7 @@ class Api::V1::PublicHangarsStatsModelsBySizeTest < ActionDispatch::IntegrationT
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
 
       response(404, "not found") do

--- a/test/integration/api/v1/stats_components_by_class_test.rb
+++ b/test/integration/api/v1/stats_components_by_class_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsComponentsByClassTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_models_by_classification_test.rb
+++ b/test/integration/api/v1/stats_models_by_classification_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsModelsByClassificationTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_models_by_manufacturer_test.rb
+++ b/test/integration/api/v1/stats_models_by_manufacturer_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsModelsByManufacturerTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_models_by_production_status_test.rb
+++ b/test/integration/api/v1/stats_models_by_production_status_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsModelsByProductionStatusTest < ActionDispatch::IntegrationTe
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_models_by_size_test.rb
+++ b/test/integration/api/v1/stats_models_by_size_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsModelsBySizeTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/PieChartStats"}
+        schema "$ref": "#/components/schemas/PieChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_models_per_month_test.rb
+++ b/test/integration/api/v1/stats_models_per_month_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsModelsPerMonthTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_ships_of_the_month_test.rb
+++ b/test/integration/api/v1/stats_ships_of_the_month_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsShipsOfTheMonthTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_vehicles_by_model_test.rb
+++ b/test/integration/api/v1/stats_vehicles_by_model_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsVehiclesByModelTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/stats_vehicles_per_month_test.rb
+++ b/test/integration/api/v1/stats_vehicles_per_month_test.rb
@@ -14,7 +14,7 @@ class Api::V1::StatsVehiclesPerMonthTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref" => "#/components/schemas/BarChartStats"}
+        schema "$ref": "#/components/schemas/BarChartStatsList"
       end
     end
   end

--- a/test/integration/api/v1/user_features_index_test.rb
+++ b/test/integration/api/v1/user_features_index_test.rb
@@ -20,7 +20,7 @@ class Api::V1::UserFeaturesIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/UserFeature"}
+        schema "$ref": "#/components/schemas/UserFeaturesList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/vehicle_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/vehicle_inventory_stock_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::VehicleInventoryStockIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/InventoryStockPosition"}
+        schema "$ref": "#/components/schemas/InventoryStockPositionsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/vehicle_loadouts_index_test.rb
+++ b/test/integration/api/v1/vehicle_loadouts_index_test.rb
@@ -22,7 +22,7 @@ class Api::V1::VehicleLoadoutsIndexTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehicleLoadout"}
+        schema "$ref": "#/components/schemas/VehicleLoadoutsList"
       end
 
       response(401, "unauthorized") do

--- a/test/integration/api/v1/wishlist_export_test.rb
+++ b/test/integration/api/v1/wishlist_export_test.rb
@@ -20,7 +20,7 @@ class Api::V1::WishlistExportTest < ActionDispatch::IntegrationTest
       ]
 
       response(200, "successful") do
-        schema type: :array, items: {"$ref": "#/components/schemas/VehicleExport"}
+        schema "$ref": "#/components/schemas/VehicleExportsList"
       end
 
       response(401, "unauthorized") do


### PR DESCRIPTION
Top of the stack: #4531 → #4533 → #4534 → this. Review the earlier ones first.

## Why

#4531 left these out on the grounds that only the cardinality was inline and the item type was already named. That was the inconsistent call — the tree already has list components for exactly this shape (`FleetEventAdminsList`, `ModelOptions`, `ManufacturerOptions`), so the same payload was spelled two different ways depending on which endpoint you looked at. This finishes the job.

## What

**29 list components** replacing 87 inline `type: :array` responses. One per item type, shared by every endpoint returning that array — the big ones cover a lot of ground:

| Component | Sites |
| --- | --- |
| `FilterOptionsList` | 21 |
| `PieChartStatsList` | 21 |
| `BarChartStatsList` | 10 |
| `VehicleExportsList`, `ModelsList` | 3 each |
| `FleetInventoryStockItemsList`, `FleetVehicleExportsList`, `HangarInventoryStockItemsList`, `ModelPaintsList`, `PublicVehiclesList` | 2 each |
| 19 more | 1 each |

`FilterOptionsList` and `BarChartStatsList` are in `shared/v1` because both schemas reference them; the rest sit in the narrowest scope that reaches them.

### Naming

Mechanical `<Plural>List` everywhere it works. Six needed a decision, each carrying a comment in the file:

- `ModelsList`, `ImagesList` — `Models` and `Images` already name the **paginated** collections (`items` + `meta`), so the bare array cannot reuse them
- `FleetInvitesList` — same collision with `FleetMembersList`, which is also paginated; named after what `GET /fleets/invites` returns
- `PublicVehiclesList`, `PublicHangarGroupsList`, `ExtendedFleetRolesList` — pluralising the qualifier suffix gives `VehiclePublicsList` and friends, so these read from the resource instead

## Verification

- `oasdiff breaking` on all three specs: **no breaking changes** (oauth: no changes at all). A `$ref` to an array component dereferences to what was there.
- No dangling refs in any spec.
- `validate-schema` / `validate-admin-schema` valid, 67 warnings before and after.
- `pnpm lint:ts` clean — Orval emits plain aliases (`export type FilterOptionsList = FilterOption[]`), structurally identical to the `FilterOption[]` it emitted before, so no call site changes.
- All 87 touched test files: 302 tests, 0 failures.

## After this

No inline request or response types remain anywhere in `test/integration`. The only inline `type: :object` left is the `q` deepObject parameter, where it is required next to `style: :deepObject` with the `$ref` alongside — documented as the one exception.

🤖
