### PR TITLE
fix(admin): stop the dropzone covering a file input's preview

### DIFF
--- a/app/frontend/shared/components/base/FormFileInput/index.vue
+++ b/app/frontend/shared/components/base/FormFileInput/index.vue
@@ -278,6 +278,13 @@ const holoModel = computed(() => {
   return undefined;
 });
 
+// The dropzone is only pinned open while there is nothing to look at. A
+// previewSrc counts: the folder upload fills the whole form that way, and
+// forcing the overlay on top of it hid every picture it just set.
+const hasPreview = computed(() => {
+  return uploadedHere.value || !!props.previewSrc || !!internalSrc.value;
+});
+
 const clearLabel = computed(() => {
   if (inputValue.value) {
     return t("actions.reset");
@@ -343,7 +350,7 @@ defineExpose({
         :allowed-types="fileTypeMap[props.allowedTypes as AllowedFileTypes]"
         :allowed-size-mb="props.allowedSizeMb"
         :transparent="transparent || avatar"
-        :active="!internalSrc"
+        :active="!hasPreview"
         @upload:done="onUploadDone"
         @clear="onUploadClear"
       />


### PR DESCRIPTION
## What

Uploading images through the views folder upload on the fleetchart edit page left the `Drop file here or browse` overlay sitting on top of every preview it had just filled in.

## Why

`FormFileInput` pinned the dropzone open with `:active=\"!internalSrc\"`, and `internalSrc` only ever tracks `props.file` — the *persisted* blob. A `previewSrc`, which is exactly how the folder upload fills the whole form, did not count, so `.direct-upload__dropzone--active { opacity: 1 !important }` stayed put over the picture.

The overlay is now only pinned open when the field genuinely has nothing to show. Over a preview it behaves like everywhere else and appears on hover, so drag & drop and `browse` stay reachable.

## Testing

- `pnpm lint:ts` — clean
- Manually: admin → `models/<id>/edit/fleetchart`, run the views folder upload; previews stay visible, the overlay only shows on hover.

🤖