### PR TITLE
fix(rsi): stop the matrix nilling four fields it has no values for

### DIFF
--- a/app/lib/rsi/models_loader.rb
+++ b/app/lib/rsi/models_loader.rb
@@ -97,15 +97,25 @@ module Rsi
         updates[attr.to_sym] = nil_or_decimal(data[attr]) if (model_updated(model, data) && nil_or_decimal(data[attr]) != model.send(:"rsi_#{attr}")) || model.send(attr).blank? || model.send(attr).zero?
       end
 
-      updates[:rsi_max_speed] = nil_or_decimal(data["afterburner_speed"])
-      updates[:max_speed] = nil_or_decimal(data["afterburner_speed"]) if model_updated(model, data) && nil_or_decimal(data["afterburner_speed"]) != model.rsi_max_speed || model.rsi_max_speed.blank? || model.rsi_max_speed.zero?
+      # These four asked whether the *matrix* value was missing, where every other
+      # field asks whether the live one is. The matrix supplies none of them for
+      # 244 of 246 ships, so the answer was always yes and the live value was
+      # overwritten on every run -- with `nil`, since the matrix has nothing to
+      # put there. The game-file loader owns these fields and refilled them
+      # afterwards, so the values flapped between correct and empty depending on
+      # which loader ran last, and an admin correction could never survive.
+      #
+      # A source may not overwrite a value with nothing, which is what the
+      # `value.present?` guard says. The shadow column is still written either
+      # way, so the change detector keeps working.
+      {max_speed: "afterburner_speed", pitch: "pitch_max", yaw: "yaw_max", roll: "roll_max"}.each do |attr, key|
+        value = nil_or_decimal(data[key])
+        updates["rsi_#{attr}"] = value
 
-      updates[:rsi_pitch] = nil_or_decimal(data["pitch_max"])
-      updates[:pitch] = nil_or_decimal(data["pitch_max"]) if model_updated(model, data) && nil_or_decimal(data["pitch_max"]) != model.rsi_pitch || model.rsi_pitch.blank? || model.rsi_pitch.zero?
-      updates[:rsi_yaw] = nil_or_decimal(data["yaw_max"])
-      updates[:yaw] = nil_or_decimal(data["yaw_max"]) if model_updated(model, data) && nil_or_decimal(data["yaw_max"]) != model.rsi_yaw || model.rsi_yaw.blank? || model.rsi_yaw.zero?
-      updates[:rsi_roll] = nil_or_decimal(data["roll_max"])
-      updates[:roll] = nil_or_decimal(data["roll_max"]) if model_updated(model, data) && nil_or_decimal(data["roll_max"]) != model.rsi_roll || model.rsi_roll.blank? || model.rsi_roll.zero?
+        next if value.blank?
+
+        updates[attr] = value if (model_updated(model, data) && value != model.send(:"rsi_#{attr}")) || model.send(attr).blank? || model.send(attr).zero?
+      end
 
       updates[:ground] = true if data["type"] == "ground" && model_updated(model, data) && data["type"] != model.classification
 

--- a/test/loaders/rsi/models_loader_test.rb
+++ b/test/loaders/rsi/models_loader_test.rb
@@ -106,6 +106,32 @@ module Rsi
       assert_equal "in-concept", model.production_status
     end
 
+    # The matrix carries none of these four for almost every ship, and it used to
+    # write `nil` over whatever the game-file loader had put there -- every run,
+    # because the guard asked whether the *matrix* value was missing rather than
+    # the live one.
+    # The Gladius is one of the ships the matrix carries no manoeuvring figures
+    # for. Today that is nearly every ship: 244 of 246 have `rsi_max_speed` NULL,
+    # the matrix having stopped supplying these fields at some point -- this
+    # fixture is an older snapshot where most ships still had them.
+    test "#leaves a value alone when the matrix has nothing to put there" do
+      @loader.one(60)
+
+      model = Model.find_by(rsi_id: 60)
+      model.update!(max_speed: 1210, pitch: 45, yaw: 40, roll: 120)
+
+      Timecop.travel(1.day)
+
+      @loader.one(60)
+
+      model.reload
+
+      assert_in_delta 1210.0, model.max_speed.to_f
+      assert_in_delta 45.0, model.pitch.to_f
+      assert_in_delta 40.0, model.yaw.to_f
+      assert_in_delta 120.0, model.roll.to_f
+    end
+
     test "#overrides present data" do
       polaris = create(:model, name: "Polaris", length: 20, rsi_id: 116, rsi_chassis_id: 4)
 


### PR DESCRIPTION
`max_speed`, `pitch`, `yaw` and `roll` asked whether the **matrix** value was missing, where every other field in the loader asks whether the **live** one is:

```ruby
updates[:max_speed] = nil_or_decimal(data["afterburner_speed"]) if
  model_updated(model, data) && ... || model.rsi_max_speed.blank? || model.rsi_max_speed.zero?
#                                      ^^^^^^^^^^^^^^^^^^^^^^^^ every other field checks model.max_speed
```

## Why that matters

Measured against the dev database:

| | |
| --- | --- |
| ships where `rsi_max_speed` is NULL | **244 of 246** |
| ships with a live `max_speed` anyway | **187** |
| of those, not `in_game` | 0 |
| `cargo`, which uses the correct guard, for comparison | 17 NULL, 1 affected |

The matrix stopped returning these four fields at some point, so `rsi_max_speed` stays NULL forever, the guard is always true, and the live column is overwritten on **every** run — with `nil`, since the matrix has nothing to put there.

The 187 live values come from the game-file loader, which owns these fields. So the values flapped between correct and empty depending on which loader ran last, and an admin correction to any of the four could never survive. That is part of the "admin corrections only partly survive" problem on `Model`.

## The fix

The four become one loop in the same shape as the `max_crew / min_crew / scm_speed` block above them, with the guard reading the live column — plus the invariant that was missing:

**A source does not overwrite a value with nothing.**

The shadow column is still written either way, so the change detector keeps working exactly as before.

## The test

It uses the **Gladius**, one of the ships the fixture carries no manoeuvring figures for. My first attempt used the 300i, which *does* supply all four — so it passed with and without the fix and proved nothing.

Restoring the original condition makes it fail with `max_speed` 1210 → 0, so it covers the defect rather than the shape of the code.

Worth noting for anyone reading the fixture: it supplies these fields for 188 of 252 ships, while production has them for 2 of 246. The fixture is an older snapshot from when the matrix still returned them.

## Not in this change

**The `rsi_*` pattern itself.** It is a change-detector, not a data source: the live column is overwritten only when the matrix changed *that field* since the last run. Replacing it with a proper source layer is the larger piece of work, and this is a bug inside the existing mechanism rather than a step toward that.

## Verification

6 tests in `test/loaders/rsi/models_loader_test.rb`, green. `standardrb` clean.

The commodity loader tests fail in my worktree, **identically on unmodified main** — the parsed `sc_data` fixture tree lives in S3 and does not come with a checkout. Unrelated to this change.

🤖
