### PR TITLE
refactor(api): extract every nested object into a component

### DIFF
--- a/.cursor/rules/backend/api-components.mdc
+++ b/.cursor/rules/backend/api-components.mdc
@@ -72,6 +72,39 @@ the admin components that subclass a v1 one
 (`Admin::V1::Schemas::Models::Model < ::V1::Schemas::Models::Model`) inherit its
 `$ref`s — anything they reach has to be `shared/v1`.
 
+## Nested objects
+
+An object nested inside a component gets its own component. Orval names an
+anonymous one after its owner and path, so the same shape under three owners
+becomes three unrelated types.
+
+```ruby
+# Good
+metrics: Shared::V1::Schemas::ModelMetrics,
+
+# Bad
+metrics: {type: :object, properties: {...}},
+```
+
+Free-form maps (`additionalProperties`, no named properties) stay inline.
+
+Two traps, both learned the hard way:
+
+- openapi-ruby deep-merges a subclass's schema into its parent's, and **a `$ref`
+  cannot be merged into**. Pointing `Model.links` at a component made
+  `ModelExtended` emit a `$ref` next to the properties it wanted to add. The fix
+  is a component that inherits the shared one —
+  `AdminModelMedia < ::Shared::V1::Schemas::ModelMedia`.
+- A cross-scope subclass **inherits the reference**, so anything a v1 component
+  points at must be in `shared/v1/` when an admin component subclasses it. After
+  extracting, diff refs against definitions in each generated spec; a dangling
+  `$ref` only warns.
+
+Also worth knowing: Orval emits an `interface` for a named component and a type
+alias for an anonymous one, and TypeScript gives interfaces no implicit index
+signature. A helper typed `Record<string, unknown>` stops accepting the value —
+type the helper against the component instead.
+
 ## Enum values
 
 Source them from the Rails model when it has them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,30 @@ Naming and placement follow the existing tree:
 - Reused by both the public and the admin schema → `shared/v1/`
 - Enums → `<scope>/v1/schemas/enums/<name>_enum.rb`, referenced by `$ref` —
   don't inline an `enum:` into a property
+- Nested objects → their own component too. A `type: :object` with named
+  properties inside another component is as anonymous as an inline body
+
+### Nested objects
+
+An object nested inside a component is a component as well. `Model.metrics` held
+33 properties inline, and Orval reproduced the whole block once per owner —
+`ComponentControllerPowerRangesHigh`, `ComponentCoolerPowerRangesHigh` and six
+more siblings for a shape that is two numbers.
+
+Two traps:
+
+- **Inheritance cannot merge into a `$ref`.** openapi-ruby deep-merges a
+  subclass's schema into its parent's, so pointing a parent property at a
+  component leaves the subclass emitting a `$ref` *beside* the properties it
+  meant to add. Give the subclass its own component that inherits the shared one
+  (`AdminModelMedia < Shared::V1::Schemas::ModelMedia`).
+- **A subclass in another scope inherits the reference.** An enum or object a v1
+  component points at has to live in `shared/v1/` if any admin component
+  subclasses that v1 component — otherwise the admin document carries a dangling
+  `$ref`. Check with a ref-vs-defined diff over the generated specs.
+
+Free-form maps stay inline: `{type: :object, additionalProperties: …}` has no
+named properties, so there is nothing to name.
 
 ### Enum components
 

--- a/app/api_components/admin/v1/schemas/import.rb
+++ b/app/api_components/admin/v1/schemas/import.rb
@@ -21,22 +21,8 @@ module Admin
             import: {type: :string},
             importData: {type: :string},
 
-            adminUser: {
-              type: :object,
-              properties: {
-                id: {type: :string, format: :uuid},
-                username: {type: :string}
-              },
-              required: %w[id username]
-            },
-            user: {
-              type: :object,
-              properties: {
-                id: {type: :string, format: :uuid},
-                username: {type: :string}
-              },
-              required: %w[id username]
-            },
+            adminUser: ::Shared::V1::Schemas::UserRefRequired,
+            user: ::Shared::V1::Schemas::UserRefRequired,
 
             startedAt: {type: :string, format: "date-time"},
             finishedAt: {type: :string, format: "date-time"},

--- a/app/api_components/admin/v1/schemas/models/admin_model_media.rb
+++ b/app/api_components/admin/v1/schemas/models/admin_model_media.rb
@@ -13,7 +13,8 @@ module Admin
           schema({
             properties: {
               fleetchartImage: {type: :string},
-              extendedHolo: {"$ref": "#/components/schemas/MediaFile"}
+              extendedHolo: {"$ref": "#/components/schemas/MediaFile"},
+              rsiStoreImage: {"$ref": "#/components/schemas/MediaFile"}
             }
           })
         end

--- a/app/api_components/admin/v1/schemas/models/admin_model_media.rb
+++ b/app/api_components/admin/v1/schemas/models/admin_model_media.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        # The admin payload adds a few internal images to the public set. A $ref
+        # cannot be merged into, so the extra properties inherit the shared
+        # component rather than being merged into the property that points at it.
+        class AdminModelMedia < ::Shared::V1::Schemas::ModelMedia
+          include OpenapiRuby::Components::Base
+
+          schema({
+            properties: {
+              fleetchartImage: {type: :string},
+              extendedHolo: {"$ref": "#/components/schemas/MediaFile"}
+            }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/cargo_holds/admin_cargo_hold.rb
+++ b/app/api_components/admin/v1/schemas/models/cargo_holds/admin_cargo_hold.rb
@@ -24,15 +24,7 @@ module Admin
                 offsetY: {type: :number},
                 offsetZ: {type: :number},
                 rotation: {type: :integer},
-                parent: {
-                  type: :object,
-                  properties: {
-                    id: {type: :string, format: :uuid},
-                    name: {type: :string},
-                    slug: {type: :string}
-                  },
-                  required: %w[id name]
-                },
+                parent: AdminCargoHoldParent,
                 createdAt: {type: :string, format: "date-time"},
                 updatedAt: {type: :string, format: "date-time"}
               },

--- a/app/api_components/admin/v1/schemas/models/cargo_holds/admin_cargo_hold_parent.rb
+++ b/app/api_components/admin/v1/schemas/models/cargo_holds/admin_cargo_hold_parent.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module CargoHolds
+          # Only id and name are guaranteed, so this is not ModelRef.
+          class AdminCargoHoldParent
+            include OpenapiRuby::Components::Base
+
+            schema({
+              type: :object,
+              properties: {
+                id: {type: :string, format: :uuid},
+                name: {type: :string},
+                slug: {type: :string}
+              },
+              required: %w[id name]
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/loaners/model_loaner.rb
+++ b/app/api_components/admin/v1/schemas/models/loaners/model_loaner.rb
@@ -15,24 +15,8 @@ module Admin
                 modelId: {type: :string, format: :uuid},
                 loanerModelId: {type: :string, format: :uuid},
                 hidden: {type: :boolean},
-                model: {
-                  type: :object,
-                  properties: {
-                    id: {type: :string, format: :uuid},
-                    name: {type: :string},
-                    slug: {type: :string}
-                  },
-                  required: %w[id name slug]
-                },
-                loanerModel: {
-                  type: :object,
-                  properties: {
-                    id: {type: :string, format: :uuid},
-                    name: {type: :string},
-                    slug: {type: :string}
-                  },
-                  required: %w[id name slug]
-                },
+                model: ModelRef,
+                loanerModel: ModelRef,
                 createdAt: {type: :string, format: "date-time"},
                 updatedAt: {type: :string, format: "date-time"}
               },

--- a/app/api_components/admin/v1/schemas/models/model.rb
+++ b/app/api_components/admin/v1/schemas/models/model.rb
@@ -16,32 +16,7 @@ module Admin
               scLength: {type: :number},
               scBeam: {type: :number},
               scHeight: {type: :number},
-              media: {
-                type: :object,
-                properties: {
-                  angledView: {"$ref": "#/components/schemas/MediaFile"},
-                  angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  fleetchartImage: {type: :string},
-                  extendedHolo: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
-                  extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  frontView: {"$ref": "#/components/schemas/MediaFile"},
-                  frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  sideView: {"$ref": "#/components/schemas/MediaFile"},
-                  sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                  rsiStoreImage: {"$ref": "#/components/schemas/MediaFile"},
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                  topView: {"$ref": "#/components/schemas/MediaFile"},
-                  topViewColored: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              }
+              media: AdminModelMedia
             },
             required: %w[hidden active media]
           })

--- a/app/api_components/admin/v1/schemas/models/model_extended.rb
+++ b/app/api_components/admin/v1/schemas/models/model_extended.rb
@@ -14,14 +14,7 @@ module Admin
                 type: :array,
                 items: {"$ref": "#/components/schemas/DockCount"}
               },
-              links: {
-                type: :object,
-                properties: {
-                  self: {type: :string, format: :uri},
-                  frontend: {type: :string, format: :uri}
-                },
-                additionalProperties: false
-              }
+              links: ::Shared::V1::Schemas::ModelExtendedLinks
             },
             required: %w[dockCounts links]
           })

--- a/app/api_components/admin/v1/schemas/models/model_ref.rb
+++ b/app/api_components/admin/v1/schemas/models/model_ref.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        # A model by id, name and slug.
+        class ModelRef
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              name: {type: :string},
+              slug: {type: :string}
+            },
+            required: %w[id name slug]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/module_packages/model_module_package.rb
+++ b/app/api_components/admin/v1/schemas/models/module_packages/model_module_package.rb
@@ -21,16 +21,7 @@ module Admin
                 modules: {type: :array, items: {"$ref": "#/components/schemas/ModelModule"}},
                 model: {"$ref": "#/components/schemas/Model"},
 
-                media: {
-                  type: :object,
-                  properties: {
-                    angledView: {"$ref": "#/components/schemas/MediaFile"},
-                    sideView: {"$ref": "#/components/schemas/MediaFile"},
-                    storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                    topView: {"$ref": "#/components/schemas/MediaFile"}
-                  },
-                  additionalProperties: false
-                },
+                media: ::Shared::V1::Schemas::ModelModulePackageMedia,
 
                 createdAt: {type: :string, format: "date-time"},
                 updatedAt: {type: :string, format: "date-time"},

--- a/app/api_components/admin/v1/schemas/models/modules/admin_model_module_hardpoint.rb
+++ b/app/api_components/admin/v1/schemas/models/modules/admin_model_module_hardpoint.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module Modules
+          class AdminModelModuleHardpoint
+            include OpenapiRuby::Components::Base
+
+            schema({
+              type: :object,
+              properties: {
+                id: {type: :string, format: :uuid},
+                modelId: {type: :string, format: :uuid},
+                slot: {type: :string}
+              },
+              additionalProperties: false
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/modules/model_module.rb
+++ b/app/api_components/admin/v1/schemas/models/modules/model_module.rb
@@ -16,15 +16,7 @@ module Admin
                 models: {type: :array, items: {"$ref": "#/components/schemas/Model"}},
                 moduleHardpoints: {
                   type: :array,
-                  items: {
-                    type: :object,
-                    properties: {
-                      id: {type: :string, format: :uuid},
-                      modelId: {type: :string, format: :uuid},
-                      slot: {type: :string}
-                    },
-                    additionalProperties: false
-                  }
+                  items: AdminModelModuleHardpoint
                 }
               }
             })

--- a/app/api_components/admin/v1/schemas/models/paints/admin_model_paint_media.rb
+++ b/app/api_components/admin/v1/schemas/models/paints/admin_model_paint_media.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module Paints
+          class AdminModelPaintMedia
+            include OpenapiRuby::Components::Base
+
+            schema({
+              type: :object,
+              properties: {
+                angledView: {"$ref": "#/components/schemas/MediaFile"},
+                angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                fleetchartImage: {type: :string},
+                frontView: {"$ref": "#/components/schemas/MediaFile"},
+                frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                sideView: {"$ref": "#/components/schemas/MediaFile"},
+                sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+                rsiStoreImage: {"$ref": "#/components/schemas/MediaFile"},
+                storeImage: {"$ref": "#/components/schemas/MediaFile"},
+                topView: {"$ref": "#/components/schemas/MediaFile"},
+                topViewColored: {"$ref": "#/components/schemas/MediaFile"}
+              },
+              additionalProperties: false
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/paints/model_paint.rb
+++ b/app/api_components/admin/v1/schemas/models/paints/model_paint.rb
@@ -17,23 +17,7 @@ module Admin
                 productionStatus: {type: :string},
                 productionNote: {type: :string},
                 model: {"$ref": "#/components/schemas/Model"},
-                media: {
-                  type: :object,
-                  properties: {
-                    angledView: {"$ref": "#/components/schemas/MediaFile"},
-                    angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                    fleetchartImage: {type: :string},
-                    frontView: {"$ref": "#/components/schemas/MediaFile"},
-                    frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                    sideView: {"$ref": "#/components/schemas/MediaFile"},
-                    sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                    rsiStoreImage: {"$ref": "#/components/schemas/MediaFile"},
-                    storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                    topView: {"$ref": "#/components/schemas/MediaFile"},
-                    topViewColored: {"$ref": "#/components/schemas/MediaFile"}
-                  },
-                  additionalProperties: false
-                }
+                media: AdminModelPaintMedia
               },
               required: %w[hidden active media model]
             })

--- a/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_craft.rb
+++ b/app/api_components/admin/v1/schemas/models/snub_crafts/model_snub_craft.rb
@@ -14,24 +14,8 @@ module Admin
                 id: {type: :string, format: :uuid},
                 modelId: {type: :string, format: :uuid},
                 snubCraftId: {type: :string, format: :uuid},
-                model: {
-                  type: :object,
-                  properties: {
-                    id: {type: :string, format: :uuid},
-                    name: {type: :string},
-                    slug: {type: :string}
-                  },
-                  required: %w[id name slug]
-                },
-                snubCraft: {
-                  type: :object,
-                  properties: {
-                    id: {type: :string, format: :uuid},
-                    name: {type: :string},
-                    slug: {type: :string}
-                  },
-                  required: %w[id name slug]
-                },
+                model: ModelRef,
+                snubCraft: ModelRef,
                 createdAt: {type: :string, format: "date-time"},
                 updatedAt: {type: :string, format: "date-time"}
               },

--- a/app/api_components/admin/v1/schemas/models/upgrades/admin_model_upgrade_media.rb
+++ b/app/api_components/admin/v1/schemas/models/upgrades/admin_model_upgrade_media.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Models
+        module Upgrades
+          class AdminModelUpgradeMedia
+            include OpenapiRuby::Components::Base
+
+            schema({
+              type: :object,
+              properties: {
+                storeImage: {"$ref": "#/components/schemas/MediaFile"}
+              },
+              additionalProperties: false
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/models/upgrades/model_upgrade.rb
+++ b/app/api_components/admin/v1/schemas/models/upgrades/model_upgrade.rb
@@ -18,13 +18,7 @@ module Admin
                 hidden: {type: :boolean},
                 pledgePrice: {type: :number},
 
-                media: {
-                  type: :object,
-                  properties: {
-                    storeImage: {"$ref": "#/components/schemas/MediaFile"}
-                  },
-                  additionalProperties: false
-                },
+                media: AdminModelUpgradeMedia,
 
                 createdAt: {type: :string, format: "date-time"},
                 updatedAt: {type: :string, format: "date-time"},

--- a/app/api_components/admin/v1/schemas/supporter_contribution_monthly_stats.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution_monthly_stats.rb
@@ -12,18 +12,7 @@ module Admin
             currency: {type: :string},
             items: {
               type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  label: {type: :string},
-                  tooltip: {type: :string},
-                  amountCents: {type: :integer},
-                  goalAmountCents: {type: :integer},
-                  count: {type: :integer}
-                },
-                additionalProperties: false,
-                required: %w[label tooltip amountCents goalAmountCents count]
-              }
+              items: SupporterContributionMonthlyStatsItem
             }
           },
           additionalProperties: false,

--- a/app/api_components/admin/v1/schemas/supporter_contribution_monthly_stats_item.rb
+++ b/app/api_components/admin/v1/schemas/supporter_contribution_monthly_stats_item.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class SupporterContributionMonthlyStatsItem
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            label: {type: :string},
+            tooltip: {type: :string},
+            amountCents: {type: :integer},
+            goalAmountCents: {type: :integer},
+            count: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[label tooltip amountCents goalAmountCents count]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/oauth/v1/schemas/oauth_pre_authorization.rb
+++ b/app/api_components/oauth/v1/schemas/oauth_pre_authorization.rb
@@ -20,14 +20,7 @@ module Oauth
             codeChallengeMethod: {type: :string},
             scopes: {
               type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  description: {type: :string}
-                },
-                required: %w[name description]
-              }
+              items: OauthScope
             }
           },
           additionalProperties: false,

--- a/app/api_components/oauth/v1/schemas/oauth_scope.rb
+++ b/app/api_components/oauth/v1/schemas/oauth_scope.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Oauth
+  module V1
+    module Schemas
+      class OauthScope
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            description: {type: :string}
+          },
+          required: %w[name description]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/cargo_hold.rb
+++ b/app/api_components/shared/v1/schemas/cargo_hold.rb
@@ -15,25 +15,8 @@ module Shared
             dimensions: {"$ref": "#/components/schemas/CargoHoldDimension"},
             capacity: {type: :integer},
             maxContainerSize: {"$ref": "#/components/schemas/CargoHoldContainerSize"},
-            limits: {
-              type: :object,
-              properties: {
-                min: {"$ref": "#/components/schemas/CargoHoldLimit"},
-                max: {"$ref": "#/components/schemas/CargoHoldLimit"}
-              },
-              additionalProperties: false,
-              required: %w[min]
-            },
-            offset: {
-              type: :object,
-              properties: {
-                x: {type: :number},
-                y: {type: :number},
-                z: {type: :number}
-              },
-              additionalProperties: false,
-              required: %w[x y z]
-            },
+            limits: CargoHoldLimits,
+            offset: CargoHoldOffset,
             rotation: {type: :integer}
           },
           additionalProperties: false,

--- a/app/api_components/shared/v1/schemas/cargo_hold_limits.rb
+++ b/app/api_components/shared/v1/schemas/cargo_hold_limits.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class CargoHoldLimits
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            min: {"$ref": "#/components/schemas/CargoHoldLimit"},
+            max: {"$ref": "#/components/schemas/CargoHoldLimit"}
+          },
+          additionalProperties: false,
+          required: %w[min]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/cargo_hold_offset.rb
+++ b/app/api_components/shared/v1/schemas/cargo_hold_offset.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class CargoHoldOffset
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            x: {type: :number},
+            y: {type: :number},
+            z: {type: :number}
+          },
+          additionalProperties: false,
+          required: %w[x y z]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component.rb
+++ b/app/api_components/shared/v1/schemas/component.rb
@@ -30,31 +30,11 @@ module Shared
             itemClass: {"$ref": "#/components/schemas/ComponentItemClassEnum"},
             itemClassLabel: {type: :string},
 
-            availability: {
-              type: :object,
-              properties: {
-                boughtAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                },
-                soldAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                }
-              },
-              additionalProperties: false,
-              required: %w[boughtAt soldAt]
-            },
+            availability: Shared::V1::Schemas::ItemAvailability,
 
             manufacturer: {"$ref": "#/components/schemas/Manufacturer"},
 
-            media: {
-              type: :object,
-              properties: {
-                storeImage: {"$ref": "#/components/schemas/MediaFile"}
-              },
-              additionalProperties: false
-            },
+            media: Shared::V1::Schemas::StoreImageMedia,
 
             typeData: {
               anyOf: [

--- a/app/api_components/shared/v1/schemas/component_angular_velocity.rb
+++ b/app/api_components/shared/v1/schemas/component_angular_velocity.rb
@@ -3,16 +3,15 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentAngularVelocity
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            pitch: {type: :number},
+            yaw: {type: :number},
+            roll: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_controller.rb
+++ b/app/api_components/shared/v1/schemas/component_controller.rb
@@ -6,35 +6,6 @@ module Shared
       class ComponentController
         include OpenapiRuby::Components::Base
 
-        ANGULAR_VELOCITY = {
-          type: :object,
-          properties: {
-            pitch: {type: :number},
-            yaw: {type: :number},
-            roll: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
@@ -42,11 +13,11 @@ module Shared
             scmSpeedBoosted: {type: :number},
             reverseSpeedBoosted: {type: :number},
             maxSpeed: {type: :number},
-            angularVelocity: ANGULAR_VELOCITY,
-            boostedAngularVelocity: ANGULAR_VELOCITY,
+            angularVelocity: ComponentAngularVelocity,
+            boostedAngularVelocity: ComponentAngularVelocity,
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number}
           },
           additionalProperties: false

--- a/app/api_components/shared/v1/schemas/component_cooler.rb
+++ b/app/api_components/shared/v1/schemas/component_cooler.rb
@@ -6,32 +6,13 @@ module Shared
       class ComponentCooler
         include OpenapiRuby::Components::Base
 
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
             coolingRate: {type: :number},
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number},
             signatureIr: {type: :number}
           },

--- a/app/api_components/shared/v1/schemas/component_damage_range.rb
+++ b/app/api_components/shared/v1/schemas/component_damage_range.rb
@@ -3,16 +3,14 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentDamageRange
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            min: {type: :number},
+            max: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_damage_type_map.rb
+++ b/app/api_components/shared/v1/schemas/component_damage_type_map.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # One range per damage type, used for both shield resistance and
+      # absorption.
+      class ComponentDamageTypeMap
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            physical: ComponentDamageRange,
+            energy: ComponentDamageRange,
+            distortion: ComponentDamageRange,
+            thermal: ComponentDamageRange,
+            biochemical: ComponentDamageRange,
+            stun: ComponentDamageRange
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_ping_properties.rb
+++ b/app/api_components/shared/v1/schemas/component_ping_properties.rb
@@ -3,16 +3,13 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentPingProperties
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            cooldownTime: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_power_range_entry.rb
+++ b/app/api_components/shared/v1/schemas/component_power_range_entry.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # One band of a component's power curve. Eight component types carried an
+      # identical copy of this shape, which gave the generated client eight
+      # unrelated types for the same two numbers.
+      class ComponentPowerRangeEntry
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            start: {type: :number},
+            modifier: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_power_ranges.rb
+++ b/app/api_components/shared/v1/schemas/component_power_ranges.rb
@@ -3,16 +3,15 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentPowerRanges
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            low: ComponentPowerRangeEntry,
+            medium: ComponentPowerRangeEntry,
+            high: ComponentPowerRangeEntry
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_quantum_drive.rb
+++ b/app/api_components/shared/v1/schemas/component_quantum_drive.rb
@@ -6,25 +6,6 @@ module Shared
       class ComponentQuantumDrive
         include OpenapiRuby::Components::Base
 
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
@@ -52,7 +33,7 @@ module Shared
             },
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number}
           },
           additionalProperties: false

--- a/app/api_components/shared/v1/schemas/component_radar.rb
+++ b/app/api_components/shared/v1/schemas/component_radar.rb
@@ -6,66 +6,17 @@ module Shared
       class ComponentRadar
         include OpenapiRuby::Components::Base
 
-        SIGNATURE_SENSITIVITY = {
-          type: :object,
-          properties: {
-            sensitivity: {type: :number},
-            piercing: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
-            signatureDetection: {
-              type: :object,
-              properties: {
-                ir: SIGNATURE_SENSITIVITY,
-                em: SIGNATURE_SENSITIVITY,
-                cs: SIGNATURE_SENSITIVITY,
-                rs: SIGNATURE_SENSITIVITY
-              },
-              additionalProperties: false
-            },
-            pingProperties: {
-              type: :object,
-              properties: {
-                cooldownTime: {type: :number}
-              },
-              additionalProperties: false
-            },
+            signatureDetection: ComponentSignatureDetection,
+            pingProperties: ComponentPingProperties,
             aimAssistRange: {type: :number},
             aimAssistMin: {type: :number},
-            sensitivityModifiers: {
-              type: :object,
-              properties: {
-                sensitivityAddition: {type: :number}
-              },
-              additionalProperties: false
-            },
+            sensitivityModifiers: ComponentSensitivityModifiers,
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number}
           },
           additionalProperties: false

--- a/app/api_components/shared/v1/schemas/component_sensitivity_modifiers.rb
+++ b/app/api_components/shared/v1/schemas/component_sensitivity_modifiers.rb
@@ -3,16 +3,13 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentSensitivityModifiers
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            sensitivityAddition: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_shield.rb
+++ b/app/api_components/shared/v1/schemas/component_shield.rb
@@ -6,47 +6,6 @@ module Shared
       class ComponentShield
         include OpenapiRuby::Components::Base
 
-        DAMAGE_TYPE_RANGE = {
-          type: :object,
-          properties: {
-            min: {type: :number},
-            max: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        DAMAGE_TYPE_MAP = {
-          type: :object,
-          properties: {
-            physical: DAMAGE_TYPE_RANGE,
-            energy: DAMAGE_TYPE_RANGE,
-            distortion: DAMAGE_TYPE_RANGE,
-            thermal: DAMAGE_TYPE_RANGE,
-            biochemical: DAMAGE_TYPE_RANGE,
-            stun: DAMAGE_TYPE_RANGE
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
@@ -55,11 +14,11 @@ module Shared
             decayRatio: {type: :number},
             downedRegenDelay: {type: :number},
             damagedRegenDelay: {type: :number},
-            resistance: DAMAGE_TYPE_MAP,
-            absorption: DAMAGE_TYPE_MAP,
+            resistance: ComponentDamageTypeMap,
+            absorption: ComponentDamageTypeMap,
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number}
           },
           additionalProperties: false,

--- a/app/api_components/shared/v1/schemas/component_signature_detection.rb
+++ b/app/api_components/shared/v1/schemas/component_signature_detection.rb
@@ -3,16 +3,16 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentSignatureDetection
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            ir: ComponentSignatureSensitivity,
+            em: ComponentSignatureSensitivity,
+            cs: ComponentSignatureSensitivity,
+            rs: ComponentSignatureSensitivity
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_signature_sensitivity.rb
+++ b/app/api_components/shared/v1/schemas/component_signature_sensitivity.rb
@@ -3,16 +3,14 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentSignatureSensitivity
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            sensitivity: {type: :number},
+            piercing: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_tractor_beam.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam.rb
@@ -6,25 +6,6 @@ module Shared
       class ComponentTractorBeam
         include OpenapiRuby::Components::Base
 
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
@@ -39,45 +20,13 @@ module Shared
             volumeForceCoefficient: {type: :number},
             tetherBreakTime: {type: :number},
             heatPerSecond: {type: :number},
-            rotation: {
-              type: :object,
-              properties: {
-                maxAngularVelocity: {type: :number},
-                degreesPerAction: {type: :number}
-              },
-              additionalProperties: false
-            },
-            movement: {
-              type: :object,
-              properties: {
-                maxSpeed: {type: :number},
-                maxAcceleration: {type: :number}
-              },
-              additionalProperties: false
-            },
-            cargoMode: {
-              type: :object,
-              properties: {
-                maxForce: {type: :number},
-                minDistance: {type: :number},
-                maxDistance: {type: :number},
-                fullStrengthDistance: {type: :number}
-              },
-              additionalProperties: false
-            },
-            towing: {
-              type: :object,
-              properties: {
-                towingForce: {type: :number},
-                towingMaxDistance: {type: :number},
-                towingMaxAcceleration: {type: :number},
-                quantumTowMassLimit: {type: :number}
-              },
-              additionalProperties: false
-            },
+            rotation: ComponentTractorBeamRotation,
+            movement: ComponentTractorBeamMovement,
+            cargoMode: ComponentTractorBeamCargoMode,
+            towing: ComponentTractorBeamTowing,
             powerConsumption: {type: :number},
             powerMinimumFraction: {type: :number},
-            powerRanges: POWER_RANGES
+            powerRanges: ComponentPowerRanges
           },
           additionalProperties: false,
           required: %w[tractorBeam]

--- a/app/api_components/shared/v1/schemas/component_tractor_beam_cargo_mode.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam_cargo_mode.rb
@@ -3,16 +3,16 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentTractorBeamCargoMode
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            maxForce: {type: :number},
+            minDistance: {type: :number},
+            maxDistance: {type: :number},
+            fullStrengthDistance: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_tractor_beam_movement.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam_movement.rb
@@ -3,16 +3,14 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentTractorBeamMovement
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            maxSpeed: {type: :number},
+            maxAcceleration: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_tractor_beam_rotation.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam_rotation.rb
@@ -3,16 +3,14 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentTractorBeamRotation
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            maxAngularVelocity: {type: :number},
+            degreesPerAction: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_tractor_beam_towing.rb
+++ b/app/api_components/shared/v1/schemas/component_tractor_beam_towing.rb
@@ -3,16 +3,16 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentTractorBeamTowing
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            towingForce: {type: :number},
+            towingMaxDistance: {type: :number},
+            towingMaxAcceleration: {type: :number},
+            quantumTowMassLimit: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_weapon.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon.rb
@@ -6,25 +6,6 @@ module Shared
       class ComponentWeapon
         include OpenapiRuby::Components::Base
 
-        POWER_RANGE_ENTRY = {
-          type: :object,
-          properties: {
-            start: {type: :number},
-            modifier: {type: :number}
-          },
-          additionalProperties: false
-        }.freeze
-
-        POWER_RANGES = {
-          type: :object,
-          properties: {
-            low: POWER_RANGE_ENTRY,
-            medium: POWER_RANGE_ENTRY,
-            high: POWER_RANGE_ENTRY
-          },
-          additionalProperties: false
-        }.freeze
-
         schema({
           type: :object,
           properties: {
@@ -32,32 +13,10 @@ module Shared
             fireRate: {type: :number},
             heatPerShot: {type: :number},
             powerConsumption: {type: :number},
-            powerRanges: POWER_RANGES,
+            powerRanges: ComponentPowerRanges,
             signatureEm: {type: :number},
-            damagePerShot: {
-              type: :object,
-              properties: {
-                physical: {type: :number},
-                energy: {type: :number},
-                distortion: {type: :number},
-                thermal: {type: :number},
-                biochemical: {type: :number},
-                stun: {type: :number}
-              },
-              additionalProperties: false
-            },
-            damagePerSecond: {
-              type: :object,
-              properties: {
-                physical: {type: :number},
-                energy: {type: :number},
-                distortion: {type: :number},
-                thermal: {type: :number},
-                biochemical: {type: :number},
-                stun: {type: :number}
-              },
-              additionalProperties: false
-            },
+            damagePerShot: ComponentWeaponDamage,
+            damagePerSecond: ComponentWeaponDamage,
             heatPerSecond: {type: :number},
             pelletsPerShot: {type: :integer},
             speed: {type: :number},
@@ -68,36 +27,9 @@ module Shared
             maxAmmo: {type: :integer},
             chargeTime: {type: :number},
             overchargeTime: {type: :number},
-            regen: {
-              type: :object,
-              properties: {
-                maxAmmoLoad: {type: :number},
-                maxRegenPerSecond: {type: :number},
-                costPerBullet: {type: :number},
-                regenerationCooldown: {type: :number},
-                requestedRegenPerSecond: {type: :number},
-                requestedAmmoLoad: {type: :number}
-              },
-              additionalProperties: false
-            },
-            heat: {
-              type: :object,
-              properties: {
-                overheatTemperature: {type: :number},
-                coolingPerSecond: {type: :number},
-                timeTillCoolingStarts: {type: :number},
-                overheatFixTime: {type: :number}
-              },
-              additionalProperties: false
-            },
-            penetration: {
-              type: :object,
-              properties: {
-                maxThickness: {type: :number},
-                baseDistance: {type: :number}
-              },
-              additionalProperties: false
-            }
+            regen: ComponentWeaponRegen,
+            heat: ComponentWeaponHeat,
+            penetration: ComponentWeaponPenetration
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_weapon_damage.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon_damage.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # Damage split by type, used for both the per-shot and the per-second
+      # figure.
+      class ComponentWeaponDamage
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            physical: {type: :number},
+            energy: {type: :number},
+            distortion: {type: :number},
+            thermal: {type: :number},
+            biochemical: {type: :number},
+            stun: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/component_weapon_heat.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon_heat.rb
@@ -3,16 +3,16 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentWeaponHeat
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            overheatTemperature: {type: :number},
+            coolingPerSecond: {type: :number},
+            timeTillCoolingStarts: {type: :number},
+            overheatFixTime: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_weapon_penetration.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon_penetration.rb
@@ -3,16 +3,14 @@
 module Shared
   module V1
     module Schemas
-      class ComponentPowerPlant
+      class ComponentWeaponPenetration
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
-            powerBase: {type: :number},
-            powerDraw: {type: :number},
-            powerRanges: ComponentPowerRanges,
-            signatureEm: {type: :number}
+            maxThickness: {type: :number},
+            baseDistance: {type: :number}
           },
           additionalProperties: false
         })

--- a/app/api_components/shared/v1/schemas/component_weapon_regen.rb
+++ b/app/api_components/shared/v1/schemas/component_weapon_regen.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ComponentWeaponRegen
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            maxAmmoLoad: {type: :number},
+            maxRegenPerSecond: {type: :number},
+            costPerBullet: {type: :number},
+            regenerationCooldown: {type: :number},
+            requestedRegenPerSecond: {type: :number},
+            requestedAmmoLoad: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/equipment.rb
+++ b/app/api_components/shared/v1/schemas/equipment.rb
@@ -49,21 +49,7 @@ module Shared
 
             manufacturer: {"$ref": "#/components/schemas/Manufacturer"},
 
-            availability: {
-              type: :object,
-              properties: {
-                boughtAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                },
-                soldAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                }
-              },
-              additionalProperties: false,
-              required: %w[boughtAt soldAt]
-            },
+            availability: Shared::V1::Schemas::ItemAvailability,
 
             storeImage: {"$ref": "#/components/schemas/MediaFile"},
 

--- a/app/api_components/shared/v1/schemas/inventory_item_ref.rb
+++ b/app/api_components/shared/v1/schemas/inventory_item_ref.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # The catalogue record a ledger entry points at.
+      class InventoryItemRef
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            type: {"$ref": "#/components/schemas/InventoryItemTypeEnum"},
+            name: {type: :string},
+            slug: {type: :string},
+            available: {type: :boolean}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/inventory_ref.rb
+++ b/app/api_components/shared/v1/schemas/inventory_ref.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # The inventory an entry belongs to, by name and slug.
+      class InventoryRef
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            slug: {type: :string}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/inventory_stock_position.rb
+++ b/app/api_components/shared/v1/schemas/inventory_stock_position.rb
@@ -29,13 +29,7 @@ module Shared
                 available: {type: :boolean}
               }
             },
-            inventory: {
-              type: :object,
-              properties: {
-                name: {type: :string},
-                slug: {type: :string}
-              }
-            }
+            inventory: Shared::V1::Schemas::InventoryRef
           },
           additionalProperties: false,
           required: %w[slug name category unit netQuantity entriesCount]

--- a/app/api_components/shared/v1/schemas/inventory_vehicle.rb
+++ b/app/api_components/shared/v1/schemas/inventory_vehicle.rb
@@ -14,15 +14,7 @@ module Shared
             id: {type: :string, format: :uuid},
             name: {type: :string},
             serial: {type: [:string, :null]},
-            model: {
-              type: :object,
-              properties: {
-                name: {type: :string},
-                slug: {type: :string},
-                cargo: {type: :number},
-                personalInventory: {type: :number}
-              }
-            }
+            model: InventoryVehicleModel
           },
           additionalProperties: false,
           required: %w[id name]

--- a/app/api_components/shared/v1/schemas/inventory_vehicle_model.rb
+++ b/app/api_components/shared/v1/schemas/inventory_vehicle_model.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class InventoryVehicleModel
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            slug: {type: :string},
+            cargo: {type: :number},
+            personalInventory: {type: :number}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/item_availability.rb
+++ b/app/api_components/shared/v1/schemas/item_availability.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # Where a tradeable item can be bought and sold. The UEX snapshot prices
+      # items at every terminal that trades them, and commodities, components,
+      # equipment, modules and paints all carry the same shape.
+      class ItemAvailability
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            boughtAt: {
+              type: :array,
+              items: {"$ref": "#/components/schemas/ItemPrice"}
+            },
+            soldAt: {
+              type: :array,
+              items: {"$ref": "#/components/schemas/ItemPrice"}
+            }
+          },
+          additionalProperties: false,
+          required: %w[boughtAt soldAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_availability.rb
+++ b/app/api_components/shared/v1/schemas/model_availability.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelAvailability
+        include OpenapiRuby::Components::Base
+
+        # Ships can also be rented, which is why this is not ItemAvailability.
+
+        schema({
+          type: :object,
+          properties: {
+            boughtAt: {
+              type: :array,
+              items: {"$ref": "#/components/schemas/ItemPrice"}
+            },
+            soldAt: {
+              type: :array,
+              items: {"$ref": "#/components/schemas/ItemPrice"}
+            },
+            rentalAt: {
+              type: :array,
+              items: {"$ref": "#/components/schemas/ItemPrice"}
+            }
+          },
+          additionalProperties: false,
+          required: %w[boughtAt soldAt rentalAt]
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_crew.rb
+++ b/app/api_components/shared/v1/schemas/model_crew.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelCrew
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            max: {type: :integer},
+            maxLabel: {type: :string},
+            min: {type: :integer},
+            minLabel: {type: :string}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_extended_links.rb
+++ b/app/api_components/shared/v1/schemas/model_extended_links.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # ModelExtended used to merge self and frontend into the links it
+      # inherited from Model. A $ref cannot be merged into, so the extended
+      # variant spells out all four.
+      class ModelExtendedLinks
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            salesPageUrl: {type: :string},
+            storeUrl: {type: :string},
+            self: {type: :string, format: :uri},
+            frontend: {type: :string, format: :uri}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_hull_door.rb
+++ b/app/api_components/shared/v1/schemas/model_hull_door.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelHullDoor
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            health: {type: :number}
+          },
+          required: %w[name health],
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_hull_part.rb
+++ b/app/api_components/shared/v1/schemas/model_hull_part.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelHullPart
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            health: {type: :number},
+            category: {"$ref": "#/components/schemas/ModelHullPartCategoryEnum"}
+          },
+          required: %w[name health category],
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_links.rb
+++ b/app/api_components/shared/v1/schemas/model_links.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelLinks
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            salesPageUrl: {type: :string},
+            storeUrl: {type: :string}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_media.rb
+++ b/app/api_components/shared/v1/schemas/model_media.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelMedia
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            angledView: {"$ref": "#/components/schemas/MediaFile"},
+            angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            fleetchartImage: {type: :string},
+            extendedHolo: {"$ref": "#/components/schemas/MediaFile"},
+            extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            frontView: {"$ref": "#/components/schemas/MediaFile"},
+            frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            sideView: {"$ref": "#/components/schemas/MediaFile"},
+            sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            storeImage: {"$ref": "#/components/schemas/MediaFile"},
+            topView: {"$ref": "#/components/schemas/MediaFile"},
+            topViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            holo: {"$ref": "#/components/schemas/MediaFile"},
+            brochure: {"$ref": "#/components/schemas/MediaFile"}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_metrics.rb
+++ b/app/api_components/shared/v1/schemas/model_metrics.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelMetrics
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            beam: {type: :number},
+            beamLabel: {type: :string},
+            cargo: {type: :number},
+            cargoLabel: {type: :string},
+            personalInventory: {type: :number},
+            personalInventoryLabel: {type: [:string, :null]},
+            fleetchartOffsetLength: {type: :number},
+            fleetchartOffsetBeam: {type: :number},
+            extendedLength: {type: :number},
+            extendedLengthLabel: {type: :string},
+            extendedBeam: {type: :number},
+            extendedBeamLabel: {type: :string},
+            extendedHeight: {type: :number},
+            extendedHeightLabel: {type: :string},
+            extendedFleetchartOffsetLength: {type: :number},
+            extendedFleetchartOffsetBeam: {type: :number},
+            height: {type: :number},
+            heightLabel: {type: :string},
+            hydrogenFuelTankSize: {type: :number},
+            isGroundVehicle: {type: :boolean},
+            length: {type: :number},
+            lengthLabel: {type: :string},
+            mass: {type: :number},
+            massLabel: {type: :string},
+            hullHealth: {type: :number},
+            hullParts: {
+              type: :array,
+              items: Shared::V1::Schemas::ModelHullPart
+            },
+            hullDoors: {
+              type: :array,
+              items: Shared::V1::Schemas::ModelHullDoor
+            },
+            quantumFuelTankSize: {type: :number},
+            weaponPoolSize: {type: :number},
+            signatureCrossSection: Shared::V1::Schemas::ModelSignatureCrossSection,
+            size: {type: :string},
+            sizeLabel: {type: :string},
+            dockSize: {type: :string}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_module_metrics.rb
+++ b/app/api_components/shared/v1/schemas/model_module_metrics.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # Shared because the admin ModelModule subclasses the public one and
+      # inherits the reference to this component.
+      class ModelModuleMetrics
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            cargo: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_module_package_media.rb
+++ b/app/api_components/shared/v1/schemas/model_module_package_media.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # The four package renders, identical in the public and the admin payload.
+      class ModelModulePackageMedia
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            angledView: {"$ref": "#/components/schemas/MediaFile"},
+            sideView: {"$ref": "#/components/schemas/MediaFile"},
+            storeImage: {"$ref": "#/components/schemas/MediaFile"},
+            topView: {"$ref": "#/components/schemas/MediaFile"}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_signature_cross_section.rb
+++ b/app/api_components/shared/v1/schemas/model_signature_cross_section.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelSignatureCrossSection
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            x: {type: :number},
+            y: {type: :number},
+            z: {type: :number}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/model_speeds.rb
+++ b/app/api_components/shared/v1/schemas/model_speeds.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class ModelSpeeds
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            groundAcceleration: {type: :number},
+            groundDecceleration: {type: :number},
+            groundMaxSpeed: {type: :number},
+            groundReverseSpeed: {type: :number},
+            maxSpeed: {type: :number},
+            pitch: {type: :number},
+            pitchBoosted: {type: :number},
+            roll: {type: :number},
+            rollBoosted: {type: :number},
+            scmSpeed: {type: :number},
+            scmSpeedBoosted: {type: :number},
+            reverseSpeedBoosted: {type: :number},
+            yaw: {type: :number},
+            yawBoosted: {type: :number}
+          },
+          additionalProperties: false
+
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/store_image_media.rb
+++ b/app/api_components/shared/v1/schemas/store_image_media.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      class StoreImageMedia
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            storeImage: {"$ref": "#/components/schemas/MediaFile"}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/user_ref.rb
+++ b/app/api_components/shared/v1/schemas/user_ref.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # A user by id and handle, neither required. UserRefRequired is the
+      # same two fields where the payload always carries them; the split keeps
+      # the published contracts as they were.
+      class UserRef
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            username: {type: :string}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/user_ref_required.rb
+++ b/app/api_components/shared/v1/schemas/user_ref_required.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # Same two fields as UserRef, but both required. Kept apart so neither
+      # published contract changes.
+      class UserRefRequired
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            username: {type: :string}
+          },
+          required: %w[id username]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/weapon_index_damage.rb
+++ b/app/api_components/shared/v1/schemas/weapon_index_damage.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shared
+  module V1
+    module Schemas
+      # Four damage types only; the full weapon component carries six.
+      class WeaponIndexDamage
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            physical: {type: :number},
+            energy: {type: :number},
+            distortion: {type: :number},
+            thermal: {type: :number}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/shared/v1/schemas/weapon_index_item.rb
+++ b/app/api_components/shared/v1/schemas/weapon_index_item.rb
@@ -17,16 +17,7 @@ module Shared
             beam: {type: :boolean},
             weaponClass: {type: :string},
             pelletsPerShot: {type: :integer},
-            damagePerShot: {
-              type: :object,
-              properties: {
-                physical: {type: :number},
-                energy: {type: :number},
-                distortion: {type: :number},
-                thermal: {type: :number}
-              },
-              additionalProperties: false
-            }
+            damagePerShot: WeaponIndexDamage
           },
           additionalProperties: false,
           required: %w[id name damagePerShot]

--- a/app/api_components/v1/schemas/commodity.rb
+++ b/app/api_components/v1/schemas/commodity.rb
@@ -18,21 +18,7 @@ module V1
           # The UEX snapshot prices commodities at every terminal that trades
           # them, which is the whole point of syncing it -- the same shape the
           # component and equipment payloads carry.
-          availability: {
-            type: :object,
-            properties: {
-              boughtAt: {
-                type: :array,
-                items: {"$ref": "#/components/schemas/ItemPrice"}
-              },
-              soldAt: {
-                type: :array,
-                items: {"$ref": "#/components/schemas/ItemPrice"}
-              }
-            },
-            additionalProperties: false,
-            required: %w[boughtAt soldAt]
-          },
+          availability: Shared::V1::Schemas::ItemAvailability,
 
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"}

--- a/app/api_components/v1/schemas/fleets/events/fleet_event.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event.rb
@@ -37,13 +37,7 @@ module V1
               archived: {type: :boolean},
               archivedAt: {type: :string, format: "date-time"},
               externalUid: {type: :string, format: :uuid},
-              createdBy: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              },
+              createdBy: Shared::V1::Schemas::UserRef,
               signupsCount: {type: :integer},
               teamCount: {type: :integer},
               past: {type: :boolean},

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_admin.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_admin.rb
@@ -14,21 +14,8 @@ module V1
               fleetEventId: {type: :string, format: :uuid},
               role: {"$ref": "#/components/schemas/FleetEventAdminRoleEnum"},
               createdAt: {type: :string, format: "date-time"},
-              user: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                },
-                required: %w[id username]
-              },
-              grantedBy: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              }
+              user: Shared::V1::Schemas::UserRefRequired,
+              grantedBy: Shared::V1::Schemas::UserRef
             },
             required: %w[id fleetEventId role user createdAt],
             additionalProperties: false

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_ship.rb
@@ -24,17 +24,7 @@ module V1
                 type: :array,
                 items: {"$ref": "#/components/schemas/ShipModel"}
               },
-              filters: {
-                type: :object,
-                properties: {
-                  classification: {type: :string},
-                  focus: {type: :string},
-                  minSize: {type: :string},
-                  maxSize: {type: :string},
-                  minCrew: {type: :integer},
-                  minCargo: {type: :number}
-                }
-              },
+              filters: ShipSlotFilters,
               slots: {
                 type: :array,
                 items: {"$ref": "#/components/schemas/FleetEventSlot"}

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_signup.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_signup.rb
@@ -18,35 +18,8 @@ module V1
               notes: {type: :string},
               confirmedAt: {type: :string, format: "date-time"},
               withdrawnAt: {type: :string, format: "date-time"},
-              user: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              },
-              vehicle: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  name: {type: :string},
-                  model: {
-                    type: :object,
-                    properties: {
-                      id: {type: :string, format: :uuid},
-                      name: {type: :string},
-                      slug: {type: :string},
-                      classification: {type: :string},
-                      focus: {type: :string},
-                      size: {type: :string},
-                      minCrew: {type: :integer},
-                      maxCrew: {type: :integer},
-                      cargo: {type: :integer},
-                      positionCount: {type: :integer}
-                    }
-                  }
-                }
-              }
+              user: Shared::V1::Schemas::UserRef,
+              vehicle: FleetEventSignupVehicle
             },
             required: %w[id fleetEventId status],
             additionalProperties: false

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_signup_vehicle.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_signup_vehicle.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventSignupVehicle
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              name: {type: :string},
+              model: FleetEventSignupVehicleModel
+            }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/events/fleet_event_signup_vehicle_model.rb
+++ b/app/api_components/v1/schemas/fleets/events/fleet_event_signup_vehicle_model.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Events
+        class FleetEventSignupVehicleModel
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              name: {type: :string},
+              slug: {type: :string},
+              classification: {type: :string},
+              focus: {type: :string},
+              size: {type: :string},
+              minCrew: {type: :integer},
+              maxCrew: {type: :integer},
+              cargo: {type: :integer},
+              positionCount: {type: :integer}
+            }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_members_metrics.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_members_metrics.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      class FleetMembersMetrics
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            membersByRole: {
+              type: :object,
+              additionalProperties: {type: :integer}
+            }
+          },
+          additionalProperties: false,
+          required: %w[membersByRole]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/fleet_members_stats.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_members_stats.rb
@@ -10,17 +10,7 @@ module V1
           type: :object,
           properties: {
             total: {type: :integer},
-            metrics: {
-              type: :object,
-              properties: {
-                membersByRole: {
-                  type: :object,
-                  additionalProperties: {type: :integer}
-                }
-              },
-              additionalProperties: false,
-              required: %w[membersByRole]
-            }
+            metrics: FleetMembersMetrics
           },
           additionalProperties: false,
           required: %w[total metrics]

--- a/app/api_components/v1/schemas/fleets/logistics/fleet_inventory.rb
+++ b/app/api_components/v1/schemas/fleets/logistics/fleet_inventory.rb
@@ -19,16 +19,7 @@ module V1
               entriesCount: {type: :integer},
               totalScu: {type: :number},
               totalUnits: {type: :number},
-              manager: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string},
-                  rsiHandle: {type: :string},
-                  discordProfileUrl: {type: :string, format: :uri},
-                  citizenidProfileUrl: {type: :string, format: :uri}
-                }
-              },
+              manager: FleetInventoryManager,
               image: {"$ref": "#/components/schemas/MediaFile"},
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"}

--- a/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_item.rb
+++ b/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_item.rb
@@ -20,37 +20,10 @@ module V1
               quality: {type: :integer, minimum: 0, maximum: 1000},
               notes: {type: :string},
               image: {"$ref": "#/components/schemas/MediaFile"},
-              item: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  type: {"$ref": "#/components/schemas/InventoryItemTypeEnum"},
-                  name: {type: :string},
-                  slug: {type: :string},
-                  available: {type: :boolean}
-                }
-              },
-              inventory: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  slug: {type: :string}
-                }
-              },
-              member: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              },
-              addedBy: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              },
+              item: Shared::V1::Schemas::InventoryItemRef,
+              inventory: Shared::V1::Schemas::InventoryRef,
+              member: Shared::V1::Schemas::UserRef,
+              addedBy: Shared::V1::Schemas::UserRef,
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"}
             },

--- a/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_manager.rb
+++ b/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_manager.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      module Logistics
+        class FleetInventoryManager
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              username: {type: :string},
+              rsiHandle: {type: :string},
+              discordProfileUrl: {type: :string, format: :uri},
+              citizenidProfileUrl: {type: :string, format: :uri}
+            }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_stock_item.rb
+++ b/app/api_components/v1/schemas/fleets/logistics/fleet_inventory_stock_item.rb
@@ -18,13 +18,7 @@ module V1
               qualityMin: {type: :integer},
               qualityMax: {type: :integer},
               netQuantity: {type: :number},
-              inventory: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  slug: {type: :string}
-                }
-              }
+              inventory: Shared::V1::Schemas::InventoryRef
             },
             required: %w[name category unit netQuantity]
           })

--- a/app/api_components/v1/schemas/fleets/missions/mission.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission.rb
@@ -20,13 +20,7 @@ module V1
               coverImage: {"$ref": "#/components/schemas/MediaFile"},
               archived: {type: :boolean},
               archivedAt: {type: :string, format: "date-time"},
-              createdBy: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  username: {type: :string}
-                }
-              },
+              createdBy: Shared::V1::Schemas::UserRef,
               teamCount: {type: :integer},
               shipCount: {type: :integer},
               createdAt: {type: :string, format: "date-time"},

--- a/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
+++ b/app/api_components/v1/schemas/fleets/missions/mission_ship.rb
@@ -24,17 +24,7 @@ module V1
                 type: :array,
                 items: {"$ref": "#/components/schemas/ShipModel"}
               },
-              filters: {
-                type: :object,
-                properties: {
-                  classification: {type: :string},
-                  focus: {type: :string},
-                  minSize: {type: :string},
-                  maxSize: {type: :string},
-                  minCrew: {type: :integer},
-                  minCargo: {type: :number}
-                }
-              },
+              filters: ::V1::Schemas::Fleets::ShipSlotFilters,
               slots: {
                 type: :array,
                 items: {"$ref": "#/components/schemas/MissionSlot"}

--- a/app/api_components/v1/schemas/fleets/ship_slot_filters.rb
+++ b/app/api_components/v1/schemas/fleets/ship_slot_filters.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Fleets
+      # What a ship slot will accept, shared by mission and event ships.
+      class ShipSlotFilters
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            classification: {type: :string},
+            focus: {type: :string},
+            minSize: {type: :string},
+            maxSize: {type: :string},
+            minCrew: {type: :integer},
+            minCargo: {type: :number}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_item.rb
+++ b/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_item.rb
@@ -20,23 +20,8 @@ module V1
               quality: {type: :integer, minimum: 0, maximum: 1000},
               notes: {type: :string},
               image: {"$ref": "#/components/schemas/MediaFile"},
-              item: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  type: {"$ref": "#/components/schemas/InventoryItemTypeEnum"},
-                  name: {type: :string},
-                  slug: {type: :string},
-                  available: {type: :boolean}
-                }
-              },
-              inventory: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  slug: {type: :string}
-                }
-              },
+              item: Shared::V1::Schemas::InventoryItemRef,
+              inventory: Shared::V1::Schemas::InventoryRef,
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"}
             },

--- a/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_stock_item.rb
+++ b/app/api_components/v1/schemas/hangar/logistics/hangar_inventory_stock_item.rb
@@ -18,13 +18,7 @@ module V1
               qualityMin: {type: :integer},
               qualityMax: {type: :integer},
               netQuantity: {type: :number},
-              inventory: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  slug: {type: :string}
-                }
-              }
+              inventory: Shared::V1::Schemas::InventoryRef
             },
             required: %w[name category unit netQuantity]
           })

--- a/app/api_components/v1/schemas/hangar/logistics/inventory_item.rb
+++ b/app/api_components/v1/schemas/hangar/logistics/inventory_item.rb
@@ -22,23 +22,8 @@ module V1
               quality: {type: :integer, minimum: 0, maximum: 1000},
               notes: {type: :string},
               image: {"$ref": "#/components/schemas/MediaFile"},
-              item: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  type: {"$ref": "#/components/schemas/InventoryItemTypeEnum"},
-                  name: {type: :string},
-                  slug: {type: :string},
-                  available: {type: :boolean}
-                }
-              },
-              inventory: {
-                type: :object,
-                properties: {
-                  name: {type: :string},
-                  slug: {type: :string}
-                }
-              },
+              item: Shared::V1::Schemas::InventoryItemRef,
+              inventory: Shared::V1::Schemas::InventoryRef,
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"}
             },

--- a/app/api_components/v1/schemas/inputs/vehicle_create_bulk_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_create_bulk_input.rb
@@ -11,16 +11,7 @@ module V1
           properties: {
             vehicles: {
               type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  modelId: {type: :string, format: :uuid},
-                  wanted: {type: :boolean},
-                  public: {type: :boolean}
-                },
-                additionalProperties: false,
-                required: %w[modelId]
-              }
+              items: VehicleCreateBulkItemInput
             }
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/inputs/vehicle_create_bulk_item_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_create_bulk_item_input.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class VehicleCreateBulkItemInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            modelId: {type: :string, format: :uuid},
+            wanted: {type: :boolean},
+            public: {type: :boolean}
+          },
+          additionalProperties: false,
+          required: %w[modelId]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_hardpoint_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_hardpoint_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class VehicleLoadoutHardpointInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            modelHardpointId: {type: :string, format: :uuid},
+            componentId: {type: [:string, :null], format: :uuid},
+            _destroy: {type: :boolean}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
+++ b/app/api_components/v1/schemas/inputs/vehicle_loadout_input.rb
@@ -14,15 +14,7 @@ module V1
             fromDefaults: {type: :boolean},
             vehicleLoadoutHardpointsAttributes: {
               type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  modelHardpointId: {type: :string, format: :uuid},
-                  componentId: {type: [:string, :null], format: :uuid},
-                  _destroy: {type: :boolean}
-                }
-              }
+              items: VehicleLoadoutHardpointInput
             }
           },
           additionalProperties: false

--- a/app/api_components/v1/schemas/models/fleetchart_view.rb
+++ b/app/api_components/v1/schemas/models/fleetchart_view.rb
@@ -12,27 +12,7 @@ module V1
           type: :object,
           properties: {
             slug: {type: :string},
-            media: {
-              type: :object,
-              properties: {
-                angledView: {"$ref": "#/components/schemas/MediaFile"},
-                angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                frontView: {"$ref": "#/components/schemas/MediaFile"},
-                frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                sideView: {"$ref": "#/components/schemas/MediaFile"},
-                sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                topView: {"$ref": "#/components/schemas/MediaFile"},
-                topViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"}
-              }
-            }
+            media: FleetchartViewMedia
           },
           required: %w[slug media]
         })

--- a/app/api_components/v1/schemas/models/fleetchart_view_media.rb
+++ b/app/api_components/v1/schemas/models/fleetchart_view_media.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      # The subset of ModelMedia a fleetchart draws with.
+      class FleetchartViewMedia
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            angledView: {"$ref": "#/components/schemas/MediaFile"},
+            angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            frontView: {"$ref": "#/components/schemas/MediaFile"},
+            frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            sideView: {"$ref": "#/components/schemas/MediaFile"},
+            sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            topView: {"$ref": "#/components/schemas/MediaFile"},
+            topViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
+            extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
+            extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/model.rb
+++ b/app/api_components/v1/schemas/models/model.rb
@@ -15,41 +15,14 @@ module V1
             name: {type: :string},
             slug: {type: :string},
 
-            availability: {
-              type: :object,
-              properties: {
-                boughtAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                },
-                soldAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                },
-                rentalAt: {
-                  type: :array,
-                  items: {"$ref": "#/components/schemas/ItemPrice"}
-                }
-              },
-              additionalProperties: false,
-              required: %w[boughtAt soldAt rentalAt]
-            },
+            availability: Shared::V1::Schemas::ModelAvailability,
 
             classification: {type: :string},
             classificationLabel: {type: :string},
 
             adiMap: {type: :boolean, default: false},
 
-            crew: {
-              type: :object,
-              properties: {
-                max: {type: :integer},
-                maxLabel: {type: :string},
-                min: {type: :integer},
-                minLabel: {type: :string}
-              },
-              additionalProperties: false
-            },
+            crew: Shared::V1::Schemas::ModelCrew,
 
             description: {type: :string},
             erkulIdentifier: {type: :string},
@@ -62,14 +35,7 @@ module V1
             lastUpdatedAt: {type: :string, format: "date-time"},
             lastUpdatedAtLabel: {type: :string},
 
-            links: {
-              type: :object,
-              properties: {
-                salesPageUrl: {type: :string},
-                storeUrl: {type: :string}
-              },
-              additionalProperties: false
-            },
+            links: Shared::V1::Schemas::ModelLinks,
 
             loaners: {
               type: :array,
@@ -78,104 +44,9 @@ module V1
 
             manufacturer: {"$ref": "#/components/schemas/Manufacturer"},
 
-            media: {
-              type: :object,
-              properties: {
-                angledView: {"$ref": "#/components/schemas/MediaFile"},
-                angledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                fleetchartImage: {type: :string},
-                extendedHolo: {"$ref": "#/components/schemas/MediaFile"},
-                extendedTopView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedTopViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedSideView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedSideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedFrontView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedFrontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                extendedAngledView: {"$ref": "#/components/schemas/MediaFile"},
-                extendedAngledViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                frontView: {"$ref": "#/components/schemas/MediaFile"},
-                frontViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                sideView: {"$ref": "#/components/schemas/MediaFile"},
-                sideViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                topView: {"$ref": "#/components/schemas/MediaFile"},
-                topViewColored: {"$ref": "#/components/schemas/MediaFile"},
-                holo: {"$ref": "#/components/schemas/MediaFile"},
-                brochure: {"$ref": "#/components/schemas/MediaFile"}
-              },
-              additionalProperties: false
-            },
+            media: Shared::V1::Schemas::ModelMedia,
 
-            metrics: {
-              type: :object,
-              properties: {
-                beam: {type: :number},
-                beamLabel: {type: :string},
-                cargo: {type: :number},
-                cargoLabel: {type: :string},
-                personalInventory: {type: :number},
-                personalInventoryLabel: {type: [:string, :null]},
-                fleetchartOffsetLength: {type: :number},
-                fleetchartOffsetBeam: {type: :number},
-                extendedLength: {type: :number},
-                extendedLengthLabel: {type: :string},
-                extendedBeam: {type: :number},
-                extendedBeamLabel: {type: :string},
-                extendedHeight: {type: :number},
-                extendedHeightLabel: {type: :string},
-                extendedFleetchartOffsetLength: {type: :number},
-                extendedFleetchartOffsetBeam: {type: :number},
-                height: {type: :number},
-                heightLabel: {type: :string},
-                hydrogenFuelTankSize: {type: :number},
-                isGroundVehicle: {type: :boolean},
-                length: {type: :number},
-                lengthLabel: {type: :string},
-                mass: {type: :number},
-                massLabel: {type: :string},
-                hullHealth: {type: :number},
-                hullParts: {
-                  type: :array,
-                  items: {
-                    type: :object,
-                    properties: {
-                      name: {type: :string},
-                      health: {type: :number},
-                      category: {"$ref": "#/components/schemas/ModelHullPartCategoryEnum"}
-                    },
-                    required: %w[name health category],
-                    additionalProperties: false
-                  }
-                },
-                hullDoors: {
-                  type: :array,
-                  items: {
-                    type: :object,
-                    properties: {
-                      name: {type: :string},
-                      health: {type: :number}
-                    },
-                    required: %w[name health],
-                    additionalProperties: false
-                  }
-                },
-                quantumFuelTankSize: {type: :number},
-                weaponPoolSize: {type: :number},
-                signatureCrossSection: {
-                  type: :object,
-                  properties: {
-                    x: {type: :number},
-                    y: {type: :number},
-                    z: {type: :number}
-                  },
-                  additionalProperties: false
-                },
-                size: {type: :string},
-                sizeLabel: {type: :string},
-                dockSize: {type: :string}
-              },
-              additionalProperties: false
-            },
+            metrics: Shared::V1::Schemas::ModelMetrics,
 
             cargoHolds: {type: :array, items: {"$ref": "#/components/schemas/CargoHold"}},
             hydrogenFuelTanks: {type: :array, items: {"$ref": "#/components/schemas/FuelTank"}},
@@ -195,26 +66,7 @@ module V1
             rsiName: {type: :string},
             rsiSlug: {type: :string},
 
-            speeds: {
-              type: :object,
-              properties: {
-                groundAcceleration: {type: :number},
-                groundDecceleration: {type: :number},
-                groundMaxSpeed: {type: :number},
-                groundReverseSpeed: {type: :number},
-                maxSpeed: {type: :number},
-                pitch: {type: :number},
-                pitchBoosted: {type: :number},
-                roll: {type: :number},
-                rollBoosted: {type: :number},
-                scmSpeed: {type: :number},
-                scmSpeedBoosted: {type: :number},
-                reverseSpeedBoosted: {type: :number},
-                yaw: {type: :number},
-                yawBoosted: {type: :number}
-              },
-              additionalProperties: false
-            },
+            speeds: Shared::V1::Schemas::ModelSpeeds,
 
             holo: {type: :string, deprecated: true},
             brochure: {type: :string, deprecated: true},

--- a/app/api_components/v1/schemas/models/model_extended.rb
+++ b/app/api_components/v1/schemas/models/model_extended.rb
@@ -12,13 +12,7 @@ module V1
               type: :array,
               items: {"$ref": "#/components/schemas/DockCount"}
             },
-            links: {
-              type: :object,
-              properties: {
-                self: {type: :string, format: :uri},
-                frontend: {type: :string, format: :uri}
-              }
-            }
+            links: Shared::V1::Schemas::ModelExtendedLinks
           },
           required: %w[dockCounts links]
         })

--- a/app/api_components/v1/schemas/models/module_packages/model_module_package.rb
+++ b/app/api_components/v1/schemas/models/module_packages/model_module_package.rb
@@ -17,16 +17,7 @@ module V1
 
               modules: {type: :array, items: {"$ref": "#/components/schemas/ModelModule"}},
 
-              media: {
-                type: :object,
-                properties: {
-                  angledView: {"$ref": "#/components/schemas/MediaFile"},
-                  sideView: {"$ref": "#/components/schemas/MediaFile"},
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                  topView: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              },
+              media: Shared::V1::Schemas::ModelModulePackageMedia,
 
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"},

--- a/app/api_components/v1/schemas/models/modules/model_module.rb
+++ b/app/api_components/v1/schemas/models/modules/model_module.rb
@@ -28,29 +28,9 @@ module V1
 
               cargoHolds: {type: :array, items: {"$ref": "#/components/schemas/CargoHold"}},
 
-              availability: {
-                type: :object,
-                properties: {
-                  boughtAt: {
-                    type: :array,
-                    items: {"$ref": "#/components/schemas/ItemPrice"}
-                  },
-                  soldAt: {
-                    type: :array,
-                    items: {"$ref": "#/components/schemas/ItemPrice"}
-                  }
-                },
-                additionalProperties: false,
-                required: %w[boughtAt soldAt]
-              },
+              availability: Shared::V1::Schemas::ItemAvailability,
 
-              media: {
-                type: :object,
-                properties: {
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              },
+              media: Shared::V1::Schemas::StoreImageMedia,
               pledgePrice: {type: :number},
               productionStatus: {type: :string},
 

--- a/app/api_components/v1/schemas/models/modules/model_module.rb
+++ b/app/api_components/v1/schemas/models/modules/model_module.rb
@@ -18,13 +18,7 @@ module V1
 
               scKey: {type: :string},
 
-              metrics: {
-                type: :object,
-                properties: {
-                  cargo: {type: :number}
-                },
-                additionalProperties: false
-              },
+              metrics: Shared::V1::Schemas::ModelModuleMetrics,
 
               cargoHolds: {type: :array, items: {"$ref": "#/components/schemas/CargoHold"}},
 

--- a/app/api_components/v1/schemas/models/options/model_option.rb
+++ b/app/api_components/v1/schemas/models/options/model_option.rb
@@ -27,13 +27,7 @@ module V1
               classificationLabel: {type: [:string, :null]},
               inHangar: {type: :boolean},
               onWishlist: {type: :boolean},
-              media: {
-                type: :object,
-                properties: {
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              }
+              media: Shared::V1::Schemas::StoreImageMedia
             },
             additionalProperties: false,
             required: %w[id name slug manufacturer classification classificationLabel inHangar onWishlist media]

--- a/app/api_components/v1/schemas/models/options/model_option.rb
+++ b/app/api_components/v1/schemas/models/options/model_option.rb
@@ -13,16 +13,7 @@ module V1
               id: {type: :string, format: :uuid},
               name: {type: :string},
               slug: {type: :string},
-              manufacturer: {
-                type: :object,
-                properties: {
-                  name: {type: [:string, :null]},
-                  slug: {type: [:string, :null]},
-                  code: {type: [:string, :null]}
-                },
-                additionalProperties: false,
-                required: %w[name slug code]
-              },
+              manufacturer: ModelOptionManufacturer,
               classification: {type: [:string, :null]},
               classificationLabel: {type: [:string, :null]},
               inHangar: {type: :boolean},

--- a/app/api_components/v1/schemas/models/options/model_option_manufacturer.rb
+++ b/app/api_components/v1/schemas/models/options/model_option_manufacturer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Options
+        class ModelOptionManufacturer
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              name: {type: [:string, :null]},
+              slug: {type: [:string, :null]},
+              code: {type: [:string, :null]}
+            },
+            additionalProperties: false,
+            required: %w[name slug code]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/paints/model_paint.rb
+++ b/app/api_components/v1/schemas/models/paints/model_paint.rb
@@ -17,21 +17,7 @@ module V1
               lastUpdatedAt: {type: :string, format: "date-time"},
               lastUpdatedAtLabel: {type: :string},
 
-              availability: {
-                type: :object,
-                properties: {
-                  boughtAt: {
-                    type: :array,
-                    items: {"$ref": "#/components/schemas/ItemPrice"}
-                  },
-                  soldAt: {
-                    type: :array,
-                    items: {"$ref": "#/components/schemas/ItemPrice"}
-                  }
-                },
-                additionalProperties: false,
-                required: %w[boughtAt soldAt]
-              },
+              availability: Shared::V1::Schemas::ItemAvailability,
 
               media: {
                 type: :object,

--- a/app/api_components/v1/schemas/models/paints/model_paint.rb
+++ b/app/api_components/v1/schemas/models/paints/model_paint.rb
@@ -19,18 +19,7 @@ module V1
 
               availability: Shared::V1::Schemas::ItemAvailability,
 
-              media: {
-                type: :object,
-                properties: {
-                  angledView: {"$ref": "#/components/schemas/MediaFile"},
-                  fleetchartImage: {type: :string},
-                  # frontView: {"$ref": "#/components/schemas/MediaFile"},
-                  sideView: {"$ref": "#/components/schemas/MediaFile"},
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"},
-                  topView: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              },
+              media: ModelPaintMedia,
 
               nameWithModel: {type: :string},
               rsiId: {type: :integer},

--- a/app/api_components/v1/schemas/models/paints/model_paint_media.rb
+++ b/app/api_components/v1/schemas/models/paints/model_paint_media.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Paints
+        class ModelPaintMedia
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              angledView: {"$ref": "#/components/schemas/MediaFile"},
+              fleetchartImage: {type: :string},
+              # frontView: {"$ref": "#/components/schemas/MediaFile"},
+              sideView: {"$ref": "#/components/schemas/MediaFile"},
+              storeImage: {"$ref": "#/components/schemas/MediaFile"},
+              topView: {"$ref": "#/components/schemas/MediaFile"}
+            },
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/upgrades/model_upgrade.rb
+++ b/app/api_components/v1/schemas/models/upgrades/model_upgrade.rb
@@ -15,13 +15,7 @@ module V1
               description: {type: :string},
               pledgePrice: {type: :number},
 
-              media: {
-                type: :object,
-                properties: {
-                  storeImage: {"$ref": "#/components/schemas/MediaFile"}
-                },
-                additionalProperties: false
-              },
+              media: Shared::V1::Schemas::StoreImageMedia,
 
               createdAt: {type: :string, format: "date-time"},
               updatedAt: {type: :string, format: "date-time"},

--- a/app/api_components/v1/schemas/support_contribution.rb
+++ b/app/api_components/v1/schemas/support_contribution.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SupportContribution
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          displayName: {type: :string},
+          username: {type: :string},
+          amountCents: {type: :integer},
+          currency: {type: :string},
+          recurring: {type: :boolean}
+        },
+        additionalProperties: false,
+        required: %w[displayName amountCents currency recurring]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/support_goal.rb
+++ b/app/api_components/v1/schemas/support_goal.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SupportGoal
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          amountCents: {type: :integer},
+          currency: {type: :string},
+          items: {
+            type: :array,
+            items: SupportGoalItem
+          }
+        },
+        additionalProperties: false,
+        required: %w[amountCents currency items]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/support_goal_item.rb
+++ b/app/api_components/v1/schemas/support_goal_item.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SupportGoalItem
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          title: {type: :string},
+          description: {type: :string},
+          amountCents: {type: :integer},
+          currency: {type: :string}
+        },
+        additionalProperties: false,
+        required: %w[title amountCents currency]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/support_monthly_total.rb
+++ b/app/api_components/v1/schemas/support_monthly_total.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class SupportMonthlyTotal
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          amountCents: {type: :integer},
+          currency: {type: :string}
+        },
+        additionalProperties: false,
+        required: %w[amountCents currency]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/support_progress.rb
+++ b/app/api_components/v1/schemas/support_progress.rb
@@ -8,52 +8,11 @@ module V1
       schema({
         type: :object,
         properties: {
-          goal: {
-            type: :object,
-            properties: {
-              amountCents: {type: :integer},
-              currency: {type: :string},
-              items: {
-                type: :array,
-                items: {
-                  type: :object,
-                  properties: {
-                    title: {type: :string},
-                    description: {type: :string},
-                    amountCents: {type: :integer},
-                    currency: {type: :string}
-                  },
-                  additionalProperties: false,
-                  required: %w[title amountCents currency]
-                }
-              }
-            },
-            additionalProperties: false,
-            required: %w[amountCents currency items]
-          },
-          monthlyTotal: {
-            type: :object,
-            properties: {
-              amountCents: {type: :integer},
-              currency: {type: :string}
-            },
-            additionalProperties: false,
-            required: %w[amountCents currency]
-          },
+          goal: SupportGoal,
+          monthlyTotal: SupportMonthlyTotal,
           contributions: {
             type: :array,
-            items: {
-              type: :object,
-              properties: {
-                displayName: {type: :string},
-                username: {type: :string},
-                amountCents: {type: :integer},
-                currency: {type: :string},
-                recurring: {type: :boolean}
-              },
-              additionalProperties: false,
-              required: %w[displayName amountCents currency recurring]
-            }
+            items: SupportContribution
           }
         },
         additionalProperties: false,

--- a/app/api_components/v1/schemas/user_feature.rb
+++ b/app/api_components/v1/schemas/user_feature.rb
@@ -18,15 +18,7 @@ module V1
           toggleable: {type: :boolean},
           fleets: {
             type: :array,
-            items: {
-              type: :object,
-              properties: {
-                name: {type: :string},
-                slug: {type: :string}
-              },
-              additionalProperties: false,
-              required: %w[name slug]
-            }
+            items: UserFeatureFleet
           },
           groups: {
             type: :array,

--- a/app/api_components/v1/schemas/user_feature_fleet.rb
+++ b/app/api_components/v1/schemas/user_feature_fleet.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class UserFeatureFleet
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          name: {type: :string},
+          slug: {type: :string}
+        },
+        additionalProperties: false,
+        required: %w[name slug]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle.rb
@@ -21,15 +21,7 @@ module V1
             hangarGroups: {type: :array, items: {"$ref": "#/components/schemas/HangarGroup"}},
             loaner: {type: :boolean},
             bundled: {type: :boolean},
-            bundledParent: {
-              type: :object,
-              properties: {
-                id: {type: :string, format: :uuid},
-                name: {type: :string},
-                slug: {type: :string},
-                customName: {type: :string}
-              }
-            },
+            bundledParent: VehicleBundledParent,
             model: {"$ref": "#/components/schemas/Model"},
             modelModuleIds: {type: :array, items: {type: :string, format: :uuid}},
             modelUpgradeIds: {type: :array, items: {type: :string, format: :uuid}},

--- a/app/api_components/v1/schemas/vehicles/vehicle_bundled_parent.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_bundled_parent.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      # The pledge a bundled snub craft came with.
+      class VehicleBundledParent
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            slug: {type: :string},
+            customName: {type: :string}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout.rb
@@ -16,15 +16,7 @@ module V1
             urlSource: {type: :string},
             hardpoints: {
               type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  id: {type: :string, format: :uuid},
-                  modelHardpointId: {type: :string, format: :uuid},
-                  hardpoint: {"$ref": "#/components/schemas/ModelHardpoint"},
-                  component: {"$ref": "#/components/schemas/Component"}
-                }
-              }
+              items: VehicleLoadoutHardpoint
             },
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}

--- a/app/api_components/v1/schemas/vehicles/vehicle_loadout_hardpoint.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_loadout_hardpoint.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Vehicles
+      class VehicleLoadoutHardpoint
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            modelHardpointId: {type: :string, format: :uuid},
+            hardpoint: {"$ref": "#/components/schemas/ModelHardpoint"},
+            component: {"$ref": "#/components/schemas/Component"}
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/vehicles/vehicle_public.rb
+++ b/app/api_components/v1/schemas/vehicles/vehicle_public.rb
@@ -17,15 +17,7 @@ module V1
             hangarGroups: {type: :array, items: {"$ref": "#/components/schemas/HangarGroupPublic"}},
             loaner: {type: :boolean},
             bundled: {type: :boolean},
-            bundledParent: {
-              type: :object,
-              properties: {
-                id: {type: :string, format: :uuid},
-                name: {type: :string},
-                slug: {type: :string},
-                customName: {type: :string}
-              }
-            },
+            bundledParent: VehicleBundledParent,
             model: {"$ref": "#/components/schemas/Model"},
             username: {type: :string},
             userAvatar: {type: :string, format: :uri},

--- a/app/frontend/frontend/components/Models/HullMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/HullMetrics/index.vue
@@ -7,18 +7,15 @@ export default {
 <script lang="ts" setup>
 import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vue";
 import MetricsCard from "@/frontend/components/Models/MetricsCard/index.vue";
-import type {
-  ModelMetricsHullPartsItem,
-  ModelMetricsHullDoorsItem,
-} from "@/services/fyApi";
+import type { ModelHullPart, ModelHullDoor } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useHullParts } from "@/frontend/composables/useHullParts";
 
 type Props = {
   hullHealth?: number;
-  hullParts?: ModelMetricsHullPartsItem[];
-  hullDoors?: ModelMetricsHullDoorsItem[];
+  hullParts?: ModelHullPart[];
+  hullDoors?: ModelHullDoor[];
 };
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/frontend/frontend/components/Models/HullPartsModal/index.vue
+++ b/app/frontend/frontend/components/Models/HullPartsModal/index.vue
@@ -7,10 +7,7 @@ export default {
 <script lang="ts" setup>
 import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import CompositionBar from "@/frontend/components/Models/CompositionBar/index.vue";
-import type {
-  ModelMetricsHullPartsItem,
-  ModelMetricsHullDoorsItem,
-} from "@/services/fyApi";
+import type { ModelHullPart, ModelHullDoor } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useHullParts,
@@ -20,8 +17,8 @@ import {
 
 type Props = {
   hullHealth?: number;
-  hullParts?: ModelMetricsHullPartsItem[];
-  hullDoors?: ModelMetricsHullDoorsItem[];
+  hullParts?: ModelHullPart[];
+  hullDoors?: ModelHullDoor[];
 };
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/frontend/frontend/composables/useHardpointStats.ts
+++ b/app/frontend/frontend/composables/useHardpointStats.ts
@@ -1,5 +1,6 @@
 import { computed, inject, toValue, type MaybeRefOrGetter } from "vue";
 import {
+  type ComponentWeaponDamage,
   HardpointCategoryEnum,
   type Hardpoint,
   type ComponentWeapon,
@@ -88,9 +89,9 @@ export const useHardpointStats = (
 
   const addDamageBreakdown = (
     result: HardpointStat[],
-    damage: Record<string, unknown>,
+    damage: ComponentWeaponDamage,
   ) => {
-    const types: [string, string][] = [
+    const types: [keyof ComponentWeaponDamage, string][] = [
       ["physical", "weapons.damagePhysical"],
       ["energy", "weapons.damageEnergy"],
       ["distortion", "weapons.damageDistortion"],

--- a/app/frontend/frontend/composables/useHullParts.ts
+++ b/app/frontend/frontend/composables/useHullParts.ts
@@ -1,5 +1,5 @@
 import { computed, toValue, type MaybeRefOrGetter } from "vue";
-import type { ModelMetricsHullPartsItem } from "@/services/fyApi";
+import type { ModelHullPart } from "@/services/fyApi";
 
 export const HULL_CATEGORY_ORDER = [
   "vital",
@@ -20,7 +20,7 @@ export const HULL_CATEGORY_COLORS: Record<string, string> = {
 export type HullPartGroup = {
   category: string;
   label: string;
-  parts: ModelMetricsHullPartsItem[];
+  parts: ModelHullPart[];
   total: number;
 };
 
@@ -32,7 +32,7 @@ export function humanizeHullPart(name: string) {
 }
 
 export function computeHullPartGroups(
-  parts: ModelMetricsHullPartsItem[] | undefined,
+  parts: ModelHullPart[] | undefined,
 ): HullPartGroup[] {
   return HULL_CATEGORY_ORDER.map((category) => {
     const grouped = (parts || [])
@@ -49,7 +49,7 @@ export function computeHullPartGroups(
 }
 
 export function useHullParts(
-  parts: MaybeRefOrGetter<ModelMetricsHullPartsItem[] | undefined>,
+  parts: MaybeRefOrGetter<ModelHullPart[] | undefined>,
 ) {
   const groups = computed(() => computeHullPartGroups(toValue(parts)));
 

--- a/app/frontend/frontend/composables/useLoadoutStats.ts
+++ b/app/frontend/frontend/composables/useLoadoutStats.ts
@@ -1,5 +1,6 @@
 import { computed, toValue, type MaybeRefOrGetter } from "vue";
 import {
+  type ComponentWeaponDamage,
   HardpointCategoryEnum,
   type Hardpoint,
   type ComponentWeapon,
@@ -49,7 +50,7 @@ function emptyBreakdown(): DamageBreakdown {
 
 function addBreakdown(
   target: DamageBreakdown,
-  damage: Partial<Record<string, number>> | undefined,
+  damage: ComponentWeaponDamage | undefined,
   multiplier: number,
 ) {
   if (!damage) return;

--- a/asyncapi/cable/admin/v1/schema.yaml
+++ b/asyncapi/cable/admin/v1/schema.yaml
@@ -158,27 +158,9 @@ components:
         importData:
           type: string
         adminUser:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-          required:
-          - id
-          - username
+          "$ref": "#/components/schemas/UserRefRequired"
         user:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-          required:
-          - id
-          - username
+          "$ref": "#/components/schemas/UserRefRequired"
         startedAt:
           type: string
           format: date-time
@@ -238,6 +220,17 @@ components:
       - IMPORTS_PAINTS_IMPORT
       - IMPORTS_UEX_PRICES_IMPORT
       - IMPORTS_UEX_COMMODITY_PRICES_IMPORT
+    UserRefRequired:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      required:
+      - id
+      - username
   messages:
     AdminNotification:
       payload:

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -316,29 +316,9 @@ components:
         maxContainerSize:
           "$ref": "#/components/schemas/CargoHoldContainerSize"
         limits:
-          type: object
-          properties:
-            min:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-            max:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-          additionalProperties: false
-          required:
-          - min
+          "$ref": "#/components/schemas/CargoHoldLimits"
         offset:
-          type: object
-          properties:
-            x:
-              type: number
-            "y":
-              type: number
-            z:
-              type: number
-          additionalProperties: false
-          required:
-          - x
-          - "y"
-          - z
+          "$ref": "#/components/schemas/CargoHoldOffset"
         rotation:
           type: integer
       additionalProperties: false
@@ -383,6 +363,30 @@ components:
       required:
       - dimensions
       - capacity
+    CargoHoldLimits:
+      type: object
+      properties:
+        min:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+        max:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+      additionalProperties: false
+      required:
+      - min
+    CargoHoldOffset:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+      required:
+      - x
+      - "y"
+      - z
     Component:
       type: object
       properties:
@@ -420,28 +424,11 @@ components:
         itemClassLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         typeData:
           anyOf:
           - "$ref": "#/components/schemas/ComponentQuantumDrive"
@@ -477,6 +464,16 @@ components:
       - media
       - createdAt
       - updatedAt
+    ComponentAngularVelocity:
+      type: object
+      properties:
+        pitch:
+          type: number
+        yaw:
+          type: number
+        roll:
+          type: number
+      additionalProperties: false
     ComponentArmor:
       type: object
       properties:
@@ -543,57 +540,15 @@ components:
         maxSpeed:
           type: number
         angularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         boostedAngularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -607,33 +562,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         signatureIr:
@@ -641,6 +570,30 @@ components:
       additionalProperties: false
       required:
       - coolingRate
+    ComponentDamageRange:
+      type: object
+      properties:
+        min:
+          type: number
+        max:
+          type: number
+      additionalProperties: false
+    ComponentDamageTypeMap:
+      type: object
+      properties:
+        physical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        energy:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        distortion:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        thermal:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        biochemical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        stun:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+      additionalProperties: false
     ComponentItemClassEnum:
       type: string
       enum:
@@ -669,6 +622,12 @@ components:
         fuelUsageEfficiencyMultiplier:
           type: number
       additionalProperties: false
+    ComponentPingProperties:
+      type: object
+      properties:
+        cooldownTime:
+          type: number
+      additionalProperties: false
     ComponentPowerPlant:
       type: object
       properties:
@@ -677,35 +636,27 @@ components:
         powerDraw:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
+      additionalProperties: false
+    ComponentPowerRangeEntry:
+      type: object
+      properties:
+        start:
+          type: number
+        modifier:
+          type: number
+      additionalProperties: false
+    ComponentPowerRanges:
+      type: object
+      properties:
+        low:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        medium:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        high:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
       additionalProperties: false
     ComponentQuantumDrive:
       type: object
@@ -751,33 +702,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -833,90 +758,28 @@ components:
       type: object
       properties:
         signatureDetection:
-          type: object
-          properties:
-            ir:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            em:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            cs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            rs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSignatureDetection"
         pingProperties:
-          type: object
-          properties:
-            cooldownTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPingProperties"
         aimAssistRange:
           type: number
         aimAssistMin:
           type: number
         sensitivityModifiers:
-          type: object
-          properties:
-            sensitivityAddition:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSensitivityModifiers"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
+          type: number
+      additionalProperties: false
+    ComponentSensitivityModifiers:
+      type: object
+      properties:
+        sensitivityAddition:
           type: number
       additionalProperties: false
     ComponentShield:
@@ -933,147 +796,41 @@ components:
         damagedRegenDelay:
           type: number
         resistance:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         absorption:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
       required:
       - maxHealth
       - maxRegen
+    ComponentSignatureDetection:
+      type: object
+      properties:
+        ir:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        em:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        cs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        rs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+      additionalProperties: false
+    ComponentSignatureSensitivity:
+      type: object
+      properties:
+        sensitivity:
+          type: number
+        piercing:
+          type: number
+      additionalProperties: false
     ComponentThruster:
       type: object
       properties:
@@ -1116,80 +873,62 @@ components:
         heatPerSecond:
           type: number
         rotation:
-          type: object
-          properties:
-            maxAngularVelocity:
-              type: number
-            degreesPerAction:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamRotation"
         movement:
-          type: object
-          properties:
-            maxSpeed:
-              type: number
-            maxAcceleration:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamMovement"
         cargoMode:
-          type: object
-          properties:
-            maxForce:
-              type: number
-            minDistance:
-              type: number
-            maxDistance:
-              type: number
-            fullStrengthDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamCargoMode"
         towing:
-          type: object
-          properties:
-            towingForce:
-              type: number
-            towingMaxDistance:
-              type: number
-            towingMaxAcceleration:
-              type: number
-            quantumTowMassLimit:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamTowing"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
       additionalProperties: false
       required:
       - tractorBeam
+    ComponentTractorBeamCargoMode:
+      type: object
+      properties:
+        maxForce:
+          type: number
+        minDistance:
+          type: number
+        maxDistance:
+          type: number
+        fullStrengthDistance:
+          type: number
+      additionalProperties: false
+    ComponentTractorBeamMovement:
+      type: object
+      properties:
+        maxSpeed:
+          type: number
+        maxAcceleration:
+          type: number
+      additionalProperties: false
+    ComponentTractorBeamRotation:
+      type: object
+      properties:
+        maxAngularVelocity:
+          type: number
+        degreesPerAction:
+          type: number
+      additionalProperties: false
+    ComponentTractorBeamTowing:
+      type: object
+      properties:
+        towingForce:
+          type: number
+        towingMaxDistance:
+          type: number
+        towingMaxAcceleration:
+          type: number
+        quantumTowMassLimit:
+          type: number
+      additionalProperties: false
     ComponentTypeEnum:
       type: string
       enum:
@@ -1352,67 +1091,13 @@ components:
         powerConsumption:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         damagePerShot:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         damagePerSecond:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         heatPerSecond:
           type: number
         pelletsPerShot:
@@ -1434,41 +1119,63 @@ components:
         overchargeTime:
           type: number
         regen:
-          type: object
-          properties:
-            maxAmmoLoad:
-              type: number
-            maxRegenPerSecond:
-              type: number
-            costPerBullet:
-              type: number
-            regenerationCooldown:
-              type: number
-            requestedRegenPerSecond:
-              type: number
-            requestedAmmoLoad:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponRegen"
         heat:
-          type: object
-          properties:
-            overheatTemperature:
-              type: number
-            coolingPerSecond:
-              type: number
-            timeTillCoolingStarts:
-              type: number
-            overheatFixTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponHeat"
         penetration:
-          type: object
-          properties:
-            maxThickness:
-              type: number
-            baseDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponPenetration"
+      additionalProperties: false
+    ComponentWeaponDamage:
+      type: object
+      properties:
+        physical:
+          type: number
+        energy:
+          type: number
+        distortion:
+          type: number
+        thermal:
+          type: number
+        biochemical:
+          type: number
+        stun:
+          type: number
+      additionalProperties: false
+    ComponentWeaponHeat:
+      type: object
+      properties:
+        overheatTemperature:
+          type: number
+        coolingPerSecond:
+          type: number
+        timeTillCoolingStarts:
+          type: number
+        overheatFixTime:
+          type: number
+      additionalProperties: false
+    ComponentWeaponPenetration:
+      type: object
+      properties:
+        maxThickness:
+          type: number
+        baseDistance:
+          type: number
+      additionalProperties: false
+    ComponentWeaponRegen:
+      type: object
+      properties:
+        maxAmmoLoad:
+          type: number
+        maxRegenPerSecond:
+          type: number
+        costPerBullet:
+          type: number
+        regenerationCooldown:
+          type: number
+        requestedRegenPerSecond:
+          type: number
+        requestedAmmoLoad:
+          type: number
       additionalProperties: false
     ExternalFuelTank:
       type: object
@@ -2152,6 +1859,21 @@ components:
       x-enumNames:
       - SHIP_MATRIX
       - GAME_FILES
+    ItemAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
     ItemPrice:
       type: object
       properties:
@@ -2314,25 +2036,7 @@ components:
         slug:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            rentalAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
-          - rentalAt
+          "$ref": "#/components/schemas/ModelAvailability"
         classification:
           type: string
         classificationLabel:
@@ -2341,17 +2045,7 @@ components:
           type: boolean
           default: false
         crew:
-          type: object
-          properties:
-            max:
-              type: integer
-            maxLabel:
-              type: string
-            min:
-              type: integer
-            minLabel:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelCrew"
         description:
           type: string
         erkulIdentifier:
@@ -2374,13 +2068,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         links:
-          type: object
-          properties:
-            salesPageUrl:
-              type: string
-            storeUrl:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelLinks"
         loaners:
           type: array
           items:
@@ -2388,156 +2076,9 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            extendedHolo:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            holo:
-              "$ref": "#/components/schemas/MediaFile"
-            brochure:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMedia"
         metrics:
-          type: object
-          properties:
-            beam:
-              type: number
-            beamLabel:
-              type: string
-            cargo:
-              type: number
-            cargoLabel:
-              type: string
-            personalInventory:
-              type: number
-            personalInventoryLabel:
-              type:
-              - string
-              - 'null'
-            fleetchartOffsetLength:
-              type: number
-            fleetchartOffsetBeam:
-              type: number
-            extendedLength:
-              type: number
-            extendedLengthLabel:
-              type: string
-            extendedBeam:
-              type: number
-            extendedBeamLabel:
-              type: string
-            extendedHeight:
-              type: number
-            extendedHeightLabel:
-              type: string
-            extendedFleetchartOffsetLength:
-              type: number
-            extendedFleetchartOffsetBeam:
-              type: number
-            height:
-              type: number
-            heightLabel:
-              type: string
-            hydrogenFuelTankSize:
-              type: number
-            isGroundVehicle:
-              type: boolean
-            length:
-              type: number
-            lengthLabel:
-              type: string
-            mass:
-              type: number
-            massLabel:
-              type: string
-            hullHealth:
-              type: number
-            hullParts:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                  category:
-                    "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
-                required:
-                - name
-                - health
-                - category
-                additionalProperties: false
-            hullDoors:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                required:
-                - name
-                - health
-                additionalProperties: false
-            quantumFuelTankSize:
-              type: number
-            weaponPoolSize:
-              type: number
-            signatureCrossSection:
-              type: object
-              properties:
-                x:
-                  type: number
-                "y":
-                  type: number
-                z:
-                  type: number
-              additionalProperties: false
-            size:
-              type: string
-            sizeLabel:
-              type: string
-            dockSize:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMetrics"
         cargoHolds:
           type: array
           items:
@@ -2579,37 +2120,7 @@ components:
         rsiSlug:
           type: string
         speeds:
-          type: object
-          properties:
-            groundAcceleration:
-              type: number
-            groundDecceleration:
-              type: number
-            groundMaxSpeed:
-              type: number
-            groundReverseSpeed:
-              type: number
-            maxSpeed:
-              type: number
-            pitch:
-              type: number
-            pitchBoosted:
-              type: number
-            roll:
-              type: number
-            rollBoosted:
-              type: number
-            scmSpeed:
-              type: number
-            scmSpeedBoosted:
-              type: number
-            reverseSpeedBoosted:
-              type: number
-            yaw:
-              type: number
-            yawBoosted:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelSpeeds"
         holo:
           type: string
           deprecated: true
@@ -2645,6 +2156,63 @@ components:
       - adiMap
       - createdAt
       - updatedAt
+    ModelAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        rentalAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
+      - rentalAt
+    ModelCrew:
+      type: object
+      properties:
+        max:
+          type: integer
+        maxLabel:
+          type: string
+        min:
+          type: integer
+        minLabel:
+          type: string
+      additionalProperties: false
+    ModelHullDoor:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+      required:
+      - name
+      - health
+      additionalProperties: false
+    ModelHullPart:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+        category:
+          "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
+      required:
+      - name
+      - health
+      - category
+      additionalProperties: false
     ModelHullPartCategoryEnum:
       type: string
       enum:
@@ -2659,6 +2227,14 @@ components:
       - BREAKABLE
       - SUBPART
       - COSMETIC
+    ModelLinks:
+      type: object
+      properties:
+        salesPageUrl:
+          type: string
+        storeUrl:
+          type: string
+      additionalProperties: false
     ModelLoaner:
       type: object
       properties:
@@ -2670,6 +2246,128 @@ components:
       required:
       - name
       - slug
+    ModelMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        extendedHolo:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        holo:
+          "$ref": "#/components/schemas/MediaFile"
+        brochure:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+    ModelMetrics:
+      type: object
+      properties:
+        beam:
+          type: number
+        beamLabel:
+          type: string
+        cargo:
+          type: number
+        cargoLabel:
+          type: string
+        personalInventory:
+          type: number
+        personalInventoryLabel:
+          type:
+          - string
+          - 'null'
+        fleetchartOffsetLength:
+          type: number
+        fleetchartOffsetBeam:
+          type: number
+        extendedLength:
+          type: number
+        extendedLengthLabel:
+          type: string
+        extendedBeam:
+          type: number
+        extendedBeamLabel:
+          type: string
+        extendedHeight:
+          type: number
+        extendedHeightLabel:
+          type: string
+        extendedFleetchartOffsetLength:
+          type: number
+        extendedFleetchartOffsetBeam:
+          type: number
+        height:
+          type: number
+        heightLabel:
+          type: string
+        hydrogenFuelTankSize:
+          type: number
+        isGroundVehicle:
+          type: boolean
+        length:
+          type: number
+        lengthLabel:
+          type: string
+        mass:
+          type: number
+        massLabel:
+          type: string
+        hullHealth:
+          type: number
+        hullParts:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullPart"
+        hullDoors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullDoor"
+        quantumFuelTankSize:
+          type: number
+        weaponPoolSize:
+          type: number
+        signatureCrossSection:
+          "$ref": "#/components/schemas/ModelSignatureCrossSection"
+        size:
+          type: string
+        sizeLabel:
+          type: string
+        dockSize:
+          type: string
+      additionalProperties: false
     ModelModule:
       type: object
       properties:
@@ -2687,36 +2385,15 @@ components:
         scKey:
           type: string
         metrics:
-          type: object
-          properties:
-            cargo:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModuleMetrics"
         cargoHolds:
           type: array
           items:
             "$ref": "#/components/schemas/CargoHold"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         pledgePrice:
           type: number
         productionStatus:
@@ -2746,6 +2423,12 @@ components:
       - media
       - createdAt
       - updatedAt
+    ModelModuleMetrics:
+      type: object
+      properties:
+        cargo:
+          type: number
+      additionalProperties: false
     ModelModulePackage:
       type: object
       properties:
@@ -2763,17 +2446,7 @@ components:
           items:
             "$ref": "#/components/schemas/ModelModule"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModulePackageMedia"
         createdAt:
           type: string
           format: date-time
@@ -2870,6 +2543,18 @@ components:
       - media
       - createdAt
       - updatedAt
+    ModelModulePackageMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
     ModelPaint:
       type: object
       properties:
@@ -2888,34 +2573,9 @@ components:
         lastUpdatedAtLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelPaintMedia"
         nameWithModel:
           type: string
         rsiId:
@@ -3039,6 +2699,20 @@ components:
       - media
       - createdAt
       - updatedAt
+    ModelPaintMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
     ModelProductionStatusEnum:
       type: string
       enum:
@@ -3049,6 +2723,48 @@ components:
       - IN_CONCEPT
       - IN_PRODUCTION
       - FLIGHT_READY
+    ModelSignatureCrossSection:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+    ModelSpeeds:
+      type: object
+      properties:
+        groundAcceleration:
+          type: number
+        groundDecceleration:
+          type: number
+        groundMaxSpeed:
+          type: number
+        groundReverseSpeed:
+          type: number
+        maxSpeed:
+          type: number
+        pitch:
+          type: number
+        pitchBoosted:
+          type: number
+        roll:
+          type: number
+        rollBoosted:
+          type: number
+        scmSpeed:
+          type: number
+        scmSpeedBoosted:
+          type: number
+        reverseSpeedBoosted:
+          type: number
+        yaw:
+          type: number
+        yawBoosted:
+          type: number
+      additionalProperties: false
     ModelUpgrade:
       type: object
       properties:
@@ -3062,11 +2778,7 @@ components:
         pledgePrice:
           type: number
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         createdAt:
           type: string
           format: date-time
@@ -3205,6 +2917,12 @@ components:
         quantumFuelFlowRate:
           type: number
       additionalProperties: false
+    StoreImageMedia:
+      type: object
+      properties:
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
     ThrusterClassEnum:
       type: string
       enum:
@@ -3253,17 +2971,7 @@ components:
         bundled:
           type: boolean
         bundledParent:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-            customName:
-              type: string
+          "$ref": "#/components/schemas/VehicleBundledParent"
         model:
           "$ref": "#/components/schemas/Model"
         modelModuleIds:
@@ -3316,6 +3024,18 @@ components:
       - modelModuleIds
       - createdAt
       - updatedAt
+    VehicleBundledParent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        customName:
+          type: string
     VehicleLoadoutMinimal:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8186,6 +8186,17 @@ components:
       - createdAt
       - updatedAt
       title: Component
+    ComponentAngularVelocity:
+      type: object
+      properties:
+        pitch:
+          type: number
+        yaw:
+          type: number
+        roll:
+          type: number
+      additionalProperties: false
+      title: ComponentAngularVelocity
     ComponentArmor:
       type: object
       properties:
@@ -8254,57 +8265,15 @@ components:
         maxSpeed:
           type: number
         angularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         boostedAngularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -8319,33 +8288,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         signatureIr:
@@ -8354,6 +8297,32 @@ components:
       required:
       - coolingRate
       title: ComponentCooler
+    ComponentDamageRange:
+      type: object
+      properties:
+        min:
+          type: number
+        max:
+          type: number
+      additionalProperties: false
+      title: ComponentDamageRange
+    ComponentDamageTypeMap:
+      type: object
+      properties:
+        physical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        energy:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        distortion:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        thermal:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        biochemical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        stun:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+      additionalProperties: false
+      title: ComponentDamageTypeMap
     ComponentInput:
       type: object
       properties:
@@ -8422,6 +8391,13 @@ components:
           type: number
       additionalProperties: false
       title: ComponentJumpDrive
+    ComponentPingProperties:
+      type: object
+      properties:
+        cooldownTime:
+          type: number
+      additionalProperties: false
+      title: ComponentPingProperties
     ComponentPowerPlant:
       type: object
       properties:
@@ -8430,37 +8406,31 @@ components:
         powerDraw:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
       title: ComponentPowerPlant
+    ComponentPowerRangeEntry:
+      type: object
+      properties:
+        start:
+          type: number
+        modifier:
+          type: number
+      additionalProperties: false
+      title: ComponentPowerRangeEntry
+    ComponentPowerRanges:
+      type: object
+      properties:
+        low:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        medium:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        high:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+      additionalProperties: false
+      title: ComponentPowerRanges
     ComponentQuantumDrive:
       type: object
       properties:
@@ -8505,33 +8475,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -8640,93 +8584,32 @@ components:
       type: object
       properties:
         signatureDetection:
-          type: object
-          properties:
-            ir:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            em:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            cs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            rs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSignatureDetection"
         pingProperties:
-          type: object
-          properties:
-            cooldownTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPingProperties"
         aimAssistRange:
           type: number
         aimAssistMin:
           type: number
         sensitivityModifiers:
-          type: object
-          properties:
-            sensitivityAddition:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSensitivityModifiers"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
       title: ComponentRadar
+    ComponentSensitivityModifiers:
+      type: object
+      properties:
+        sensitivityAddition:
+          type: number
+      additionalProperties: false
+      title: ComponentSensitivityModifiers
     ComponentShield:
       type: object
       properties:
@@ -8741,141 +8624,15 @@ components:
         damagedRegenDelay:
           type: number
         resistance:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         absorption:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -8883,6 +8640,28 @@ components:
       - maxHealth
       - maxRegen
       title: ComponentShield
+    ComponentSignatureDetection:
+      type: object
+      properties:
+        ir:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        em:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        cs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        rs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+      additionalProperties: false
+      title: ComponentSignatureDetection
+    ComponentSignatureSensitivity:
+      type: object
+      properties:
+        sensitivity:
+          type: number
+        piercing:
+          type: number
+      additionalProperties: false
+      title: ComponentSignatureSensitivity
     ComponentSortEnum:
       type: string
       enum:
@@ -8939,81 +8718,67 @@ components:
         heatPerSecond:
           type: number
         rotation:
-          type: object
-          properties:
-            maxAngularVelocity:
-              type: number
-            degreesPerAction:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamRotation"
         movement:
-          type: object
-          properties:
-            maxSpeed:
-              type: number
-            maxAcceleration:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamMovement"
         cargoMode:
-          type: object
-          properties:
-            maxForce:
-              type: number
-            minDistance:
-              type: number
-            maxDistance:
-              type: number
-            fullStrengthDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamCargoMode"
         towing:
-          type: object
-          properties:
-            towingForce:
-              type: number
-            towingMaxDistance:
-              type: number
-            towingMaxAcceleration:
-              type: number
-            quantumTowMassLimit:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamTowing"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
       additionalProperties: false
       required:
       - tractorBeam
       title: ComponentTractorBeam
+    ComponentTractorBeamCargoMode:
+      type: object
+      properties:
+        maxForce:
+          type: number
+        minDistance:
+          type: number
+        maxDistance:
+          type: number
+        fullStrengthDistance:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamCargoMode
+    ComponentTractorBeamMovement:
+      type: object
+      properties:
+        maxSpeed:
+          type: number
+        maxAcceleration:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamMovement
+    ComponentTractorBeamRotation:
+      type: object
+      properties:
+        maxAngularVelocity:
+          type: number
+        degreesPerAction:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamRotation
+    ComponentTractorBeamTowing:
+      type: object
+      properties:
+        towingForce:
+          type: number
+        towingMaxDistance:
+          type: number
+        towingMaxAcceleration:
+          type: number
+        quantumTowMassLimit:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamTowing
     ComponentTypeEnum:
       type: string
       enum:
@@ -9177,67 +8942,13 @@ components:
         powerConsumption:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         damagePerShot:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         damagePerSecond:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         heatPerSecond:
           type: number
         pelletsPerShot:
@@ -9259,43 +8970,69 @@ components:
         overchargeTime:
           type: number
         regen:
-          type: object
-          properties:
-            maxAmmoLoad:
-              type: number
-            maxRegenPerSecond:
-              type: number
-            costPerBullet:
-              type: number
-            regenerationCooldown:
-              type: number
-            requestedRegenPerSecond:
-              type: number
-            requestedAmmoLoad:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponRegen"
         heat:
-          type: object
-          properties:
-            overheatTemperature:
-              type: number
-            coolingPerSecond:
-              type: number
-            timeTillCoolingStarts:
-              type: number
-            overheatFixTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponHeat"
         penetration:
-          type: object
-          properties:
-            maxThickness:
-              type: number
-            baseDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponPenetration"
       additionalProperties: false
       title: ComponentWeapon
+    ComponentWeaponDamage:
+      type: object
+      properties:
+        physical:
+          type: number
+        energy:
+          type: number
+        distortion:
+          type: number
+        thermal:
+          type: number
+        biochemical:
+          type: number
+        stun:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponDamage
+    ComponentWeaponHeat:
+      type: object
+      properties:
+        overheatTemperature:
+          type: number
+        coolingPerSecond:
+          type: number
+        timeTillCoolingStarts:
+          type: number
+        overheatFixTime:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponHeat
+    ComponentWeaponPenetration:
+      type: object
+      properties:
+        maxThickness:
+          type: number
+        baseDistance:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponPenetration
+    ComponentWeaponRegen:
+      type: object
+      properties:
+        maxAmmoLoad:
+          type: number
+        maxRegenPerSecond:
+          type: number
+        costPerBullet:
+          type: number
+        regenerationCooldown:
+          type: number
+        requestedRegenPerSecond:
+          type: number
+        requestedAmmoLoad:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponRegen
     Components:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7344,6 +7344,53 @@ components:
       - name
       - permanent
       title: AdminFleetRole
+    AdminModelMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        extendedHolo:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        holo:
+          "$ref": "#/components/schemas/MediaFile"
+        brochure:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: AdminModelMedia
     AdminNotification:
       type: object
       properties:
@@ -7929,20 +7976,7 @@ components:
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         createdAt:
           type: string
           format: date-time
@@ -8120,28 +8154,11 @@ components:
         itemClassLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         typeData:
           anyOf:
           - "$ref": "#/components/schemas/ComponentQuantumDrive"
@@ -9386,20 +9403,7 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         retired:
@@ -10980,6 +10984,22 @@ components:
       - id
       - name
       title: InventoryVehicle
+    ItemAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
+      title: ItemAvailability
     ItemPrice:
       type: object
       properties:
@@ -11359,25 +11379,7 @@ components:
         slug:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            rentalAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
-          - rentalAt
+          "$ref": "#/components/schemas/ModelAvailability"
         classification:
           type: string
         classificationLabel:
@@ -11386,17 +11388,7 @@ components:
           type: boolean
           default: false
         crew:
-          type: object
-          properties:
-            max:
-              type: integer
-            maxLabel:
-              type: string
-            min:
-              type: integer
-            minLabel:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelCrew"
         description:
           type: string
         erkulIdentifier:
@@ -11419,13 +11411,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         links:
-          type: object
-          properties:
-            salesPageUrl:
-              type: string
-            storeUrl:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelLinks"
         loaners:
           type: array
           items:
@@ -11433,158 +11419,9 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            extendedHolo:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            holo:
-              "$ref": "#/components/schemas/MediaFile"
-            brochure:
-              "$ref": "#/components/schemas/MediaFile"
-            rsiStoreImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/AdminModelMedia"
         metrics:
-          type: object
-          properties:
-            beam:
-              type: number
-            beamLabel:
-              type: string
-            cargo:
-              type: number
-            cargoLabel:
-              type: string
-            personalInventory:
-              type: number
-            personalInventoryLabel:
-              type:
-              - string
-              - 'null'
-            fleetchartOffsetLength:
-              type: number
-            fleetchartOffsetBeam:
-              type: number
-            extendedLength:
-              type: number
-            extendedLengthLabel:
-              type: string
-            extendedBeam:
-              type: number
-            extendedBeamLabel:
-              type: string
-            extendedHeight:
-              type: number
-            extendedHeightLabel:
-              type: string
-            extendedFleetchartOffsetLength:
-              type: number
-            extendedFleetchartOffsetBeam:
-              type: number
-            height:
-              type: number
-            heightLabel:
-              type: string
-            hydrogenFuelTankSize:
-              type: number
-            isGroundVehicle:
-              type: boolean
-            length:
-              type: number
-            lengthLabel:
-              type: string
-            mass:
-              type: number
-            massLabel:
-              type: string
-            hullHealth:
-              type: number
-            hullParts:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                  category:
-                    "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
-                required:
-                - name
-                - health
-                - category
-                additionalProperties: false
-            hullDoors:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                required:
-                - name
-                - health
-                additionalProperties: false
-            quantumFuelTankSize:
-              type: number
-            weaponPoolSize:
-              type: number
-            signatureCrossSection:
-              type: object
-              properties:
-                x:
-                  type: number
-                "y":
-                  type: number
-                z:
-                  type: number
-              additionalProperties: false
-            size:
-              type: string
-            sizeLabel:
-              type: string
-            dockSize:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMetrics"
         cargoHolds:
           type: array
           items:
@@ -11626,37 +11463,7 @@ components:
         rsiSlug:
           type: string
         speeds:
-          type: object
-          properties:
-            groundAcceleration:
-              type: number
-            groundDecceleration:
-              type: number
-            groundMaxSpeed:
-              type: number
-            groundReverseSpeed:
-              type: number
-            maxSpeed:
-              type: number
-            pitch:
-              type: number
-            pitchBoosted:
-              type: number
-            roll:
-              type: number
-            rollBoosted:
-              type: number
-            scmSpeed:
-              type: number
-            scmSpeedBoosted:
-              type: number
-            reverseSpeedBoosted:
-              type: number
-            yaw:
-              type: number
-            yawBoosted:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelSpeeds"
         holo:
           type: string
           deprecated: true
@@ -11709,6 +11516,27 @@ components:
       - hidden
       - active
       title: Model
+    ModelAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        rentalAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
+      - rentalAt
+      title: ModelAvailability
     ModelCreateInput:
       type: object
       properties:
@@ -11809,6 +11637,19 @@ components:
       - name
       - manufacturerId
       title: ModelCreateInput
+    ModelCrew:
+      type: object
+      properties:
+        max:
+          type: integer
+        maxLabel:
+          type: string
+        min:
+          type: integer
+        minLabel:
+          type: string
+      additionalProperties: false
+      title: ModelCrew
     ModelExtended:
       type: object
       properties:
@@ -11824,25 +11665,7 @@ components:
         slug:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            rentalAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
-          - rentalAt
+          "$ref": "#/components/schemas/ModelAvailability"
         classification:
           type: string
         classificationLabel:
@@ -11851,17 +11674,7 @@ components:
           type: boolean
           default: false
         crew:
-          type: object
-          properties:
-            max:
-              type: integer
-            maxLabel:
-              type: string
-            min:
-              type: integer
-            minLabel:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelCrew"
         description:
           type: string
         erkulIdentifier:
@@ -11884,19 +11697,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         links:
-          type: object
-          properties:
-            salesPageUrl:
-              type: string
-            storeUrl:
-              type: string
-            self:
-              type: string
-              format: uri
-            frontend:
-              type: string
-              format: uri
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelExtendedLinks"
         loaners:
           type: array
           items:
@@ -11904,158 +11705,9 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            extendedHolo:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            holo:
-              "$ref": "#/components/schemas/MediaFile"
-            brochure:
-              "$ref": "#/components/schemas/MediaFile"
-            rsiStoreImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/AdminModelMedia"
         metrics:
-          type: object
-          properties:
-            beam:
-              type: number
-            beamLabel:
-              type: string
-            cargo:
-              type: number
-            cargoLabel:
-              type: string
-            personalInventory:
-              type: number
-            personalInventoryLabel:
-              type:
-              - string
-              - 'null'
-            fleetchartOffsetLength:
-              type: number
-            fleetchartOffsetBeam:
-              type: number
-            extendedLength:
-              type: number
-            extendedLengthLabel:
-              type: string
-            extendedBeam:
-              type: number
-            extendedBeamLabel:
-              type: string
-            extendedHeight:
-              type: number
-            extendedHeightLabel:
-              type: string
-            extendedFleetchartOffsetLength:
-              type: number
-            extendedFleetchartOffsetBeam:
-              type: number
-            height:
-              type: number
-            heightLabel:
-              type: string
-            hydrogenFuelTankSize:
-              type: number
-            isGroundVehicle:
-              type: boolean
-            length:
-              type: number
-            lengthLabel:
-              type: string
-            mass:
-              type: number
-            massLabel:
-              type: string
-            hullHealth:
-              type: number
-            hullParts:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                  category:
-                    "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
-                required:
-                - name
-                - health
-                - category
-                additionalProperties: false
-            hullDoors:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                required:
-                - name
-                - health
-                additionalProperties: false
-            quantumFuelTankSize:
-              type: number
-            weaponPoolSize:
-              type: number
-            signatureCrossSection:
-              type: object
-              properties:
-                x:
-                  type: number
-                "y":
-                  type: number
-                z:
-                  type: number
-              additionalProperties: false
-            size:
-              type: string
-            sizeLabel:
-              type: string
-            dockSize:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMetrics"
         cargoHolds:
           type: array
           items:
@@ -12097,37 +11749,7 @@ components:
         rsiSlug:
           type: string
         speeds:
-          type: object
-          properties:
-            groundAcceleration:
-              type: number
-            groundDecceleration:
-              type: number
-            groundMaxSpeed:
-              type: number
-            groundReverseSpeed:
-              type: number
-            maxSpeed:
-              type: number
-            pitch:
-              type: number
-            pitchBoosted:
-              type: number
-            roll:
-              type: number
-            rollBoosted:
-              type: number
-            scmSpeed:
-              type: number
-            scmSpeedBoosted:
-              type: number
-            reverseSpeedBoosted:
-              type: number
-            yaw:
-              type: number
-            yawBoosted:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelSpeeds"
         holo:
           type: string
           deprecated: true
@@ -12189,6 +11811,21 @@ components:
       - dockCounts
       - links
       title: ModelExtended
+    ModelExtendedLinks:
+      type: object
+      properties:
+        salesPageUrl:
+          type: string
+        storeUrl:
+          type: string
+        self:
+          type: string
+          format: uri
+        frontend:
+          type: string
+          format: uri
+      additionalProperties: false
+      title: ModelExtendedLinks
     ModelHardpoint:
       type: object
       properties:
@@ -12559,6 +12196,33 @@ components:
       - meta
       - items
       title: ModelHardpoints
+    ModelHullDoor:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+      required:
+      - name
+      - health
+      additionalProperties: false
+      title: ModelHullDoor
+    ModelHullPart:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+        category:
+          "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
+      required:
+      - name
+      - health
+      - category
+      additionalProperties: false
+      title: ModelHullPart
     ModelHullPartCategoryEnum:
       type: string
       enum:
@@ -12583,6 +12247,15 @@ components:
       required:
       - modelId
       title: ModelLinkInput
+    ModelLinks:
+      type: object
+      properties:
+        salesPageUrl:
+          type: string
+        storeUrl:
+          type: string
+      additionalProperties: false
+      title: ModelLinks
     ModelLoaner:
       type: object
       properties:
@@ -12683,6 +12356,130 @@ components:
       - meta
       - items
       title: ModelLoaners
+    ModelMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        extendedHolo:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        holo:
+          "$ref": "#/components/schemas/MediaFile"
+        brochure:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: ModelMedia
+    ModelMetrics:
+      type: object
+      properties:
+        beam:
+          type: number
+        beamLabel:
+          type: string
+        cargo:
+          type: number
+        cargoLabel:
+          type: string
+        personalInventory:
+          type: number
+        personalInventoryLabel:
+          type:
+          - string
+          - 'null'
+        fleetchartOffsetLength:
+          type: number
+        fleetchartOffsetBeam:
+          type: number
+        extendedLength:
+          type: number
+        extendedLengthLabel:
+          type: string
+        extendedBeam:
+          type: number
+        extendedBeamLabel:
+          type: string
+        extendedHeight:
+          type: number
+        extendedHeightLabel:
+          type: string
+        extendedFleetchartOffsetLength:
+          type: number
+        extendedFleetchartOffsetBeam:
+          type: number
+        height:
+          type: number
+        heightLabel:
+          type: string
+        hydrogenFuelTankSize:
+          type: number
+        isGroundVehicle:
+          type: boolean
+        length:
+          type: number
+        lengthLabel:
+          type: string
+        mass:
+          type: number
+        massLabel:
+          type: string
+        hullHealth:
+          type: number
+        hullParts:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullPart"
+        hullDoors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullDoor"
+        quantumFuelTankSize:
+          type: number
+        weaponPoolSize:
+          type: number
+        signatureCrossSection:
+          "$ref": "#/components/schemas/ModelSignatureCrossSection"
+        size:
+          type: string
+        sizeLabel:
+          type: string
+        dockSize:
+          type: string
+      additionalProperties: false
+      title: ModelMetrics
     ModelModule:
       type: object
       properties:
@@ -12710,26 +12507,9 @@ components:
           items:
             "$ref": "#/components/schemas/CargoHold"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         pledgePrice:
           type: number
         productionStatus:
@@ -13135,20 +12915,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
           type: object
           properties:
@@ -13588,6 +13355,17 @@ components:
       additionalProperties: false
       example: {}
       title: ModelQuery
+    ModelSignatureCrossSection:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+      title: ModelSignatureCrossSection
     ModelSnubCraft:
       type: object
       properties:
@@ -13748,6 +13526,39 @@ components:
       - RSI_ID_ASC
       - RSI_ID_DESC
       title: ModelSortEnum
+    ModelSpeeds:
+      type: object
+      properties:
+        groundAcceleration:
+          type: number
+        groundDecceleration:
+          type: number
+        groundMaxSpeed:
+          type: number
+        groundReverseSpeed:
+          type: number
+        maxSpeed:
+          type: number
+        pitch:
+          type: number
+        pitchBoosted:
+          type: number
+        roll:
+          type: number
+        rollBoosted:
+          type: number
+        scmSpeed:
+          type: number
+        scmSpeedBoosted:
+          type: number
+        reverseSpeedBoosted:
+          type: number
+        yaw:
+          type: number
+        yawBoosted:
+          type: number
+      additionalProperties: false
+      title: ModelSpeeds
     ModelUpdateInput:
       type: object
       properties:
@@ -14620,6 +14431,13 @@ components:
       - usersCountTotal
       - fleetsCountTotal
       title: Stats
+    StoreImageMedia:
+      type: object
+      properties:
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: StoreImageMedia
     SupporterContribution:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7194,18 +7194,7 @@ components:
         rotation:
           type: integer
         parent:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-          required:
-          - id
-          - name
+          "$ref": "#/components/schemas/AdminCargoHoldParent"
         createdAt:
           type: string
           format: date-time
@@ -7224,6 +7213,20 @@ components:
       - createdAt
       - updatedAt
       title: AdminCargoHold
+    AdminCargoHoldParent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+      required:
+      - id
+      - name
+      title: AdminCargoHoldParent
     AdminCargoHolds:
       type: object
       properties:
@@ -7389,8 +7392,57 @@ components:
           "$ref": "#/components/schemas/MediaFile"
         brochure:
           "$ref": "#/components/schemas/MediaFile"
+        rsiStoreImage:
+          "$ref": "#/components/schemas/MediaFile"
       additionalProperties: false
       title: AdminModelMedia
+    AdminModelModuleHardpoint:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        modelId:
+          type: string
+          format: uuid
+        slot:
+          type: string
+      additionalProperties: false
+      title: AdminModelModuleHardpoint
+    AdminModelPaintMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        rsiStoreImage:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: AdminModelPaintMedia
+    AdminModelUpgradeMedia:
+      type: object
+      properties:
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: AdminModelUpgradeMedia
     AdminNotification:
       type: object
       properties:
@@ -7781,29 +7833,9 @@ components:
         maxContainerSize:
           "$ref": "#/components/schemas/CargoHoldContainerSize"
         limits:
-          type: object
-          properties:
-            min:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-            max:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-          additionalProperties: false
-          required:
-          - min
+          "$ref": "#/components/schemas/CargoHoldLimits"
         offset:
-          type: object
-          properties:
-            x:
-              type: number
-            "y":
-              type: number
-            z:
-              type: number
-          additionalProperties: false
-          required:
-          - x
-          - "y"
-          - z
+          "$ref": "#/components/schemas/CargoHoldOffset"
         rotation:
           type: integer
       additionalProperties: false
@@ -7873,6 +7905,32 @@ components:
       - dimensions
       - capacity
       title: CargoHoldLimit
+    CargoHoldLimits:
+      type: object
+      properties:
+        min:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+        max:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+      additionalProperties: false
+      required:
+      - min
+      title: CargoHoldLimits
+    CargoHoldOffset:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+      required:
+      - x
+      - "y"
+      - z
+      title: CargoHoldOffset
     CargoHoldQuery:
       type: object
       properties:
@@ -10715,27 +10773,9 @@ components:
         importData:
           type: string
         adminUser:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-          required:
-          - id
-          - username
+          "$ref": "#/components/schemas/UserRefRequired"
         user:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-          required:
-          - id
-          - username
+          "$ref": "#/components/schemas/UserRefRequired"
         startedAt:
           type: string
           format: date-time
@@ -10872,6 +10912,21 @@ components:
       - DEPOSIT
       - WITHDRAWAL
       title: InventoryEntryTypeEnum
+    InventoryItemRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          "$ref": "#/components/schemas/InventoryItemTypeEnum"
+        name:
+          type: string
+        slug:
+          type: string
+        available:
+          type: boolean
+      title: InventoryItemRef
     InventoryItemTypeEnum:
       type: string
       enum:
@@ -10883,6 +10938,14 @@ components:
       - COMPONENT
       - EQUIPMENT
       title: InventoryItemTypeEnum
+    InventoryRef:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+      title: InventoryRef
     InventoryStockPosition:
       type: object
       properties:
@@ -10930,12 +10993,7 @@ components:
             available:
               type: boolean
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
       additionalProperties: false
       required:
       - slug
@@ -10969,21 +11027,24 @@ components:
           - string
           - 'null'
         model:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
-            cargo:
-              type: number
-            personalInventory:
-              type: number
+          "$ref": "#/components/schemas/InventoryVehicleModel"
       additionalProperties: false
       required:
       - id
       - name
       title: InventoryVehicle
+    InventoryVehicleModel:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        cargo:
+          type: number
+        personalInventory:
+          type: number
+      title: InventoryVehicleModel
     ItemAvailability:
       type: object
       properties:
@@ -12271,33 +12332,9 @@ components:
         hidden:
           type: boolean
         model:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ModelRef"
         loanerModel:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ModelRef"
         createdAt:
           type: string
           format: date-time
@@ -12497,11 +12534,7 @@ components:
         scKey:
           type: string
         metrics:
-          type: object
-          properties:
-            cargo:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModuleMetrics"
         cargoHolds:
           type: array
           items:
@@ -12543,17 +12576,7 @@ components:
         moduleHardpoints:
           type: array
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                format: uuid
-              modelId:
-                type: string
-                format: uuid
-              slot:
-                type: string
-            additionalProperties: false
+            "$ref": "#/components/schemas/AdminModelModuleHardpoint"
       additionalProperties: false
       required:
       - id
@@ -12617,6 +12640,13 @@ components:
           - 'null'
       additionalProperties: false
       title: ModelModuleInput
+    ModelModuleMetrics:
+      type: object
+      properties:
+        cargo:
+          type: number
+      additionalProperties: false
+      title: ModelModuleMetrics
     ModelModulePackage:
       type: object
       properties:
@@ -12640,17 +12670,7 @@ components:
         model:
           "$ref": "#/components/schemas/Model"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModulePackageMedia"
         createdAt:
           type: string
           format: date-time
@@ -12793,6 +12813,19 @@ components:
             format: uuid
       additionalProperties: false
       title: ModelModulePackageInput
+    ModelModulePackageMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: ModelModulePackageMedia
     ModelModulePackageQuery:
       type: object
       properties:
@@ -12917,31 +12950,7 @@ components:
         availability:
           "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            rsiStoreImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/AdminModelPaintMedia"
         nameWithModel:
           type: string
         rsiId:
@@ -13355,6 +13364,21 @@ components:
       additionalProperties: false
       example: {}
       title: ModelQuery
+    ModelRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+      required:
+      - id
+      - name
+      - slug
+      title: ModelRef
     ModelSignatureCrossSection:
       type: object
       properties:
@@ -13379,33 +13403,9 @@ components:
           type: string
           format: uuid
         model:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ModelRef"
         snubCraft:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-          required:
-          - id
-          - name
-          - slug
+          "$ref": "#/components/schemas/ModelRef"
         createdAt:
           type: string
           format: date-time
@@ -13859,11 +13859,7 @@ components:
         pledgePrice:
           type: number
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/AdminModelUpgradeMedia"
         createdAt:
           type: string
           format: date-time
@@ -14528,30 +14524,33 @@ components:
         items:
           type: array
           items:
-            type: object
-            properties:
-              label:
-                type: string
-              tooltip:
-                type: string
-              amountCents:
-                type: integer
-              goalAmountCents:
-                type: integer
-              count:
-                type: integer
-            additionalProperties: false
-            required:
-            - label
-            - tooltip
-            - amountCents
-            - goalAmountCents
-            - count
+            "$ref": "#/components/schemas/SupporterContributionMonthlyStatsItem"
       additionalProperties: false
       required:
       - currency
       - items
       title: SupporterContributionMonthlyStats
+    SupporterContributionMonthlyStatsItem:
+      type: object
+      properties:
+        label:
+          type: string
+        tooltip:
+          type: string
+        amountCents:
+          type: integer
+        goalAmountCents:
+          type: integer
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - label
+      - tooltip
+      - amountCents
+      - goalAmountCents
+      - count
+      title: SupporterContributionMonthlyStatsItem
     SupporterContributionQuery:
       type: object
       properties:
@@ -14858,6 +14857,27 @@ components:
       additionalProperties: false
       example: {}
       title: UserQuery
+    UserRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      title: UserRef
+    UserRefRequired:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      required:
+      - id
+      - username
+      title: UserRefRequired
     UserResourceAccessEnum:
       type: string
       enum: []
@@ -15291,6 +15311,19 @@ components:
       items:
         "$ref": "#/components/schemas/WeaponIndexItem"
       title: WeaponIndex
+    WeaponIndexDamage:
+      type: object
+      properties:
+        physical:
+          type: number
+        energy:
+          type: number
+        distortion:
+          type: number
+        thermal:
+          type: number
+      additionalProperties: false
+      title: WeaponIndexDamage
     WeaponIndexItem:
       type: object
       properties:
@@ -15312,17 +15345,7 @@ components:
         pelletsPerShot:
           type: integer
         damagePerShot:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/WeaponIndexDamage"
       additionalProperties: false
       required:
       - id

--- a/swagger/oauth/v1/schema.yaml
+++ b/swagger/oauth/v1/schema.yaml
@@ -208,15 +208,7 @@ components:
         scopes:
           type: array
           items:
-            type: object
-            properties:
-              name:
-                type: string
-              description:
-                type: string
-            required:
-            - name
-            - description
+            "$ref": "#/components/schemas/OauthScope"
       additionalProperties: false
       required:
       - clientId
@@ -226,6 +218,17 @@ components:
       - scope
       - scopes
       title: OauthPreAuthorization
+    OauthScope:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+      required:
+      - name
+      - description
+      title: OauthScope
     StandardError:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10963,20 +10963,7 @@ components:
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         createdAt:
           type: string
           format: date-time
@@ -11106,28 +11093,11 @@ components:
         itemClassLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         typeData:
           anyOf:
           - "$ref": "#/components/schemas/ComponentQuantumDrive"
@@ -12220,20 +12190,7 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         retired:
@@ -16589,6 +16546,22 @@ components:
       - id
       - name
       title: InventoryVehicle
+    ItemAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
+      title: ItemAvailability
     ItemPrice:
       type: object
       properties:
@@ -17314,25 +17287,7 @@ components:
         slug:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            rentalAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
-          - rentalAt
+          "$ref": "#/components/schemas/ModelAvailability"
         classification:
           type: string
         classificationLabel:
@@ -17341,17 +17296,7 @@ components:
           type: boolean
           default: false
         crew:
-          type: object
-          properties:
-            max:
-              type: integer
-            maxLabel:
-              type: string
-            min:
-              type: integer
-            minLabel:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelCrew"
         description:
           type: string
         erkulIdentifier:
@@ -17374,13 +17319,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         links:
-          type: object
-          properties:
-            salesPageUrl:
-              type: string
-            storeUrl:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelLinks"
         loaners:
           type: array
           items:
@@ -17388,156 +17327,9 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            extendedHolo:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            holo:
-              "$ref": "#/components/schemas/MediaFile"
-            brochure:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMedia"
         metrics:
-          type: object
-          properties:
-            beam:
-              type: number
-            beamLabel:
-              type: string
-            cargo:
-              type: number
-            cargoLabel:
-              type: string
-            personalInventory:
-              type: number
-            personalInventoryLabel:
-              type:
-              - string
-              - 'null'
-            fleetchartOffsetLength:
-              type: number
-            fleetchartOffsetBeam:
-              type: number
-            extendedLength:
-              type: number
-            extendedLengthLabel:
-              type: string
-            extendedBeam:
-              type: number
-            extendedBeamLabel:
-              type: string
-            extendedHeight:
-              type: number
-            extendedHeightLabel:
-              type: string
-            extendedFleetchartOffsetLength:
-              type: number
-            extendedFleetchartOffsetBeam:
-              type: number
-            height:
-              type: number
-            heightLabel:
-              type: string
-            hydrogenFuelTankSize:
-              type: number
-            isGroundVehicle:
-              type: boolean
-            length:
-              type: number
-            lengthLabel:
-              type: string
-            mass:
-              type: number
-            massLabel:
-              type: string
-            hullHealth:
-              type: number
-            hullParts:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                  category:
-                    "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
-                required:
-                - name
-                - health
-                - category
-                additionalProperties: false
-            hullDoors:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                required:
-                - name
-                - health
-                additionalProperties: false
-            quantumFuelTankSize:
-              type: number
-            weaponPoolSize:
-              type: number
-            signatureCrossSection:
-              type: object
-              properties:
-                x:
-                  type: number
-                "y":
-                  type: number
-                z:
-                  type: number
-              additionalProperties: false
-            size:
-              type: string
-            sizeLabel:
-              type: string
-            dockSize:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMetrics"
         cargoHolds:
           type: array
           items:
@@ -17579,37 +17371,7 @@ components:
         rsiSlug:
           type: string
         speeds:
-          type: object
-          properties:
-            groundAcceleration:
-              type: number
-            groundDecceleration:
-              type: number
-            groundMaxSpeed:
-              type: number
-            groundReverseSpeed:
-              type: number
-            maxSpeed:
-              type: number
-            pitch:
-              type: number
-            pitchBoosted:
-              type: number
-            roll:
-              type: number
-            rollBoosted:
-              type: number
-            scmSpeed:
-              type: number
-            scmSpeedBoosted:
-              type: number
-            reverseSpeedBoosted:
-              type: number
-            yaw:
-              type: number
-            yawBoosted:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelSpeeds"
         holo:
           type: string
           deprecated: true
@@ -17646,6 +17408,40 @@ components:
       - createdAt
       - updatedAt
       title: Model
+    ModelAvailability:
+      type: object
+      properties:
+        boughtAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        soldAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+        rentalAt:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ItemPrice"
+      additionalProperties: false
+      required:
+      - boughtAt
+      - soldAt
+      - rentalAt
+      title: ModelAvailability
+    ModelCrew:
+      type: object
+      properties:
+        max:
+          type: integer
+        maxLabel:
+          type: string
+        min:
+          type: integer
+        minLabel:
+          type: string
+      additionalProperties: false
+      title: ModelCrew
     ModelExtended:
       type: object
       properties:
@@ -17661,25 +17457,7 @@ components:
         slug:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            rentalAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
-          - rentalAt
+          "$ref": "#/components/schemas/ModelAvailability"
         classification:
           type: string
         classificationLabel:
@@ -17688,17 +17466,7 @@ components:
           type: boolean
           default: false
         crew:
-          type: object
-          properties:
-            max:
-              type: integer
-            maxLabel:
-              type: string
-            min:
-              type: integer
-            minLabel:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelCrew"
         description:
           type: string
         erkulIdentifier:
@@ -17721,19 +17489,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         links:
-          type: object
-          properties:
-            salesPageUrl:
-              type: string
-            storeUrl:
-              type: string
-            self:
-              type: string
-              format: uri
-            frontend:
-              type: string
-              format: uri
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelExtendedLinks"
         loaners:
           type: array
           items:
@@ -17741,156 +17497,9 @@ components:
         manufacturer:
           "$ref": "#/components/schemas/Manufacturer"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            extendedHolo:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            holo:
-              "$ref": "#/components/schemas/MediaFile"
-            brochure:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMedia"
         metrics:
-          type: object
-          properties:
-            beam:
-              type: number
-            beamLabel:
-              type: string
-            cargo:
-              type: number
-            cargoLabel:
-              type: string
-            personalInventory:
-              type: number
-            personalInventoryLabel:
-              type:
-              - string
-              - 'null'
-            fleetchartOffsetLength:
-              type: number
-            fleetchartOffsetBeam:
-              type: number
-            extendedLength:
-              type: number
-            extendedLengthLabel:
-              type: string
-            extendedBeam:
-              type: number
-            extendedBeamLabel:
-              type: string
-            extendedHeight:
-              type: number
-            extendedHeightLabel:
-              type: string
-            extendedFleetchartOffsetLength:
-              type: number
-            extendedFleetchartOffsetBeam:
-              type: number
-            height:
-              type: number
-            heightLabel:
-              type: string
-            hydrogenFuelTankSize:
-              type: number
-            isGroundVehicle:
-              type: boolean
-            length:
-              type: number
-            lengthLabel:
-              type: string
-            mass:
-              type: number
-            massLabel:
-              type: string
-            hullHealth:
-              type: number
-            hullParts:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                  category:
-                    "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
-                required:
-                - name
-                - health
-                - category
-                additionalProperties: false
-            hullDoors:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  health:
-                    type: number
-                required:
-                - name
-                - health
-                additionalProperties: false
-            quantumFuelTankSize:
-              type: number
-            weaponPoolSize:
-              type: number
-            signatureCrossSection:
-              type: object
-              properties:
-                x:
-                  type: number
-                "y":
-                  type: number
-                z:
-                  type: number
-              additionalProperties: false
-            size:
-              type: string
-            sizeLabel:
-              type: string
-            dockSize:
-              type: string
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelMetrics"
         cargoHolds:
           type: array
           items:
@@ -17932,37 +17541,7 @@ components:
         rsiSlug:
           type: string
         speeds:
-          type: object
-          properties:
-            groundAcceleration:
-              type: number
-            groundDecceleration:
-              type: number
-            groundMaxSpeed:
-              type: number
-            groundReverseSpeed:
-              type: number
-            maxSpeed:
-              type: number
-            pitch:
-              type: number
-            pitchBoosted:
-              type: number
-            roll:
-              type: number
-            rollBoosted:
-              type: number
-            scmSpeed:
-              type: number
-            scmSpeedBoosted:
-              type: number
-            reverseSpeedBoosted:
-              type: number
-            yaw:
-              type: number
-            yawBoosted:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelSpeeds"
         holo:
           type: string
           deprecated: true
@@ -18005,6 +17584,21 @@ components:
       - dockCounts
       - links
       title: ModelExtended
+    ModelExtendedLinks:
+      type: object
+      properties:
+        salesPageUrl:
+          type: string
+        storeUrl:
+          type: string
+        self:
+          type: string
+          format: uri
+        frontend:
+          type: string
+          format: uri
+      additionalProperties: false
+      title: ModelExtendedLinks
     ModelHardpoint:
       type: object
       properties:
@@ -18221,6 +17815,33 @@ components:
       - EMP
       - UTILITY_ITEMS
       title: ModelHardpointTypeEnum
+    ModelHullDoor:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+      required:
+      - name
+      - health
+      additionalProperties: false
+      title: ModelHullDoor
+    ModelHullPart:
+      type: object
+      properties:
+        name:
+          type: string
+        health:
+          type: number
+        category:
+          "$ref": "#/components/schemas/ModelHullPartCategoryEnum"
+      required:
+      - name
+      - health
+      - category
+      additionalProperties: false
+      title: ModelHullPart
     ModelHullPartCategoryEnum:
       type: string
       enum:
@@ -18236,6 +17857,15 @@ components:
       - SUBPART
       - COSMETIC
       title: ModelHullPartCategoryEnum
+    ModelLinks:
+      type: object
+      properties:
+        salesPageUrl:
+          type: string
+        storeUrl:
+          type: string
+      additionalProperties: false
+      title: ModelLinks
     ModelLoaner:
       type: object
       properties:
@@ -18248,6 +17878,130 @@ components:
       - name
       - slug
       title: ModelLoaner
+    ModelMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        extendedHolo:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        holo:
+          "$ref": "#/components/schemas/MediaFile"
+        brochure:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: ModelMedia
+    ModelMetrics:
+      type: object
+      properties:
+        beam:
+          type: number
+        beamLabel:
+          type: string
+        cargo:
+          type: number
+        cargoLabel:
+          type: string
+        personalInventory:
+          type: number
+        personalInventoryLabel:
+          type:
+          - string
+          - 'null'
+        fleetchartOffsetLength:
+          type: number
+        fleetchartOffsetBeam:
+          type: number
+        extendedLength:
+          type: number
+        extendedLengthLabel:
+          type: string
+        extendedBeam:
+          type: number
+        extendedBeamLabel:
+          type: string
+        extendedHeight:
+          type: number
+        extendedHeightLabel:
+          type: string
+        extendedFleetchartOffsetLength:
+          type: number
+        extendedFleetchartOffsetBeam:
+          type: number
+        height:
+          type: number
+        heightLabel:
+          type: string
+        hydrogenFuelTankSize:
+          type: number
+        isGroundVehicle:
+          type: boolean
+        length:
+          type: number
+        lengthLabel:
+          type: string
+        mass:
+          type: number
+        massLabel:
+          type: string
+        hullHealth:
+          type: number
+        hullParts:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullPart"
+        hullDoors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelHullDoor"
+        quantumFuelTankSize:
+          type: number
+        weaponPoolSize:
+          type: number
+        signatureCrossSection:
+          "$ref": "#/components/schemas/ModelSignatureCrossSection"
+        size:
+          type: string
+        sizeLabel:
+          type: string
+        dockSize:
+          type: string
+      additionalProperties: false
+      title: ModelMetrics
     ModelModule:
       type: object
       properties:
@@ -18275,26 +18029,9 @@ components:
           items:
             "$ref": "#/components/schemas/CargoHold"
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         pledgePrice:
           type: number
         productionStatus:
@@ -18538,11 +18275,7 @@ components:
         onWishlist:
           type: boolean
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
       additionalProperties: false
       required:
       - id
@@ -18587,20 +18320,7 @@ components:
         lastUpdatedAtLabel:
           type: string
         availability:
-          type: object
-          properties:
-            boughtAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-            soldAt:
-              type: array
-              items:
-                "$ref": "#/components/schemas/ItemPrice"
-          additionalProperties: false
-          required:
-          - boughtAt
-          - soldAt
+          "$ref": "#/components/schemas/ItemAvailability"
         media:
           type: object
           properties:
@@ -18979,6 +18699,17 @@ components:
       additionalProperties: false
       example: {}
       title: ModelQuery
+    ModelSignatureCrossSection:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+      title: ModelSignatureCrossSection
     ModelSortEnum:
       type: string
       enum:
@@ -19048,6 +18779,39 @@ components:
       - RSI_ID_ASC
       - RSI_ID_DESC
       title: ModelSortEnum
+    ModelSpeeds:
+      type: object
+      properties:
+        groundAcceleration:
+          type: number
+        groundDecceleration:
+          type: number
+        groundMaxSpeed:
+          type: number
+        groundReverseSpeed:
+          type: number
+        maxSpeed:
+          type: number
+        pitch:
+          type: number
+        pitchBoosted:
+          type: number
+        roll:
+          type: number
+        rollBoosted:
+          type: number
+        scmSpeed:
+          type: number
+        scmSpeedBoosted:
+          type: number
+        reverseSpeedBoosted:
+          type: number
+        yaw:
+          type: number
+        yawBoosted:
+          type: number
+      additionalProperties: false
+      title: ModelSpeeds
     ModelUpgrade:
       type: object
       properties:
@@ -19061,11 +18825,7 @@ components:
         pledgePrice:
           type: number
         media:
-          type: object
-          properties:
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/StoreImageMedia"
         createdAt:
           type: string
           format: date-time
@@ -19729,6 +19489,13 @@ components:
       - wishlistsCount
       - shipOfTheMonthCount
       title: Stats
+    StoreImageMedia:
+      type: object
+      properties:
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: StoreImageMedia
     SuccessResponse:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -14802,44 +14802,47 @@ components:
         slug:
           type: string
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            angledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            frontView:
-              "$ref": "#/components/schemas/MediaFile"
-            frontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-            topViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedAngledViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedFrontViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedSideViewColored:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopView:
-              "$ref": "#/components/schemas/MediaFile"
-            extendedTopViewColored:
-              "$ref": "#/components/schemas/MediaFile"
+          "$ref": "#/components/schemas/FleetchartViewMedia"
       required:
       - slug
       - media
       title: FleetchartView
+    FleetchartViewMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        angledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        frontView:
+          "$ref": "#/components/schemas/MediaFile"
+        frontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+        topViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedAngledViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedFrontViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedSideViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopView:
+          "$ref": "#/components/schemas/MediaFile"
+        extendedTopViewColored:
+          "$ref": "#/components/schemas/MediaFile"
+      title: FleetchartViewMedia
     FleetchartViewQuery:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -11164,6 +11164,17 @@ components:
       - createdAt
       - updatedAt
       title: Component
+    ComponentAngularVelocity:
+      type: object
+      properties:
+        pitch:
+          type: number
+        yaw:
+          type: number
+        roll:
+          type: number
+      additionalProperties: false
+      title: ComponentAngularVelocity
     ComponentArmor:
       type: object
       properties:
@@ -11232,57 +11243,15 @@ components:
         maxSpeed:
           type: number
         angularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         boostedAngularVelocity:
-          type: object
-          properties:
-            pitch:
-              type: number
-            yaw:
-              type: number
-            roll:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentAngularVelocity"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -11297,33 +11266,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         signatureIr:
@@ -11332,6 +11275,32 @@ components:
       required:
       - coolingRate
       title: ComponentCooler
+    ComponentDamageRange:
+      type: object
+      properties:
+        min:
+          type: number
+        max:
+          type: number
+      additionalProperties: false
+      title: ComponentDamageRange
+    ComponentDamageTypeMap:
+      type: object
+      properties:
+        physical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        energy:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        distortion:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        thermal:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        biochemical:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+        stun:
+          "$ref": "#/components/schemas/ComponentDamageRange"
+      additionalProperties: false
+      title: ComponentDamageTypeMap
     ComponentItemClassEnum:
       type: string
       enum:
@@ -11362,6 +11331,13 @@ components:
           type: number
       additionalProperties: false
       title: ComponentJumpDrive
+    ComponentPingProperties:
+      type: object
+      properties:
+        cooldownTime:
+          type: number
+      additionalProperties: false
+      title: ComponentPingProperties
     ComponentPowerPlant:
       type: object
       properties:
@@ -11370,37 +11346,31 @@ components:
         powerDraw:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
       title: ComponentPowerPlant
+    ComponentPowerRangeEntry:
+      type: object
+      properties:
+        start:
+          type: number
+        modifier:
+          type: number
+      additionalProperties: false
+      title: ComponentPowerRangeEntry
+    ComponentPowerRanges:
+      type: object
+      properties:
+        low:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        medium:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+        high:
+          "$ref": "#/components/schemas/ComponentPowerRangeEntry"
+      additionalProperties: false
+      title: ComponentPowerRanges
     ComponentQuantumDrive:
       type: object
       properties:
@@ -11445,33 +11415,7 @@ components:
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -11567,93 +11511,32 @@ components:
       type: object
       properties:
         signatureDetection:
-          type: object
-          properties:
-            ir:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            em:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            cs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-            rs:
-              type: object
-              properties:
-                sensitivity:
-                  type: number
-                piercing:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSignatureDetection"
         pingProperties:
-          type: object
-          properties:
-            cooldownTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPingProperties"
         aimAssistRange:
           type: number
         aimAssistMin:
           type: number
         sensitivityModifiers:
-          type: object
-          properties:
-            sensitivityAddition:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentSensitivityModifiers"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
       title: ComponentRadar
+    ComponentSensitivityModifiers:
+      type: object
+      properties:
+        sensitivityAddition:
+          type: number
+      additionalProperties: false
+      title: ComponentSensitivityModifiers
     ComponentShield:
       type: object
       properties:
@@ -11668,141 +11551,15 @@ components:
         damagedRegenDelay:
           type: number
         resistance:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         absorption:
-          type: object
-          properties:
-            physical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            energy:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            distortion:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            thermal:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            biochemical:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-            stun:
-              type: object
-              properties:
-                min:
-                  type: number
-                max:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentDamageTypeMap"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
       additionalProperties: false
@@ -11810,6 +11567,28 @@ components:
       - maxHealth
       - maxRegen
       title: ComponentShield
+    ComponentSignatureDetection:
+      type: object
+      properties:
+        ir:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        em:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        cs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+        rs:
+          "$ref": "#/components/schemas/ComponentSignatureSensitivity"
+      additionalProperties: false
+      title: ComponentSignatureDetection
+    ComponentSignatureSensitivity:
+      type: object
+      properties:
+        sensitivity:
+          type: number
+        piercing:
+          type: number
+      additionalProperties: false
+      title: ComponentSignatureSensitivity
     ComponentSortEnum:
       type: string
       enum:
@@ -11866,81 +11645,67 @@ components:
         heatPerSecond:
           type: number
         rotation:
-          type: object
-          properties:
-            maxAngularVelocity:
-              type: number
-            degreesPerAction:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamRotation"
         movement:
-          type: object
-          properties:
-            maxSpeed:
-              type: number
-            maxAcceleration:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamMovement"
         cargoMode:
-          type: object
-          properties:
-            maxForce:
-              type: number
-            minDistance:
-              type: number
-            maxDistance:
-              type: number
-            fullStrengthDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamCargoMode"
         towing:
-          type: object
-          properties:
-            towingForce:
-              type: number
-            towingMaxDistance:
-              type: number
-            towingMaxAcceleration:
-              type: number
-            quantumTowMassLimit:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentTractorBeamTowing"
         powerConsumption:
           type: number
         powerMinimumFraction:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
       additionalProperties: false
       required:
       - tractorBeam
       title: ComponentTractorBeam
+    ComponentTractorBeamCargoMode:
+      type: object
+      properties:
+        maxForce:
+          type: number
+        minDistance:
+          type: number
+        maxDistance:
+          type: number
+        fullStrengthDistance:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamCargoMode
+    ComponentTractorBeamMovement:
+      type: object
+      properties:
+        maxSpeed:
+          type: number
+        maxAcceleration:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamMovement
+    ComponentTractorBeamRotation:
+      type: object
+      properties:
+        maxAngularVelocity:
+          type: number
+        degreesPerAction:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamRotation
+    ComponentTractorBeamTowing:
+      type: object
+      properties:
+        towingForce:
+          type: number
+        towingMaxDistance:
+          type: number
+        towingMaxAcceleration:
+          type: number
+        quantumTowMassLimit:
+          type: number
+      additionalProperties: false
+      title: ComponentTractorBeamTowing
     ComponentTypeEnum:
       type: string
       enum:
@@ -12104,67 +11869,13 @@ components:
         powerConsumption:
           type: number
         powerRanges:
-          type: object
-          properties:
-            low:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            medium:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-            high:
-              type: object
-              properties:
-                start:
-                  type: number
-                modifier:
-                  type: number
-              additionalProperties: false
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentPowerRanges"
         signatureEm:
           type: number
         damagePerShot:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         damagePerSecond:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-            biochemical:
-              type: number
-            stun:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponDamage"
         heatPerSecond:
           type: number
         pelletsPerShot:
@@ -12186,43 +11897,69 @@ components:
         overchargeTime:
           type: number
         regen:
-          type: object
-          properties:
-            maxAmmoLoad:
-              type: number
-            maxRegenPerSecond:
-              type: number
-            costPerBullet:
-              type: number
-            regenerationCooldown:
-              type: number
-            requestedRegenPerSecond:
-              type: number
-            requestedAmmoLoad:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponRegen"
         heat:
-          type: object
-          properties:
-            overheatTemperature:
-              type: number
-            coolingPerSecond:
-              type: number
-            timeTillCoolingStarts:
-              type: number
-            overheatFixTime:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponHeat"
         penetration:
-          type: object
-          properties:
-            maxThickness:
-              type: number
-            baseDistance:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ComponentWeaponPenetration"
       additionalProperties: false
       title: ComponentWeapon
+    ComponentWeaponDamage:
+      type: object
+      properties:
+        physical:
+          type: number
+        energy:
+          type: number
+        distortion:
+          type: number
+        thermal:
+          type: number
+        biochemical:
+          type: number
+        stun:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponDamage
+    ComponentWeaponHeat:
+      type: object
+      properties:
+        overheatTemperature:
+          type: number
+        coolingPerSecond:
+          type: number
+        timeTillCoolingStarts:
+          type: number
+        overheatFixTime:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponHeat
+    ComponentWeaponPenetration:
+      type: object
+      properties:
+        maxThickness:
+          type: number
+        baseDistance:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponPenetration
+    ComponentWeaponRegen:
+      type: object
+      properties:
+        maxAmmoLoad:
+          type: number
+        maxRegenPerSecond:
+          type: number
+        costPerBullet:
+          type: number
+        regenerationCooldown:
+          type: number
+        requestedRegenPerSecond:
+          type: number
+        requestedAmmoLoad:
+          type: number
+      additionalProperties: false
+      title: ComponentWeaponRegen
     Components:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10800,29 +10800,9 @@ components:
         maxContainerSize:
           "$ref": "#/components/schemas/CargoHoldContainerSize"
         limits:
-          type: object
-          properties:
-            min:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-            max:
-              "$ref": "#/components/schemas/CargoHoldLimit"
-          additionalProperties: false
-          required:
-          - min
+          "$ref": "#/components/schemas/CargoHoldLimits"
         offset:
-          type: object
-          properties:
-            x:
-              type: number
-            "y":
-              type: number
-            z:
-              type: number
-          additionalProperties: false
-          required:
-          - x
-          - "y"
-          - z
+          "$ref": "#/components/schemas/CargoHoldOffset"
         rotation:
           type: integer
       additionalProperties: false
@@ -10871,6 +10851,32 @@ components:
       - dimensions
       - capacity
       title: CargoHoldLimit
+    CargoHoldLimits:
+      type: object
+      properties:
+        min:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+        max:
+          "$ref": "#/components/schemas/CargoHoldLimit"
+      additionalProperties: false
+      required:
+      - min
+      title: CargoHoldLimits
+    CargoHoldOffset:
+      type: object
+      properties:
+        x:
+          type: number
+        "y":
+          type: number
+        z:
+          type: number
+      additionalProperties: false
+      required:
+      - x
+      - "y"
+      - z
+      title: CargoHoldOffset
     ChannelsEnum:
       type: string
       enum:
@@ -12593,13 +12599,7 @@ components:
           type: string
           format: uuid
         createdBy:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
         signupsCount:
           type: integer
         teamCount:
@@ -12677,24 +12677,9 @@ components:
           type: string
           format: date-time
         user:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-          required:
-          - id
-          - username
+          "$ref": "#/components/schemas/UserRefRequired"
         grantedBy:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
       required:
       - id
       - fleetEventId
@@ -12963,20 +12948,7 @@ components:
           items:
             "$ref": "#/components/schemas/ShipModel"
         filters:
-          type: object
-          properties:
-            classification:
-              type: string
-            focus:
-              type: string
-            minSize:
-              type: string
-            maxSize:
-              type: string
-            minCrew:
-              type: integer
-            minCargo:
-              type: number
+          "$ref": "#/components/schemas/ShipSlotFilters"
         slots:
           type: array
           items:
@@ -13133,45 +13105,9 @@ components:
           type: string
           format: date-time
         user:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
         vehicle:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            model:
-              type: object
-              properties:
-                id:
-                  type: string
-                  format: uuid
-                name:
-                  type: string
-                slug:
-                  type: string
-                classification:
-                  type: string
-                focus:
-                  type: string
-                size:
-                  type: string
-                minCrew:
-                  type: integer
-                maxCrew:
-                  type: integer
-                cargo:
-                  type: integer
-                positionCount:
-                  type: integer
+          "$ref": "#/components/schemas/FleetEventSignupVehicle"
       required:
       - id
       - fleetEventId
@@ -13260,6 +13196,42 @@ components:
           - 'null'
       additionalProperties: false
       title: FleetEventSignupUpdateInput
+    FleetEventSignupVehicle:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        model:
+          "$ref": "#/components/schemas/FleetEventSignupVehicleModel"
+      title: FleetEventSignupVehicle
+    FleetEventSignupVehicleModel:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        classification:
+          type: string
+        focus:
+          type: string
+        size:
+          type: string
+        minCrew:
+          type: integer
+        maxCrew:
+          type: integer
+        cargo:
+          type: integer
+        positionCount:
+          type: integer
+      title: FleetEventSignupVehicleModel
     FleetEventSlot:
       type: object
       properties:
@@ -13612,21 +13584,7 @@ components:
         totalUnits:
           type: number
         manager:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
-            rsiHandle:
-              type: string
-            discordProfileUrl:
-              type: string
-              format: uri
-            citizenidProfileUrl:
-              type: string
-              format: uri
+          "$ref": "#/components/schemas/FleetInventoryManager"
         image:
           "$ref": "#/components/schemas/MediaFile"
         createdAt:
@@ -13702,42 +13660,13 @@ components:
         image:
           "$ref": "#/components/schemas/MediaFile"
         item:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              "$ref": "#/components/schemas/InventoryItemTypeEnum"
-            name:
-              type: string
-            slug:
-              type: string
-            available:
-              type: boolean
+          "$ref": "#/components/schemas/InventoryItemRef"
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
         member:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
         addedBy:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
         createdAt:
           type: string
           format: date-time
@@ -13847,6 +13776,23 @@ components:
       - items
       - meta
       title: FleetInventoryItemsList
+    FleetInventoryManager:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        rsiHandle:
+          type: string
+        discordProfileUrl:
+          type: string
+          format: uri
+        citizenidProfileUrl:
+          type: string
+          format: uri
+      title: FleetInventoryManager
     FleetInventoryStockItem:
       type: object
       properties:
@@ -13867,12 +13813,7 @@ components:
         netQuantity:
           type: number
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
       required:
       - name
       - category
@@ -14150,21 +14091,24 @@ components:
       - meta
       - items
       title: FleetMembersList
+    FleetMembersMetrics:
+      type: object
+      properties:
+        membersByRole:
+          type: object
+          additionalProperties:
+            type: integer
+      additionalProperties: false
+      required:
+      - membersByRole
+      title: FleetMembersMetrics
     FleetMembersStats:
       type: object
       properties:
         total:
           type: integer
         metrics:
-          type: object
-          properties:
-            membersByRole:
-              type: object
-              additionalProperties:
-                type: integer
-          additionalProperties: false
-          required:
-          - membersByRole
+          "$ref": "#/components/schemas/FleetMembersMetrics"
       additionalProperties: false
       required:
       - total
@@ -15264,26 +15208,9 @@ components:
         image:
           "$ref": "#/components/schemas/MediaFile"
         item:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              "$ref": "#/components/schemas/InventoryItemTypeEnum"
-            name:
-              type: string
-            slug:
-              type: string
-            available:
-              type: boolean
+          "$ref": "#/components/schemas/InventoryItemRef"
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
         createdAt:
           type: string
           format: date-time
@@ -15418,12 +15345,7 @@ components:
         netQuantity:
           type: number
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
       required:
       - name
       - category
@@ -16285,26 +16207,9 @@ components:
         image:
           "$ref": "#/components/schemas/MediaFile"
         item:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              "$ref": "#/components/schemas/InventoryItemTypeEnum"
-            name:
-              type: string
-            slug:
-              type: string
-            available:
-              type: boolean
+          "$ref": "#/components/schemas/InventoryItemRef"
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
         createdAt:
           type: string
           format: date-time
@@ -16381,6 +16286,21 @@ components:
       additionalProperties: false
       example: {}
       title: InventoryItemQuery
+    InventoryItemRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          "$ref": "#/components/schemas/InventoryItemTypeEnum"
+        name:
+          type: string
+        slug:
+          type: string
+        available:
+          type: boolean
+      title: InventoryItemRef
     InventoryItemTypeEnum:
       type: string
       enum:
@@ -16420,6 +16340,14 @@ components:
       - items
       - meta
       title: InventoryItemsList
+    InventoryRef:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+      title: InventoryRef
     InventoryStockPosition:
       type: object
       properties:
@@ -16467,12 +16395,7 @@ components:
             available:
               type: boolean
         inventory:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
+          "$ref": "#/components/schemas/InventoryRef"
       additionalProperties: false
       required:
       - slug
@@ -16531,21 +16454,24 @@ components:
           - string
           - 'null'
         model:
-          type: object
-          properties:
-            name:
-              type: string
-            slug:
-              type: string
-            cargo:
-              type: number
-            personalInventory:
-              type: number
+          "$ref": "#/components/schemas/InventoryVehicleModel"
       additionalProperties: false
       required:
       - id
       - name
       title: InventoryVehicle
+    InventoryVehicleModel:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        cargo:
+          type: number
+        personalInventory:
+          type: number
+      title: InventoryVehicleModel
     ItemAvailability:
       type: object
       properties:
@@ -16843,13 +16769,7 @@ components:
           type: string
           format: date-time
         createdBy:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            username:
-              type: string
+          "$ref": "#/components/schemas/UserRef"
         teamCount:
           type: integer
         shipCount:
@@ -16957,20 +16877,7 @@ components:
           items:
             "$ref": "#/components/schemas/ShipModel"
         filters:
-          type: object
-          properties:
-            classification:
-              type: string
-            focus:
-              type: string
-            minSize:
-              type: string
-            maxSize:
-              type: string
-            minCrew:
-              type: integer
-            minCargo:
-              type: number
+          "$ref": "#/components/schemas/ShipSlotFilters"
         slots:
           type: array
           items:
@@ -18019,11 +17926,7 @@ components:
         scKey:
           type: string
         metrics:
-          type: object
-          properties:
-            cargo:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModuleMetrics"
         cargoHolds:
           type: array
           items:
@@ -18062,6 +17965,13 @@ components:
       - createdAt
       - updatedAt
       title: ModelModule
+    ModelModuleMetrics:
+      type: object
+      properties:
+        cargo:
+          type: number
+      additionalProperties: false
+      title: ModelModuleMetrics
     ModelModulePackage:
       type: object
       properties:
@@ -18079,17 +17989,7 @@ components:
           items:
             "$ref": "#/components/schemas/ModelModule"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelModulePackageMedia"
         createdAt:
           type: string
           format: date-time
@@ -18187,6 +18087,19 @@ components:
       - createdAt
       - updatedAt
       title: ModelModulePackage
+    ModelModulePackageMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: ModelModulePackageMedia
     ModelModulePackageSortEnum:
       type: string
       enum:
@@ -18243,25 +18156,7 @@ components:
         slug:
           type: string
         manufacturer:
-          type: object
-          properties:
-            name:
-              type:
-              - string
-              - 'null'
-            slug:
-              type:
-              - string
-              - 'null'
-            code:
-              type:
-              - string
-              - 'null'
-          additionalProperties: false
-          required:
-          - name
-          - slug
-          - code
+          "$ref": "#/components/schemas/ModelOptionManufacturer"
         classification:
           type:
           - string
@@ -18288,6 +18183,27 @@ components:
       - onWishlist
       - media
       title: ModelOption
+    ModelOptionManufacturer:
+      type: object
+      properties:
+        name:
+          type:
+          - string
+          - 'null'
+        slug:
+          type:
+          - string
+          - 'null'
+        code:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      required:
+      - name
+      - slug
+      - code
+      title: ModelOptionManufacturer
     ModelOptions:
       type: object
       properties:
@@ -18322,19 +18238,7 @@ components:
         availability:
           "$ref": "#/components/schemas/ItemAvailability"
         media:
-          type: object
-          properties:
-            angledView:
-              "$ref": "#/components/schemas/MediaFile"
-            fleetchartImage:
-              type: string
-            sideView:
-              "$ref": "#/components/schemas/MediaFile"
-            storeImage:
-              "$ref": "#/components/schemas/MediaFile"
-            topView:
-              "$ref": "#/components/schemas/MediaFile"
-          additionalProperties: false
+          "$ref": "#/components/schemas/ModelPaintMedia"
         nameWithModel:
           type: string
         rsiId:
@@ -18459,6 +18363,21 @@ components:
       - createdAt
       - updatedAt
       title: ModelPaint
+    ModelPaintMedia:
+      type: object
+      properties:
+        angledView:
+          "$ref": "#/components/schemas/MediaFile"
+        fleetchartImage:
+          type: string
+        sideView:
+          "$ref": "#/components/schemas/MediaFile"
+        storeImage:
+          "$ref": "#/components/schemas/MediaFile"
+        topView:
+          "$ref": "#/components/schemas/MediaFile"
+      additionalProperties: false
+      title: ModelPaintMedia
     ModelPaintQuery:
       type: object
       properties:
@@ -19417,6 +19336,22 @@ components:
       - name
       - slug
       title: ShipModel
+    ShipSlotFilters:
+      type: object
+      properties:
+        classification:
+          type: string
+        focus:
+          type: string
+        minSize:
+          type: string
+        maxSize:
+          type: string
+        minCrew:
+          type: integer
+        minCargo:
+          type: number
+      title: ShipSlotFilters
     SortInput:
       type: object
       properties:
@@ -19502,71 +19437,83 @@ components:
         success:
           type: boolean
       title: SuccessResponse
+    SupportContribution:
+      type: object
+      properties:
+        displayName:
+          type: string
+        username:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        recurring:
+          type: boolean
+      additionalProperties: false
+      required:
+      - displayName
+      - amountCents
+      - currency
+      - recurring
+      title: SupportContribution
+    SupportGoal:
+      type: object
+      properties:
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SupportGoalItem"
+      additionalProperties: false
+      required:
+      - amountCents
+      - currency
+      - items
+      title: SupportGoal
+    SupportGoalItem:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+      additionalProperties: false
+      required:
+      - title
+      - amountCents
+      - currency
+      title: SupportGoalItem
+    SupportMonthlyTotal:
+      type: object
+      properties:
+        amountCents:
+          type: integer
+        currency:
+          type: string
+      additionalProperties: false
+      required:
+      - amountCents
+      - currency
+      title: SupportMonthlyTotal
     SupportProgress:
       type: object
       properties:
         goal:
-          type: object
-          properties:
-            amountCents:
-              type: integer
-            currency:
-              type: string
-            items:
-              type: array
-              items:
-                type: object
-                properties:
-                  title:
-                    type: string
-                  description:
-                    type: string
-                  amountCents:
-                    type: integer
-                  currency:
-                    type: string
-                additionalProperties: false
-                required:
-                - title
-                - amountCents
-                - currency
-          additionalProperties: false
-          required:
-          - amountCents
-          - currency
-          - items
+          "$ref": "#/components/schemas/SupportGoal"
         monthlyTotal:
-          type: object
-          properties:
-            amountCents:
-              type: integer
-            currency:
-              type: string
-          additionalProperties: false
-          required:
-          - amountCents
-          - currency
+          "$ref": "#/components/schemas/SupportMonthlyTotal"
         contributions:
           type: array
           items:
-            type: object
-            properties:
-              displayName:
-                type: string
-              username:
-                type: string
-              amountCents:
-                type: integer
-              currency:
-                type: string
-              recurring:
-                type: boolean
-            additionalProperties: false
-            required:
-            - displayName
-            - amountCents
-            - currency
-            - recurring
+            "$ref": "#/components/schemas/SupportContribution"
       additionalProperties: false
       required:
       - monthlyTotal
@@ -19780,16 +19727,7 @@ components:
         fleets:
           type: array
           items:
-            type: object
-            properties:
-              name:
-                type: string
-              slug:
-                type: string
-            additionalProperties: false
-            required:
-            - name
-            - slug
+            "$ref": "#/components/schemas/UserFeatureFleet"
         groups:
           type: array
           items:
@@ -19804,6 +19742,18 @@ components:
       - fleets
       - groups
       title: UserFeature
+    UserFeatureFleet:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+      additionalProperties: false
+      required:
+      - name
+      - slug
+      title: UserFeatureFleet
     UserFeatureScopeEnum:
       type: string
       enum:
@@ -19857,6 +19807,27 @@ components:
       - publicWishlist
       - supporter
       title: UserPublic
+    UserRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      title: UserRef
+    UserRefRequired:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      required:
+      - id
+      - username
+      title: UserRefRequired
     UserResourceAccessEnum:
       type: string
       enum: []
@@ -20002,17 +19973,7 @@ components:
         bundled:
           type: boolean
         bundledParent:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-            customName:
-              type: string
+          "$ref": "#/components/schemas/VehicleBundledParent"
         model:
           "$ref": "#/components/schemas/Model"
         modelModuleIds:
@@ -20066,6 +20027,19 @@ components:
       - createdAt
       - updatedAt
       title: Vehicle
+    VehicleBundledParent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        customName:
+          type: string
+      title: VehicleBundledParent
     VehicleCheckSerialInput:
       type: object
       properties:
@@ -20090,22 +20064,25 @@ components:
         vehicles:
           type: array
           items:
-            type: object
-            properties:
-              modelId:
-                type: string
-                format: uuid
-              wanted:
-                type: boolean
-              public:
-                type: boolean
-            additionalProperties: false
-            required:
-            - modelId
+            "$ref": "#/components/schemas/VehicleCreateBulkItemInput"
       additionalProperties: false
       required:
       - vehicles
       title: VehicleCreateBulkInput
+    VehicleCreateBulkItemInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+        wanted:
+          type: boolean
+        public:
+          type: boolean
+      additionalProperties: false
+      required:
+      - modelId
+      title: VehicleCreateBulkItemInput
     VehicleCreateInput:
       type: object
       properties:
@@ -20257,18 +20234,7 @@ components:
         hardpoints:
           type: array
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                format: uuid
-              modelHardpointId:
-                type: string
-                format: uuid
-              hardpoint:
-                "$ref": "#/components/schemas/ModelHardpoint"
-              component:
-                "$ref": "#/components/schemas/Component"
+            "$ref": "#/components/schemas/VehicleLoadoutHardpoint"
         createdAt:
           type: string
           format: date-time
@@ -20284,6 +20250,37 @@ components:
       - createdAt
       - updatedAt
       title: VehicleLoadout
+    VehicleLoadoutHardpoint:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        modelHardpointId:
+          type: string
+          format: uuid
+        hardpoint:
+          "$ref": "#/components/schemas/ModelHardpoint"
+        component:
+          "$ref": "#/components/schemas/Component"
+      title: VehicleLoadoutHardpoint
+    VehicleLoadoutHardpointInput:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        modelHardpointId:
+          type: string
+          format: uuid
+        componentId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        _destroy:
+          type: boolean
+      title: VehicleLoadoutHardpointInput
     VehicleLoadoutInput:
       type: object
       properties:
@@ -20298,21 +20295,7 @@ components:
         vehicleLoadoutHardpointsAttributes:
           type: array
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                format: uuid
-              modelHardpointId:
-                type: string
-                format: uuid
-              componentId:
-                type:
-                - string
-                - 'null'
-                format: uuid
-              _destroy:
-                type: boolean
+            "$ref": "#/components/schemas/VehicleLoadoutHardpointInput"
       additionalProperties: false
       title: VehicleLoadoutInput
     VehicleLoadoutMinimal:
@@ -20375,17 +20358,7 @@ components:
         bundled:
           type: boolean
         bundledParent:
-          type: object
-          properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
-            slug:
-              type: string
-            customName:
-              type: string
+          "$ref": "#/components/schemas/VehicleBundledParent"
         model:
           "$ref": "#/components/schemas/Model"
         username:
@@ -20657,6 +20630,19 @@ components:
       items:
         "$ref": "#/components/schemas/WeaponIndexItem"
       title: WeaponIndex
+    WeaponIndexDamage:
+      type: object
+      properties:
+        physical:
+          type: number
+        energy:
+          type: number
+        distortion:
+          type: number
+        thermal:
+          type: number
+      additionalProperties: false
+      title: WeaponIndexDamage
     WeaponIndexItem:
       type: object
       properties:
@@ -20678,17 +20664,7 @@ components:
         pelletsPerShot:
           type: integer
         damagePerShot:
-          type: object
-          properties:
-            physical:
-              type: number
-            energy:
-              type: number
-            distortion:
-              type: number
-            thermal:
-              type: number
-          additionalProperties: false
+          "$ref": "#/components/schemas/WeaponIndexDamage"
       additionalProperties: false
       required:
       - id


### PR DESCRIPTION
Top of the stack: #4531 → #4533 → #4534 → #4536 → #4537 → this.

## Why

The last anonymous shapes. 141 objects were nested inside components, and Orval names those after their owner and path, so one shape under several owners became several unrelated types:

```
ComponentControllerPowerRangesHigh   ComponentCoolerPowerRangesHigh
ComponentControllerPowerRangesLow    ComponentCoolerPowerRangesLow
ComponentControllerPowerRangesMedium ComponentCoolerPowerRangesMedium
… and six more component types, for a shape that is two numbers
```

48 generated types for `{start, modifier}`, 24 for `{min, max}`, 16 for the low/medium/high triple. `Model.metrics` held 33 properties inline and got reproduced in full four times over.

## What

**63 components** replacing all 141 sites. Grouped by shape first, so it is far fewer than one per site — the count of distinct shapes was 62, and several turned out to be the same thing under different owners.

Eight component types carried a **byte-identical copy** of `POWER_RANGE_ENTRY` and `POWER_RANGES` as Ruby constants. Those are now two components, and the constants are gone. Shield `resistance` and `absorption` share one `ComponentDamageTypeMap`; weapon `damagePerShot` and `damagePerSecond` share one `ComponentWeaponDamage`; five payloads share `ItemAvailability`; six share `InventoryRef`.

Where two variants differed only in `required`, both are kept — `UserRef` and `UserRefRequired`, `CargoHoldOffset` and `ModelSignatureCrossSection` — so no published contract moves. The comments say why.

## Three things worth reviewing

**A `$ref` cannot be deep-merged into.** openapi-ruby merges a subclass's schema into its parent's, so pointing `Model.links` at a component left `ModelExtended` emitting a `$ref` *beside* the two properties it wanted to add. Same for the admin `Model.media`. Both now use a component that inherits the shared one (`AdminModelMedia < Shared::V1::Schemas::ModelMedia`), which reproduces the old document exactly. I scanned all three specs for `$ref`-with-siblings afterwards: zero.

**A cross-scope subclass inherits the reference.** `ModelModuleMetrics` started in `v1/` and the admin document came out with a dangling `$ref`, because the admin `ModelModule` subclasses the public one. Moved to `shared/v1/`. `bin/generate-schema` failed loudly on this one, but a ref-vs-definition diff over each spec is the reliable check and is now in the rule.

**`AdminModelMedia` had dropped `rsiStoreImage`.** oasdiff classes a removed optional response property as a *warning*, and the admin job runs `--fail-on ERR` — so it passed. The generated client is what caught it. Worth knowing that the admin gate is weaker than the public one.

## Frontend

Only two of the 141 anonymous types were imported by app code (`ModelMetricsHullPartsItem`, `ModelMetricsHullDoorsItem` → `ModelHullPart`, `ModelHullDoor`); everything else is reached through the parent type and keeps working.

One non-obvious consequence: Orval emits an `interface` for a named component and a type alias for an anonymous one, and TypeScript gives interfaces no implicit index signature. Two damage helpers typed `Record<string, unknown>` / `Partial<Record<string, number>>` stopped accepting the value. They are now typed against `ComponentWeaponDamage`, which is the signature they should have had.

## Verification

- `oasdiff breaking` on all three specs, **including warnings**, not just errors: nothing to report.
- No dangling `$ref` and no `$ref`-with-siblings in any spec.
- `bin/generate-schema` + `bin/generate-asyncapi` + `git diff --exit-code`: clean, which is the `api-schema-check` gate.
- `standardrb`, `pnpm lint`, `pnpm lint:ts`: clean.
- 280 integration tests across models, components, equipment, commodities, paints, hardpoints, loadouts, inventories, vehicles, fleet stats, admin models and oauth, plus `test/asyncapi`: 0 failures.
- 141 vitest tests over the touched composables and model components: 0 failures.

Net: −688 lines, and the schemas shrink by about 1,300 lines of duplicated structure.

## After this

Nothing in `app/api_components/` or `test/integration/` defines a request type, a response type, an enum or a nested object inline. What remains inline is only what has nothing to name: free-form `additionalProperties` maps (`Import.input`, `FleetMembersMetrics.membersByRole`, `FleetModelCountsStats`) and `FeatureFlagName`, which is deliberately referenced by nothing.

🤖
