### PR TITLE
fix(api): containerFit rejected every request, and the last inline enums

### DIFF
--- a/.cursor/rules/backend/api-components.mdc
+++ b/.cursor/rules/backend/api-components.mdc
@@ -97,16 +97,38 @@ Check for an existing component before adding one. `SortInput`,
 `StandardError`, `SuccessResponse`, `MessageResponse` and the
 `BaseList` / `Meta` pair cover most small payloads.
 
-## The one inline exception
+## Query parameters
 
-The `q` deepObject query parameter needs a literal `type: :object` alongside
-`style: :deepObject`, and carries its `$ref` to a `<Name>Query` component:
+A deepObject parameter carries a plain `$ref` and nothing else. The
+`type: :object` that used to sit beside it was redundant — removing it produces
+a byte-identical document.
 
 ```ruby
 parameter name: "q", in: :query,
-  schema: {type: :object, "$ref": "#/components/schemas/ModelQuery"},
+  schema: {"$ref": "#/components/schemas/ModelQuery"},
   style: :deepObject, explode: true, required: false
 ```
+
+**Spell the properties out.** Request validation coerces the strings a query
+string delivers only for declared properties, so a map typed through
+`additionalProperties` rejects every request no matter what the value type says
+— `additionalProperties: {type: :integer}` on `containerFit` 400'd every call
+until it was replaced by `ContainerFitQuery`, which lists its seven keys.
+
+Numeric filters use `type: :number`, never `:integer`: only `:number` coerces.
+
+## Reference components by class
+
+`$ref` strings work, but `schema({})`, `parameter`, `request_body` and
+`response ... schema` all accept the component class and emit the same `$ref`:
+
+```ruby
+status: V1::Schemas::Enums::HangarSyncStatusEnum
+```
+
+A typo becomes a `NameError` while generating instead of a dangling reference
+that only warns. Most of the tree still uses strings; prefer the class form in
+new code.
 
 ## After changing components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,9 +309,33 @@ Before adding a component, check whether one already fits: `SortInput`,
 `StandardError`, `SuccessResponse`, `MessageResponse` and the `BaseList` /
 `Meta` pair cover most small payloads.
 
-The `q` deepObject query parameter is the one exception to "no inline object":
-it needs a literal `type: :object` next to `style: :deepObject`, and carries its
-`$ref` to a `<Name>Query` component alongside.
+A deepObject query parameter is no exception — it carries a plain `$ref` to a
+`<Name>Query` component and nothing else. The `type: :object` that used to sit
+next to the `$ref` was redundant; dropping it produces an identical document.
+
+```ruby
+parameter name: "q", in: :query,
+  schema: {"$ref": "#/components/schemas/ModelQuery"},
+  style: :deepObject, explode: true, required: false
+```
+
+Query components must spell out their properties. Request validation coerces the
+strings a query string delivers only for **declared properties** — a map typed
+through `additionalProperties` rejects every request, whatever the value type
+says. `ContainerFitQuery` lists its seven keys for exactly that reason.
+
+### Reference components by class, not by string
+
+`$ref` strings work, but the DSL and `schema({})` both accept the component
+class itself and turn it into the same `$ref`:
+
+```ruby
+status: V1::Schemas::Enums::HangarSyncStatusEnum
+```
+
+A typo is then a `NameError` at generate time instead of a dangling reference
+that only `strict_reference_validation` warns about. Most of the tree still uses
+the string form; prefer the class form in new code.
 
 ## Feature Flags
 

--- a/app/api_components/cable/v1/schemas/enums/hangar_sync_failed_status_enum.rb
+++ b/app/api_components/cable/v1/schemas/enums/hangar_sync_failed_status_enum.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Cable
+  module V1
+    module Schemas
+      module Enums
+        # Single value: it discriminates this message variant from the others on
+        # the channel.
+        class HangarSyncFailedStatusEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = %w[failed].freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/cable/v1/schemas/enums/hangar_sync_finished_status_enum.rb
+++ b/app/api_components/cable/v1/schemas/enums/hangar_sync_finished_status_enum.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Cable
+  module V1
+    module Schemas
+      module Enums
+        # Single value: it discriminates this message variant from the others on
+        # the channel.
+        class HangarSyncFinishedStatusEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = %w[finished].freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/cable/v1/schemas/hangar_sync_failed_message.rb
+++ b/app/api_components/cable/v1/schemas/hangar_sync_failed_message.rb
@@ -9,7 +9,7 @@ module Cable
         schema({
           type: :object,
           properties: {
-            status: {type: :string, enum: %w[failed]},
+            status: Cable::V1::Schemas::Enums::HangarSyncFailedStatusEnum,
             error: {type: :string}
           },
           additionalProperties: false,

--- a/app/api_components/cable/v1/schemas/hangar_sync_finished_message.rb
+++ b/app/api_components/cable/v1/schemas/hangar_sync_finished_message.rb
@@ -9,7 +9,7 @@ module Cable
         schema({
           type: :object,
           properties: {
-            status: {type: :string, enum: %w[finished]},
+            status: Cable::V1::Schemas::Enums::HangarSyncFinishedStatusEnum,
             result: {"$ref": "#/components/schemas/HangarSyncResult"}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/enums/hangar_sync_submit_status_enum.rb
+++ b/app/api_components/v1/schemas/enums/hangar_sync_submit_status_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Enums
+      # Single value on purpose: POST /hangar/sync only ever answers "queued".
+      # HangarSyncStatusEnum carries the states the sync itself moves through.
+      class HangarSyncSubmitStatusEnum
+        include OpenapiRuby::Components::Base
+
+        VALUES = %w[pending].freeze
+
+        schema({
+          type: :string,
+          enum: VALUES,
+          "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/hangar_sync_submit_result.rb
+++ b/app/api_components/v1/schemas/hangar/hangar_sync_submit_result.rb
@@ -10,7 +10,7 @@ module V1
           type: :object,
           properties: {
             id: {type: :string, format: :uuid},
-            status: {type: :string, enum: %w[pending]}
+            status: V1::Schemas::Enums::HangarSyncSubmitStatusEnum
           },
           additionalProperties: false,
           required: %w[id status]

--- a/app/api_components/v1/schemas/queries/container_fit_query.rb
+++ b/app/api_components/v1/schemas/queries/container_fit_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Queries
+      # A map of container size in SCU to how many of them a ship must take, as
+      # containerFit[16]=2&containerFit[32]=1. The sizes are the ones
+      # CargoHoldContainerCapacity validates against; the controller ignores any
+      # entry whose quantity is not positive.
+      #
+      # Spelled out property by property rather than as an additionalProperties
+      # map: query values arrive as strings, and request validation only coerces
+      # them for declared properties. A map typed through additionalProperties
+      # rejects every request, which is what this parameter did before.
+      class ContainerFitQuery
+        include OpenapiRuby::Components::Base
+
+        SIZES = ::CargoHoldContainerCapacity::CONTAINER_SIZES
+
+        schema({
+          type: :object,
+          properties: SIZES.to_h { |size| [size.to_s, {type: :number, minimum: 0}] },
+          additionalProperties: false,
+          example: {}
+        })
+      end
+    end
+  end
+end

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -24,6 +24,7 @@ import { useI18n } from "@/shared/composables/useI18n";
 import {
   models as fetchModels,
   ModelProductionStatusEnum,
+  type ContainerFitQuery,
   type Model,
   type ModelQuery,
   type Models,
@@ -55,6 +56,9 @@ const hangarOnly = ref(false);
 
 const containerFilterActive = ref(false);
 
+// Must stay in step with CargoHoldContainerCapacity::CONTAINER_SIZES. The
+// generated ContainerFitQuery keys the same set, so annotating containerFit
+// with it turns a size that is not in the schema into a type error.
 const CONTAINER_SIZES = [1, 2, 4, 8, 16, 24, 32] as const;
 
 const MAX_SHIPS = 4;
@@ -183,12 +187,12 @@ const fetchCargoModels = async (params: FilterGroupParams<Model>) => {
     q.inHangar = true;
   }
 
-  const containerFit: Record<string, number> = {};
+  const containerFit: ContainerFitQuery = {};
   if (containerFilterActive.value && hasContainerRequests.value) {
     for (const size of CONTAINER_SIZES) {
       const qty = Number(containerRequests.value[size]);
       if (qty > 0) {
-        containerFit[String(size)] = qty;
+        containerFit[`${size}`] = qty;
       }
     }
   }

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -1882,28 +1882,36 @@ components:
       type: object
       properties:
         status:
-          type: string
-          enum:
-          - failed
+          "$ref": "#/components/schemas/HangarSyncFailedStatusEnum"
         error:
           type: string
       additionalProperties: false
       required:
       - status
       - error
+    HangarSyncFailedStatusEnum:
+      type: string
+      enum:
+      - failed
+      x-enumNames:
+      - FAILED
     HangarSyncFinishedMessage:
       type: object
       properties:
         status:
-          type: string
-          enum:
-          - finished
+          "$ref": "#/components/schemas/HangarSyncFinishedStatusEnum"
         result:
           "$ref": "#/components/schemas/HangarSyncResult"
       additionalProperties: false
       required:
       - status
       - result
+    HangarSyncFinishedStatusEnum:
+      type: string
+      enum:
+      - finished
+      x-enumNames:
+      - FINISHED
     HangarSyncResult:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -218,7 +218,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/CargoHoldQuery"
         style: deepObject
         explode: true
@@ -341,7 +340,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/CommodityQuery"
         style: deepObject
         explode: true
@@ -558,7 +556,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ComponentQuery"
         style: deepObject
         explode: true
@@ -767,7 +764,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/DestroyedFleetQuery"
         required: false
       responses:
@@ -898,7 +894,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/DockQuery"
         style: deepObject
         explode: true
@@ -1081,7 +1076,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/EquipmentQuery"
         style: deepObject
         explode: true
@@ -1862,7 +1856,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetQuery"
         required: false
       responses:
@@ -1897,7 +1890,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetQuery"
         required: false
       responses:
@@ -1941,7 +1933,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/AdminFleetMemberQuery"
         required: false
       responses:
@@ -2298,7 +2289,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FundingGoalQuery"
         style: deepObject
         explode: true
@@ -2485,7 +2475,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ImageQuery"
         style: deepObject
         explode: true
@@ -2633,7 +2622,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ImportQuery"
         style: deepObject
         explode: true
@@ -2748,7 +2736,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ItemPriceQuery"
         style: deepObject
         explode: true
@@ -2935,7 +2922,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ManufacturerQuery"
         style: deepObject
         explode: true
@@ -2977,7 +2963,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ManufacturerQuery"
         required: false
       responses:
@@ -3165,7 +3150,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelHardpointLoadoutQuery"
         style: deepObject
         explode: true
@@ -3351,7 +3335,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelHardpointQuery"
         style: deepObject
         explode: true
@@ -3537,7 +3520,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelLoanerQuery"
         style: deepObject
         explode: true
@@ -3720,7 +3702,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelModulePackageQuery"
         style: deepObject
         explode: true
@@ -3902,7 +3883,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelModuleQuery"
         style: deepObject
         explode: true
@@ -4222,7 +4202,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelPaintQuery"
         style: deepObject
         explode: true
@@ -4412,7 +4391,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelPositionQuery"
         style: deepObject
         explode: true
@@ -4632,7 +4610,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelSnubCraftQuery"
         style: deepObject
         explode: true
@@ -4815,7 +4792,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelUpgradeQuery"
         style: deepObject
         explode: true
@@ -5078,7 +5054,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelQuery"
         style: deepObject
         explode: true
@@ -5832,7 +5807,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/OauthApplicationQuery"
         required: false
       responses:
@@ -6250,7 +6224,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/SupporterContributionQuery"
         style: deepObject
         explode: true
@@ -6286,7 +6259,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/SupporterContributionQuery"
         style: deepObject
         explode: true
@@ -6322,7 +6294,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/SupporterContributionQuery"
         style: deepObject
         explode: true
@@ -6502,7 +6473,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/UserQuery"
         style: deepObject
         explode: true
@@ -6544,7 +6514,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/UserQuery"
         required: false
       responses:
@@ -6863,7 +6832,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/VehicleQuery"
         style: deepObject
         explode: true
@@ -7053,7 +7021,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/VideoQuery"
         style: deepObject
         explode: true

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -17,12 +17,7 @@ paths:
       - Commodities
       operationId: commodities
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -77,12 +72,7 @@ paths:
       - Components
       operationId: components
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -130,12 +120,7 @@ paths:
       - Equipment
       operationId: equipment
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -274,12 +259,7 @@ paths:
       - ManufacturersFilters
       operationId: manufacturerOptions
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -370,12 +350,7 @@ paths:
       - ModelsFilters
       operationId: modelOptions
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -2568,12 +2543,7 @@ paths:
       - FleetInventories
       operationId: fleetInventories
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -2669,12 +2639,7 @@ paths:
       - FleetInventoryItems
       operationId: fleetInventoryItems
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -3115,12 +3080,7 @@ paths:
       - FleetInventoryItems
       operationId: fleetAllInventoryItems
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -3257,12 +3217,7 @@ paths:
       - fleetInviteUrls
       operationId: fleetInviteUrls
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -3418,12 +3373,7 @@ paths:
       - FleetMembers
       operationId: fleetMembers
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -5051,12 +5001,7 @@ paths:
       - Fleets
       operationId: fleetVehicles
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -5368,12 +5313,7 @@ paths:
       - Hangar
       operationId: hangar
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -5763,12 +5703,7 @@ paths:
       - HangarInventories
       operationId: hangarInventories
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -5863,12 +5798,7 @@ paths:
       - HangarInventoryItems
       operationId: hangarInventoryItems
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -6278,12 +6208,7 @@ paths:
       - HangarInventoryItems
       operationId: hangarAllInventoryItems
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -6625,12 +6550,7 @@ paths:
       - Images
       operationId: images
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -6690,12 +6610,7 @@ paths:
       - Manufacturers
       operationId: manufacturers
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -6979,12 +6894,7 @@ paths:
       - ModelPaints
       operationId: paints
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7014,12 +6924,7 @@ paths:
       - Models
       operationId: models
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7158,12 +7063,7 @@ paths:
       - Models
       operationId: modelsWithDocks
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7292,12 +7192,7 @@ paths:
       - Models
       operationId: modelImages
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7333,12 +7228,7 @@ paths:
       - Models
       operationId: modelLoaners
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7374,12 +7264,7 @@ paths:
       - Models
       operationId: modelModulePackages
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7415,12 +7300,7 @@ paths:
       - Models
       operationId: modelModules
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7587,12 +7467,7 @@ paths:
       - Models
       operationId: modelVariants
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7628,12 +7503,7 @@ paths:
       - Models
       operationId: modelVideos
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -7731,12 +7601,7 @@ paths:
       - Notifications
       operationId: notifications
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -8612,12 +8477,7 @@ paths:
       - Fleets
       operationId: publicFleetVehicles
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -8756,12 +8616,7 @@ paths:
       - PublicHangar
       operationId: publicHangar
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -9000,12 +8855,7 @@ paths:
       - PublicWishlist
       operationId: publicWishlist
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -10096,12 +9946,7 @@ paths:
       - VehicleInventoryItems
       operationId: vehicleInventoryItems
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:
@@ -10692,12 +10537,7 @@ paths:
       - Wishlist
       operationId: wishlist
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: string
-          default: '1'
-        required: false
+      - "$ref": "#/components/parameters/PageParameter"
       - name: perPage
         in: query
         schema:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7029,7 +7029,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelQuery"
         style: deepObject
         explode: true
@@ -7037,9 +7036,7 @@ paths:
       - name: containerFit
         in: query
         schema:
-          type: object
-          additionalProperties:
-            type: integer
+          "$ref": "#/components/schemas/ContainerFitQuery"
         style: deepObject
         explode: true
         required: false
@@ -12446,6 +12443,33 @@ components:
       required:
       - token
       title: ConfirmAccountInput
+    ContainerFitQuery:
+      type: object
+      properties:
+        '1':
+          type: number
+          minimum: 0
+        '2':
+          type: number
+          minimum: 0
+        '4':
+          type: number
+          minimum: 0
+        '8':
+          type: number
+          minimum: 0
+        '16':
+          type: number
+          minimum: 0
+        '24':
+          type: number
+          minimum: 0
+        '32':
+          type: number
+          minimum: 0
+      additionalProperties: false
+      example: {}
+      title: ContainerFitQuery
     Dock:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -16305,14 +16305,19 @@ components:
           type: string
           format: uuid
         status:
-          type: string
-          enum:
-          - pending
+          "$ref": "#/components/schemas/HangarSyncSubmitStatusEnum"
       additionalProperties: false
       required:
       - id
       - status
       title: HangarSyncSubmitResult
+    HangarSyncSubmitStatusEnum:
+      type: string
+      enum:
+      - pending
+      x-enumNames:
+      - PENDING
+      title: HangarSyncSubmitStatusEnum
     Hardpoint:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -32,7 +32,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/CommodityQuery"
         style: deepObject
         explode: true
@@ -93,7 +92,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ComponentQuery"
         style: deepObject
         explode: true
@@ -147,7 +145,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/EquipmentQuery"
         style: deepObject
         explode: true
@@ -257,7 +254,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/EquipmentItemTypeFilterQuery"
         style: deepObject
         explode: true
@@ -293,7 +289,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ManufacturerQuery"
         style: deepObject
         explode: true
@@ -390,7 +385,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelQuery"
         style: deepObject
         explode: true
@@ -2690,7 +2684,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetInventoryItemQuery"
         style: deepObject
         explode: true
@@ -3137,7 +3130,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetInventoryItemQuery"
         style: deepObject
         explode: true
@@ -3441,7 +3433,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetMemberQuery"
         style: deepObject
         explode: true
@@ -4747,7 +4738,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetMemberQuery"
         style: deepObject
         explode: true
@@ -4792,7 +4782,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -5077,7 +5066,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -5138,7 +5126,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -5189,7 +5176,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -5397,7 +5383,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -5439,7 +5424,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -5477,7 +5461,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -5795,7 +5778,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarInventoryQuery"
         style: deepObject
         explode: true
@@ -5896,7 +5878,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarInventoryItemQuery"
         style: deepObject
         explode: true
@@ -6312,7 +6293,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarInventoryItemQuery"
         style: deepObject
         explode: true
@@ -6350,7 +6330,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/InventoryStockQuery"
         style: deepObject
         explode: true
@@ -6438,7 +6417,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -6662,7 +6640,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ImageQuery"
         style: deepObject
         explode: true
@@ -6728,7 +6705,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ManufacturerQuery"
         style: deepObject
         explode: true
@@ -7018,7 +6994,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelPaintQuery"
         style: deepObject
         explode: true
@@ -7202,7 +7177,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/ModelQuery"
         style: deepObject
         explode: true
@@ -7776,7 +7750,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/NotificationQuery"
         style: deepObject
         explode: true
@@ -8442,7 +8415,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -8659,7 +8631,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -8706,7 +8677,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetVehicleQuery"
         style: deepObject
         explode: true
@@ -8805,7 +8775,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -8864,7 +8833,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -9051,7 +9019,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true
@@ -10148,7 +10115,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/InventoryItemQuery"
         style: deepObject
         explode: true
@@ -10745,7 +10711,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/HangarQuery"
         style: deepObject
         explode: true

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7089,7 +7089,6 @@ paths:
       - name: q
         in: query
         schema:
-          type: object
           "$ref": "#/components/schemas/FleetchartViewQuery"
         style: deepObject
         explode: true

--- a/test/integration/admin/api/v1/cargo_holds_test.rb
+++ b/test/integration/admin/api/v1/cargo_holds_test.rb
@@ -16,10 +16,7 @@ class Admin::Api::V1::CargoHoldsTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/CargoHoldQuery"
-        },
+        schema: {"$ref": "#/components/schemas/CargoHoldQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/commodities_test.rb
+++ b/test/integration/admin/api/v1/commodities_test.rb
@@ -38,10 +38,7 @@ class Admin::Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Commodity.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/CommodityQuery"
-        },
+        schema: {"$ref": "#/components/schemas/CommodityQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/components_test.rb
+++ b/test/integration/admin/api/v1/components_test.rb
@@ -41,10 +41,7 @@ class Admin::Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Component.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ComponentQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ComponentQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/destroyed_fleets_index_test.rb
+++ b/test/integration/admin/api/v1/destroyed_fleets_index_test.rb
@@ -15,7 +15,7 @@ class Admin::Api::V1::DestroyedFleetsIndexTest < ActionDispatch::IntegrationTest
 
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "source", in: :query, description: "discarded (soft-deleted) or purged (hard-deleted)", schema: {"$ref": "#/components/schemas/DestroyedFleetSourceEnum"}, required: false
-      parameter name: "q", in: :query, schema: {type: :object, "$ref": "#/components/schemas/DestroyedFleetQuery"}, required: false
+      parameter name: "q", in: :query, schema: {"$ref": "#/components/schemas/DestroyedFleetQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/DestroyedFleets"

--- a/test/integration/admin/api/v1/docks_test.rb
+++ b/test/integration/admin/api/v1/docks_test.rb
@@ -44,10 +44,7 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Dock.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/DockQuery"
-        },
+        schema: {"$ref": "#/components/schemas/DockQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/equipment_test.rb
+++ b/test/integration/admin/api/v1/equipment_test.rb
@@ -38,10 +38,7 @@ class Admin::Api::V1::EquipmentTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Equipment.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/EquipmentQuery"
-        },
+        schema: {"$ref": "#/components/schemas/EquipmentQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/fleet_members_index_test.rb
+++ b/test/integration/admin/api/v1/fleet_members_index_test.rb
@@ -17,7 +17,7 @@ class Admin::Api::V1::FleetMembersIndexTest < ActionDispatch::IntegrationTest
 
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter "$ref": "#/components/parameters/SortingParameter"
-      parameter name: :q, in: :query, schema: {type: :object, "$ref": "#/components/schemas/AdminFleetMemberQuery"}, required: false
+      parameter name: :q, in: :query, schema: {"$ref": "#/components/schemas/AdminFleetMemberQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/AdminFleetMembers"

--- a/test/integration/admin/api/v1/fleets_index_test.rb
+++ b/test/integration/admin/api/v1/fleets_index_test.rb
@@ -15,7 +15,7 @@ class Admin::Api::V1::FleetsIndexTest < ActionDispatch::IntegrationTest
 
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter "$ref": "#/components/parameters/SortingParameter"
-      parameter name: "q", in: :query, schema: {type: :object, "$ref": "#/components/schemas/FleetQuery"}, required: false
+      parameter name: "q", in: :query, schema: {"$ref": "#/components/schemas/FleetQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/Fleets"

--- a/test/integration/admin/api/v1/fleets_options_test.rb
+++ b/test/integration/admin/api/v1/fleets_options_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::FleetsOptionsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter "$ref": "#/components/parameters/PageParameter"
-      parameter name: "q", in: :query, schema: {type: :object, "$ref": "#/components/schemas/FleetQuery"}, required: false
+      parameter name: "q", in: :query, schema: {"$ref": "#/components/schemas/FleetQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/FleetOptions"

--- a/test/integration/admin/api/v1/funding_goals_test.rb
+++ b/test/integration/admin/api/v1/funding_goals_test.rb
@@ -38,10 +38,7 @@ class Admin::Api::V1::FundingGoalsTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: FundingGoal.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FundingGoalQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FundingGoalQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/images_test.rb
+++ b/test/integration/admin/api/v1/images_test.rb
@@ -42,10 +42,7 @@ class Admin::Api::V1::ImagesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Image.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ImageQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ImageQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/imports_test.rb
+++ b/test/integration/admin/api/v1/imports_test.rb
@@ -18,10 +18,7 @@ class Admin::Api::V1::ImportsTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Import.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ImportQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ImportQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/item_prices_test.rb
+++ b/test/integration/admin/api/v1/item_prices_test.rb
@@ -45,10 +45,7 @@ class Admin::Api::V1::ItemPricesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: ItemPrice.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ItemPriceQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ItemPriceQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/manufacturers_options_test.rb
+++ b/test/integration/admin/api/v1/manufacturers_options_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::ManufacturersOptionsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter "$ref": "#/components/parameters/PageParameter"
-      parameter name: :q, in: :query, schema: {type: :object, "$ref": "#/components/schemas/ManufacturerQuery"}, required: false
+      parameter name: :q, in: :query, schema: {"$ref": "#/components/schemas/ManufacturerQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/ManufacturerOptions"

--- a/test/integration/admin/api/v1/manufacturers_test.rb
+++ b/test/integration/admin/api/v1/manufacturers_test.rb
@@ -44,10 +44,7 @@ class Admin::Api::V1::ManufacturersTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Manufacturer.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ManufacturerQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ManufacturerQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_hardpoint_loadouts_test.rb
+++ b/test/integration/admin/api/v1/model_hardpoint_loadouts_test.rb
@@ -44,10 +44,7 @@ class Admin::Api::V1::ModelHardpointLoadoutsTest < ActionDispatch::IntegrationTe
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelHardpointLoadoutQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelHardpointLoadoutQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_hardpoints_test.rb
+++ b/test/integration/admin/api/v1/model_hardpoints_test.rb
@@ -44,10 +44,7 @@ class Admin::Api::V1::ModelHardpointsTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelHardpointQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelHardpointQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_loaners_test.rb
+++ b/test/integration/admin/api/v1/model_loaners_test.rb
@@ -44,10 +44,7 @@ class Admin::Api::V1::ModelLoanersTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelLoanerQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelLoanerQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_module_packages_test.rb
+++ b/test/integration/admin/api/v1/model_module_packages_test.rb
@@ -41,10 +41,7 @@ class Admin::Api::V1::ModelModulePackagesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelModulePackage.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelModulePackageQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelModulePackageQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_modules_test.rb
+++ b/test/integration/admin/api/v1/model_modules_test.rb
@@ -37,10 +37,7 @@ class Admin::Api::V1::ModelModulesTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelModule.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelModuleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelModuleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_paints_test.rb
+++ b/test/integration/admin/api/v1/model_paints_test.rb
@@ -41,10 +41,7 @@ class Admin::Api::V1::ModelPaintsTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelPaint.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelPaintQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelPaintQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_positions_test.rb
+++ b/test/integration/admin/api/v1/model_positions_test.rb
@@ -41,10 +41,7 @@ class Admin::Api::V1::ModelPositionsTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelPosition.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelPositionQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelPositionQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_snub_crafts_test.rb
+++ b/test/integration/admin/api/v1/model_snub_crafts_test.rb
@@ -45,10 +45,7 @@ class Admin::Api::V1::ModelSnubCraftsTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelSnubCraftQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelSnubCraftQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/model_upgrades_test.rb
+++ b/test/integration/admin/api/v1/model_upgrades_test.rb
@@ -38,10 +38,7 @@ class Admin::Api::V1::ModelUpgradesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelUpgrade.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelUpgradeQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelUpgradeQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/models_test.rb
+++ b/test/integration/admin/api/v1/models_test.rb
@@ -38,10 +38,7 @@ class Admin::Api::V1::ModelsTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/oauth_applications_test.rb
+++ b/test/integration/admin/api/v1/oauth_applications_test.rb
@@ -38,7 +38,7 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter "$ref": "#/components/parameters/PageParameter"
-      parameter name: :q, in: :query, schema: {type: :object, "$ref": "#/components/schemas/OauthApplicationQuery"}, required: false
+      parameter name: :q, in: :query, schema: {"$ref": "#/components/schemas/OauthApplicationQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/OauthApplications"

--- a/test/integration/admin/api/v1/supporter_contributions_per_month_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_per_month_test.rb
@@ -14,10 +14,7 @@ class Admin::Api::V1::SupporterContributionsPerMonthTest < ActionDispatch::Integ
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/SupporterContributionQuery"
-        },
+        schema: {"$ref": "#/components/schemas/SupporterContributionQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_stats_test.rb
@@ -14,10 +14,7 @@ class Admin::Api::V1::SupporterContributionsStatsTest < ActionDispatch::Integrat
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/SupporterContributionQuery"
-        },
+        schema: {"$ref": "#/components/schemas/SupporterContributionQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/supporter_contributions_test.rb
+++ b/test/integration/admin/api/v1/supporter_contributions_test.rb
@@ -42,10 +42,7 @@ class Admin::Api::V1::SupporterContributionsTest < ActionDispatch::IntegrationTe
       parameter name: "perPage", in: :query, schema: {type: :string, default: SupporterContribution.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/SupporterContributionQuery"
-        },
+        schema: {"$ref": "#/components/schemas/SupporterContributionQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/users_options_test.rb
+++ b/test/integration/admin/api/v1/users_options_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::V1::UsersOptionsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter "$ref": "#/components/parameters/PageParameter"
-      parameter name: :q, in: :query, schema: {type: :object, "$ref": "#/components/schemas/UserQuery"}, required: false
+      parameter name: :q, in: :query, schema: {"$ref": "#/components/schemas/UserQuery"}, required: false
 
       response(200, "successful") do
         schema "$ref": "#/components/schemas/UserOptions"

--- a/test/integration/admin/api/v1/users_test.rb
+++ b/test/integration/admin/api/v1/users_test.rb
@@ -17,10 +17,7 @@ class Admin::Api::V1::UsersTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: User.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/UserQuery"
-        },
+        schema: {"$ref": "#/components/schemas/UserQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/vehicles_test.rb
+++ b/test/integration/admin/api/v1/vehicles_test.rb
@@ -17,10 +17,7 @@ class Admin::Api::V1::VehiclesTest < ActionDispatch::IntegrationTest
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter "$ref": "#/components/parameters/SortingParameter"
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/VehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/VehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/admin/api/v1/videos_test.rb
+++ b/test/integration/admin/api/v1/videos_test.rb
@@ -41,10 +41,7 @@ class Admin::Api::V1::VideosTest < ActionDispatch::IntegrationTest
       parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Video.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/VideoQuery"
-        },
+        schema: {"$ref": "#/components/schemas/VideoQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/commodities_test.rb
+++ b/test/integration/api/v1/commodities_test.rb
@@ -13,7 +13,7 @@ class Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
       tags "Commodities"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Commodity.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/CommodityQuery"},

--- a/test/integration/api/v1/commodities_test.rb
+++ b/test/integration/api/v1/commodities_test.rb
@@ -16,10 +16,7 @@ class Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Commodity.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/CommodityQuery"
-        },
+        schema: {"$ref": "#/components/schemas/CommodityQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/components_test.rb
+++ b/test/integration/api/v1/components_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
       tags "Components"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Component.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ComponentQuery"},

--- a/test/integration/api/v1/components_test.rb
+++ b/test/integration/api/v1/components_test.rb
@@ -16,10 +16,7 @@ class Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Component.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ComponentQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ComponentQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/equipment_test.rb
+++ b/test/integration/api/v1/equipment_test.rb
@@ -16,10 +16,7 @@ class Api::V1::EquipmentTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Equipment.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/EquipmentQuery"
-        },
+        schema: {"$ref": "#/components/schemas/EquipmentQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/equipment_test.rb
+++ b/test/integration/api/v1/equipment_test.rb
@@ -13,7 +13,7 @@ class Api::V1::EquipmentTest < ActionDispatch::IntegrationTest
       tags "Equipment"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Equipment.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/EquipmentQuery"},

--- a/test/integration/api/v1/filters_equipment_item_types_test.rb
+++ b/test/integration/api/v1/filters_equipment_item_types_test.rb
@@ -14,10 +14,7 @@ class Api::V1::FiltersEquipmentItemTypesTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/EquipmentItemTypeFilterQuery"
-        },
+        schema: {"$ref": "#/components/schemas/EquipmentItemTypeFilterQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/filters_manufacturers_options_test.rb
+++ b/test/integration/api/v1/filters_manufacturers_options_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FiltersManufacturersOptionsTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Manufacturer.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ManufacturerQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ManufacturerQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/filters_manufacturers_options_test.rb
+++ b/test/integration/api/v1/filters_manufacturers_options_test.rb
@@ -13,7 +13,7 @@ class Api::V1::FiltersManufacturersOptionsTest < ActionDispatch::IntegrationTest
       tags "ManufacturersFilters"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Manufacturer.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ManufacturerQuery"},

--- a/test/integration/api/v1/filters_models_options_test.rb
+++ b/test/integration/api/v1/filters_models_options_test.rb
@@ -13,7 +13,7 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
       tags "ModelsFilters"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ModelQuery"},

--- a/test/integration/api/v1/filters_models_options_test.rb
+++ b/test/integration/api/v1/filters_models_options_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_all_inventory_items_index_test.rb
+++ b/test/integration/api/v1/fleets_all_inventory_items_index_test.rb
@@ -18,10 +18,7 @@ class Api::V1::FleetsAllInventoryItemsIndexTest < ActionDispatch::IntegrationTes
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetInventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetInventoryItemQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetInventoryItemQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_all_inventory_items_index_test.rb
+++ b/test/integration/api/v1/fleets_all_inventory_items_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::FleetsAllInventoryItemsIndexTest < ActionDispatch::IntegrationTes
       tags "FleetInventoryItems"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetInventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/FleetInventoryItemQuery"},

--- a/test/integration/api/v1/fleets_inventories_index_test.rb
+++ b/test/integration/api/v1/fleets_inventories_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::FleetsInventoriesIndexTest < ActionDispatch::IntegrationTest
       tags "FleetInventories"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
 
       security [

--- a/test/integration/api/v1/fleets_inventory_items_index_test.rb
+++ b/test/integration/api/v1/fleets_inventory_items_index_test.rb
@@ -19,10 +19,7 @@ class Api::V1::FleetsInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetInventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetInventoryItemQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetInventoryItemQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_inventory_items_index_test.rb
+++ b/test/integration/api/v1/fleets_inventory_items_index_test.rb
@@ -16,7 +16,7 @@ class Api::V1::FleetsInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       tags "FleetInventoryItems"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetInventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/FleetInventoryItemQuery"},

--- a/test/integration/api/v1/fleets_invite_urls_index_test.rb
+++ b/test/integration/api/v1/fleets_invite_urls_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::FleetsInviteUrlsIndexTest < ActionDispatch::IntegrationTest
       tags "fleetInviteUrls"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetVehicle.default_per_page}, required: false
 
       security [

--- a/test/integration/api/v1/fleets_members_index_test.rb
+++ b/test/integration/api/v1/fleets_members_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::FleetsMembersIndexTest < ActionDispatch::IntegrationTest
       tags "FleetMembers"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/FleetMemberQuery"},

--- a/test/integration/api/v1/fleets_members_index_test.rb
+++ b/test/integration/api/v1/fleets_members_index_test.rb
@@ -18,10 +18,7 @@ class Api::V1::FleetsMembersIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: 30}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetMemberQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetMemberQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_stats_members_test.rb
+++ b/test/integration/api/v1/fleets_stats_members_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FleetsStatsMembersTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetMemberQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetMemberQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_stats_model_counts_test.rb
+++ b/test/integration/api/v1/fleets_stats_model_counts_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FleetsStatsModelCountsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_vehicles_export_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_export_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FleetsVehiclesExportTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_vehicles_hangar_link_export_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_hangar_link_export_test.rb
@@ -16,10 +16,7 @@ class Api::V1::FleetsVehiclesHangarLinkExportTest < ActionDispatch::IntegrationT
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_vehicles_index_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_index_test.rb
@@ -18,10 +18,7 @@ class Api::V1::FleetsVehiclesIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetVehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/fleets_vehicles_index_test.rb
+++ b/test/integration/api/v1/fleets_vehicles_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::FleetsVehiclesIndexTest < ActionDispatch::IntegrationTest
       tags "Fleets"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetVehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},

--- a/test/integration/api/v1/hangar_all_inventory_items_index_test.rb
+++ b/test/integration/api/v1/hangar_all_inventory_items_index_test.rb
@@ -16,10 +16,7 @@ class Api::V1::HangarAllInventoryItemsIndexTest < ActionDispatch::IntegrationTes
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarInventoryItemQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarInventoryItemQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_all_inventory_items_index_test.rb
+++ b/test/integration/api/v1/hangar_all_inventory_items_index_test.rb
@@ -13,7 +13,7 @@ class Api::V1::HangarAllInventoryItemsIndexTest < ActionDispatch::IntegrationTes
       tags "HangarInventoryItems"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarInventoryItemQuery"},

--- a/test/integration/api/v1/hangar_all_inventory_stock_index_test.rb
+++ b/test/integration/api/v1/hangar_all_inventory_stock_index_test.rb
@@ -14,10 +14,7 @@ class Api::V1::HangarAllInventoryStockIndexTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/InventoryStockQuery"
-        },
+        schema: {"$ref": "#/components/schemas/InventoryStockQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_export_test.rb
+++ b/test/integration/api/v1/hangar_export_test.rb
@@ -14,10 +14,7 @@ class Api::V1::HangarExportTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_inventories_index_test.rb
+++ b/test/integration/api/v1/hangar_inventories_index_test.rb
@@ -16,10 +16,7 @@ class Api::V1::HangarInventoriesIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Inventory.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarInventoryQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarInventoryQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_inventories_index_test.rb
+++ b/test/integration/api/v1/hangar_inventories_index_test.rb
@@ -13,7 +13,7 @@ class Api::V1::HangarInventoriesIndexTest < ActionDispatch::IntegrationTest
       tags "HangarInventories"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Inventory.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarInventoryQuery"},

--- a/test/integration/api/v1/hangar_inventory_items_index_test.rb
+++ b/test/integration/api/v1/hangar_inventory_items_index_test.rb
@@ -18,10 +18,7 @@ class Api::V1::HangarInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarInventoryItemQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarInventoryItemQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_inventory_items_index_test.rb
+++ b/test/integration/api/v1/hangar_inventory_items_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::HangarInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       tags "HangarInventoryItems"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarInventoryItemQuery"},

--- a/test/integration/api/v1/hangar_link_export_test.rb
+++ b/test/integration/api/v1/hangar_link_export_test.rb
@@ -14,10 +14,7 @@ class Api::V1::HangarLinkExportTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_stats_show_test.rb
+++ b/test/integration/api/v1/hangar_stats_show_test.rb
@@ -14,10 +14,7 @@ class Api::V1::HangarStatsShowTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_test.rb
+++ b/test/integration/api/v1/hangar_test.rb
@@ -42,10 +42,7 @@ class Api::V1::HangarTest < ActionDispatch::IntegrationTest
         type: :string, default: Vehicle.default_per_page
       }, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/hangar_test.rb
+++ b/test/integration/api/v1/hangar_test.rb
@@ -37,7 +37,7 @@ class Api::V1::HangarTest < ActionDispatch::IntegrationTest
         {OpenId: ["hangar", "hangar:read"]}
       ]
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {
         type: :string, default: Vehicle.default_per_page
       }, required: false

--- a/test/integration/api/v1/images_index_test.rb
+++ b/test/integration/api/v1/images_index_test.rb
@@ -16,10 +16,7 @@ class Api::V1::ImagesIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Image.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ImageQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ImageQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/images_index_test.rb
+++ b/test/integration/api/v1/images_index_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ImagesIndexTest < ActionDispatch::IntegrationTest
       tags "Images"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Image.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ImageQuery"},

--- a/test/integration/api/v1/manufacturers_test.rb
+++ b/test/integration/api/v1/manufacturers_test.rb
@@ -16,10 +16,7 @@ class Api::V1::ManufacturersTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Manufacturer.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ManufacturerQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ManufacturerQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/manufacturers_test.rb
+++ b/test/integration/api/v1/manufacturers_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ManufacturersTest < ActionDispatch::IntegrationTest
       tags "Manufacturers"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Manufacturer.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ManufacturerQuery"},

--- a/test/integration/api/v1/model_paints_test.rb
+++ b/test/integration/api/v1/model_paints_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ModelPaintsTest < ActionDispatch::IntegrationTest
       tags "ModelPaints"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelPaint.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ModelPaintQuery"},

--- a/test/integration/api/v1/model_paints_test.rb
+++ b/test/integration/api/v1/model_paints_test.rb
@@ -16,10 +16,7 @@ class Api::V1::ModelPaintsTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelPaint.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelPaintQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelPaintQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/models_fleetchart_views_test.rb
+++ b/test/integration/api/v1/models_fleetchart_views_test.rb
@@ -14,10 +14,7 @@ class Api::V1::ModelsFleetchartViewsTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetchartViewQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetchartViewQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/models_images_test.rb
+++ b/test/integration/api/v1/models_images_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsImagesTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Image.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -16,15 +16,12 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelQuery"},
         style: :deepObject,
         explode: true,
         required: false
       parameter name: "containerFit", in: :query,
-        schema: {type: :object, additionalProperties: {type: :integer}},
+        schema: {"$ref": "#/components/schemas/ContainerFitQuery"},
         style: :deepObject,
         explode: true,
         required: false
@@ -50,6 +47,20 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
     assert_api_response :get, 200, params: {q: {"nameOrDescriptionCont" => models.first.name}} do
       assert_equal 1, parsed_body["items"].count
     end
+  end
+
+  test "GET /models accepts a containerFit map" do
+    create_list(:model, 2)
+
+    assert_api_response :get, 200, params: {containerFit: {"16" => 2, "32" => 1}}
+  end
+
+  # Plain get rather than the DSL: declaring a 400 here would replace the
+  # auto-injected SchemaValidationError response and move the schema.
+  test "GET /models rejects a containerFit size outside the standard set" do
+    get "/api/v1/models", params: {containerFit: {"7" => 1}}
+
+    assert_response :bad_request
   end
 
   test "GET /models honours perPage" do

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ModelQuery"},

--- a/test/integration/api/v1/models_loaners_test.rb
+++ b/test/integration/api/v1/models_loaners_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsLoanersTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_module_packages_test.rb
+++ b/test/integration/api/v1/models_module_packages_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsModulePackagesTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelModule.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_modules_test.rb
+++ b/test/integration/api/v1/models_modules_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsModulesTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: ModelModule.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_variants_test.rb
+++ b/test/integration/api/v1/models_variants_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsVariantsTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_videos_test.rb
+++ b/test/integration/api/v1/models_videos_test.rb
@@ -15,7 +15,7 @@ class Api::V1::ModelsVideosTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Video.default_per_page}, required: false
 
       response(200, "successful") do

--- a/test/integration/api/v1/models_with_docks_test.rb
+++ b/test/integration/api/v1/models_with_docks_test.rb
@@ -16,10 +16,7 @@ class Api::V1::ModelsWithDocksTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/ModelQuery"
-        },
+        schema: {"$ref": "#/components/schemas/ModelQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/models_with_docks_test.rb
+++ b/test/integration/api/v1/models_with_docks_test.rb
@@ -13,7 +13,7 @@ class Api::V1::ModelsWithDocksTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Model.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/ModelQuery"},

--- a/test/integration/api/v1/notifications_test.rb
+++ b/test/integration/api/v1/notifications_test.rb
@@ -19,7 +19,7 @@ class Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
         {OpenId: ["notifications", "notifications:read"]}
       ]
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {
         type: :string, default: Notification.default_per_page
       }, required: false

--- a/test/integration/api/v1/notifications_test.rb
+++ b/test/integration/api/v1/notifications_test.rb
@@ -24,10 +24,7 @@ class Api::V1::NotificationsTest < ActionDispatch::IntegrationTest
         type: :string, default: Notification.default_per_page
       }, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/NotificationQuery"
-        },
+        schema: {"$ref": "#/components/schemas/NotificationQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_fleets_stats_model_counts_test.rb
+++ b/test/integration/api/v1/public_fleets_stats_model_counts_test.rb
@@ -16,10 +16,7 @@ class Api::V1::PublicFleetsStatsModelCountsTest < ActionDispatch::IntegrationTes
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_fleets_vehicles_embed_test.rb
+++ b/test/integration/api/v1/public_fleets_vehicles_embed_test.rb
@@ -16,10 +16,7 @@ class Api::V1::PublicFleetsVehiclesEmbedTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_fleets_vehicles_test.rb
+++ b/test/integration/api/v1/public_fleets_vehicles_test.rb
@@ -18,10 +18,7 @@ class Api::V1::PublicFleetsVehiclesTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetVehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/FleetVehicleQuery"
-        },
+        schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_fleets_vehicles_test.rb
+++ b/test/integration/api/v1/public_fleets_vehicles_test.rb
@@ -15,7 +15,7 @@ class Api::V1::PublicFleetsVehiclesTest < ActionDispatch::IntegrationTest
       tags "Fleets"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: FleetVehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/FleetVehicleQuery"},

--- a/test/integration/api/v1/public_hangars_show_test.rb
+++ b/test/integration/api/v1/public_hangars_show_test.rb
@@ -18,10 +18,7 @@ class Api::V1::PublicHangarsShowTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_hangars_show_test.rb
+++ b/test/integration/api/v1/public_hangars_show_test.rb
@@ -15,7 +15,7 @@ class Api::V1::PublicHangarsShowTest < ActionDispatch::IntegrationTest
       tags "PublicHangar"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarQuery"},

--- a/test/integration/api/v1/public_hangars_stats_show_test.rb
+++ b/test/integration/api/v1/public_hangars_stats_show_test.rb
@@ -16,10 +16,7 @@ class Api::V1::PublicHangarsStatsShowTest < ActionDispatch::IntegrationTest
       produces "application/json"
 
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_wishlists_show_test.rb
+++ b/test/integration/api/v1/public_wishlists_show_test.rb
@@ -18,10 +18,7 @@ class Api::V1::PublicWishlistsShowTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/public_wishlists_show_test.rb
+++ b/test/integration/api/v1/public_wishlists_show_test.rb
@@ -15,7 +15,7 @@ class Api::V1::PublicWishlistsShowTest < ActionDispatch::IntegrationTest
       tags "PublicWishlist"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarQuery"},

--- a/test/integration/api/v1/vehicle_inventory_items_index_test.rb
+++ b/test/integration/api/v1/vehicle_inventory_items_index_test.rb
@@ -18,10 +18,7 @@ class Api::V1::VehicleInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/InventoryItemQuery"
-        },
+        schema: {"$ref": "#/components/schemas/InventoryItemQuery"},
         style: :deepObject,
         explode: true,
         required: false

--- a/test/integration/api/v1/vehicle_inventory_items_index_test.rb
+++ b/test/integration/api/v1/vehicle_inventory_items_index_test.rb
@@ -15,7 +15,7 @@ class Api::V1::VehicleInventoryItemsIndexTest < ActionDispatch::IntegrationTest
       tags "VehicleInventoryItems"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: InventoryItem.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/InventoryItemQuery"},

--- a/test/integration/api/v1/wishlist_test.rb
+++ b/test/integration/api/v1/wishlist_test.rb
@@ -31,7 +31,7 @@ class Api::V1::WishlistTest < ActionDispatch::IntegrationTest
       tags "Wishlist"
       produces "application/json"
 
-      parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
+      parameter "$ref": "#/components/parameters/PageParameter"
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
         schema: {"$ref": "#/components/schemas/HangarQuery"},

--- a/test/integration/api/v1/wishlist_test.rb
+++ b/test/integration/api/v1/wishlist_test.rb
@@ -34,10 +34,7 @@ class Api::V1::WishlistTest < ActionDispatch::IntegrationTest
       parameter name: "page", in: :query, schema: {type: :string, default: "1"}, required: false
       parameter name: "perPage", in: :query, schema: {type: :string, default: Vehicle.default_per_page}, required: false
       parameter name: "q", in: :query,
-        schema: {
-          type: :object,
-          "$ref": "#/components/schemas/HangarQuery"
-        },
+        schema: {"$ref": "#/components/schemas/HangarQuery"},
         style: :deepObject,
         explode: true,
         required: false


### PR DESCRIPTION
Top of the stack: #4531 → #4533 → #4534 → #4536 → this.

Four things, one commit each.

## 1. The three single-value status enums

`HangarSyncSubmitResult.status` (`pending`) and the two cable messages (`failed`, `finished`) were the last inline enums. #4534 argued they are constants rather than enums; that reasoning holds, but it leaves a reader deciding case by case whether an inline enum was deliberate. Three one-value components cost less than that judgement call.

**Written as Ruby class references, not `$ref` strings:**

```ruby
status: V1::Schemas::Enums::HangarSyncSubmitStatusEnum
```

This works — `deep_stringify` in `components/base.rb`, `dsl/context.rb`, `response_context.rb` and `operation_context.rb` all turn a component class into the same `$ref`. A typo is a `NameError` while generating instead of a dangling reference that only `strict_reference_validation` warns about. Roughly 2,100 string refs remain across components and tests; converting them is a mechanical sweep worth its own PR, verifiable by the generated YAML staying byte-identical.

`api-schema-check` on #4536 caught a stale cable document while this was in review: #4534 extracted `ModelHullPartCategoryEnum`, which the cable document embeds through the `Model` schema, without running `bin/generate-asyncapi`. Fixed at the source in #4534 and the stack rebased, so nothing about it lands here.

## 2. The redundant `type: :object` is gone

Every deepObject parameter carried `type: :object` next to its `$ref`. The referenced component is already `type: :object`, so the sibling added nothing — and one endpoint (`public_hangars_embed`) had been written without it all along, producing the same document. Removed from the other 68; oasdiff reports **no changes at all**. The "one inline exception" in the rule is gone with it.

## 3. `containerFit` rejected every request — a real bug

`GET /models` declared the parameter as `additionalProperties: {type: :integer}`. Request validation coerces the strings a query string delivers **only for declared properties**, so:

```
containerFit[16]=2  →  400 {"details":["Invalid query parameter 'containerFit': value at `/16` is not an integer"]}
```

Every container-filtered search 400'd, which means the cargo-grids container filter could not return anything. Nothing covered it — the parameter was declared in the test but never exercised.

`:number` alone does not fix it (`additionalProperties` is the problem, not the type), though `:number` matters too: `q[lengthGteq]=10` validates and an `:integer` in the same position would not. `ContainerFitQuery` spells out the seven sizes `CargoHoldContainerCapacity::CONTAINER_SIZES` validates against:

| request | before | after |
| --- | --- | --- |
| `containerFit[16]=2` | 400 | **200** |
| `containerFit[16]=2&containerFit[32]=1` | 400 | **200** |
| `containerFit[7]=1` (not a standard size) | 400 | 400 |
| `containerFit[16]=x` | 400 | 400 |
| `containerFit[16]=-1` | 400 | 400 |

Two regression tests added. The negative one uses a plain `get` rather than the DSL, because declaring a 400 there would replace the auto-injected `SchemaValidationError` response and move the schema.

`cargo-grids.vue` now annotates its map with the generated `ContainerFitQuery`, so a size the schema does not know is a compile error. Its `CONTAINER_SIZES` literal still duplicates the Ruby constant — the generated artifact is a type, not a runtime array, so there is nothing to import; the comment says so.

## 4. Rule updates

Drops the `q` exception, and records the two things that cost time: query components must declare their properties or validation rejects everything, and numeric filters need `:number` rather than `:integer`. Adds the class-reference form as preferred for new code.

## Verification

- `oasdiff breaking` on all three specs: no breaking changes. Commit 2 alone: no changes at all.
- `bin/generate-asyncapi` + `git diff --exit-code` clean, same for `swagger` — the `api-schema-check` gate.
- `standardrb`, `pnpm lint`, `pnpm lint:ts` clean.
- 752 integration tests across all 69 touched files, plus `test/asyncapi`: 0 failures.

🤖
