### PR TITLE
feat(sc_data): filter and sort components through the build

### DIFF
--- a/app/controllers/admin/api/v1/components_controller.rb
+++ b/app/controllers/admin/api/v1/components_controller.rb
@@ -11,7 +11,12 @@ module Admin
 
           component_query_params["sorts"] = sorting_params(Component, component_query_params[:sorts])
 
-          @q = authorized_scope(Component.all).includes(:manufacturer, :item_prices).ransack(component_query_params)
+          # The fallback join, not the fast one: the admin list has to show a
+          # retired component, and one an admin created by hand that no load has
+          # described yet.
+          @q = authorized_scope(Component.with_facts(false))
+            .includes(:manufacturer, :item_prices)
+            .ransack(component_query_params)
 
           @components = @q.result
             .page(params[:page])

--- a/app/controllers/api/v1/components_controller.rb
+++ b/app/controllers/api/v1/components_controller.rb
@@ -37,11 +37,29 @@ module Api
       def index
         components_query_params["sorts"] = "name asc"
 
-        @q = Component.includes(:manufacturer).ransack(components_query_params)
+        # `with_facts` because the filters resolve against the joined build.
+        # Without it a fact condition raises rather than quietly matching the
+        # column, which is the failure mode to want.
+        #
+        # The same flag ransack gets decides the join: for the default it is an
+        # inner join to the build we are on, which already leaves out everything
+        # that build does not describe. `currentVersion=false` needs the fallback
+        # join, or a retired component would be filtered out by the join before
+        # ransack ever sees it.
+        @q = Component.with_facts(current_version)
+          .includes(:manufacturer)
+          .ransack(components_query_params)
 
         @components = @q.result
           .page(params[:page])
           .per(per_page(Component))
+      end
+
+      # Read rather than removed from the query: `current_version` stays a
+      # ransackable scope, so ransack applies it as well. The exists check it adds
+      # is redundant beside the inner join and free beside the fallback one.
+      private def current_version
+        components_query_params.fetch(:current_version, true)
       end
 
       private def components_query_params

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -93,6 +93,63 @@ class Component < ApplicationRecord
     end
   }
 
+  # The build a filter resolves against, joined as `component_facts`. Two shapes
+  # behind one alias, so a ransacker stays a single static expression either way.
+  #
+  # This one is the catalogue we are on, and an inner join to it *is*
+  # `current_version`: a row the build describes has a build row, and a row it
+  # does not describe is not in the catalogue. So no column fallback is needed
+  # here -- and leaving it out is what keeps the filter on an indexed column.
+  #
+  # `COALESCE(build, column)` spans two tables, so no index applies and every row
+  # has to be touched. Measured on equipment when this was first built the wrong
+  # way: 5.18ms against 0.13ms, an index scan turning into a seq scan. Components
+  # are eight thousand rows against equipment's five, so the same mistake costs
+  # more here.
+  def self.current_facts_join(source)
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      INNER JOIN component_builds AS component_facts
+        ON component_facts.component_id = components.id
+       AND component_facts.environment = ?
+       AND component_facts.version = ?
+    SQL
+  end
+
+  # Everything: rows only an older build describes, and rows no load ever did.
+  # The fallback is unavoidable here, so it is folded into the subquery rather
+  # than into each condition -- the ransackers stay identical, and the cost lands
+  # only on this path, which is `currentVersion=false` and the admin list.
+  def self.all_facts_join(source)
+    facts = ComponentBuild::FILTERABLE.map { |fact| "COALESCE(b.#{fact}, c.#{fact}) AS #{fact}" }.join(", ")
+
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      LEFT JOIN (
+        SELECT c.id AS component_id, #{facts}
+        FROM components c
+        LEFT JOIN (
+          SELECT DISTINCT ON (component_id) *
+          FROM component_builds
+          WHERE environment = ?
+          ORDER BY component_id, (version = ?) DESC, created_at DESC
+        ) b ON b.component_id = c.id
+      ) AS component_facts ON component_facts.component_id = components.id
+    SQL
+  end
+
+  scope :with_facts, ->(current_only = true, source = ::ScData::Source.current) {
+    joins(
+      ActiveModel::Type::Boolean.new.cast(current_only) ? current_facts_join(source) : all_facts_join(source)
+    )
+  }
+
+  # One fact, off whichever build the join supplied. Referencing the alias
+  # without `with_facts` raises rather than returning the wrong rows, which is
+  # the failure mode to want here -- ransack drops a condition it cannot place
+  # without saying a word.
+  def self.fact_sql(fact)
+    Arel.sql("component_facts.#{fact}")
+  end
+
   # Not in the build we are on. Said out loud in the API, which until now offered
   # a component the export had dropped as though it were current.
   def retired?
@@ -171,14 +228,29 @@ class Component < ApplicationRecord
 
   enum :item_class,
     {stealth: 0, civilian: 1, industrial: 2, military: 3, competition: 4}
-  ransacker :item_class, formatter: proc { |v| Component.item_classes[v] } do |parent|
-    parent.table[:item_class]
-  end
 
   enum :tracking_signal,
     {infrared: 0, cross_section: 1, electromagnetic: 2}
-  ransacker :tracking_signal, formatter: proc { |v| Component.tracking_signals[v] } do |parent|
-    parent.table[:tracking_signal]
+
+  # `type` is what makes a comparison boolean rather than string-wise, the same
+  # reason ItemPriceConcern passes it.
+  FACT_RANSACK_TYPES = {hidden: :boolean}.freeze
+
+  # Filtering and sorting read the build. Each of these shadows a real column of
+  # the same name -- a ransacker wins over a column -- so every query parameter
+  # keeps working untouched, with no API or frontend change.
+  (ComponentBuild::FILTERABLE - %i[item_class tracking_signal]).each do |fact|
+    ransacker(fact, type: FACT_RANSACK_TYPES[fact]) { Component.fact_sql(fact) }
+  end
+
+  # The two enums keep their formatters, which turn the name a client sends into
+  # the integer the column stores.
+  ransacker :item_class, formatter: proc { |v| Component.item_classes[v] } do
+    Component.fact_sql(:item_class)
+  end
+
+  ransacker :tracking_signal, formatter: proc { |v| Component.tracking_signals[v] } do
+    Component.fact_sql(:tracking_signal)
   end
 
   def self.ransackable_attributes(auth_object = nil)
@@ -240,15 +312,24 @@ class Component < ApplicationRecord
     ]
   end
 
+  # Read off the build table rather than through the rows: the builds we are on
+  # *are* the current catalogue, so this needs neither the join nor
+  # `current_version` and stays a single index scan.
+  def self.build_facet(fact, source = ::ScData::Source.current)
+    scope = ComponentBuild.current(source).where.not(fact => nil)
+    scope = yield(scope) if block_given?
+
+    scope.distinct.pluck(fact).compact_blank.sort
+  end
+
   def self.categories
-    current_version.distinct.pluck(:category).compact_blank.sort
+    build_facet(:category)
   end
 
   def self.sub_types(category: nil)
-    scope = current_version
-    scope = scope.where(category: category) if category.present?
-
-    scope.distinct.pluck(:component_sub_type).compact_blank.sort
+    build_facet(:component_sub_type) do |scope|
+      category.present? ? scope.where(category:) : scope
+    end
   end
 
   def self.item_type_filters

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -78,6 +78,17 @@ class ComponentBuild < ApplicationRecord
   # column, and `visible` moves with the filters rather than with the readers.
   READ_THROUGH = (FACTS - %i[manufacturer_id hidden]).freeze
 
+  # The facts Component filters and sorts by. One list, so a ransacker and the
+  # fallback join's column list cannot drift apart.
+  #
+  # The six YAML columns are left out on purpose: nothing filters on a serialized
+  # structure, and folding each into the fallback subquery would widen it for no
+  # gain. `description` too -- no filter reaches it.
+  FILTERABLE = %i[
+    name size grade item_type item_class component_class component_type
+    component_sub_type category tracking_signal hidden
+  ].freeze
+
   # The same serialization and enums Component declares, because a build row
   # holding `0` has to read as `stealth` here too, and a YAML string has to come
   # back as the structure it encodes.

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -40,6 +40,11 @@ FactoryBot.define do
     name { Faker::Name.name }
     component_class { "RSIModular" }
 
+    # Needed now that the catalogue filter is an inner join to the build: without
+    # a version there is no build, and a component without a build is not in the
+    # catalogue at all. The same reason the equipment factory carries one.
+    version { Rails.configuration.sc_data[:version] }
+
     transient { with_build { true } }
 
     # A build describing the component, mirroring what the backfill did for the

--- a/test/integration/api/v1/components_test.rb
+++ b/test/integration/api/v1/components_test.rb
@@ -85,14 +85,29 @@ class Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Asserted by membership rather than by count: the factory gives every
+  # component the current version now -- it has to, since the catalogue filter is
+  # an inner join to the build -- so the two from `setup` are current as well and
+  # a count would be measuring them too.
   test "GET /components filters out older game versions via currentVersion" do
     current = create(:component, category: "coolers", version: Rails.configuration.sc_data[:version])
-    create(:component, category: "coolers", version: "0.0.1-live.1")
+    older = create(:component, category: "coolers", version: "0.0.1-live.1")
 
     assert_api_response :get, 200, params: {q: {"currentVersion" => true}} do
-      items = parsed_body["items"]
-      assert_equal 1, items.count
-      assert_equal current.name, items.first["name"]
+      names = parsed_body["items"].map { |item| item["name"] }
+
+      assert_includes names, current.name
+      assert_not_includes names, older.name
+    end
+  end
+
+  test "GET /components keeps older game versions when currentVersion is off" do
+    older = create(:component, category: "coolers", version: "0.0.1-live.1")
+
+    assert_api_response :get, 200, params: {q: {"currentVersion" => false}} do
+      names = parsed_body["items"].map { |item| item["name"] }
+
+      assert_includes names, older.name
     end
   end
 end

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -157,7 +157,7 @@ module ScData
       # so this also pins that the build lands beside the identity row rather than
       # replacing it.
       test "#apply_build works the same for a component" do
-        component = create(:component)
+        component = create(:component, :without_build)
 
         @loader.apply_build(component, {name: "Gorgon", component_class: "Shield"})
 
@@ -169,8 +169,8 @@ module ScData
       end
 
       test "#retire_absent_builds drops a component's current build but keeps the component" do
-        kept = create(:component)
-        dropped = create(:component)
+        kept = create(:component, :without_build)
+        dropped = create(:component, :without_build)
         create(:component_build, component: kept)
         create(:component_build, component: dropped)
 

--- a/test/models/component_build_test.rb
+++ b/test/models/component_build_test.rb
@@ -52,7 +52,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test "a component carries one row per build, not two" do
-    component = create(:component)
+    component = create(:component, :without_build)
     create(:component_build, component:, environment: @environment, version: @version)
 
     duplicate = build(
@@ -64,7 +64,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test "a later build of the same environment sits beside the earlier one" do
-    component = create(:component)
+    component = create(:component, :without_build)
     create(:component_build, component:, environment: @environment, version: "0.0.1-live.1")
     create(:component_build, component:, environment: @environment, version: "0.0.2-live.2")
 
@@ -72,7 +72,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test "the same component can be described by more than one environment" do
-    component = create(:component)
+    component = create(:component, :without_build)
     create(:component_build, component:, environment: "live", version: @version)
     create(:component_build, component:, environment: "ptu", version: @version)
 
@@ -88,7 +88,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test ".for_source keeps only the current environment" do
-    component = create(:component)
+    component = create(:component, :without_build)
     mine = create(:component_build, component:, environment: @environment, version: @version)
     create(:component_build, component:, environment: "somewhere-else", version: @version)
 
@@ -96,7 +96,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test ".current also narrows to the version the environment is on" do
-    component = create(:component)
+    component = create(:component, :without_build)
     current = create(:component_build, component:, environment: @environment, version: @version)
     create(:component_build, component:, environment: @environment, version: "0.0.1-live.1")
 
@@ -134,7 +134,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test ".retained_versions keeps the newest builds of an environment" do
-    component = create(:component)
+    component = create(:component, :without_build)
     %w[0.0.1 0.0.2 0.0.3 0.0.4].each_with_index do |version, index|
       create(
         :component_build,
@@ -149,7 +149,7 @@ class ComponentBuildTest < ActiveSupport::TestCase
   end
 
   test "builds go when the component does" do
-    component = create(:component)
+    component = create(:component, :without_build)
     create(:component_build, component:)
 
     assert_difference("ComponentBuild.count", -1) do

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -146,6 +146,89 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal "Old Name", old.reload.name
   end
 
+  # Everything below sets a build value that *disagrees* with the column. While
+  # both are written they are identical, so a filter reading the wrong one still
+  # passes every other test in this file -- disagreement is the only way to show
+  # which side answered.
+  test "a text filter matches the name the build carries" do
+    component = create(:component, :without_build, name: "Column Name")
+    create(:component_build, component:, name: "Gorgon Shield")
+
+    result = Component.with_facts.ransack(name_cont: "Gorgon").result
+
+    assert_equal [component.id], result.pluck(:id)
+  end
+
+  test "a type filter follows the build, not the column" do
+    component = create(:component, :without_build, item_type: "old_type")
+    create(:component_build, component:, item_type: "Cooler")
+
+    assert_equal [component.id], Component.with_facts.ransack(item_type_eq: "Cooler").result.pluck(:id)
+    assert_empty Component.with_facts.ransack(item_type_eq: "old_type").result.pluck(:id)
+  end
+
+  # The ransacker has to keep its formatter, or the enum name never reaches the
+  # integer the column stores.
+  test "an enum filter follows the build" do
+    component = create(:component, :without_build, item_class: nil)
+    create(:component_build, component:, item_class: :military)
+
+    assert_equal [component.id], Component.with_facts.ransack(item_class_eq: "military").result.pluck(:id)
+  end
+
+  test "the hidden filter follows the build" do
+    component = create(:component, :without_build, hidden: false)
+    create(:component_build, component:, hidden: true)
+
+    assert_equal [component.id], Component.with_facts.ransack(hidden_eq: true).result.pluck(:id)
+    assert_empty Component.with_facts.ransack(hidden_eq: false).result.pluck(:id)
+  end
+
+  # The reader falls back to the column for a component no load ever described, so
+  # the filter has to as well on the path that shows such a component.
+  test "a filter falls back to the column when there is no build at all" do
+    component = create(:component, :without_build, item_type: "hand_made")
+
+    assert_equal [component.id],
+      Component.with_facts(false).ransack(item_type_eq: "hand_made").result.pluck(:id)
+  end
+
+  # And is left out of the catalogue, which is what makes the fallback droppable
+  # on the fast path: nothing the current build does not describe is in it.
+  test "the current catalogue leaves out a component with no build" do
+    create(:component, :without_build, item_type: "hand_made")
+
+    assert_empty Component.with_facts.ransack(item_type_eq: "hand_made").result.pluck(:id)
+  end
+
+  test "sorting orders by the name the build carries" do
+    first = create(:component, :without_build, name: "Zulu Column")
+    second = create(:component, :without_build, name: "Alpha Column")
+    create(:component_build, component: first, name: "Alpha Build")
+    create(:component_build, component: second, name: "Zulu Build")
+
+    ordered = Component.with_facts.order(Component.fact_sql(:name).asc).pluck(:id)
+
+    assert_equal [first.id, second.id], ordered
+  end
+
+  test "the facet lists come from the build" do
+    component = create(:component, :without_build, category: "old_category")
+    create(:component_build, component:, category: "coolers", component_sub_type: "Military")
+
+    assert_equal ["coolers"], Component.categories
+    assert_equal ["Military"], Component.sub_types
+  end
+
+  test "the facet lists narrow by the build's category" do
+    cooler = create(:component, :without_build)
+    shield = create(:component, :without_build)
+    create(:component_build, component: cooler, category: "coolers", component_sub_type: "Military")
+    create(:component_build, component: shield, category: "shields", component_sub_type: "Civilian")
+
+    assert_equal ["Military"], Component.sub_types(category: "coolers")
+  end
+
   test ".current_version narrows to the patch the game ships, or opts out" do
     current = create(:component, version: ScData::Source.version)
     retired = create(:component, version: "0.0.1-live.1")

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -264,7 +264,9 @@ module Manufacturers
       plan = ::Manufacturers::Deduplicator.new(dropped_codes: ["TRAS"]).plan
 
       assert_empty plan[:dropped]
-      assert_includes plan[:log].join("\n"), "1 records still point at it"
+      # Two, not one: the component's build carries the manufacturer as well,
+      # which is exactly why ComponentBuild is in ASSOCIATED_MODELS.
+      assert_includes plan[:log].join("\n"), "2 records still point at it"
     end
 
     test "#plan reports no record left without a manufacturer" do


### PR DESCRIPTION
> **Stacked on #4559** — base is `feat/component-reads`. That one moves the readers; this one moves the filters, the last thing still on components' own columns.

Every query parameter keeps its name. A ransacker wins over a real column of the same name, so redirecting them needs no API change, no schema change and no frontend change.

## Two joins behind one alias

A ransacker is static — it emits one expression — so both shapes are aliased `component_facts` and `with_facts` picks between them.

**The catalogue we are on** is an inner join to the current build. That join *is* `current_version`: a row that build does not describe is not in the catalogue. So no column fallback is needed here.

**Everything else** — `currentVersion=false`, and the admin list, which has to show a retired component and one no load has described yet — uses the fallback, with `COALESCE` folded into the subquery rather than into each condition.

The public controller reads the same flag ransack gets, so the join and the scope agree. Components differ from equipment here: `current_version` is a ransackable scope on this model, so it stays in the query and the controller only mirrors the flag.

## This is the step I got wrong on equipment

The first cut there coalesced on every condition, mirroring the readers. It was **9x slower**, and every test still passed — an expression spanning two tables cannot use an index, so every row gets touched.

So this time the plan was checked, not inferred. Measured on 8,717 components, filtered page of 50:

| | median |
| --- | --- |
| before (columns) | 1.48ms |
| **now, current catalogue** | **0.56ms** |
| now, `currentVersion=false` | 7.89ms |

```
Index Scan using index_component_builds_on_environment_and_item_type on component_builds component_facts
  Index Cond: ((environment = 'live') AND (item_type = 'Cooler'))
-> Index Scan using components_pkey on components
```

An index scan into a nested loop on the primary key, using the index the expand migration added. **2.6x faster than before**, not 9x slower.

The facet lists (`categories`, `sub_types`) read the build table directly, needing neither the join nor `current_version`.

## Tests that can actually fail

Nine new model tests, all built by making the build **disagree** with the column — the only way to show which side answered, since while both are written they are identical. Pointing `fact_sql` back at the column makes **5 of them fail**.

They cover the text filter, a type filter, the enum formatter path, `hidden`, the column fallback with no build at all, the catalogue leaving such a component out, sorting, and both facet lists.

## Three test changes this forced

All from one root cause, and worth naming rather than sliding in: **the factory now gives every component the current version.** With the catalogue filter on row existence, a component without a build is not in the catalogue at all, so without a version every component in every test would have gone invisible.

- `component_build_test` uses `:without_build` at the seven call sites where it manages its own builds — they otherwise collide on the unique index
- the `currentVersion` integration test asserts membership rather than a count, since the two components from `setup` are current now as well. A count there was measuring unrelated setup
- the deduplicator expects **"2 records still point at it"** for a single component: its build carries the manufacturer too. That is not a workaround — it is the realistic count, and exactly why `ComponentBuild` is in `ASSOCIATED_MODELS`

## Deliberately not here

**`manufacturer_id` stays on the column.** `belongs_to :manufacturer` reads it and the public API's `manufacturer_slug_in` traverses that association; moving the filter alone would let a filter and a displayed manufacturer disagree.

**The columns stay.** Dropping them should lag by at least a release.

## Verification

1,698 model and public-API tests, plus the admin, loader-helper and deduplicator suites — green. `standardrb` clean.

The `ScData::Loader::*` suites fail in this worktree: **134 tests, 19 failures, 18 errors, identical on unmodified main**, verified by checking main's files out over mine and re-running. The parsed `sc_data` fixture tree is not part of a checkout.

🤖
