### PR TITLE
feat(sc_data): read component facts off the build

### DIFF
--- a/app/api_components/shared/v1/schemas/component.rb
+++ b/app/api_components/shared/v1/schemas/component.rb
@@ -16,6 +16,7 @@ module Shared
             scRef: {type: :string},
 
             hidden: {type: :boolean},
+            retired: {type: :boolean},
 
             category: {type: :string},
             type: ::Shared::V1::Schemas::Enums::ComponentTypeEnum,
@@ -60,7 +61,7 @@ module Shared
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id name slug hidden availability media createdAt updatedAt]
+          required: %w[id name slug hidden retired availability media createdAt updatedAt]
         })
       end
     end

--- a/app/controllers/admin/api/v1/components_controller.rb
+++ b/app/controllers/admin/api/v1/components_controller.rb
@@ -32,7 +32,7 @@ module Admin
         end
 
         def update
-          return if @component.update(component_params)
+          return if @component.update_with_facts(component_params)
 
           render json: ValidationError.new("component.update", errors: @component.errors), status: :bad_request
         end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -68,6 +68,73 @@ class Component < ApplicationRecord
   # What each build of the game says about this component. Written alongside the
   # columns for now, so reads can move over a catalogue at a time.
   has_many :builds, class_name: "ComponentBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "ComponentBuild", inverse_of: :component
+
+  # The newest build of this environment that still describes the component,
+  # which is what a record the export dropped falls back to. Without it a retired
+  # component would read as nameless, and a hardpoint or a paint pointing at one
+  # has to resolve to something.
+  has_one :last_build,
+    -> { for_source.order(created_at: :desc) },
+    class_name: "ComponentBuild", inverse_of: :component
+
+  # Whether the build we are on describes this component, rather than whether the
+  # version string on the row still matches it. An exists check rather than a
+  # join, so nothing fans out and `currentVersion=false` stays the plain table.
+  #
+  # Overrides ScDataVersioned for components only. Unlike equipment this scope is
+  # reachable through ransack -- see `ransackable_scopes` -- which passes the flag
+  # as its single argument, so the source stays a defaulted second parameter.
+  scope :current_version, ->(flag = true, source = ::ScData::Source.current) {
+    if ActiveModel::Type::Boolean.new.cast(flag)
+      where(id: ComponentBuild.current(source).select(:component_id))
+    else
+      all
+    end
+  }
+
+  # Not in the build we are on. Said out loud in the API, which until now offered
+  # a component the export had dropped as though it were current.
+  def retired?
+    build.blank?
+  end
+
+  # The build we are on, or the last one that described the component.
+  def facts
+    build || last_build
+  end
+
+  # An admin correction is a correction to the build we are on, so it has to
+  # reach the build as well as the row.
+  #
+  # The next load overwrites it, and that is the point: the game files hold what
+  # is actually in the game, so a wrong value here is a parser bug and the fix
+  # belongs in the parser. Nothing is curated on components the way Model splits
+  # its `rsi_*` columns from the ones a person maintains.
+  def update_with_facts(attributes)
+    transaction do
+      return false unless update(attributes)
+
+      facts_attributes = attributes.to_h.symbolize_keys.slice(*ComponentBuild::FACTS)
+
+      # Reloaded rather than read off the association: validating the row above
+      # consults a fact reader, which caches whatever the build was at that
+      # moment -- a nil, for a row whose build is written afterwards.
+      reload_build&.update!(facts_attributes) if facts_attributes.present?
+
+      true
+    end
+  end
+
+  # Read through the build, falling back to the column. The column still answers
+  # for a component no load has given a build -- an admin can create one by hand.
+  ComponentBuild::READ_THROUGH.each do |fact|
+    define_method(fact) do
+      value = facts&.public_send(fact)
+
+      value.nil? ? super() : value
+    end
+  end
 
   has_many :model_paints, dependent: :nullify
 

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -80,9 +80,18 @@ class ComponentBuild < ApplicationRecord
 
   # The same serialization and enums Component declares, because a build row
   # holding `0` has to read as `stealth` here too, and a YAML string has to come
-  # back as the structure it encodes. Without them, moving the readers over turns
-  # every enum-backed fact into a raw integer and durability into a blob.
+  # back as the structure it encodes.
+  #
+  # All six of Component's serialized columns, not the one that caught the eye:
+  # missing `type_data` alone made the weapons endpoint call `dig` on a raw YAML
+  # string, because the reader falls through to the column only on nil and a
+  # string is not nil.
+  serialize :type_data, coder: YAML
   serialize :durability, coder: YAML
+  serialize :power_connection, coder: YAML
+  serialize :heat_connection, coder: YAML
+  serialize :ammunition, coder: YAML
+  serialize :inventory_consumption, coder: YAML
 
   enum :item_class,
     {stealth: 0, civilian: 1, industrial: 2, military: 3, competition: 4}

--- a/app/views/api/v1/components/_base.jbuilder
+++ b/app/views/api/v1/components/_base.jbuilder
@@ -30,6 +30,10 @@ json.type_data component.type_data
 
 json.hidden component.hidden
 
+# Not in the build we are on. Until now the API offered a component the
+# export had dropped as though it were current.
+json.retired component.retired?
+
 json.hardpoints do
   json.array! component.hardpoints, partial: "api/v1/hardpoints/base", as: :hardpoint
 end

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -403,6 +403,8 @@ components:
           type: string
         hidden:
           type: boolean
+        retired:
+          type: boolean
         category:
           type: string
         type:
@@ -460,6 +462,7 @@ components:
       - name
       - slug
       - hidden
+      - retired
       - availability
       - media
       - createdAt

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8173,6 +8173,8 @@ components:
           type: string
         hidden:
           type: boolean
+        retired:
+          type: boolean
         category:
           type: string
         type:
@@ -8238,6 +8240,7 @@ components:
       - name
       - slug
       - hidden
+      - retired
       - availability
       - media
       - createdAt

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10973,6 +10973,8 @@ components:
           type: string
         hidden:
           type: boolean
+        retired:
+          type: boolean
         category:
           type: string
         type:
@@ -11030,6 +11032,7 @@ components:
       - name
       - slug
       - hidden
+      - retired
       - availability
       - media
       - createdAt

--- a/test/factories/component_builds.rb
+++ b/test/factories/component_builds.rb
@@ -1,6 +1,49 @@
+# == Schema Information
+#
+# Table name: component_builds
+#
+#  id                    :uuid             not null, primary key
+#  ammunition            :string
+#  category              :string
+#  component_class       :string
+#  component_sub_type    :string
+#  component_type        :string
+#  description           :text
+#  durability            :string
+#  environment           :string           not null
+#  grade                 :string
+#  heat_connection       :string
+#  hidden                :boolean          default(FALSE)
+#  inventory_consumption :string
+#  item_class            :integer
+#  item_type             :string
+#  name                  :string
+#  power_connection      :string
+#  size                  :string
+#  tracking_signal       :integer
+#  type_data             :string
+#  version               :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  component_id          :uuid             not null
+#  manufacturer_id       :uuid
+#
+# Indexes
+#
+#  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
+#  index_component_builds_on_component_id                     (component_id)
+#  index_component_builds_on_environment_and_component_class  (environment,component_class)
+#  index_component_builds_on_environment_and_item_type        (environment,item_type)
+#  index_component_builds_on_environment_and_version          (environment,version)
+#  index_component_builds_on_manufacturer_id                  (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (component_id => components.id) ON DELETE => cascade
+#
 FactoryBot.define do
   factory :component_build do
-    component
+    association :component, factory: [:component, :without_build]
     environment { ScData::Source.environment }
     version { ScData::Source.version }
     sequence(:name) { |n| "#{Faker::Company.name} Shield #{n}" }

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -40,6 +40,34 @@ FactoryBot.define do
     name { Faker::Name.name }
     component_class { "RSIModular" }
 
+    transient { with_build { true } }
+
+    # A build describing the component, mirroring what the backfill did for the
+    # rows already in the table. Keyed on the row's own version, so
+    # `create(:component, version: <older>)` is retired here too, and skipped
+    # entirely for a row with no version -- the export never named it.
+    after(:create) do |component, evaluator|
+      next unless evaluator.with_build
+      next if component.version.blank?
+
+      component.builds.create!(
+        environment: ScData::Source.environment,
+        version: component.version,
+        **component.attributes.symbolize_keys.slice(*ComponentBuild::FACTS)
+      )
+
+      # Validating the row consulted a fact reader, which cached the build as it
+      # was then -- absent. Dropped so the record behaves like a freshly loaded one.
+      component.association(:build).reset
+      component.association(:last_build).reset
+    end
+
+    # For tests that manage builds themselves and would otherwise collide with
+    # the one above.
+    trait :without_build do
+      with_build { false }
+    end
+
     trait :with_manufacturer do
       manufacturer
     end

--- a/test/models/component_build_test.rb
+++ b/test/models/component_build_test.rb
@@ -2,6 +2,49 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: component_builds
+#
+#  id                    :uuid             not null, primary key
+#  ammunition            :string
+#  category              :string
+#  component_class       :string
+#  component_sub_type    :string
+#  component_type        :string
+#  description           :text
+#  durability            :string
+#  environment           :string           not null
+#  grade                 :string
+#  heat_connection       :string
+#  hidden                :boolean          default(FALSE)
+#  inventory_consumption :string
+#  item_class            :integer
+#  item_type             :string
+#  name                  :string
+#  power_connection      :string
+#  size                  :string
+#  tracking_signal       :integer
+#  type_data             :string
+#  version               :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  component_id          :uuid             not null
+#  manufacturer_id       :uuid
+#
+# Indexes
+#
+#  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
+#  index_component_builds_on_component_id                     (component_id)
+#  index_component_builds_on_environment_and_component_class  (environment,component_class)
+#  index_component_builds_on_environment_and_item_type        (environment,item_type)
+#  index_component_builds_on_environment_and_version          (environment,version)
+#  index_component_builds_on_manufacturer_id                  (manufacturer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (component_id => components.id) ON DELETE => cascade
+#
 class ComponentBuildTest < ActiveSupport::TestCase
   setup do
     @environment = ScData::Source.environment
@@ -69,13 +112,25 @@ class ComponentBuildTest < ActiveSupport::TestCase
     assert_equal "infrared", build_row.tracking_signal
   end
 
-  # Component serializes this column as YAML, so the build has to as well --
-  # otherwise the structure comes back as the string it was encoded into.
-  test "durability comes back as the structure it went in as" do
-    durability = {"health" => 1200, "parts" => ["front", "rear"]}
-    build_row = create(:component_build, durability:)
+  # Component serializes six columns as YAML, so the build has to serialize the
+  # same six -- otherwise a structure comes back as the string it was encoded
+  # into, and the reader passes it straight through because a string is not nil.
+  # Missing `type_data` alone had the weapons endpoint calling `dig` on a string.
+  test "every serialized fact comes back as the structure it went in as" do
+    values = {
+      type_data: {"beam" => true, "weapon_class" => "laser"},
+      durability: {"health" => 1200, "parts" => ["front", "rear"]},
+      power_connection: {"draw" => 120},
+      heat_connection: {"output" => 45},
+      ammunition: {"count" => 300},
+      inventory_consumption: {"rate" => 2}
+    }
 
-    assert_equal durability, build_row.reload.durability
+    build_row = create(:component_build, **values)
+
+    values.each do |fact, value|
+      assert_equal value, build_row.reload.public_send(fact), "#{fact} did not round-trip"
+    end
   end
 
   test ".retained_versions keeps the newest builds of an environment" do

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -66,4 +66,91 @@ class ComponentTest < ActiveSupport::TestCase
       Component.create!(name: "Copy", sc_key: "fr66")
     end
   end
+
+  # A record the export dropped keeps the values of the last build that described
+  # it -- a hardpoint or a paint pointing at one has to resolve to something --
+  # and says so, rather than serving them as if they were current.
+  test "a retired component reads the last build that described it, and is marked" do
+    component = create(:component, :without_build, name: "Column Name")
+    create(
+      :component_build,
+      component:, environment: ScData::Source.environment,
+      version: "0.0.1-live.1", name: "Gorgon", size: "3"
+    )
+
+    assert_equal "Gorgon", component.reload.name
+    assert_equal "3", component.size
+    assert_predicate component, :retired?
+  end
+
+  test "a component in the current build reads that build, and is not retired" do
+    component = create(:component, :without_build, name: "Column Name")
+    create(:component_build, component:, name: "Gorgon")
+
+    assert_equal "Gorgon", component.reload.name
+    assert_not_predicate component, :retired?
+  end
+
+  test "the current build wins over an earlier one" do
+    component = create(:component, :without_build)
+    create(:component_build, component:, version: "0.0.1-live.1", size: "1")
+    create(:component_build, component:, size: "4")
+
+    assert_equal "4", component.reload.size
+  end
+
+  # An admin can create a component by hand, and no load has given it a build yet.
+  test "a component with no build at all falls back to its own columns" do
+    component = create(:component, :without_build, name: "Hand Made", size: "2")
+
+    assert_equal "Hand Made", component.reload.name
+    assert_equal "2", component.size
+    assert_predicate component, :retired?
+  end
+
+  # An enum-backed fact has to read as its name from the build too, not as the
+  # integer the column stores.
+  test "an enum fact read off the build keeps its name" do
+    component = create(:component, :without_build)
+    create(:component_build, component:, item_class: :military)
+
+    assert_equal "military", component.reload.item_class
+  end
+
+  # And a serialized one as its structure. Six columns are YAML on Component; the
+  # build has to match all six or the reader passes a raw string through, because
+  # a string is not nil.
+  test "a serialized fact read off the build keeps its structure" do
+    component = create(:component, :without_build)
+    create(:component_build, component:, type_data: {"beam" => true})
+
+    assert_equal({"beam" => true}, component.reload.type_data)
+  end
+
+  # Without this the reader would go on serving the build's old value.
+  test "#update_with_facts writes the correction to the build as well" do
+    component = create(:component, name: "Typo", version: ScData::Source.version)
+
+    assert component.update_with_facts({name: "Corrected"})
+
+    assert_equal "Corrected", component.reload.name
+    assert_equal "Corrected", component.build.name
+  end
+
+  test "#update_with_facts leaves a retired component's build alone" do
+    component = create(:component, :without_build, name: "Typo")
+    old = create(:component_build, component:, version: "0.0.1-live.1", name: "Old Name")
+
+    assert component.update_with_facts({name: "Corrected"})
+
+    assert_equal "Old Name", old.reload.name
+  end
+
+  test ".current_version narrows to the patch the game ships, or opts out" do
+    current = create(:component, version: ScData::Source.version)
+    retired = create(:component, version: "0.0.1-live.1")
+
+    assert_equal [current.id], Component.current_version.pluck(:id)
+    assert_includes Component.current_version(false).pluck(:id), retired.id
+  end
 end


### PR DESCRIPTION
> **Stacked on #4557** — base is `feat/component-builds`. That one adds the table and dual-writes; this one moves the reads.

Components stop reading their own columns. Both halves in one step, as equipment did in #4530: whether the component exists in the build we are on, and what that build says about it.

## Currency is row existence

```ruby
scope :current_version, ->(flag = true, source = ::ScData::Source.current) {
  if ActiveModel::Type::Boolean.new.cast(flag)
    where(id: ComponentBuild.current(source).select(:component_id))
  else
    all
  end
}
```

An exists check rather than a join, so nothing fans out and `currentVersion=false` stays the plain table.

**One difference from equipment:** this scope is reachable through ransack — Component lists it in `ransackable_scopes`, where the equipment and commodity controllers take the parameter off the query and call the scope themselves. Ransack passes the flag as the single argument, so the source stays a defaulted second parameter and both callers work.

## Facts come from the build

Three steps: the current build, else the last build that described the component, else the column.

The fallback is not optional here. Components are referenced — a hardpoint, a model paint, a module or a mission can point at one the export has dropped — and a hard delegation would make those read as nameless. So the last build answers instead, and `retired` says so in the API, which until now served a dropped component as though it were current.

The column still answers for a component no load has given a build; an admin can create one by hand.

Admin corrections reach the build through `update_with_facts`, or the reader goes on serving the old value and the correction looks like it did nothing. The next load overwrites it, which is intended: the game files hold what is in the game, so a wrong value is a parser bug.

## What the expand PR's tests missed

**Component serializes six columns as YAML, not the one I had matched.** `type_data`, `durability`, `power_connection`, `heat_connection`, `ammunition`, `inventory_consumption` — I grepped for `durability`, found it, and moved on.

Missing `type_data` alone broke the weapons endpoint:

```
undefined method 'dig' for an instance of String
  app/views/api/v1/components/weapons.jbuilder:9
```

Because the reader falls through to the column only on `nil`, and a raw YAML string is not nil — so it passed straight through to a caller expecting a Hash. All six are declared on the build now, and one test round-trips every one of them rather than the one that caught my eye.

The same shape as the enum trap on equipment, and the reason to enumerate declarations rather than search for the one you remember.

## The factory

A build hook and a `:without_build` trait, both needed now: with `current_version` on row existence, a component without a build is retired, so every existing test that relies on being current would have flipped. Keyed on the row's own version, so `create(:component, version: <older>)` is retired here too, and skipped for a row with no version at all.

## Verification

- 9 new `Component` tests: the fallback chain, the retired marker, current-build-wins, column fallback with no build, enum names, serialized structures, both `update_with_facts` paths, and `current_version` both ways
- Pointing the reader back at the column makes **5 of them fail**, so they cover the defect rather than the shape of the code
- 2,516 tests across the models, the public API, the admin API and the `apply_build` suite — 0 failures
- REST, admin and AsyncAPI schemas regenerated for the new `retired` property; the cable document embeds the REST component and would reject it otherwise
- `standardrb` clean, `db/schema.rb` untouched

The 2 errors in that run are the worktree's mailer gap — `Errno::ECONNREFUSED` to `localhost:3000` — which fails identically on unmodified main here.

## Next

Filters and sorting through the build, then the same three steps for commodities.

🤖
