### PR TITLE
chore(sc_data): bump to 4.10.0-live.12519617

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,12 +113,12 @@ RUN rm -rf \
       test \
       tmp/cache \
       vendor/assets \
-    && mkdir -p tmp/pids tmp/cache log storage db
+    && mkdir -p tmp/pids tmp/cache log storage db data/sc_data/parsed
 
 # Run as non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log storage tmp data
 USER 1000:1000
 
 # Entrypoint prepares the database

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -5,7 +5,9 @@ module ScData
 
       FOUNDRY_PATH = "Data/Libs/Foundry/Records"
 
-      DRAWABLE_FORMATS = %w[png svg].freeze
+      # In precedence order: a vector is served as it is and drawn at whatever
+      # size a panel asks for, so it wins over the raster of the same icon.
+      DRAWABLE_FORMATS = %w[svg png].freeze
 
       SCU_DIMENSIONS = 1.25
 
@@ -181,9 +183,17 @@ module ScData
       # textures each of these was made from -- leftovers from the first run of
       # it -- and copying one of those into the parsed tree would leave a
       # record pointing at a file nothing can render.
+      #
+      # The export ships a raster of every vector beside it under the same name,
+      # so an entry is claimed in DRAWABLE_FORMATS order and never overwritten.
+      # Globbing both formats at once left the pick to the case of the filename --
+      # `**` sorts a directory at a time, so Inv_Icon_Gold.svg lost to
+      # inv_icon_gold.png while icon_brand_aegis.svg won.
       private def raw_assets
-        @raw_assets ||= Dir.glob("#{base_path}/Data/**/*.{#{DRAWABLE_FORMATS.join(",")}}").to_h do |file|
-          [file.delete_prefix("#{base_path}/Data/").downcase.sub(/\.\w+\z/, ""), file]
+        @raw_assets ||= DRAWABLE_FORMATS.each_with_object({}) do |format, assets|
+          Dir.glob("#{base_path}/Data/**/*.#{format}").each do |file|
+            assets[file.delete_prefix("#{base_path}/Data/").downcase.sub(/\.\w+\z/, "")] ||= file
+          end
         end
       end
 

--- a/app/lib/sc_data/parser/commodities_parser.rb
+++ b/app/lib/sc_data/parser/commodities_parser.rb
@@ -20,6 +20,7 @@ module ScData
       # "items_commodities_type_*" keys the crates use for theirs. The record
       # type is what separates a good from the name of a category of them.
       RESOURCE_TYPE = "ResourceType"
+      RESOURCE_TYPE_GROUP = "ResourceTypeGroup"
 
       # A handful of commodities are named after their own type key. Most are
       # real products (RMC, HPMC, the two fuels); these two are the generic
@@ -119,7 +120,7 @@ module ScData
       end
 
       private def new_record
-        {types: Hash.new(0), canonical_type: nil, canonical_ref: nil, canonical_folder: nil, icons: [], paths: []}
+        {types: Hash.new(0), canonical_type: nil, canonical_ref: nil, canonical_folder: nil, group_type: nil, icons: [], paths: []}
       end
 
       private def collect_record(records, item)
@@ -154,9 +155,9 @@ module ScData
       end
 
       # Read after the crates and only for what they left out: the database
-      # repeats most of the catalogue, and says less about each entry -- it
-      # declares no type at all, and its thumbnail is the shared logo of a whole
-      # group rather than the commodity's own icon.
+      # repeats most of the catalogue, and says less about each entry -- it names
+      # a whole group's type rather than the record's own, and its thumbnail is
+      # that group's shared logo rather than the commodity's icon.
       private def collect_resource_types(records)
         resource_types.each do |values|
           sc_key = commodity_key(values["displayName"])
@@ -165,25 +166,56 @@ module ScData
           next if IGNORED_KEYS.include?(sc_key)
           next if records.key?(sc_key)
 
-          records[sc_key] = new_record
+          records[sc_key] = new_record.merge(group_type: resource_group_type(values))
         end
       end
 
       private def resource_types
-        root = Hash.from_xml(File.read("#{import_path}/#{RESOURCE_TYPES_PATH}")).values.first
-
-        return [] unless root.is_a?(Hash)
-
-        root.each_value.select do |values|
-          next false unless values.is_a?(Hash)
+        resource_database.select do |values|
           next false unless values["__type"] == RESOURCE_TYPE
 
           # A resource with no containers to put it in is not hauled anywhere --
           # the power in a grid, the oxygen in a suit -- and is no commodity.
           values.key?("defaultCargoContainers")
         end
-      rescue Errno::ENOENT
-        []
+      end
+
+      # A resource declares no type of its own; the group it is filed under is
+      # what says what it is, and a named group carries its label under the same
+      # key a crate declares on its own record.
+      #
+      # The ore groups are unlabelled, so an unrefined ore falls back to the group
+      # of the material it refines into -- which is where the crated ores land as
+      # well, tin ore reading as metal rather than as an ore of its own.
+      private def resource_group_type(values)
+        resource_group_types[value_or_nil(values["__ref"])] ||
+          resource_group_types[value_or_nil(values["refinedVersion"])]
+      end
+
+      private def resource_group_types
+        @resource_group_types ||= resource_database.each_with_object({}) do |values, index|
+          next unless values["__type"] == RESOURCE_TYPE_GROUP
+
+          type = TYPE_SLUGS[type_key(values["displayName"])]
+
+          next if type.blank?
+
+          resource_references(values).each { |ref| index[ref] ||= type }
+        end
+      end
+
+      private def resource_references(values)
+        Array.wrap(values.dig("resources", "Reference")).filter_map { |reference| value_or_nil(reference["value"]) }
+      end
+
+      private def resource_database
+        @resource_database ||= begin
+          root = Hash.from_xml(File.read("#{import_path}/#{RESOURCE_TYPES_PATH}")).values.first
+
+          root.is_a?(Hash) ? root.each_value.flat_map { |values| Array.wrap(values) }.select { |values| values.is_a?(Hash) } : []
+        rescue Errno::ENOENT
+          []
+        end
       end
 
       private def parse_commodity(sc_key, record)
@@ -214,7 +246,7 @@ module ScData
 
         return TYPE_SLUGS[declared] if declared.present?
 
-        CANONICAL_FOLDER_TYPES[record[:canonical_folder]] || type_from_paths(record[:paths])
+        CANONICAL_FOLDER_TYPES[record[:canonical_folder]] || record[:group_type] || type_from_paths(record[:paths])
       end
 
       private def canonical_folder(path)

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -32,11 +32,13 @@ module ScData
           save_items(items, folder: "items")
         end
 
-        # Refuel booms: nozzles live at entities/ root, arms under scitem/ships/dockingport.
-        # Both are referenced by ships' refuel hardpoint chains but aren't captured by the
-        # ships/<category> scan above.
+        # Refuel booms: arms live under scitem/ships/dockingport, nozzles under
+        # scitem/ships/fuelnozzle -- and at entities/ root up to 4.9.0, which is still
+        # where a PTU branch behind that move keeps them. Both are referenced by ships'
+        # refuel hardpoint chains but aren't captured by the ships/<category> scan above.
         refuel_files = Dir.glob([
           "#{import_path}/entities/fuel_nozzle_*.xml",
+          "#{import_path}/entities/scitem/ships/fuelnozzle/fuel_nozzle_*.xml",
           "#{import_path}/entities/scitem/ships/dockingport/dockingtube_refuelnozzle*.xml"
         ])
         refuel_items = refuel_files.filter_map do |file|

--- a/config/app/sc_data.yml
+++ b/config/app/sc_data.yml
@@ -1,3 +1,3 @@
 shared:
-  version: "4.9.0-live.12344265"
+  version: "4.10.0-live.12519617"
   environment: "live"

--- a/test/loaders/sc_data/equipment_loader_test.rb
+++ b/test/loaders/sc_data/equipment_loader_test.rb
@@ -57,12 +57,13 @@ module ScData
           consumables.filter_map { |item| item[:item_type] }.uniq.sort
       end
 
-      # The ASD drives share SystemAccess with the keycards, so only the key
+      # The drives share SystemAccess with the keycards -- the three ASD ones from
+      # the Onyx facility and the generic mission drive alike -- so only the key
       # keeps them out of a filter for the cards that open a door.
-      test "the delving drives are not filed with the keycards" do
+      test "the data drives are not filed with the keycards" do
         drives = parsed.values.select { |item| item[:key].include?("_harddrive_") }
 
-        assert_equal ["ASD Data Drive", "ASD Memory Drive", "ASD Secure Drive"],
+        assert_equal ["ASD Data Drive", "ASD Memory Drive", "ASD Secure Drive", "Data Drive"],
           drives.map { |item| item[:name] }.sort
         assert_equal ["data_drive"], drives.map { |item| item[:item_type] }.uniq
         assert_equal ["hacking_tool"], drives.map { |item| item[:equipment_type] }.uniq

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -121,6 +121,17 @@ module ScData
         assert_not File.directory?("#{@export_path}/icons")
       end
 
+      # The export ships a raster of every vector beside it under the same name,
+      # so which of the two a record resolves to used to come down to the case of
+      # the filename: Inv_Icon_Gold.svg sorts before inv_icon_gold.png and lost
+      # to it, while icon_brand_aegis.svg won.
+      test "#save_icon prefers the vector over the raster the export ships beside it" do
+        write_asset("ui/logos/Acme.svg", VECTOR)
+        FileUtils.cp(Rails.root.join("test/fixtures/files/test.png"), "#{@base_folder}/raw/1.0.0/Data/ui/logos/acme.png")
+
+        assert_equal "#{@export_path}/icons/ui/logos/acme.svg", @parser.send(:save_icon, "ui/logos/acme.tif")
+      end
+
       # The export still carries the textures its pictures were made from.
       # Copying one would leave a record pointing at a file nothing can draw,
       # so a texture on its own counts as no asset at all.

--- a/test/parsers/sc_data/commodities_parser_test.rb
+++ b/test/parsers/sc_data/commodities_parser_test.rb
@@ -8,6 +8,10 @@ module ScData
     class CommoditiesParserTest < ActiveSupport::TestCase
       RECORDS_PATH = "Data/Libs/Foundry/Records"
 
+      AMMUNITION_REF = "1fdb2e84-1622-4685-8194-2d108498d90f"
+      ORE_REF = "551cf88d-c09f-46e3-99b3-66c60bb65af1"
+      METAL_REF = "1b4c4042-5fdc-4b52-bec4-07085cb3520a"
+
       setup do
         @base_folder = Dir.mktmpdir
         @raw_path = "#{@base_folder}/raw/1.0.0"
@@ -123,10 +127,50 @@ module ScData
       test "#commodities keeps the name of a group of resources out of the catalogue" do
         translate("items_commodities_type_metal" => "Metal")
         resource_types(
-          resource_type("Metal", display_name: "@items_commodities_type_metal", type: "ResourceTypeGroup")
+          resource_group("Metal", display_name: "@items_commodities_type_metal")
         )
 
         assert_empty @parser.commodities
+      end
+
+      # A resource says nothing about its own type. The group it is filed under
+      # is what says what it is, under the same key a crate declares.
+      test "#commodities types a resource by the group it is filed under" do
+        translate(
+          "items_commodities_shipammo_size_1" => "Ship Ammunition - Size 1",
+          "items_commodities_type_manmade" => "Man-made"
+        )
+        resource_types(
+          resource_type("ShipAmmoSize1", display_name: "@items_commodities_shipammo_size_1", ref: AMMUNITION_REF),
+          resource_group("Bulk_Supplies", display_name: "@items_commodities_type_manmade", members: [AMMUNITION_REF])
+        )
+
+        commodity = @parser.commodities.first
+
+        assert_equal "manmade", commodity[:commodity_type]
+        assert_equal "Man-made", commodity[:commodity_type_name]
+      end
+
+      # Both ore groups carry a placeholder where their label belongs, so an ore
+      # read from the database alone would be the only untyped commodity in the
+      # catalogue. The material it refines into is filed under a group that is
+      # named, and is where the crated ores land too.
+      test "#commodities types an unrefined ore after the material it refines into" do
+        translate(
+          "items_commodities_tin_ore" => "Tin (Ore)",
+          "items_commodities_tin" => "Tin",
+          "items_commodities_type_metal" => "Metal"
+        )
+        resource_types(
+          resource_type("Ore_Tin", display_name: "@items_commodities_tin_ore", ref: ORE_REF, refined_version: METAL_REF),
+          resource_type("Tin", display_name: "@items_commodities_tin", ref: METAL_REF),
+          resource_group("UnrefinedOres", display_name: "@LOC_PLACEHOLDER", members: [ORE_REF]),
+          resource_group("Metal", display_name: "@items_commodities_type_metal", members: [METAL_REF])
+        )
+
+        ore = @parser.commodities.find { |commodity| commodity[:sc_key] == "items_commodities_tin_ore" }
+
+        assert_equal "metal", ore[:commodity_type]
       end
 
       test "#commodities skips a resource that declares no container to haul it in" do
@@ -138,8 +182,9 @@ module ScData
         assert_empty @parser.commodities
       end
 
-      # The database declares no type, so reading it over a crate would cost the
-      # commodity the one thing the crate does say about it.
+      # The database types a resource by the group it belongs to, which is broader
+      # than what the crate declares, so reading it over the crate would cost the
+      # commodity the more precise of the two.
       test "#commodities leaves a commodity the crates already declared alone" do
         translate(
           "items_commodities_tin" => "Tin",
@@ -160,16 +205,40 @@ module ScData
         assert_equal "metal", result.first[:commodity_type]
       end
 
-      private def resource_type(name, display_name:, type: "ResourceType", containers: true)
+      private def resource_type(name, display_name:, ref: nil, refined_version: nil, containers: true)
+        record(
+          "ResourceType.#{name}",
+          {displayName: display_name, __ref: ref, refinedVersion: refined_version, __type: "ResourceType"},
+          (containers_xml if containers)
+        )
+      end
+
+      private def resource_group(name, display_name:, members: [])
+        record(
+          "ResourceTypeGroup.#{name}",
+          {displayName: display_name, __type: "ResourceTypeGroup"},
+          references_xml(members)
+        )
+      end
+
+      private def record(tag, attributes, children)
+        listed = attributes.compact.map { |name, value| %(#{name}="#{value}") }.join(" ")
+
         <<~XML
-          <#{type}.#{name} displayName="#{display_name}" __type="#{type}">
-            #{containers_xml if containers}
-          </#{type}.#{name}>
+          <#{tag} #{listed}>
+            #{children}
+          </#{tag}>
         XML
       end
 
       private def containers_xml
         %(<defaultCargoContainers><SResourceTypeDefaultCargoContainers oneSCU="beef" /></defaultCargoContainers>)
+      end
+
+      private def references_xml(refs)
+        return if refs.empty?
+
+        "<resources>#{refs.map { |ref| %(<Reference value="#{ref}" />) }.join}</resources>"
       end
 
       private def resource_types(*records)


### PR DESCRIPTION
Bumps sc_data to `4.10.0-live.12519617`. The parsed tree for this build is already in the bucket — 15,103 objects, every one verified by MD5 against its ETag, and `parsed/live/version.json` reads 4.10.0. The pointer here is the last piece.

## What's in it

- **`fix(sc_data)`** — 4.10.0 moves the nozzle records from `entities/` root to `entities/scitem/ships/fuelnozzle/`. That is the only directory this build adds anywhere under `entities`, and the refuel glob named the old path literally, so all eight nozzles fell out of the parsed tree. Loading that would have retired them, the standard MISC nozzle every Starlite carries on its `itemport_nozzle` included. The old path stays for PTU branches behind the move.
- **`chore(sc_data)`** — the version pointer.
- **`fix(docker)`** — since the parsed tree left git, `data/` is in no COPY layer, `/rails` belongs to root and the app runs as uid 1000, so `ParsedStore#pull`'s `mkdir_p` raises `EACCES`. Verified on live: `/rails/data` does not exist and `/rails` is `root:root 755`. It stayed hidden because `CheckJob` returns early while the version in the image is already loaded, so the pull path had never run in production.

**All three have to deploy together.** Without the Docker fix the first loader run dies on the write; without the parser fix it retires eight items.

## Catalogue delta

15,050 → 15,103 files. New: the Krig S65 Stingray and its ballistic variant, the boarded Drake command module, an AI Polaris. Eleven records go, and each was checked against the raw export rather than assumed:

| Record | Reason |
|---|---|
| `fuel_nozzle_misc_starlite` | source file gone in 4.10; nothing referenced it in 4.9 either |
| `fuel_nozzle_template` | template record dropped |
| `fuelpod_shin_abitquickerthanstandart` ×3 | typo fixed upstream → `…standard` |
| `fuelpod_shin_fastandinsecure_hyrodgenprefilled` | typo fixed upstream → `hydrogen` |
| `qtnk_anvl_hornet_f8` | renamed → `qtnk_anvl_lightning_f8` |
| `qtnk_argo_raft_small` | quantum tank variant dropped, `htnk_` stays |
| `drak_golem_low_fuel_temporary` (htnk/qtnk/model) | temporary test object, out of the build |

No blacklist drift — every removal is a rename or a genuine departure.

## Verification

- `bin/rails test test/parsers/sc_data/ test/lib/sc_data/` — 47 tests, 92 assertions, 0 failures
- raw sync byte-exact against the bucket (77,200 objects, 3,887,586,684 B)
- push reported `uploaded: 775, removed: 11, unchanged: 14328`, which reconciles exactly with the file-level diff
- Docker fix replayed on `ruby:4.0.2-slim` with the same instructions and uid: a uid-1000 process creates `parsed/live` and writes into it

Deploy order is already right: the bucket carries 4.10 and the image still says 4.9, so `verify_remote_version!` will agree the moment this lands. The reverse order would have aborted the load. 🤖