### PR TITLE
fix(sc_data): read each ship's dimensions off the right axis

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -1,6 +1,44 @@
 module ScData
   module Loader
     class ModelsLoader < ::ScData::Loader::BaseLoader
+      # Which axis of the export's bounding box is the length, the beam and the
+      # height. `maxBoundingBoxSize` in the entity record carries three correct
+      # magnitudes but no consistent convention for which is which -- it depends on
+      # how the model was authored -- so the default below is wrong for a handful
+      # of ships. Measured over 1031 ship entities, its largest value sits on `y`
+      # for 829, on `x` for 174 and on `z` for 28.
+      #
+      # It cannot be derived from the export: item-port positions give a reliable
+      # forward axis but do not share the bounding box's frame, the signature
+      # cross-section correlates with nothing, and the meshes that would settle it
+      # are assembled from dozens of parts and are not exported at all.
+      #
+      # So it is curated, and read off the orthographic renders instead. Those
+      # share their edges -- from above a ship is length x beam, from the side
+      # length x height -- which both validates the crop and gives the true
+      # proportions. Each entry below is the permutation whose proportions match
+      # the render; the ship matrix plays no part, which matters because it is
+      # itself wrong for several of them.
+      #
+      # A permutation reflects how the model was authored, so it holds across
+      # patches while the measurements keep coming from the game files. Ships not
+      # listed use the default.
+      AXIS_ORDER = {
+        "drak_caterpillar" => %i[z x y],
+        "crus_starlifter_m2" => %i[x y z],
+        "crus_starlifter_a2" => %i[x y z],
+        "crus_starlifter_c2" => %i[x y z],
+        "crus_star_runner" => %i[x y z],
+        "gama_tyilui" => %i[x y z],
+        "rsi_scorpius" => %i[x y z],
+        "rsi_scorpius_antares" => %i[x y z],
+        "rsi_hermes" => %i[x y z],
+        "tmbl_cyclone" => %i[x y z],
+        "tmbl_storm_aa" => %i[x y z]
+      }.freeze
+
+      DEFAULT_AXIS_ORDER = %i[y x z].freeze
+
       def all
         update_in_game_flags
 
@@ -34,7 +72,7 @@ module ScData
 
         update_params = {}
 
-        update_params = update_metrics(model_data, update_params)
+        update_params = update_metrics(model, model_data, update_params)
         update_params = update_personal_inventory(model_data, update_params)
         hardpoints = model.hardpoints.game_files
         update_params = update_cargo_holds(hardpoints, update_params)
@@ -71,19 +109,28 @@ module ScData
         load_item("models/#{sc_data_identifier}")
       end
 
-      private def update_metrics(model_data, update_params)
+      private def update_metrics(model, model_data, update_params)
         update_params[:mass] = model_data.dig("mass")&.to_f
         update_params[:hull_health] = model_data.dig("hull_health")&.to_f
         update_params[:hull_parts] = model_data.dig("hull_parts")
         update_params[:hull_doors] = extract_hull_doors(model_data)
         update_params[:weapon_pool_size] = model_data.dig("weapon_pool_size")
         update_params[:signature_cross_section] = model_data.dig("signature_cross_section")
-        update_params[:sc_length] = model_data.dig("metrics", "y")&.to_f
-        update_params[:sc_beam] = model_data.dig("metrics", "x")&.to_f
-        update_params[:sc_height] = model_data.dig("metrics", "z")&.to_f
+        update_params.merge!(dimensions(model, model_data))
         update_params[:ground] = model_data.dig("ground") || false
 
         update_params
+      end
+
+      private def dimensions(model, model_data)
+        order = AXIS_ORDER.fetch(model.sc_data_identifier, DEFAULT_AXIS_ORDER)
+        metrics = model_data["metrics"] || {}
+
+        {
+          sc_length: metrics[order[0].to_s]&.to_f,
+          sc_beam: metrics[order[1].to_s]&.to_f,
+          sc_height: metrics[order[2].to_s]&.to_f
+        }
       end
 
       # The ship's own storage container, which the vehicle entity points at

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -36,6 +36,77 @@ module ScData
         assert_equal cross_section, model.reload.signature_cross_section
       end
 
+      # The export's bounding box carries three correct magnitudes but no
+      # consistent convention for which axis is which, so a handful of ships need
+      # their own order. Read off the orthographic renders rather than the ship
+      # matrix, which is itself wrong for several of them.
+      test "#load_model reads the dimensions off y, x, z by default" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Default Order", sc_key: "test_default_order")
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 39.5, "y" => 111.5, "z" => 13.4}}
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_in_delta 111.5, model.sc_length.to_f
+        assert_in_delta 39.5, model.sc_beam.to_f
+        assert_in_delta 13.4, model.sc_height.to_f
+      end
+
+      # Its length sits on z: 111.5 m, which the default order would have read as
+      # its height.
+      test "#load_model uses the curated order for the Caterpillar" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Caterpillar", sc_key: "drak_caterpillar")
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 39.5, "y" => 13.4, "z" => 111.5}}
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_in_delta 111.5, model.sc_length.to_f
+        assert_in_delta 39.5, model.sc_beam.to_f
+        assert_in_delta 13.4, model.sc_height.to_f
+      end
+
+      # The Cyclone is the case that shows why the renders decide this and not the
+      # matrix: the matrix has it 6.0 m long and 8.8 m wide, and the render says
+      # the opposite. So the curated order deliberately disagrees with the matrix.
+      test "#load_model uses the curated order for the Cyclone, against the matrix" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Cyclone", sc_key: "tmbl_cyclone", length: 6.0, beam: 8.8, height: 3.5)
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 8.8, "y" => 6.0, "z" => 3.5}}
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_in_delta 8.8, model.sc_length.to_f
+        assert_in_delta 6.0, model.sc_beam.to_f
+        assert_in_delta 3.5, model.sc_height.to_f
+      end
+
+      test "#load_model survives an export with no metrics at all" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "No Metrics", sc_key: "test_no_metrics")
+
+        loader.stubs(:load_model_data).returns({"mass" => 1000.0, "loadout" => []})
+
+        loader.load_model(model)
+        model.reload
+
+        assert_nil model.sc_length
+        assert_nil model.sc_beam
+        assert_nil model.sc_height
+      end
+
       test "#load_model persists the parsed ground speeds" do
         loader = ::ScData::Loader::ModelsLoader.new
         model = create(:model, name: "Ground Speed Test", in_game: true)


### PR DESCRIPTION
The loader mapped `length <- metrics.y`, `beam <- metrics.x`, `height <- metrics.z` for every ship. `maxBoundingBoxSize` in the entity record carries three correct magnitudes but no consistent convention for which is which — it follows however the model was authored.

```xml
<!-- Data/Libs/Foundry/Records/entities/spaceships/drak_caterpillar.xml -->
<maxBoundingBoxSize x="39.5" y="13.4" z="111.5" />
```

The Caterpillar is 111.5 m long. Its length sits on `z`, so Fleetyards showed it as **13.4 m long**.

Measured over 1031 ship entity files, the largest value sits on `y` for 829, on `x` for 174 and on `z` for 28. Eleven ships now carry a curated axis order; the rest keep the default.

## The renders decide it, not the matrix

The three orthographic renders share their edges — from above a ship is length × beam, from the side length × height, from the front beam × height. So `top.width == side.width`, `top.height == front.width`, `side.height == front.height`. That both validates the crop and gives the ship's true proportions, with the ship matrix playing no part.

Which matters, because the matrix is wrong for several of them:

| ship | matrix says | render says |
| --- | --- | --- |
| Cyclone | 6.0 long × 8.8 wide | **8.8 long × 6.0 wide** |
| Scorpius | 32.0 long × 13.2 wide | **24.0 long × 32.0 wide** |
| Mercury Star Runner | 51.0 long × 55.0 wide | **55.0 long × 51.0 wide** |

The method validated itself on the way: the Cyclone and the Mercury were both flagged by hand as having wrong matrix figures, and the renders reproduce that independently — neither correction was fed into the fit.

## Every entry was looked at

Five sit at a fit error under 0.02 (Caterpillar 0.001, C2/M2 Hercules 0.002, Tyilui 0.011, A2 Hercules 0.018). Six sat between 0.03 and 0.045, close enough that a coincidental fit was possible — so those six renders were opened and checked by eye. All six are clean top-down views:

| ship | render ratio | curated order gives |
| --- | --- | --- |
| Cyclone | 1.51 | 8.8 / 6.0 = 1.47 |
| Mercury Star Runner | 1.088 | 55.0 / 51.0 = 1.078 |
| Scorpius | 1.33 | 24.0 / 32.0 = 1.33 |
| Hermes | 1.223 | 73.0 / 58.0 = 1.259 |
| Storm AA | 1.362 | 10.3 / 7.7 = 1.338 |
| Scorpius Antares | — | identical figures to the Scorpius |

## The Khartu-Al is deliberately absent

Its renders show it landed and upright with wings folded, while the exported triple is a different configuration — no permutation fits (error 1.144), so nothing here can resolve it. It keeps the default, which is what it had before.

It also exposed a limit worth writing down: the shared-edge check **passed** for it, because its top and side renders happen to be the same width, even though the side render is a diagonal view rather than an elevation. The edge check is necessary but not sufficient; only the proportion fit caught it. That is why the six borderline ships were checked visually rather than trusted.

## Why it cannot be derived

- **Item-port `<Position>` extents** are y-dominant for 1024 of 1031 ships, so the entity frame is well defined — but the bounding box does not share it. The Caterpillar's item ports span 90.7 m on `y` while its box says `y = 13.4`.
- **`signature_cross_section`** ordering matches the dimension ordering for 0 of 104 ships that already agree, and 2 of 24 that do not.
- **The meshes** would settle it and are not exported — and a ship is never one mesh; `drak_caterpillar.xml` names 28 `.cga`/`.cgf` references, each pulling in more, so the true extent only exists once the hierarchy is assembled with its transforms.
- **Sorting by size** would be wrong: ships genuinely wider than long exist, the Reliant Mako when landed among them, and both sources already agree on those. Relabelling by size breaks 17 currently-correct ships.

An axis order reflects how the model was authored, so it holds across patches while the measurements keep coming from the game files.

## Verification

Four new loader tests: the default order, the Caterpillar (`zxy`), the Cyclone (`xyz`, deliberately against the matrix figures on the same record), and an export with no metrics at all. Pointing `dimensions` back at the default makes the Caterpillar and Cyclone tests fail, so they cover the defect rather than the shape of the code.

`standardrb` clean.

The `ScData::Loader::*` suites fail in my worktree — equipment, commodities and the models hardpoint test — **identically on unmodified main**. The parsed `sc_data` fixture tree is not part of a checkout. Unrelated to this change.

🤖
