### PR TITLE
feat(paints): import the paints of a single model from the admin UI

### DIFF
--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -4,7 +4,8 @@ module Admin
   module Api
     module V1
       class ModelsController < ::Admin::Api::BaseController
-        before_action :set_model, only: %i[show update destroy use_rsi_image reload_one reload_one_matrix reload_one_scdata]
+        before_action :set_model,
+          only: %i[show update destroy use_rsi_image reload_one reload_one_matrix reload_one_scdata reload_one_paints]
 
         rescue_from ActiveRecord::RecordNotFound do |_exception|
           not_found(I18n.t("messages.record_not_found.model", slug: params[:slug]))
@@ -137,6 +138,12 @@ module Admin
 
         def reload_one_scdata
           Loaders::ScData::ModelJob.perform_async(@model.id) if @model.sc_data_identifier.present?
+
+          render json: {message: "Jobs enqueued"}, status: :ok
+        end
+
+        def reload_one_paints
+          Loaders::PaintsImportJob.perform_async(current_admin_user.id, @model.id)
 
           render json: {message: "Jobs enqueued"}, status: :ok
         end

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -18,8 +18,12 @@ import {
   useCreateModelPaint as useCreateModelPaintMutation,
   useUpdateModelPaint as useUpdateModelPaintMutation,
   useDestroyModelPaint as useDestroyModelPaintMutation,
+  useReloadOneModelPaints as useReloadOneModelPaintsMutation,
   getListModelPaintsQueryKey,
+  ImportTypeEnum,
 } from "@/services/fyAdminApi";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useImportLoading } from "@/admin/composables/useImportLoading";
 import { useQueryClient } from "@tanstack/vue-query";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
@@ -37,6 +41,7 @@ const props = defineProps<Props>();
 const { t } = useI18n();
 const comlink = useComlink();
 const queryClient = useQueryClient();
+const { displayConfirm, displaySuccess } = useAppNotifications();
 
 const editableList = ref<{
   editingId: string | null;
@@ -67,6 +72,47 @@ const invalidatePaints = () =>
   queryClient.invalidateQueries({
     queryKey: getListModelPaintsQueryKey(),
   });
+
+// Import
+const paintsImportInputMatch = computed(() => ({
+  modelId: props.model.id,
+}));
+
+const { isImporting } = useImportLoading(
+  ImportTypeEnum.IMPORTS_PAINTS_IMPORT,
+  paintsImportInputMatch,
+);
+
+const importMutation = useReloadOneModelPaintsMutation({
+  mutation: {
+    onSuccess: () => {
+      displaySuccess({
+        text: t("messages.model.importPaintsStarted"),
+      });
+    },
+  },
+});
+
+const isImportingPaints = computed(
+  () => isImporting.value || importMutation.isPending.value,
+);
+
+// The import runs in the background, so the list only holds what the paints
+// looked like before it started until the import reports back.
+watch(isImporting, (importing, wasImporting) => {
+  if (wasImporting && !importing) void invalidatePaints();
+});
+
+const importPaints = () => {
+  if (!props.model.id) return;
+
+  displayConfirm({
+    text: t("messages.confirm.model.importPaints"),
+    onConfirm: async () => {
+      await importMutation.mutateAsync({ id: props.model.id! });
+    },
+  });
+};
 
 // Edit
 const editForm = ref<ModelPaintInput>({});
@@ -175,13 +221,24 @@ const bulkCopy = (selectedIds: string[]) => {
 <template>
   <div class="flex items-center justify-between mb-4">
     <Heading hero>{{ t("headlines.admin.models.edit.paints") }}</Heading>
-    <Btn
-      :disabled="editableList?.creating"
-      @click="editableList?.startCreate()"
-    >
-      <i class="fa-duotone fa-plus" />
-      {{ t("actions.add") }}
-    </Btn>
+    <div class="flex items-center gap-2">
+      <Btn
+        v-tooltip="t('actions.models.importPaints')"
+        :loading="isImportingPaints"
+        spinner
+        @click="importPaints"
+      >
+        <i class="fa-duotone fa-palette" />
+        {{ t("actions.models.importPaints") }}
+      </Btn>
+      <Btn
+        :disabled="editableList?.creating"
+        @click="editableList?.startCreate()"
+      >
+        <i class="fa-duotone fa-plus" />
+        {{ t("actions.add") }}
+      </Btn>
+    </div>
   </div>
 
   <InlineEditableList

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -229,6 +229,7 @@
         "sync": "Sync from RSI",
         "syncMatrix": "Sync Matrix",
         "syncScData": "Sync SC Data",
+        "importPaints": "Import Paints",
         "exchangeStoreImage": "Use RSI Image",
         "images": "Images",
         "openTableConfiguration": "Open Table Configuration"

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -150,7 +150,8 @@
         "onSale": "%{model} now on Sale!",
         "syncStarted": "Model sync started. You will be notified when it completes.",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
-        "syncScDataStarted": "Model SC data sync started. You will be notified when it completes."
+        "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
+        "importPaintsStarted": "Paint import started. You will be notified when it completes."
       },
       "fundingGoal": {
         "created": "Funding goal created.",
@@ -374,6 +375,7 @@
           "sync": "Are you sure you want to sync this model from RSI?",
           "syncMatrix": "Are you sure you want to sync the ship matrix data for this model?",
           "syncScData": "Are you sure you want to sync the SC data for this model?",
+          "importPaints": "Are you sure you want to import this model's paints from the hangar data? A paint the source names for a whole series is imported for every model of that series.",
           "exchangeStoreImage": "Are you sure you want to replace the store image with the RSI image?",
           "reloadMatrix": "Are you sure you want to reload the models matrix? This will enqueue background jobs.",
           "reloadScData": "Are you sure you want to reload SC data? This will enqueue background jobs.",

--- a/app/jobs/loaders/paints_import_job.rb
+++ b/app/jobs/loaders/paints_import_job.rb
@@ -2,25 +2,32 @@
 
 module Loaders
   class PaintsImportJob < ::Loaders::BaseJob
-    def perform(admin_user_id = nil)
-      import = Imports::PaintsImport.create(admin_user_id:)
+    def perform(admin_user_id = nil, model_id = nil)
+      model = Model.find(model_id) if model_id.present?
+
+      import = Imports::PaintsImport.create(admin_user_id:, input: model.present? ? {model_id: model.id} : nil)
 
       import.start!
 
-      results = ::PaintsImporter.new.run
+      results = ::PaintsImporter.new(model:).run
 
       AdminReport.deliver(
         task_type: "paints_import",
-        title: "Paints Import Results",
+        title: model.present? ? "Paints Import Results for #{model.name}" : "Paints Import Results",
         body: ::PaintsImporter.github_issue_body(results),
         actionable: ::PaintsImporter.actionable?(results),
+        # A targeted run reports on a single model, so it needs its own dedupe
+        # key -- otherwise its small body becomes "last seen" for the full run.
+        report_key: model.present? ? "paints_import_#{model.id}" : nil,
         record: import
       )
 
       import.finish!
     rescue => e
-      import.fail!
-      import.update!(info: e.message)
+      # The model lookup happens before the import exists -- a model deleted
+      # between enqueue and run leaves nothing to mark as failed.
+      import&.fail!
+      import&.update!(info: e.message)
 
       raise e
     end

--- a/app/lib/paints_importer.rb
+++ b/app/lib/paints_importer.rb
@@ -1,16 +1,16 @@
 require "open-uri"
 
 class PaintsImporter
+  # A targeted run narrows down which paints it looks at to the ones the given
+  # model has, not where they land: a paint the source names for a whole series
+  # belongs on every model of that series, whichever one triggered the run.
+  def initialize(model: nil)
+    @model = model
+  end
+
   def run
-    paints = []
-
-    Imports::HangarSync.find_each do |import|
-      paints << extract_paints(import)
-    end
-
-    paints.flatten!
-    paints.uniq!
-    paints.compact!
+    paints = collect_paints
+    paints = paints.select { |paint| paint_for_target?(paint) } if @model.present?
 
     results = paints.map do |paint|
       import_paint(paint)
@@ -79,6 +79,14 @@ class PaintsImporter
   end
 
   def list_paints(filter = nil)
+    collect_paints.select do |paint|
+      return true if filter.blank?
+
+      paint[:model_name].include?(filter) || paint[:name].include?(filter)
+    end
+  end
+
+  private def collect_paints
     paints = []
 
     Imports::HangarSync.find_each do |import|
@@ -89,11 +97,11 @@ class PaintsImporter
     paints.uniq!
     paints.compact!
 
-    paints.select do |paint|
-      return true if filter.blank?
+    paints
+  end
 
-      paint[:model_name].include?(filter) || paint[:name].include?(filter)
-    end
+  private def paint_for_target?(paint)
+    Array(models_mapping(paint[:model_name])).include?(@model.name)
   end
 
   private def extract_paints(import)

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -41,6 +41,7 @@ v1_admin_api_routes = lambda do
       put "reload-one" => "models#reload_one"
       put "reload-one-matrix" => "models#reload_one_matrix"
       put "reload-one-scdata" => "models#reload_one_scdata"
+      put "reload-one-paints" => "models#reload_one_paints"
     end
   end
 

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5422,6 +5422,47 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/{id}/reload-one-paints":
+    parameters:
+    - name: id
+      in: path
+      description: Model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    put:
+      summary: Reload Single Model Paints
+      tags:
+      - Models
+      operationId: reloadOneModelPaints
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MessageResponse"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/models/{id}/reload-one-scdata":
     parameters:
     - name: id

--- a/test/integration/admin/api/v1/models_reload_one_paints_test.rb
+++ b/test/integration/admin/api/v1/models_reload_one_paints_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::ModelsReloadOnePaintsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/models/{id}/reload-one-paints" do
+    parameter name: "id", in: :path, description: "Model id", schema: {type: :string, format: :uuid}
+
+    put("Reload Single Model Paints") do
+      operationId "reloadOneModelPaints"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::MessageResponse
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:models])
+  end
+
+  test "PUT /models/:id/reload-one-paints enqueues the loader for the model" do
+    model = create(:model)
+    Loaders::PaintsImportJob.expects(:perform_async).with(@user.id, model.id)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: model.id}, body: {}
+  end
+
+  test "PUT /models/:id/reload-one-paints returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, path_params: {id: SecureRandom.uuid}, body: {}
+  end
+
+  test "PUT /models/:id/reload-one-paints returns 401 when not signed in" do
+    model = create(:model)
+
+    assert_api_response :put, 401, path_params: {id: model.id}, body: {}
+  end
+
+  test "PUT /models/:id/reload-one-paints returns 403 for admin without access" do
+    model = create(:model)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, path_params: {id: model.id}, body: {}
+  end
+end

--- a/test/jobs/loaders/paints_import_job_test.rb
+++ b/test/jobs/loaders/paints_import_job_test.rb
@@ -9,10 +9,10 @@ module Loaders
       AdminNotificationsChannel.stubs(:broadcast_to)
     end
 
-    def stub_importer(results)
+    def stub_importer(results, model: nil)
       importer = mock("PaintsImporter")
       importer.expects(:run).returns(results)
-      PaintsImporter.stubs(:new).returns(importer)
+      PaintsImporter.stubs(:new).with(model:).returns(importer)
     end
 
     def results(new: [], new_with_error: [], model_not_found: [])
@@ -59,6 +59,35 @@ module Loaders
       GithubIssueCreator.expects(:new).returns(creator)
 
       ::Loaders::PaintsImportJob.new.perform
+    end
+
+    test "#perform for a single model runs the importer for that model only" do
+      model = create(:model)
+      stub_importer(results(new: [{model_name: model.name, name: "Red Alert"}]), model:)
+
+      ::Loaders::PaintsImportJob.new.perform(nil, model.id)
+
+      import = Imports::PaintsImport.sole
+      assert_equal({"model_id" => model.id}, import.input)
+      assert import.finished?
+      notification = AdminNotification.find_by(notification_type: "paints_import")
+      assert_equal "Paints Import Results for #{model.name}", notification.title
+    end
+
+    test "#perform for a single model keeps its issue dedupe separate from the full run" do
+      model = create(:model)
+      stub_importer(results(new_with_error: [{model_name: model.name, name: "Red Alert"}]), model:)
+
+      creator = mock("GithubIssueCreator")
+      creator.expects(:run).returns(true)
+      GithubIssueCreator.expects(:new).with(
+        task_type: "paints_import",
+        report_key: "paints_import_#{model.id}",
+        title: "Paints Import Results for #{model.name}",
+        body: anything
+      ).returns(creator)
+
+      ::Loaders::PaintsImportJob.new.perform(nil, model.id)
     end
 
     test "#perform folds an unchanged empty report into one notification" do

--- a/test/lib/paints_importer_test.rb
+++ b/test/lib/paints_importer_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+
+class PaintsImporterTest < ActiveSupport::TestCase
+  IMAGE_URL = "https://robertsspaceindustries.com/media/paint.jpg"
+
+  setup do
+    stub_request(:get, IMAGE_URL)
+      .to_return(status: 200, body: "image", headers: {"Content-Type" => "image/jpeg"})
+  end
+
+  def hangar_sync(*names)
+    create(
+      :import,
+      :hangar_sync,
+      input: names.map { |name| {"type" => "skin", "name" => name, "image" => IMAGE_URL} }
+    )
+  end
+
+  test "#run imports a paint for every model the source name maps to" do
+    aurora_cl = create(:model, name: "Aurora Mk I CL")
+    aurora_es = create(:model, name: "Aurora Mk I ES")
+    hangar_sync("Aurora Mk I - Dread Pirate Paint")
+
+    PaintsImporter.new.run
+
+    assert_equal ["Dread Pirate"], aurora_cl.paints.pluck(:name)
+    assert_equal ["Dread Pirate"], aurora_es.paints.pluck(:name)
+  end
+
+  test "#run for a single model imports a series paint into the whole series" do
+    aurora_cl = create(:model, name: "Aurora Mk I CL")
+    aurora_es = create(:model, name: "Aurora Mk I ES")
+    hangar_sync("Aurora Mk I - Dread Pirate Paint")
+
+    results = PaintsImporter.new(model: aurora_cl).run
+
+    assert_equal ["Dread Pirate"], aurora_cl.paints.pluck(:name)
+    assert_equal ["Dread Pirate"], aurora_es.paints.pluck(:name)
+    assert_equal 2, results[:new][:count]
+  end
+
+  test "#run for a single model skips paints belonging to other models" do
+    arrow = create(:model, name: "Arrow")
+    nomad = create(:model, name: "Nomad")
+    hangar_sync("Nomad - Ice Break Paint", "Arrow - Twilight Paint")
+
+    results = PaintsImporter.new(model: arrow).run
+
+    assert_equal ["Twilight"], arrow.paints.pluck(:name)
+    assert_empty nomad.paints
+    assert_equal 0, results[:model_not_found][:count]
+  end
+
+  test "#run for a single model reports a paint it already has as existing" do
+    arrow = create(:model, name: "Arrow")
+    create(:model_paint, model: arrow, name: "Twilight")
+    hangar_sync("Arrow - Twilight Paint")
+
+    results = PaintsImporter.new(model: arrow).run
+
+    assert_equal 1, results[:existing][:count]
+    assert_equal 0, results[:new][:count]
+    assert_equal ["Twilight"], arrow.paints.pluck(:name)
+  end
+end


### PR DESCRIPTION
## Why

Reloading paints was all-or-nothing: `Loaders::PaintsImportJob` walked every hangar sync and wrote every skin it could map. A single new paint on a single ship meant waiting for the full run, and there was no way to fill in one model on demand.

## What

`PaintsImporter.new(model:)` narrows the source skins down to the ones whose name maps to that model. Where they land is unchanged — a paint the source names for a whole series is still written to every model of that series, whichever one triggered the run. Without `model:` the importer behaves exactly as before.

`PUT /models/:id/reload-one-paints` enqueues the job for one model. The targeted run records its model in the import `input`, so the admin UI can tell it apart from the full run, and reports under its own dedupe key — otherwise its small body would become "last seen" for the full run and the next full report would open a duplicate issue.

In the admin, a model's paint list gets an **Import Paints** button: confirm dialog, toast, a spinner that stays on while the import is in flight (matched by import type + `modelId`), and a list refresh once the import reports back over the cable.

## Tests

- New `test/lib/paints_importer_test.rb` — the importer had no test coverage at all: family mapping, a targeted run importing a series paint into the whole series, a targeted run skipping other models' paints, and an already-present paint reported as existing.
- New `test/integration/admin/api/v1/models_reload_one_paints_test.rb` — the endpoint, 200/404/403/401.
- `paints_import_job_test.rb` extended for the single-model path and its separate report key.

The schema diff is purely additive (one new path), so nothing breaks for API consumers.

🤖
