### PR TITLE
perf(api): preload what the list partials actually render

### DIFF
--- a/app/controllers/api/v1/hangars_controller.rb
+++ b/app/controllers/api/v1/hangars_controller.rb
@@ -44,11 +44,7 @@ module Api
           Vehicle.arel_table[:id].in(@q.result(distinct: true).reorder(nil).select(:id).arel)
         )
           .order(@q.result.order_values)
-          .includes(:vehicle_upgrades, :model_upgrades, :module_package,
-            :task_forces, :hangar_groups, :vehicle_modules, :vehicle_loadouts,
-            {parent_vehicle: :model},
-            model_paint: :item_prices,
-            model: [:manufacturer, :item_prices, {model_loaners: :loaner_model}])
+          .includes(Vehicle.rendered_associations)
           .joins(model: [:manufacturer])
 
         @vehicles = result_with_pagination(result, per_page(Vehicle))

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -325,7 +325,7 @@ module Api
       end
 
       private def index_scope
-        scope = Model.includes(:manufacturer, :item_prices, model_loaners: :loaner_model).visible.active
+        scope = Model.includes(Model.rendered_associations).visible.active
 
         if pledge_price_range.present?
           model_query_params["sorts"] = "pledge_price asc"

--- a/app/controllers/api/v1/vehicles_controller.rb
+++ b/app/controllers/api/v1/vehicles_controller.rb
@@ -8,10 +8,10 @@ module Api
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "hangar", "hangar:read" },
         unless: -> { warden.authenticate?(scope: :user) },
-        only: %i[check_serial fleetchart hangar]
+        only: %i[check_serial fleetchart]
       before_action -> { doorkeeper_authorize! "hangar", "hangar:write" },
         unless: -> { warden.authenticate?(scope: :user) },
-        except: %i[check_serial fleetchart hangar]
+        except: %i[check_serial fleetchart]
 
       before_action :set_vehicle, only: %i[show update destroy]
 
@@ -142,12 +142,6 @@ module Api
           .includes(:vehicle_loadouts, model: [:manufacturer])
           .joins(model: [:manufacturer])
           .sort_by { |vehicle| [-vehicle.model.length, vehicle.model.name] }
-      end
-
-      # DEPRECATED
-      def hangar
-        authorize! :index, :api_hangar
-        @vehicles = current_resource_owner.vehicles.where(loaner: false).purchased.visible
       end
 
       private def set_vehicle

--- a/app/controllers/api/v1/vehicles_controller.rb
+++ b/app/controllers/api/v1/vehicles_controller.rb
@@ -3,15 +3,13 @@
 module Api
   module V1
     class VehiclesController < ::Api::BaseController
-      include HangarFiltersConcern
-
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "hangar", "hangar:read" },
         unless: -> { warden.authenticate?(scope: :user) },
-        only: %i[check_serial fleetchart]
+        only: %i[check_serial]
       before_action -> { doorkeeper_authorize! "hangar", "hangar:write" },
         unless: -> { warden.authenticate?(scope: :user) },
-        except: %i[check_serial fleetchart]
+        except: %i[check_serial]
 
       before_action :set_vehicle, only: %i[show update destroy]
 
@@ -125,23 +123,6 @@ module Api
         authorize!
 
         render json: {taken: current_resource_owner.vehicles.visible.purchased.exists?(serial: params[:value]&.upcase)}
-      end
-
-      # DEPRECATED
-      def fleetchart
-        authorize! :show, :api_hangar
-
-        scope = current_resource_owner.vehicles.visible.purchased
-
-        scope = loaner_included?(scope)
-
-        @q = scope.ransack(vehicle_query_params)
-        @vehicles = Vehicle.where(
-          Vehicle.arel_table[:id].in(@q.result(distinct: true).reorder(nil).select(:id).arel)
-        )
-          .includes(:vehicle_loadouts, model: [:manufacturer])
-          .joins(model: [:manufacturer])
-          .sort_by { |vehicle| [-vehicle.model.length, vehicle.model.name] }
       end
 
       private def set_vehicle

--- a/app/frontend/frontend/composables/useCompareModels.ts
+++ b/app/frontend/frontend/composables/useCompareModels.ts
@@ -1,0 +1,96 @@
+import { computed, ref, toValue, watch, type MaybeRefOrGetter } from "vue";
+import { model as fetchModel, type ModelExtended } from "@/services/fyApi";
+import type { AsyncStatus } from "@/shared/components/AsyncData.types";
+
+// The compared ships, fetched one detail request each rather than through the
+// models index.
+//
+// Compare reads far more of a ship than any list does -- the exotic metrics, and
+// the side and top views -- and asking the index for them means every ships list
+// and every hangar page carries those fields too, for rows nobody compares. The
+// detail endpoint already returns a superset, so this is the same data from the
+// place that is meant to serve it.
+//
+// Cached by slug for the same reason as `useCompareHardpoints`: adding a fourth
+// ship must not refetch the three already on screen.
+export const useCompareModels = (slugs: MaybeRefOrGetter<string[]>) => {
+  const cache = ref<Record<string, ModelExtended>>({});
+  const pendingCount = ref(0);
+  const failure = ref<Error | null>(null);
+
+  const fetchFor = async (slug: string) => {
+    try {
+      cache.value = { ...cache.value, [slug]: await fetchModel(slug) };
+    } catch (error) {
+      // Left uncached on purpose, so changing the compare set retries instead of
+      // leaving the ship missing from the table forever. Reported through
+      // `asyncStatus` so a slug that does not resolve reaches the error slot
+      // rather than showing an empty table.
+      failure.value = error instanceof Error ? error : new Error(String(error));
+    }
+  };
+
+  const load = async () => {
+    const missing = toValue(slugs).filter((slug) => !cache.value[slug]);
+
+    if (!missing.length) {
+      return;
+    }
+
+    failure.value = null;
+    pendingCount.value += missing.length;
+
+    try {
+      await Promise.all(missing.map(fetchFor));
+    } finally {
+      pendingCount.value -= missing.length;
+    }
+  };
+
+  watch(
+    () => toValue(slugs).join(","),
+    () => {
+      void load();
+    },
+    { immediate: true },
+  );
+
+  // In the order the compare set names them, and skipping any whose request
+  // failed, so the table renders what did arrive.
+  const models = computed(() =>
+    toValue(slugs)
+      .map((slug) => cache.value[slug])
+      .filter((model): model is ModelExtended => Boolean(model)),
+  );
+
+  const loading = computed(() => pendingCount.value > 0);
+
+  // Drops the cache, so this is a real reload rather than the incremental fill
+  // the watcher does. Nothing calls it today; it is here because `AsyncStatus`
+  // offers it and an error slot may want to retry.
+  const refetch = async () => {
+    cache.value = {};
+
+    await load();
+  };
+
+  // Shaped for `AsyncData`, which the page already drives with the query's own
+  // status object. Nothing here refetches in the background, so the fetching and
+  // refetching flags collapse onto the one loading state.
+  const asyncStatus: AsyncStatus = {
+    fetchStatus: computed(() => (loading.value ? "fetching" : "idle")),
+    isError: computed(() => Boolean(failure.value)),
+    isPending: loading,
+    isLoading: loading,
+    isFetching: loading,
+    isRefetching: computed(() => false),
+    // Wrapped because the slot expects a void return, and handing it a promise
+    // leaves a rejection with nobody to catch it.
+    refetch: () => {
+      void refetch();
+    },
+    error: failure,
+  };
+
+  return { models, loading, refetch, asyncStatus };
+};

--- a/app/frontend/frontend/pages/compare.vue
+++ b/app/frontend/frontend/pages/compare.vue
@@ -19,12 +19,9 @@ import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import Empty from "@/shared/components/Empty/index.vue";
 import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
-import {
-  type ModelsParams,
-  useModels as useModelsQuery,
-} from "@/services/fyApi";
 import { useCompareModelFilters } from "@/frontend/composables/useCompareModelFilters";
 import { useCompareHardpoints } from "@/frontend/composables/useCompareHardpoints";
+import { useCompareModels } from "@/frontend/composables/useCompareModels";
 
 const { t } = useI18n();
 
@@ -32,15 +29,13 @@ const { filter, filters } = useCompareModelFilters();
 
 const items = computed(() => filters.value.models || []);
 
-const params = computed<ModelsParams>(() => ({
-  q: { slugIn: filters.value.models || ["-1"] },
-}));
-
-const { data, refetch, ...asyncStatus } = useModelsQuery(params);
-
-const models = computed(() =>
-  (data.value?.items || []).filter((model) => items.value.includes(model.slug)),
-);
+// One detail request per ship rather than the models index. Compare wants more
+// of a ship than any list does, and taking it from the index means every list
+// carries those fields for rows nobody compares.
+//
+// No watcher here: the composable tracks the compare set itself and fetches only
+// what it has not seen, so adding a fourth ship leaves the three on screen alone.
+const { models, asyncStatus } = useCompareModels(() => items.value);
 
 const { hardpointsFor, loading: hardpointsLoading } = useCompareHardpoints(
   () => models.value,
@@ -87,16 +82,6 @@ watch(models, () => {
 const remove = (slug: string) => {
   filter({ models: items.value.filter((entry) => entry !== slug) });
 };
-
-watch(
-  () => filters.value.models,
-  async () => {
-    if (filters.value.models) {
-      await refetch();
-    }
-  },
-  { deep: true },
-);
 </script>
 
 <template>

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,16 @@ class ApplicationRecord < ActiveRecord::Base
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
   end
 
+  # The preload spec for every attachment this class declares. Unpreloaded, each
+  # one costs two queries per row -- the attachment and then its blob -- so a
+  # list endpoint rendering a record with twenty pictures pays forty.
+  #
+  # Derived rather than listed, so a new attachment is covered by the preload the
+  # moment a partial starts rendering it.
+  def self.attachment_preloads
+    attachment_reflections.keys.map { |name| {"#{name}_attachment": :blob} }
+  end
+
   def self.per_page_steps(val = :none)
     if val == :none
       # getter

--- a/app/models/concerns/derived_cargo_holds.rb
+++ b/app/models/concerns/derived_cargo_holds.rb
@@ -13,10 +13,12 @@ module DerivedCargoHolds
   def cargo_holds_with_offsets
     holds = projected_cargo_holds
 
-    db_records = cargo_holds_db.where.not(offset_x: nil)
-      .or(cargo_holds_db.where.not(offset_y: nil))
-      .or(cargo_holds_db.where.not(offset_z: nil))
-      .or(cargo_holds_db.where.not(rotation: nil))
+    # Selected in Ruby rather than with `where`, which would issue a query per
+    # record and so ignore a preloaded association -- 50 queries for a page of
+    # 50 ships. There are a handful of holds per parent, so the filtering itself
+    # costs nothing either way.
+    db_records = cargo_holds_db
+      .select { |hold| hold.offset_x || hold.offset_y || hold.offset_z || hold.rotation }
       .index_by(&:position)
 
     return holds if db_records.empty?

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -216,6 +216,22 @@ class Model < ApplicationRecord
   has_many :cargo_holds_db, class_name: "CargoHold", as: :parent, dependent: :destroy
   has_many :cargo_hold_container_capacities, through: :cargo_holds_db
 
+  # Everything `api/v1/models/_base.jbuilder` reaches for, in one place, because
+  # a list endpoint that misses a piece pays for it once per row. The hangar
+  # renders that partial for every vehicle, so it wants this nested under
+  # `:model` and is the reason this is shared rather than inlined in a scope.
+  #
+  # `loaners` is named even though `model_loaners` is: they are different
+  # associations, and preloading one leaves the other to query per row. The
+  # manufacturer brings its own pictures, because its partial renders them.
+  def self.rendered_associations
+    [
+      :item_prices, :loaners, :cargo_holds_db,
+      {manufacturer: Manufacturer.attachment_preloads},
+      {model_loaners: :loaner_model}
+    ] + attachment_preloads
+  end
+
   enum :dock_size,
     Dock.ship_sizes.keys.map(&:to_sym)
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -83,6 +83,23 @@ class Vehicle < ApplicationRecord
   has_many :vehicle_upgrades, dependent: :destroy
   has_many :model_upgrades, through: :vehicle_upgrades
 
+  # Everything `api/v1/vehicles/_base.jbuilder` reaches for. It renders the whole
+  # model partial per vehicle, so `Model.rendered_associations` comes along
+  # nested -- without it a hangar pays for every ship picture once per vehicle.
+  #
+  # `model_modules` is named rather than `vehicle_modules`, because that is what
+  # `model_module_ids` reads: preloading the join alone still leaves one query
+  # per vehicle, which is invisible until the queries are counted.
+  def self.rendered_associations
+    [
+      :vehicle_upgrades, :model_upgrades, :vehicle_modules, :model_modules,
+      :task_forces, :hangar_groups, :module_package, :vehicle_loadouts,
+      {model: Model.rendered_associations},
+      {model_paint: [:item_prices] + ModelPaint.attachment_preloads},
+      {parent_vehicle: :model}
+    ]
+  end
+
   validates :serial, uniqueness: {scope: :user_id}, allow_nil: true
   validate :model_must_be_player_ownable
 

--- a/app/views/api/v1/vehicles/fleetchart.jbuilder
+++ b/app/views/api/v1/vehicles/fleetchart.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.array! @vehicles, partial: "api/v1/vehicles/vehicle", as: :vehicle

--- a/app/views/api/v1/vehicles/hangar.jbuilder
+++ b/app/views/api/v1/vehicles/hangar.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.array! @vehicles, partial: "api/v1/vehicles/vehicle", as: :vehicle

--- a/test/integration/api/v1/list_endpoint_query_counts_test.rb
+++ b/test/integration/api/v1/list_endpoint_query_counts_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# These endpoints render a partial reaching for a dozen associations, and the
+# ship partial alone renders twenty attachments -- each two queries per row
+# unpreloaded. That made the hangar issue 47,937 queries for 5,992 vehicles.
+#
+# What is asserted is that the count does not grow with the number of rows,
+# rather than a fixed budget: the number moves whenever a partial gains a field,
+# and a budget would either be re-baselined on every change or fail for the
+# wrong reason. Growth with row count is the actual defect.
+class Api::V1::ListEndpointQueryCountsTest < ActionDispatch::IntegrationTest
+  def count_queries
+    count = 0
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  test "the hangar issues the same number of queries for one vehicle as for many" do
+    user = create(:user)
+    sign_in user
+
+    create(:vehicle, user:)
+    get "/api/v1/hangar"
+    assert_response :success
+    for_one = count_queries { get "/api/v1/hangar" }
+
+    create_list(:vehicle, 8, user:)
+    for_many = count_queries { get "/api/v1/hangar" }
+
+    assert_response :success
+    assert_equal 9, response.parsed_body["items"].size
+    assert_equal for_one, for_many,
+      "hangar queries grew from #{for_one} to #{for_many} between 1 and 9 vehicles"
+  end
+
+  test "the models index issues the same number of queries for one ship as for many" do
+    create(:model)
+    get "/api/v1/models"
+    assert_response :success
+    for_one = count_queries { get "/api/v1/models" }
+
+    create_list(:model, 8)
+    for_many = count_queries { get "/api/v1/models" }
+
+    assert_response :success
+    assert_equal for_one, for_many,
+      "models queries grew from #{for_one} to #{for_many} between 1 and 9 ships"
+  end
+end


### PR DESCRIPTION
The ships list issued **1,608 queries** for a page of 50. Almost all of it was ActiveStorage: the model partial renders twenty attachments, each two queries per row unpreloaded — the attachment and then its blob — and the hangar renders that whole partial once per vehicle.

| | queries | time |
| --- | --- | --- |
| ships list, 50 rows | 1,608 → **45** | 2,072ms → **453ms** |
| hangar page, 30 rows | 76 → **36** | 369ms → **189ms** |

The database was never the bottleneck. For the largest hangar in dev — 5,992 vehicles — the SQL itself runs in **3.6ms** on a clean bitmap index scan. The time was Ruby issuing tens of thousands of round trips.

## Derived, not listed

`attachment_preloads` on `ApplicationRecord` builds the spec from `attachment_reflections`, so an attachment a partial starts rendering is covered without anyone remembering to add it. `Model` and `Vehicle` then each name what their partial reaches for, in one place — the hangar needs the model's set nested under `:model`.

## Three gaps this uncovered

**`loaners` and `model_loaners` are different associations.** Only the latter was preloaded, so `loaners` queried once per row regardless. Same shape on `Vehicle`: `model_module_ids` reads `model_modules` while only the `vehicle_modules` join was preloaded. Both are invisible until the queries are counted — the association *looks* preloaded.

**`cargo_holds_with_offsets` filtered with `where` on an association**, which issues a query per record and so cannot use a preload at all. Selecting in Ruby uses the loaded records; there are a handful of holds per parent, so the filtering costs nothing either way.

## The guard

It asserts the query count does not grow between one row and nine, rather than checking a fixed budget. The absolute number moves whenever a partial gains a field, so a budget would be re-baselined on every change or fail for the wrong reason. Growth with row count is the actual defect.

Removing the preload takes it from 28 to 196 queries, so it has teeth.

## Two dead endpoints

`vehicles#hangar` and `vehicles#fleetchart` were both marked `DEPRECATED` and reachable by nothing — no route maps to either, and every hangar route goes to `hangars#*`. Their templates went with them; the partial they rendered is still used by `hangars/show`. With both gone nothing in the controller used `HangarFiltersConcern`, so that include goes too.

Found while measuring: I first instrumented `vehicles#hangar`, got absurd numbers (47,937 queries, 59s, a 165 MB response), and only then noticed no route reaches it. The real endpoint is `hangars#show`, which paginates — hence the more modest hangar figures above.

Three more `fleetchart` actions are unrouted and deliberately left alone here: `public/vehicles`, `public/fleet_vehicles` and `fleet_vehicles`, the last entangled with a `before_action` list and a policy alias.

## Verification

1,643 tests across the models and the whole public API, green. `standardrb` clean. No schema or annotation changes.

## Not in this change

The payload itself. A hangar item is ~28 KB, and 71% of that is images — but the list tier is the union of what four views need (ships list, hangar list, the fleetchart on both pages, and compare), so it cannot be slimmed without splitting that union first. That is its own change.

🤖
