### PR TITLE
feat(sc_data): give components a row per build

### DIFF
--- a/app/lib/sc_data/loader/items_loader.rb
+++ b/app/lib/sc_data/loader/items_loader.rb
@@ -71,6 +71,7 @@ module ScData
           update_params[:version] = sc_version
 
           apply(component, update_params)
+          apply_build(component, update_params.except(:sc_key, :sc_ref, :version))
 
           if item["icon"].present?
             attach_icon(component, :icon, item["icon"])
@@ -91,6 +92,9 @@ module ScData
         end
 
         retire_absent(Component, loaded)
+        retire_absent_builds(ComponentBuild, :component_id, loaded)
+
+        prune_builds(ComponentBuild)
       end
 
       # A build that stops shipping a paint's swatch has to take the picture

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -65,6 +65,10 @@ class Component < ApplicationRecord
 
   belongs_to :manufacturer, optional: true
 
+  # What each build of the game says about this component. Written alongside the
+  # columns for now, so reads can move over a catalogue at a time.
+  has_many :builds, class_name: "ComponentBuild", dependent: :destroy
+
   has_many :model_paints, dependent: :nullify
 
   has_many :hardpoints, as: :parent, dependent: :destroy, autosave: true

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: component_builds
+#
+#  id                    :uuid             not null, primary key
+#  ammunition            :string
+#  category              :string
+#  component_class       :string
+#  component_sub_type    :string
+#  component_type        :string
+#  description           :text
+#  durability            :string
+#  environment           :string           not null
+#  grade                 :string
+#  heat_connection       :string
+#  hidden                :boolean          default(FALSE)
+#  inventory_consumption :string
+#  item_class            :integer
+#  item_type             :string
+#  name                  :string
+#  power_connection      :string
+#  size                  :string
+#  tracking_signal       :integer
+#  type_data             :string
+#  version               :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  component_id          :uuid             not null
+#  manufacturer_id       :uuid
+#
+# Indexes
+#
+#  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
+#  index_component_builds_on_component_id                     (component_id)
+#  index_component_builds_on_environment_and_component_class  (environment,component_class)
+#  index_component_builds_on_environment_and_item_type        (environment,item_type)
+#  index_component_builds_on_environment_and_version          (environment,version)
+#  index_component_builds_on_manufacturer_id                  (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (component_id => components.id) ON DELETE => cascade
+#
+# What one build of the game says about a component.
+#
+# The columns here are exactly the ones `ScData::Loader::ItemsLoader` writes.
+# Everything that identifies the component, or that a person set by hand, stays on
+# Component -- so a load can rewrite a build without touching the row a hardpoint,
+# a model paint or an uploaded icon hangs off.
+class ComponentBuild < ApplicationRecord
+  belongs_to :component
+  belongs_to :manufacturer, optional: true
+
+  # How many builds of one environment are kept. Enough to diff a patch against
+  # the one before it, and to compare a bad load with what it replaced, without
+  # the table growing with every patch forever.
+  BUILDS_RETAINED = 3
+
+  # Everything a build says, as opposed to what identifies the component. Taken
+  # from Component's own paper_trail list, which already named the specs that move
+  # between builds, plus `category` -- the loader writes it and it decides
+  # `hidden`, so it belongs to the build even though paper_trail skips it.
+  #
+  # The data migration carries its own copy on purpose: a migration has to keep
+  # running against the schema of its own moment, not this list as it later
+  # becomes.
+  FACTS = %i[
+    manufacturer_id name description size grade item_type item_class
+    component_class component_type component_sub_type category type_data
+    durability power_connection heat_connection ammunition
+    inventory_consumption tracking_signal hidden
+  ].freeze
+
+  # The facts Component reads through its build. `manufacturer_id` and `hidden`
+  # are held back for the same reasons as on equipment: the association reads the
+  # column, and `visible` moves with the filters rather than with the readers.
+  READ_THROUGH = (FACTS - %i[manufacturer_id hidden]).freeze
+
+  # The same serialization and enums Component declares, because a build row
+  # holding `0` has to read as `stealth` here too, and a YAML string has to come
+  # back as the structure it encodes. Without them, moving the readers over turns
+  # every enum-backed fact into a raw integer and durability into a blob.
+  serialize :durability, coder: YAML
+
+  enum :item_class,
+    {stealth: 0, civilian: 1, industrial: 2, military: 3, competition: 4}
+
+  enum :tracking_signal,
+    {infrared: 0, cross_section: 1, electromagnetic: 2}
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :component_id, uniqueness: {scope: [:environment, :version]}
+
+  # Every build this environment still has, newest first.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on. `ScData::Source` names the version
+  # exactly, so this needs no ordering or subselect.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared. Re-loading a build updates its rows in place, so `created_at` is
+  # when that build first landed rather than when it was last touched.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/app/services/manufacturers/deduplicator.rb
+++ b/app/services/manufacturers/deduplicator.rb
@@ -14,7 +14,9 @@ module Manufacturers
     # Tables carrying `manufacturer_id`. Checked against the schema on the way in
     # so a table added later fails loudly here rather than quietly orphaning its
     # rows.
-    ASSOCIATED_MODELS = [Model, Component, Equipment, EquipmentBuild, ModelModule].freeze
+    ASSOCIATED_MODELS = [
+      Model, Component, ComponentBuild, Equipment, EquipmentBuild, ModelModule
+    ].freeze
 
     Result = Struct.new(:renamed, :dropped, :merged)
 

--- a/db/data/20260827150100_backfill_component_builds.rb
+++ b/db/data/20260827150100_backfill_component_builds.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Seeds a build row from what each component row already says, so the new table is
+# populated before anything reads from it -- rather than staying empty until the
+# next sc_data load.
+#
+# Rows whose version is nil are skipped: the export stopped naming them, so there
+# is no build they describe.
+class BackfillComponentBuilds < ActiveRecord::Migration[8.1]
+  # Its own copy on purpose: a migration has to keep running against the schema of
+  # its own moment, not `ComponentBuild::FACTS` as that later becomes.
+  FACTS = %i[
+    manufacturer_id name description size grade item_type item_class
+    component_class component_type component_sub_type category type_data
+    durability power_connection heat_connection ammunition
+    inventory_consumption tracking_signal hidden
+  ].freeze
+
+  # Eight thousand components, so batched rather than one transaction.
+  BATCH_SIZE = 500
+
+  def up
+    environment = ScData::Source.environment
+
+    Component.where.not(version: nil).find_each(batch_size: BATCH_SIZE) do |component|
+      # Keyed on the version the row itself carries, not just the environment: a
+      # component whose build already exists must be updated in place rather than
+      # have some other build's row repointed at it.
+      build = component.builds.find_or_initialize_by(
+        environment:, version: component.version
+      )
+
+      build.update!(FACTS.index_with { |fact| component.public_send(fact) })
+    end
+  end
+
+  def down
+    ComponentBuild.delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_25_120100)
+DataMigrate::Data.define(version: 2026_08_27_150100)

--- a/db/migrate/20260827150000_create_component_builds.rb
+++ b/db/migrate/20260827150000_create_component_builds.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a component, following the shape
+# `equipment_builds` established.
+#
+# The field list is not invented here: `Component`'s paper_trail `only:` already
+# names exactly the specs that move between builds, and its comment already
+# anticipated "a row per build". This is that row.
+#
+# Unlike equipment, components are referenced -- hardpoints, model paints, model
+# modules and missions all carry a `component_id`. Nothing about that changes: the
+# identity row keeps its id and its associations, and the build rows sit beside it.
+# Re-parenting the loadout tables is a later and separate question.
+class CreateComponentBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :component_builds, id: :uuid do |t|
+      # Cascade: a build says something about a component, and says nothing at
+      # all once the component is gone.
+      t.references :component, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      t.uuid :manufacturer_id
+      t.string :name
+      t.text :description
+      t.string :size
+      t.string :grade
+      t.string :item_type
+      t.integer :item_class
+      t.string :component_class
+      t.string :component_type
+      t.string :component_sub_type
+      t.string :category
+      t.string :type_data
+      t.string :durability
+      t.string :power_connection
+      t.string :heat_connection
+      t.string :ammunition
+      t.string :inventory_consumption
+      t.integer :tracking_signal
+      t.boolean :hidden, default: false
+
+      t.timestamps
+    end
+
+    # One row per component per build. Re-loading the same build updates it in
+    # place; a new build adds a row beside it.
+    add_index :component_builds, [:component_id, :environment, :version],
+      unique: true, name: "index_component_builds_on_component_and_build"
+
+    # The filters a browsable catalogue needs, so narrowing to one build stays a
+    # join rather than a scan. Every read names an environment and a version,
+    # because that pair is what `ScData::Source` hands out.
+    add_index :component_builds, [:environment, :version]
+    add_index :component_builds, [:environment, :component_class]
+    add_index :component_builds, [:environment, :item_type]
+    add_index :component_builds, :manufacturer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -210,6 +210,39 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_120000) do
     t.index ["share_key"], name: "index_compare_images_on_share_key", unique: true, where: "(share_key IS NOT NULL)"
     t.index ["short_code"], name: "index_compare_images_on_short_code", unique: true, where: "(short_code IS NOT NULL)"
     t.index ["slug_set"], name: "index_compare_images_on_slug_set", unique: true
+  end
+
+  create_table "component_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "ammunition"
+    t.string "category"
+    t.string "component_class"
+    t.uuid "component_id", null: false
+    t.string "component_sub_type"
+    t.string "component_type"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "durability"
+    t.string "environment", null: false
+    t.string "grade"
+    t.string "heat_connection"
+    t.boolean "hidden", default: false
+    t.string "inventory_consumption"
+    t.integer "item_class"
+    t.string "item_type"
+    t.uuid "manufacturer_id"
+    t.string "name"
+    t.string "power_connection"
+    t.string "size"
+    t.integer "tracking_signal"
+    t.string "type_data"
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.index ["component_id", "environment", "version"], name: "index_component_builds_on_component_and_build", unique: true
+    t.index ["component_id"], name: "index_component_builds_on_component_id"
+    t.index ["environment", "component_class"], name: "index_component_builds_on_environment_and_component_class"
+    t.index ["environment", "item_type"], name: "index_component_builds_on_environment_and_item_type"
+    t.index ["environment", "version"], name: "index_component_builds_on_environment_and_version"
+    t.index ["manufacturer_id"], name: "index_component_builds_on_manufacturer_id"
   end
 
   create_table "components", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -1522,6 +1555,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_120000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_notifications", "admin_users", on_delete: :cascade
   add_foreign_key "cargo_hold_container_capacities", "cargo_holds"
+  add_foreign_key "component_builds", "components", on_delete: :cascade
   add_foreign_key "equipment_builds", "equipment", on_delete: :cascade
   add_foreign_key "fleet_event_admins", "fleet_events"
   add_foreign_key "fleet_event_admins", "users"

--- a/test/factories/component_builds.rb
+++ b/test/factories/component_builds.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :component_build do
+    component
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+    sequence(:name) { |n| "#{Faker::Company.name} Shield #{n}" }
+    component_class { "Shield" }
+    item_type { "Shield" }
+    size { "2" }
+    grade { "A" }
+    hidden { false }
+  end
+end

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -151,6 +151,35 @@ module ScData
         assert_equal "behr_rifle_ballistic_01", equipment.sc_key
         refute EquipmentBuild.column_names.include?("sc_key")
       end
+
+      # The same helper, the second catalogue. Components differ from equipment in
+      # being referenced -- hardpoints, paints and modules carry a component_id --
+      # so this also pins that the build lands beside the identity row rather than
+      # replacing it.
+      test "#apply_build works the same for a component" do
+        component = create(:component)
+
+        @loader.apply_build(component, {name: "Gorgon", component_class: "Shield"})
+
+        build = component.builds.sole
+        assert_equal "Gorgon", build.name
+        assert_equal "Shield", build.component_class
+        assert_equal ::ScData::Source.environment, build.environment
+        assert_equal ::ScData::Source.version, build.version
+      end
+
+      test "#retire_absent_builds drops a component's current build but keeps the component" do
+        kept = create(:component)
+        dropped = create(:component)
+        create(:component_build, component: kept)
+        create(:component_build, component: dropped)
+
+        @loader.retire_absent_builds(ComponentBuild, :component_id, [kept.id])
+
+        assert_equal 1, ComponentBuild.current.count
+        assert Component.exists?(dropped.id), "the row itself has to stay"
+        assert_empty dropped.builds.current
+      end
     end
   end
 end

--- a/test/models/component_build_test.rb
+++ b/test/models/component_build_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ComponentBuildTest < ActiveSupport::TestCase
+  setup do
+    @environment = ScData::Source.environment
+    @version = ScData::Source.version
+  end
+
+  test "a component carries one row per build, not two" do
+    component = create(:component)
+    create(:component_build, component:, environment: @environment, version: @version)
+
+    duplicate = build(
+      :component_build, component:, environment: @environment, version: @version
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :component_id
+  end
+
+  test "a later build of the same environment sits beside the earlier one" do
+    component = create(:component)
+    create(:component_build, component:, environment: @environment, version: "0.0.1-live.1")
+    create(:component_build, component:, environment: @environment, version: "0.0.2-live.2")
+
+    assert_equal 2, component.builds.count
+  end
+
+  test "the same component can be described by more than one environment" do
+    component = create(:component)
+    create(:component_build, component:, environment: "live", version: @version)
+    create(:component_build, component:, environment: "ptu", version: @version)
+
+    assert_equal 2, component.builds.count
+  end
+
+  test "requires the build it describes" do
+    build_row = build(:component_build, environment: nil, version: nil)
+
+    assert_not build_row.valid?
+    assert_includes build_row.errors.attribute_names, :environment
+    assert_includes build_row.errors.attribute_names, :version
+  end
+
+  test ".for_source keeps only the current environment" do
+    component = create(:component)
+    mine = create(:component_build, component:, environment: @environment, version: @version)
+    create(:component_build, component:, environment: "somewhere-else", version: @version)
+
+    assert_equal [mine.id], ComponentBuild.for_source.pluck(:id)
+  end
+
+  test ".current also narrows to the version the environment is on" do
+    component = create(:component)
+    current = create(:component_build, component:, environment: @environment, version: @version)
+    create(:component_build, component:, environment: @environment, version: "0.0.1-live.1")
+
+    assert_equal [current.id], ComponentBuild.current.pluck(:id)
+  end
+
+  # A build row holding 0 has to read back as its name, or moving the readers over
+  # turns every enum-backed fact into a raw integer.
+  test "the enums keep their names" do
+    build_row = create(:component_build, item_class: :military, tracking_signal: :infrared)
+
+    assert_equal "military", build_row.reload.item_class
+    assert_equal "infrared", build_row.tracking_signal
+  end
+
+  # Component serializes this column as YAML, so the build has to as well --
+  # otherwise the structure comes back as the string it was encoded into.
+  test "durability comes back as the structure it went in as" do
+    durability = {"health" => 1200, "parts" => ["front", "rear"]}
+    build_row = create(:component_build, durability:)
+
+    assert_equal durability, build_row.reload.durability
+  end
+
+  test ".retained_versions keeps the newest builds of an environment" do
+    component = create(:component)
+    %w[0.0.1 0.0.2 0.0.3 0.0.4].each_with_index do |version, index|
+      create(
+        :component_build,
+        component:, environment: @environment, version:,
+        created_at: index.days.ago.end_of_day
+      )
+    end
+
+    retained = ComponentBuild.retained_versions(@environment, keep: 2)
+
+    assert_equal %w[0.0.2 0.0.1], retained
+  end
+
+  test "builds go when the component does" do
+    component = create(:component)
+    create(:component_build, component:)
+
+    assert_difference("ComponentBuild.count", -1) do
+      component.destroy
+    end
+  end
+end


### PR DESCRIPTION
The second catalogue to separate what a thing *is* from what a build says about it, following the shape #4522 established for equipment. `components` keeps its identity — the row a hardpoint, a paint or an uploaded icon hangs off — and everything `ItemsLoader` writes is now also recorded per build.

Expand and dual-write only. Reads still go through the columns, which are written identically, so this is behaviour-preserving.

## The field list was already decided

`Component`'s paper_trail `only:` names exactly the specs that move between builds, and its comment already anticipated the destination:

> a row per build. `version` is deliberately not tracked: it moves on every import […] Only a spec that actually changed is worth keeping.

So `FACTS` is that list. `category` joins it — the loader writes it and it decides `hidden`, so it belongs to the build even though paper_trail skips it.

## Two things components have that equipment did not

**`durability` is YAML in a string column**, and **`item_class` and `tracking_signal` are enums.** The build repeats all three declarations. Without them, moving the readers over later turns a structure into a blob and two facts into raw integers — the same trap the equipment build hit with its three enums, so there are tests for both here rather than a discovery later.

**Components are referenced.** Hardpoints, model paints, model modules and missions all carry a `component_id`, where nothing referenced equipment at all. Nothing about that changes: the identity row keeps its id and its associations, and the build rows sit beside it. Re-parenting the loadout tables is a later and separate question, and the `apply_build` test pins that the build lands beside the identity row rather than replacing it.

## The deduplicator guard earns its keep again

`ComponentBuild` is registered in `ASSOCIATED_MODELS`. Taking it out makes the guard fail with:

```
component_builds reference manufacturer_id but are not in ASSOCIATED_MODELS
```

That is the same guard that caught this being forgotten for `EquipmentBuild`, so I checked it fires rather than assuming.

## The backfill

Seeds a build from what each row already says, so the table is populated before anything reads it. Keyed on the version the row carries rather than only its environment — a component that already has a build is then updated in place instead of having another build's row repointed at it, which the equipment backfill could have done on a non-empty table. Batched at 500; 53s over the dev catalogue's eight thousand components.

## Deliberately not here

**No factory build hook.** Nothing reads a build yet, and the existing component tests set `version` explicitly where they need it — a default build would only change what they exercise. It comes with the read switch, where it is actually needed.

**Reads, filters and `current_version`.** Those follow, one PR each, as they did for equipment.

## Verification

- 10 new `ComponentBuild` tests: one row per build, builds beside each other, two environments, the scopes, `retained_versions`, cascade on destroy, and the enum and YAML round-trips
- 3 new `apply_build` tests covering the component path and `retire_absent_builds`
- 407 model and deduplicator tests, and 1,293 public API tests, all green
- `standardrb` clean; the schema diff touches only the new table

The `ScData::Loader::*` suites fail in my worktree — equipment, commodities and the models hardpoint test — **identically on unmodified main**, because the parsed `sc_data` fixture tree is not part of a checkout. Unrelated to this change.

🤖
