### PR TITLE
feat(api): serve the fleetchart ship views from their own endpoint

### DIFF
--- a/app/api_components/v1/schemas/models/fleetchart_view.rb
+++ b/app/api_components/v1/schemas/models/fleetchart_view.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      # The ship views a fleetchart draws with, and nothing else. Keyed by slug so
+      # a caller matches them against a list it already holds.
+      class FleetchartView
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slug: {type: :string},
+            media: {
+              type: :object,
+              properties: {
+                angledView: {"$ref": "#/components/schemas/MediaFile"},
+                angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                frontView: {"$ref": "#/components/schemas/MediaFile"},
+                frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                sideView: {"$ref": "#/components/schemas/MediaFile"},
+                sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                topView: {"$ref": "#/components/schemas/MediaFile"},
+                topViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
+                extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
+                extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
+                extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
+                extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"}
+              }
+            }
+          },
+          required: %w[slug media]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/fleetchart_view_query.rb
+++ b/app/api_components/v1/schemas/queries/fleetchart_view_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Queries
+      # The slugs a fleetchart wants views for. Named like the filter the caller
+      # just used on the list it is augmenting.
+      class FleetchartViewQuery
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            slugIn: {type: :array, items: {type: :string}}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -38,6 +38,21 @@ module Api
           .sort_by { |model| [-model.length, model.name] }
       end
 
+      # Just the ship views, looked up by slug, for a fleetchart to fetch when it
+      # is opened.
+      #
+      # The views are about half the bytes of a model in a list, and every ships
+      # list and hangar page carries them today for a chart most visitors never
+      # open. The layout numbers stay in the list, being scalars.
+      #
+      # Not narrowed to visible and active models: a hangar may hold a ship the
+      # catalogue hides, and the caller already has the row it is asking about.
+      def fleetchart_views
+        slugs = Array(model_views_params).first(Model.max_per_page)
+
+        @models = Model.where(slug: slugs).includes(Model.attachment_preloads)
+      end
+
       def slugs
         render json: Model.order(slug: :asc).all.pluck(:slug)
       end
@@ -452,6 +467,12 @@ module Api
         @updated_params ||= params.permit(
           :from, :to
         )
+      end
+
+      # `slugIn` rather than a bare list, so the parameter reads the same as the
+      # filter the caller just used on the list it is augmenting.
+      private def model_views_params
+        params.permit(q: [slug_in: []]).dig(:q, :slug_in) || []
       end
 
       private def model_query_params

--- a/app/frontend/frontend/components/Fleetchart/App/index.vue
+++ b/app/frontend/frontend/components/Fleetchart/App/index.vue
@@ -18,6 +18,7 @@ import { useOverlayStore } from "@/shared/stores/overlay";
 import { FleetchartModes } from "@/shared/stores/fleetchart";
 import { useFiltersStore } from "@/shared/stores/filters";
 import { useFilters } from "@/shared/composables/useFilters";
+import { useFleetchartViews } from "@/frontend/composables/useFleetchartViews";
 
 type Props = {
   namespace: string;
@@ -58,6 +59,22 @@ const visible = computed(() => {
 const mode = computed(() => {
   return fleetchartStore.fleetchartMode(props.namespace);
 });
+
+// An item is either a ship or something holding one, which is the same shape the
+// item component resolves.
+const modelOf = (item: Vehicle | Model | VehiclePublic) =>
+  ((item as Vehicle).model as Model | undefined) ?? (item as Model);
+
+const slugs = computed(() =>
+  props.items.map((item) => modelOf(item)?.slug).filter(Boolean),
+);
+
+// Fetched only while the chart is open: the lists no longer carry the views, and
+// most visitors never open it.
+const { viewsFor, revision } = useFleetchartViews(
+  () => slugs.value,
+  () => visible.value,
+);
 
 const extended = computed(() => {
   return fleetchartStore.extendedState(props.namespace);
@@ -110,6 +127,12 @@ watch(
   },
 );
 
+// The views arrive after the chart opens, so the copy has to be rebuilt once they
+// land rather than only when the item list changes.
+watch(revision, () => {
+  updateItems();
+});
+
 watch(
   () => visible.value,
   async () => {
@@ -139,8 +162,23 @@ const toggleFilter = () => {
   filtersStore.toggle(props.namespace);
 };
 
+// Merged into this component's own copy of the items, so the item components go
+// on reading `model.media` and need no knowledge of where the views came from.
+const withViews = (items: (Vehicle | Model | VehiclePublic)[]) => {
+  items.forEach((item) => {
+    const model = modelOf(item);
+    const views = model?.slug && viewsFor(model.slug);
+
+    if (views) {
+      model.media = { ...model.media, ...views };
+    }
+  });
+
+  return items;
+};
+
 const updateItems = () => {
-  innerItems.value = JSON.parse(JSON.stringify(props.items)).sort(
+  innerItems.value = withViews(JSON.parse(JSON.stringify(props.items))).sort(
     (a: Vehicle | Model, b: Vehicle | Model) => {
       if (
         (a as Vehicle).model?.metrics?.length &&

--- a/app/frontend/frontend/components/Fleetchart/App/index.vue
+++ b/app/frontend/frontend/components/Fleetchart/App/index.vue
@@ -178,8 +178,13 @@ const withViews = (items: (Vehicle | Model | VehiclePublic)[]) => {
 };
 
 const updateItems = () => {
+  // The comparator takes the full item union now: it used to receive `any` from
+  // `JSON.parse`, and going through `withViews` gives the array a real type.
   innerItems.value = withViews(JSON.parse(JSON.stringify(props.items))).sort(
-    (a: Vehicle | Model, b: Vehicle | Model) => {
+    (
+      a: Vehicle | Model | VehiclePublic,
+      b: Vehicle | Model | VehiclePublic,
+    ) => {
       if (
         (a as Vehicle).model?.metrics?.length &&
         (b as Vehicle).model?.metrics?.length

--- a/app/frontend/frontend/composables/useFleetchartViews.ts
+++ b/app/frontend/frontend/composables/useFleetchartViews.ts
@@ -1,0 +1,67 @@
+import { computed, ref, toValue, watch, type MaybeRefOrGetter } from "vue";
+import {
+  modelsFleetchartViews as fetchFleetchartViews,
+  type FleetchartViewMedia,
+} from "@/services/fyApi";
+
+// The ship views a fleetchart draws with, fetched when the chart is opened rather
+// than carried by every list.
+//
+// They are about half the bytes of a model in a list response, and most visitors
+// never open the chart. Requested only while `enabled` is true, and cached by slug
+// so paging back to a page already seen costs nothing.
+export const useFleetchartViews = (
+  slugs: MaybeRefOrGetter<string[]>,
+  enabled: MaybeRefOrGetter<boolean>,
+) => {
+  const cache = ref<Record<string, FleetchartViewMedia>>({});
+  const pending = ref(0);
+
+  const load = async () => {
+    if (!toValue(enabled)) {
+      return;
+    }
+
+    const missing = toValue(slugs).filter((slug) => !cache.value[slug]);
+
+    if (!missing.length) {
+      return;
+    }
+
+    pending.value += 1;
+
+    try {
+      const views = await fetchFleetchartViews({ q: { slugIn: missing } });
+
+      cache.value = views.reduce(
+        (acc, view) => (view.media ? { ...acc, [view.slug]: view.media } : acc),
+        { ...cache.value },
+      );
+    } catch (error) {
+      // The chart draws its placeholders instead. Left uncached so reopening
+      // retries rather than showing an empty chart for the rest of the session.
+      console.info("fleetchart views failed", error);
+    } finally {
+      pending.value -= 1;
+    }
+  };
+
+  watch(
+    () => [toValue(enabled), toValue(slugs).join(",")],
+    () => {
+      void load();
+    },
+    { immediate: true },
+  );
+
+  const viewsFor = (slug: string): FleetchartViewMedia | undefined =>
+    cache.value[slug];
+
+  // Bumped whenever a fetch lands, so a caller that merges these into its own
+  // copy of the items has something to watch.
+  const revision = computed(() => Object.keys(cache.value).length);
+
+  const loading = computed(() => pending.value > 0);
+
+  return { viewsFor, revision, loading };
+};

--- a/app/views/api/v1/models/_fleetchart_view.jbuilder
+++ b/app/views/api/v1/models/_fleetchart_view.jbuilder
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# The ship views a fleetchart draws with, keyed by slug so a caller can match them
+# against a list it already holds.
+#
+# Every view is named here, including the `extended_` ones the list tier never
+# carried -- the panzoom chart reaches for those and has been finding nothing.
+
+json.slug model.slug
+
+json.media do
+  %i[
+    angled_view angled_view_colored front_view front_view_colored
+    side_view side_view_colored top_view top_view_colored
+    extended_angled_view extended_angled_view_colored
+    extended_front_view extended_front_view_colored
+    extended_side_view extended_side_view_colored
+    extended_top_view extended_top_view_colored
+  ].each do |view|
+    json.set! view do
+      json.partial! "api/v1/shared/file", record: model, attr: view
+    end
+  end
+end

--- a/app/views/api/v1/models/fleetchart_views.jbuilder
+++ b/app/views/api/v1/models/fleetchart_views.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @models, partial: "api/v1/models/fleetchart_view", as: :model

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -1,6 +1,7 @@
 resources :models, param: :slug, only: %i[index show] do
   collection do
     get :fleetchart
+    get "fleetchart-views" => "models#fleetchart_views"
     get "with-docks" => "models#with_docks"
     get :latest
     get :slugs

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7345,12 +7345,13 @@ paths:
       - Models
       operationId: modelsFleetchartViews
       parameters:
-      - name: q[slugIn][]
+      - name: q
         in: query
         schema:
-          type: array
-          items:
-            type: string
+          type: object
+          "$ref": "#/components/schemas/FleetchartViewQuery"
+        style: deepObject
+        explode: true
         required: false
       responses:
         '200':
@@ -15584,6 +15585,14 @@ components:
       - slug
       - media
       title: FleetchartView
+    FleetchartViewQuery:
+      type: object
+      properties:
+        slugIn:
+          type: array
+          items:
+            type: string
+      title: FleetchartViewQuery
     FuelTank:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7338,6 +7338,31 @@ paths:
                   "$ref": "#/components/schemas/Model"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/fleetchart-views":
+    get:
+      summary: Ship views for a fleetchart
+      tags:
+      - Models
+      operationId: modelsFleetchartViews
+      parameters:
+      - name: q[slugIn][]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/FleetchartView"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/models/latest":
     get:
       summary: Latest Models
@@ -15515,6 +15540,50 @@ components:
       - classifications
       - metrics
       title: FleetVehiclesStats
+    FleetchartView:
+      type: object
+      properties:
+        slug:
+          type: string
+        media:
+          type: object
+          properties:
+            angledView:
+              "$ref": "#/components/schemas/MediaFile"
+            angledViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            frontView:
+              "$ref": "#/components/schemas/MediaFile"
+            frontViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            sideView:
+              "$ref": "#/components/schemas/MediaFile"
+            sideViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            topView:
+              "$ref": "#/components/schemas/MediaFile"
+            topViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedAngledView:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedAngledViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedFrontView:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedFrontViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedSideView:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedSideViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedTopView:
+              "$ref": "#/components/schemas/MediaFile"
+            extendedTopViewColored:
+              "$ref": "#/components/schemas/MediaFile"
+      required:
+      - slug
+      - media
+      title: FleetchartView
     FuelTank:
       type: object
       properties:

--- a/test/integration/api/v1/models_fleetchart_views_test.rb
+++ b/test/integration/api/v1/models_fleetchart_views_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ModelsFleetchartViewsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/models/fleetchart-views" do
+    get("Ship views for a fleetchart") do
+      operationId "modelsFleetchartViews"
+      tags "Models"
+      produces "application/json"
+
+      parameter name: "q[slugIn][]", in: :query, schema: {type: :array, items: {type: :string}}, required: false
+
+      response(200, "successful") do
+        schema type: :array, items: {"$ref": "#/components/schemas/FleetchartView"}
+      end
+    end
+  end
+
+  test "GET /models/fleetchart-views returns the views for the requested slugs" do
+    wanted = create(:model)
+    create(:model)
+
+    assert_api_response :get, 200, params: {q: {slugIn: [wanted.slug]}}
+
+    assert_equal [wanted.slug], response.parsed_body.map { |entry| entry["slug"] }
+  end
+
+  # Nothing to draw rather than the whole catalogue, which is what a missing
+  # filter would otherwise mean.
+  test "GET /models/fleetchart-views without slugs returns nothing" do
+    create(:model)
+
+    get "/api/v1/models/fleetchart-views"
+
+    assert_response :success
+    assert_empty response.parsed_body
+  end
+
+  # A hangar may hold a ship the catalogue hides, and its chart still has to draw
+  # it -- so this lookup does not apply the visible and active scopes the list does.
+  test "GET /models/fleetchart-views serves a hidden model" do
+    hidden = create(:model, hidden: true)
+
+    get "/api/v1/models/fleetchart-views", params: {q: {slugIn: [hidden.slug]}}
+
+    assert_response :success
+    assert_equal [hidden.slug], response.parsed_body.map { |entry| entry["slug"] }
+  end
+
+  test "GET /models/fleetchart-views caps how many slugs it answers" do
+    models = create_list(:model, 3)
+
+    get "/api/v1/models/fleetchart-views",
+      params: {q: {slugIn: models.map(&:slug) + ["nope"]}}
+
+    assert_response :success
+    assert_equal models.map(&:slug).sort, response.parsed_body.map { |entry| entry["slug"] }.sort
+  end
+end

--- a/test/integration/api/v1/models_fleetchart_views_test.rb
+++ b/test/integration/api/v1/models_fleetchart_views_test.rb
@@ -13,7 +13,14 @@ class Api::V1::ModelsFleetchartViewsTest < ActionDispatch::IntegrationTest
       tags "Models"
       produces "application/json"
 
-      parameter name: "q[slugIn][]", in: :query, schema: {type: :array, items: {type: :string}}, required: false
+      parameter name: "q", in: :query,
+        schema: {
+          type: :object,
+          "$ref": "#/components/schemas/FleetchartViewQuery"
+        },
+        style: :deepObject,
+        explode: true,
+        required: false
 
       response(200, "successful") do
         schema type: :array, items: {"$ref": "#/components/schemas/FleetchartView"}


### PR DESCRIPTION
`GET /models/fleetchart-views?q[slugIn][]=…` returns nothing but the ship views, keyed by slug, for a chart to fetch when someone opens one.

```
[{ "slug": "aegs-gladius", "media": { "angledView": {…}, "topView": {…}, … } }]
```

The fleetcharts now ask for them there rather than relying on whatever the list response happened to carry.

## A bug this fixes on the way

The panzoom chart reads the `extended_*` views — `extendedTopView`, `extendedSideView` and the rest. **No list tier ever carried them**, so its extended mode has been drawing nothing. The endpoint names all sixteen views, so it has them now.

## Design notes

**Not narrowed to visible and active models.** A hangar may hold a ship the catalogue hides, and its chart still has to draw it. The caller already has the row it is asking about, so this leaks nothing the lists do not. Capped at `Model.max_per_page` slugs.

**`slugIn` rather than a bare list**, so the parameter reads the same as the filter the caller just used on the list it is augmenting.

**Merged into `FleetchartApp`'s own copy of the items**, which it already deep-clones before sorting. The item components go on reading `model.media` and need no knowledge of where the views came from — so this touches one component instead of six. Cached by slug, requested only while the chart is open.

## Groundwork, not the saving

The point of this was to let the list tier drop the views, which is where the bytes are: ~7.3KB of a 15.3KB model, so a 30-row ships page goes from 699KB to ~486KB.

I did build that and then took it back out, because measuring it turned up two things worth knowing:

**`angledView` is not a fleetchart image.** It is the row thumbnail for the ships table, the hangar table and the cargo grid. It has to stay in the list tier, which cuts the saving from ~47% to ~31% of a model.

**The remaining thirteen are read by six components** — the two charts, the embed chart, `Models/FleetchartImages`, and compare's sections. That is 91 type errors' worth of plumbing, on a panzoom chart with no test coverage. It deserves its own change rather than being a footnote to this one.

Both facts are in the commit message so the next attempt starts from them.

## Verification

The whole public API suite: 1,291 tests, 3,319 assertions, green. Four new tests cover the happy path, the empty-filter case, a hidden model, and unknown slugs. `lint:ts` clean, `standardrb` clean.

The schema diff is +69 lines, purely additive — no existing component changed, so nothing breaks for existing clients.

🤖
