### PR TITLE
feat(models): show what the game files measure next to the matrix figure

### DIFF
--- a/app/api_components/shared/v1/schemas/model_metrics.rb
+++ b/app/api_components/shared/v1/schemas/model_metrics.rb
@@ -27,6 +27,18 @@ module Shared
             extendedFleetchartOffsetBeam: {type: :number},
             height: {type: :number},
             heightLabel: {type: :string},
+            # What the game files measure, where the fields above are what the
+            # matrix publishes. Absent when the export has no measurement, and
+            # the two disagree often enough that neither replaces the other.
+            gameFiles: {
+              type: :object,
+              properties: {
+                length: {type: :number},
+                beam: {type: :number},
+                height: {type: :number}
+              },
+              additionalProperties: false
+            },
             hydrogenFuelTankSize: {type: :number},
             isGroundVehicle: {type: :boolean},
             length: {type: :number},

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -26,19 +26,21 @@ const props = withDefaults(defineProps<Props>(), {
 const soldAt = computed(() => props.model.availability.soldAt);
 const rentalAt = computed(() => props.model.availability.rentalAt);
 
-// The game files measure a ship themselves, and for about a third of ships their
-// figure disagrees with the one the matrix publishes -- by anything from a third
-// under to nearly triple. Neither source is reliably right, so the second figure
-// is shown rather than resolved away, and only where it actually differs: for the
-// other two thirds it would just repeat the number above it.
+// The game files measure a ship themselves, and for 91 of 211 ships their figure
+// differs from the one the matrix publishes. Often that is not an error: a ship
+// has up to three size sets -- landed, in flight, and with a cargo grid or wings
+// deployed -- and neither source records which one it measured. So the second
+// figure is shown rather than resolved away, and only where it differs, since for
+// the other 120 it would just repeat the number above it.
 const GAME_FILE_TOLERANCE = 0.01;
 
 const gameFileFigure = (
   key: "length" | "beam" | "height",
   shown: number | undefined,
 ) => {
-  // Only against the retracted figure. The extended one measures a different
-  // shape, so the game files have nothing to say about it.
+  // Not against the extended figure, which names a specific configuration. The
+  // game-file measurement names none, so pairing the two would assert something
+  // neither source says.
   if (props.extended) {
     return undefined;
   }

--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -26,6 +26,44 @@ const props = withDefaults(defineProps<Props>(), {
 const soldAt = computed(() => props.model.availability.soldAt);
 const rentalAt = computed(() => props.model.availability.rentalAt);
 
+// The game files measure a ship themselves, and for about a third of ships their
+// figure disagrees with the one the matrix publishes -- by anything from a third
+// under to nearly triple. Neither source is reliably right, so the second figure
+// is shown rather than resolved away, and only where it actually differs: for the
+// other two thirds it would just repeat the number above it.
+const GAME_FILE_TOLERANCE = 0.01;
+
+const gameFileFigure = (
+  key: "length" | "beam" | "height",
+  shown: number | undefined,
+) => {
+  // Only against the retracted figure. The extended one measures a different
+  // shape, so the game files have nothing to say about it.
+  if (props.extended) {
+    return undefined;
+  }
+
+  const measured = props.model.metrics.gameFiles?.[key];
+
+  if (!measured || !shown) {
+    return undefined;
+  }
+
+  return Math.abs(measured - shown) / shown > GAME_FILE_TOLERANCE
+    ? measured
+    : undefined;
+};
+
+const gameFileLength = computed(() =>
+  gameFileFigure("length", props.model.metrics.length),
+);
+const gameFileBeam = computed(() =>
+  gameFileFigure("beam", props.model.metrics.beam),
+);
+const gameFileHeight = computed(() =>
+  gameFileFigure("height", props.model.metrics.height),
+);
+
 const displayLength = computed(() => {
   if (props.extended && props.model.metrics.extendedLength) {
     return props.model.metrics.extendedLength;
@@ -80,17 +118,44 @@ const openAvailability = () => {
         <div class="metrics-card__tile__value">
           {{ toNumber(displayLength || "", "distance") }}
         </div>
+        <div
+          v-if="gameFileLength"
+          v-tooltip="t('model.gameFilesMeasurementHint')"
+          class="metrics-card__tile__note"
+          data-test="game-file-length"
+        >
+          {{ t("model.gameFiles") }}
+          {{ toNumber(gameFileLength, "distance") }}
+        </div>
       </div>
       <div class="metrics-card__tile">
         <div class="metrics-card__tile__label">{{ t("model.beam") }}</div>
         <div class="metrics-card__tile__value">
           {{ toNumber(displayBeam || "", "distance") }}
         </div>
+        <div
+          v-if="gameFileBeam"
+          v-tooltip="t('model.gameFilesMeasurementHint')"
+          class="metrics-card__tile__note"
+          data-test="game-file-beam"
+        >
+          {{ t("model.gameFiles") }}
+          {{ toNumber(gameFileBeam, "distance") }}
+        </div>
       </div>
       <div class="metrics-card__tile">
         <div class="metrics-card__tile__label">{{ t("model.height") }}</div>
         <div class="metrics-card__tile__value">
           {{ toNumber(displayHeight || "", "distance") }}
+        </div>
+        <div
+          v-if="gameFileHeight"
+          v-tooltip="t('model.gameFilesMeasurementHint')"
+          class="metrics-card__tile__note"
+          data-test="game-file-height"
+        >
+          {{ t("model.gameFiles") }}
+          {{ toNumber(gameFileHeight, "distance") }}
         </div>
       </div>
       <div class="metrics-card__tile">

--- a/app/frontend/shared/components/metricsCard.scss
+++ b/app/frontend/shared/components/metricsCard.scss
@@ -253,6 +253,20 @@
       color: #fff;
     }
 
+    // A second figure for the same stat from another source, shown only where it
+    // disagrees with the one above. Deliberately quiet: it is a discrepancy worth
+    // seeing, not a value competing for the eye.
+    &__note {
+      margin-top: 5px;
+      font-size: 11px;
+      line-height: 1.3;
+      color: $gray-light;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     &__unit {
       font-family: "Open Sans", sans-serif;
       font-weight: 600;

--- a/app/frontend/translations/de/main.json
+++ b/app/frontend/translations/de/main.json
@@ -62,7 +62,9 @@
       "soldAt": "Verkauft bei?",
       "rentalAt": "Vermietung bei?",
       "poweredByUex": "Bereitgestellt von UEX",
-      "lastUpdatedAt": "Zuletzt aktualisiert am?"
+      "lastUpdatedAt": "Zuletzt aktualisiert am?",
+      "gameFiles": "Im Spiel:",
+      "gameFilesMeasurementHint": "Was die Spieldateien für dieses Schiff messen. Der Wert kann von der RSI-Angabe abweichen; keiner von beiden ist verlässlich der genauere."
     },
     "component": {
       "manufacturer": "Hersteller",

--- a/app/frontend/translations/de/main.json
+++ b/app/frontend/translations/de/main.json
@@ -64,7 +64,7 @@
       "poweredByUex": "Bereitgestellt von UEX",
       "lastUpdatedAt": "Zuletzt aktualisiert am?",
       "gameFiles": "Im Spiel:",
-      "gameFilesMeasurementHint": "Was die Spieldateien für dieses Schiff messen. Der Wert kann von der RSI-Angabe abweichen; keiner von beiden ist verlässlich der genauere."
+      "gameFilesMeasurementHint": "Was die Spieldateien für dieses Schiff messen. Keine der beiden Quellen gibt an, welche Konfiguration gemessen wurde -- gelandet, im Flug oder mit ausgefahrenem Cargo-Grid beziehungsweise Flügeln -- die Werte können also abweichen, ohne dass einer falsch ist. In der Regel ist Flug der Standard."
     },
     "component": {
       "manufacturer": "Hersteller",

--- a/app/frontend/translations/en/main.json
+++ b/app/frontend/translations/en/main.json
@@ -62,7 +62,9 @@
       "soldAt": "Sold at?",
       "rentalAt": "Rental at?",
       "poweredByUex": "Powered by UEX",
-      "lastUpdatedAt": "Last updated at?"
+      "lastUpdatedAt": "Last updated at?",
+      "gameFiles": "In game:",
+      "gameFilesMeasurementHint": "What the game files measure for this ship. It can differ from the figure RSI publishes; neither is reliably the more accurate one."
     },
     "component": {
       "manufacturer": "Manufacturer",

--- a/app/frontend/translations/en/main.json
+++ b/app/frontend/translations/en/main.json
@@ -64,7 +64,7 @@
       "poweredByUex": "Powered by UEX",
       "lastUpdatedAt": "Last updated at?",
       "gameFiles": "In game:",
-      "gameFilesMeasurementHint": "What the game files measure for this ship. It can differ from the figure RSI publishes; neither is reliably the more accurate one."
+      "gameFilesMeasurementHint": "What the game files measure for this ship. Neither source says which configuration it measured -- landed, in flight, or with a cargo grid or wings deployed -- so the two figures can differ without either being wrong. Flight is usually the default."
     },
     "component": {
       "manufacturer": "Manufacturer",

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -347,6 +347,13 @@ class Model < ApplicationRecord
     sc_key.presence || slug&.tr("-", "_")
   end
 
+  # Whether the game files measured this ship at all. Zero counts as unmeasured:
+  # the export writes 0 for a handful of ships rather than leaving the field out,
+  # and a zero dimension is never a real one.
+  def game_file_metrics?
+    [sc_length, sc_beam, sc_height].compact.any? { |value| !value.zero? }
+  end
+
   def self.production_status_filters
     PRODUCTION_STATUSES.map do |item|
       Filter.new(

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -143,9 +143,13 @@ json.metrics do
   json.height_label model.height_label
 
   # What the game files measure, alongside what the matrix publishes, rather than
-  # instead of it. The two disagree for 76 of 211 ships, by anything from -88% to
-  # +266%, and no rule resolves them -- the metric orientation varies per ship, so
-  # neither source is reliably the right one. Nobody could see the disagreement
+  # instead of it. They differ for 91 of 211 ships, and the difference usually has
+  # a cause rather than being an error: a ship has up to three size sets -- landed,
+  # in flight, and with a cargo grid or wings deployed -- and *neither source
+  # records which one it measured*. Flight is normally the default.
+  #
+  # So this cannot be resolved automatically, only labelled by a person. Serving
+  # both is the honest shape until then; nobody could see the difference at all
   # while these columns were written and read by nothing.
   #
   # Omitted rather than sent as zero when the export has no measurement, which is

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -141,6 +141,23 @@ json.metrics do
   json.extended_fleetchart_offset_beam model.extended_fleetchart_offset_beam&.to_f
   json.height model.height.to_f
   json.height_label model.height_label
+
+  # What the game files measure, alongside what the matrix publishes, rather than
+  # instead of it. The two disagree for 76 of 211 ships, by anything from -88% to
+  # +266%, and no rule resolves them -- the metric orientation varies per ship, so
+  # neither source is reliably the right one. Nobody could see the disagreement
+  # while these columns were written and read by nothing.
+  #
+  # Omitted rather than sent as zero when the export has no measurement, which is
+  # the one case that *is* recognisable (5 ships).
+  if model.game_file_metrics?
+    json.game_files do
+      json.length model.sc_length&.to_f
+      json.beam model.sc_beam&.to_f
+      json.height model.sc_height&.to_f
+    end
+  end
+
   json.hydrogen_fuel_tank_size model.hydrogen_fuel_tank_size&.to_f
   json.is_ground_vehicle model.ground
   json.length model.length.to_f

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -2333,6 +2333,16 @@ components:
           type: number
         heightLabel:
           type: string
+        gameFiles:
+          type: object
+          properties:
+            length:
+              type: number
+            beam:
+              type: number
+            height:
+              type: number
+          additionalProperties: false
         hydrogenFuelTankSize:
           type: number
         isGroundVehicle:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -12481,6 +12481,16 @@ components:
           type: number
         heightLabel:
           type: string
+        gameFiles:
+          type: object
+          properties:
+            length:
+              type: number
+            beam:
+              type: number
+            height:
+              type: number
+          additionalProperties: false
         hydrogenFuelTankSize:
           type: number
         isGroundVehicle:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -17876,6 +17876,16 @@ components:
           type: number
         heightLabel:
           type: string
+        gameFiles:
+          type: object
+          properties:
+            length:
+              type: number
+            beam:
+              type: number
+            height:
+              type: number
+          additionalProperties: false
         hydrogenFuelTankSize:
           type: number
         isGroundVehicle:

--- a/test/integration/api/v1/models_show_test.rb
+++ b/test/integration/api/v1/models_show_test.rb
@@ -31,6 +31,33 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
     assert_api_response :get, 200, path_params: {slug: model.slug}
   end
 
+  # The matrix figure and the game-file measurement disagree for a third of
+  # ships, so both are served rather than one overwriting the other.
+  test "GET /models/:slug carries the game-file measurements alongside the matrix ones" do
+    model = create(:model, length: 111.5, beam: 39.5, height: 20.0,
+      sc_length: 13.4, sc_beam: 39.5, sc_height: 111.5)
+
+    get "/api/v1/models/#{model.slug}"
+
+    assert_response :success
+    metrics = response.parsed_body["metrics"]
+
+    assert_in_delta 111.5, metrics["length"]
+    assert_in_delta 13.4, metrics.dig("gameFiles", "length")
+    assert_in_delta 111.5, metrics.dig("gameFiles", "height")
+  end
+
+  # Zero is the one unmeasured case the export makes recognisable, and a zero
+  # dimension would read as a real disagreement.
+  test "GET /models/:slug leaves out game-file measurements the export does not have" do
+    model = create(:model, sc_length: 0, sc_beam: 0, sc_height: 0)
+
+    get "/api/v1/models/#{model.slug}"
+
+    assert_response :success
+    assert_nil response.parsed_body["metrics"]["gameFiles"]
+  end
+
   test "GET /models/:slug returns 404 for unknown model" do
     assert_api_response :get, 404, path_params: {slug: "unknown-model"}
   end


### PR DESCRIPTION
`sc_length`, `sc_beam` and `sc_height` have been written by the sc_data loader and read by nothing. The displayed dimensions come from the ship matrix alone, so the fact that the two sources disagree for **91 of 211 ships** has been invisible.

This serves the game-file measurement as `metrics.gameFiles` and shows it under the length, beam and height tiles on the ship page — a quiet second line, and only where it differs by more than 1%. For the other 120 ships nothing changes.

**Fleetcharts and compare are untouched.** They keep reading `metrics.length/beam/height`; this only adds a line to the detail page. That was deliberate: making the difference visible is safe, switching the source is not (see below).

## Why both figures rather than one

A ship has up to three size sets — landed, in flight, and a third for deployable geometry like the Hull C's cargo grid or the Stingray's combat configuration — and **neither source records which one it measured.** Flight is normally the default. So a difference is usually not an error, and it cannot be resolved automatically, only labelled by a person.

The Aurora Mk II is the clearest case: matrix `[27.5, 10.5, 5.5]`, game files `[27.4, 27.7, 8.0]`. The length agrees; the beam nearly triples because the wings are out.

## What the disagreements actually are

Measured, with a tolerance of 5% or 0.5 m — relative alone over-reports small vehicles, where 0.3 m on a 1.5 m bike reads as 25%:

| | |
| --- | --- |
| agree | 120 |
| axis order differs | 36 |
| deployed geometry (length holds, cross-section grows) | 30 |
| unexplained | 25 |
| no game-file measurement (zeros) | 5 |

Deployed geometry has a clear signature: across that group the game figure is larger on beam for 25 ships against 5 smaller, and on height for 32 against 11, while the length mostly agrees.

## Why the axes are not fixed here

The export does not order its axes consistently — the Caterpillar's matrix length of 111.5 m arrives as its game-file height, the X1's length as its beam. That is our bug and the largest group, but it is not fixable from the data we store:

- **`signature_cross_section`** is the only other per-axis figure we keep. Its ordering matches the dimension ordering for **0 of 104** agreeing ships and 2 of 24 reordered ones — it measures something else entirely.
- **"the longest axis is the length"** is wrong for 28 ships. 21 are wider than long (Ares Inferno, Mercury Star Runner, Reliant Mako, the Cyclone family), 7 taller than long (Khartu-Al is 32 m tall, Nox, ATLS, Syulen). Worse, the game files already agree exactly with the matrix for those, so relabelling by size would break 17 currently-correct ships and take the match count from 120 down to 112.
- **Cargo grid geometry** carries dimensions but no positions, and grids are sometimes mounted crosswise to the ship, so it says nothing about orientation either.

The information is in the raw game files, not in the three numbers the parser reduces them to. The fix belongs in the parser, where the entity's orientation is still available.

## Verification

1,300 tests across the models and the whole public API, green. Two new tests cover the served field and the zero case. `lint:ts` exit 0, `standardrb` and prettier clean. The REST schema, the admin schema and the AsyncAPI cable document were all regenerated — the cable document embeds the REST component and rejects an undeclared property, which is how the first run failed.

🤖
