### PR TITLE
fix(navigation): right-align the nav item badge

### DIFF
--- a/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.scss
+++ b/app/frontend/shared/components/AppNavigation/NavItem/NavItemInner/index.scss
@@ -2,6 +2,7 @@
   position: relative;
   min-height: 30px;
   display: flex;
+  flex-grow: 1;
   align-items: center;
 
   .nav-item-icon {
@@ -13,6 +14,7 @@
   .nav-item-text {
     white-space: normal;
     overflow-wrap: anywhere;
+    margin-inline-end: 10px;
   }
 
   .nav-item-badge {


### PR DESCRIPTION
## What

The unread notifications count in the expanded (non-collapsed) navigation sat flush against its label instead of at the right edge of the nav item.

`.nav-item-badge` already declared `margin-inline-start: auto` to push itself to the trailing edge, but `.nav-item-inner` — the flex container it lives in — never grew, so it was only as wide as its content. With no free space on the line the auto margin resolved to `0` and the badge ended up directly next to the label text.

## How

- `flex-grow: 1` on `.nav-item-inner` so it fills the nav item and the existing auto margin actually has space to distribute.
- `margin-inline-end: 10px` on `.nav-item-text` as a minimum gap, for the case where a long label wraps and collapses the auto margin back to `0`.

The collapsed/slim state is untouched: there the badge is the absolutely positioned dot on the icon (`.nav-item-badge--dot`), which overrides the margin anyway.

## Testing

`pnpm vitest run app/frontend/shared/components/AppNavigation` — 6/6 passing.

🤖