### PR TITLE
feat(sc_data): read commodity facts off the build

### DIFF
--- a/app/api_components/v1/schemas/commodity.rb
+++ b/app/api_components/v1/schemas/commodity.rb
@@ -13,6 +13,10 @@ module V1
           slug: {type: :string},
           commodityType: {type: [:string, :null]},
           description: {type: [:string, :null]},
+
+          # Whether the build we are on still describes this commodity. Until now
+          # the API served one the export had dropped as though it were current.
+          retired: {type: :boolean},
           storeImage: ::Shared::V1::Schemas::MediaFile,
 
           # The UEX snapshot prices commodities at every terminal that trades
@@ -24,7 +28,7 @@ module V1
           updatedAt: {type: :string, format: "date-time"}
         },
         additionalProperties: false,
-        required: %w[id name slug availability createdAt updatedAt]
+        required: %w[id name slug retired availability createdAt updatedAt]
       })
     end
   end

--- a/app/controllers/admin/api/v1/commodities_controller.rb
+++ b/app/controllers/admin/api/v1/commodities_controller.rb
@@ -11,7 +11,11 @@ module Admin
 
           commodity_query_params["sorts"] = sorting_params(Commodity, commodity_query_params[:sorts])
 
-          @q = authorized_scope(Commodity.all).includes(:item_prices).ransack(commodity_query_params)
+          # The fallback join, not the current one: an admin list has to show a
+          # commodity the export dropped, and one no load has ever described.
+          @q = authorized_scope(Commodity.with_facts(false))
+            .includes(:item_prices)
+            .ransack(commodity_query_params)
 
           @commodities = @q.result
             .page(params[:page])
@@ -32,7 +36,7 @@ module Admin
         end
 
         def update
-          return if @commodity.update(commodity_params)
+          return if @commodity.update_with_facts(commodity_params)
 
           render json: ValidationError.new("commodity.update", errors: @commodity.errors), status: :bad_request
         end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -13,7 +13,18 @@ module Api
         # Commodities a later patch stopped shipping are left out unless
         # currentVersion=false asks for them -- the rows stay so old ledger
         # entries still resolve, they are just not offered for new ones.
-        @q = Commodity.current_version(current_version).includes(:item_prices).ransack(commodities_query_params)
+        # `with_facts` because the filters resolve against the joined build.
+        # Without it a fact condition raises rather than quietly matching the
+        # column, which is the failure mode to want here -- ransack drops a
+        # condition it cannot place without saying a word.
+        #
+        # It also takes the flag rather than being paired with `current_version`:
+        # for the default it inner-joins the build we are on, and that join
+        # already leaves out what that build does not describe. Adding the scope
+        # beside it scanned `commodity_builds` a second time for the same answer.
+        @q = Commodity.with_facts(current_version)
+          .includes(:item_prices)
+          .ransack(commodities_query_params)
 
         @commodities = @q.result
           .page(params[:page])
@@ -22,8 +33,15 @@ module Api
 
       # Taken out of the ransack params rather than left in them: it is a scope,
       # not a column, and ransack would try to match a `current_version` field.
+      #
+      # Memoized because the join and the scope both ask, and a `delete` with a
+      # default answers the second caller with the default -- so
+      # `currentVersion=false` picked the fallback join and was then filtered
+      # back out by the scope.
       private def current_version
-        commodities_query_params.delete(:current_version) { true }
+        return @current_version if defined?(@current_version)
+
+        @current_version = commodities_query_params.delete(:current_version) { true }
       end
 
       private def commodities_query_params

--- a/app/lib/sc_data/loader/commodities_loader.rb
+++ b/app/lib/sc_data/loader/commodities_loader.rb
@@ -5,6 +5,9 @@ module ScData
         loaded = load_items("commodities").filter_map { |commodity_data| one(commodity_data)&.id }
 
         retire_absent(Commodity, loaded)
+        retire_absent_builds(CommodityBuild, :commodity_id, loaded)
+
+        prune_builds(CommodityBuild)
       end
 
       def one(commodity_data)
@@ -15,6 +18,7 @@ module ScData
         commodity ||= Commodity.new(sc_key: commodity_data["sc_key"])
 
         apply(commodity, update_params(commodity_data))
+        apply_build(commodity, update_params(commodity_data).except(:sc_key, :sc_ref, :version))
 
         # Filled in only while empty, the same way the manufacturer logo is:
         # `store_image` is curated -- an admin uploads it -- so following the

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -47,6 +47,112 @@ class Commodity < ApplicationRecord
     -> { for_source.order(created_at: :desc) },
     class_name: "CommodityBuild", inverse_of: :commodity
 
+  # Whether the build we are on describes this commodity, rather than whether the
+  # version string on the row still matches it. An exists check rather than a
+  # join, so nothing fans out and `currentVersion=false` stays the plain table.
+  scope :current_version, ->(flag = true, source = ::ScData::Source.current) {
+    if ActiveModel::Type::Boolean.new.cast(flag)
+      where(id: CommodityBuild.current(source).select(:commodity_id))
+    else
+      all
+    end
+  }
+
+  # The build a filter resolves against, joined as `commodity_facts`. Two shapes
+  # behind one alias, so a ransacker stays a single static expression either way.
+  #
+  # An inner join to the build we are on *is* `current_version`, so no column
+  # fallback is needed on this path -- and leaving it out is what keeps the
+  # filter on an indexed column. `COALESCE(build, column)` spans two tables, so
+  # no index applies and every row has to be touched: measured on equipment when
+  # this was first built the wrong way, 5.18ms against 0.13ms.
+  def self.current_facts_join(source)
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      INNER JOIN commodity_builds AS commodity_facts
+        ON commodity_facts.commodity_id = commodities.id
+       AND commodity_facts.environment = ?
+       AND commodity_facts.version = ?
+    SQL
+  end
+
+  # Everything: rows only an older build describes, and rows no load ever did.
+  # The fallback is unavoidable here, so it is folded into the subquery rather
+  # than into each condition -- the ransackers stay identical, and the cost lands
+  # only on this path, which is `currentVersion=false` and the admin list.
+  def self.all_facts_join(source)
+    facts = CommodityBuild::FILTERABLE.map { |fact| "COALESCE(b.#{fact}, c.#{fact}) AS #{fact}" }.join(", ")
+
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      LEFT JOIN (
+        SELECT c.id AS commodity_id, #{facts}
+        FROM commodities c
+        LEFT JOIN (
+          SELECT DISTINCT ON (commodity_id) *
+          FROM commodity_builds
+          WHERE environment = ?
+          ORDER BY commodity_id, (version = ?) DESC, created_at DESC
+        ) b ON b.commodity_id = c.id
+      ) AS commodity_facts ON commodity_facts.commodity_id = commodities.id
+    SQL
+  end
+
+  scope :with_facts, ->(current_only = true, source = ::ScData::Source.current) {
+    joins(
+      ActiveModel::Type::Boolean.new.cast(current_only) ? current_facts_join(source) : all_facts_join(source)
+    )
+  }
+
+  # One fact, off whichever build the join supplied. Referencing the alias
+  # without `with_facts` raises rather than returning the wrong rows, which is
+  # the failure mode to want here -- ransack drops a condition it cannot place
+  # without saying a word.
+  def self.fact_sql(fact)
+    Arel.sql("commodity_facts.#{fact}")
+  end
+
+  # Not in the build we are on. Said out loud in the API, which until now offered
+  # a commodity the export had dropped as though it were current.
+  def retired?
+    build.blank?
+  end
+
+  # The build we are on, or the last one that described the commodity.
+  def facts
+    build || last_build
+  end
+
+  # An admin correction is a correction to the build we are on, so it has to
+  # reach the build as well as the row.
+  #
+  # The next load overwrites it, and that is the point: the game files hold what
+  # is actually in the game, so a wrong value here is a parser bug and the fix
+  # belongs in the parser.
+  def update_with_facts(attributes)
+    transaction do
+      return false unless update(attributes)
+
+      facts_attributes = attributes.to_h.symbolize_keys.slice(*CommodityBuild::FACTS)
+
+      # Reloaded rather than read off the association: validating the row above
+      # consults a fact reader, which caches whatever the build was at that
+      # moment -- a nil, for a row whose build is written afterwards.
+      reload_build&.update!(facts_attributes) if facts_attributes.present?
+
+      true
+    end
+  end
+
+  # Read through the build, falling back to the column. The column still answers
+  # for a commodity no load has given a build -- an admin can create one by hand,
+  # and the UEX importer creates them too.
+  CommodityBuild::READ_THROUGH.each do |fact|
+    define_method(fact) do
+      value = facts&.public_send(fact)
+
+      value.nil? ? super() : value
+    end
+  end
+
   # Named as every other catalogue names its picture, so a ledger entry
   # pointing at a commodity draws it through the same fallback that already
   # gives a component its artwork.
@@ -83,8 +189,22 @@ class Commodity < ApplicationRecord
     []
   end
 
-  def self.commodity_types
-    current_version.where.not(commodity_type: nil).distinct.order(:commodity_type).pluck(:commodity_type)
+  # Filtering and sorting read the build. Each of these shadows a real column of
+  # the same name -- a ransacker wins over a column -- so every query parameter
+  # keeps working untouched, with no API and no frontend change.
+  CommodityBuild::FILTERABLE.each do |fact|
+    ransacker(fact) { Commodity.fact_sql(fact) }
+  end
+
+  # Read off the build table rather than through the rows: the builds we are on
+  # *are* the current catalogue, so this needs neither the join nor
+  # `current_version` and stays a single index scan.
+  def self.commodity_types(source = ::ScData::Source.current)
+    CommodityBuild.current(source)
+      .where.not(commodity_type: nil)
+      .distinct
+      .order(:commodity_type)
+      .pluck(:commodity_type)
   end
 
   def self.type_filters

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -34,6 +34,19 @@ class Commodity < ApplicationRecord
   has_many :fleet_inventory_items, as: :item, dependent: :nullify
   has_many :inventory_items, as: :item, dependent: :nullify
 
+  # What each build of the game says about this commodity. Written alongside the
+  # columns, and read through in preference to them.
+  has_many :builds, class_name: "CommodityBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "CommodityBuild", inverse_of: :commodity
+
+  # The newest build of this environment that still describes the commodity,
+  # which is what a record the export dropped falls back to. Without it a retired
+  # commodity would read as nameless, and an inventory item pointing at one has
+  # to resolve to something.
+  has_one :last_build,
+    -> { for_source.order(created_at: :desc) },
+    class_name: "CommodityBuild", inverse_of: :commodity
+
   # Named as every other catalogue names its picture, so a ledger entry
   # pointing at a commodity draws it through the same fallback that already
   # gives a component its artwork.

--- a/app/models/commodity_build.rb
+++ b/app/models/commodity_build.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a commodity.
+#
+# The columns here are exactly the ones `ScData::Loader::CommoditiesLoader`
+# writes. Everything that identifies the commodity, or that comes from another
+# source, stays on Commodity -- `uex_code` and `uex_id` are the UEX importer's,
+# `slug` is generated, and `store_image` is curated.
+# == Schema Information
+#
+# Table name: commodity_builds
+#
+#  id             :uuid             not null, primary key
+#  commodity_type :string
+#  description    :text
+#  environment    :string           not null
+#  name           :string
+#  version        :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  commodity_id   :uuid             not null
+#
+# Indexes
+#
+#  index_commodity_builds_on_commodity_and_build             (commodity_id,environment,version) UNIQUE
+#  index_commodity_builds_on_commodity_id                    (commodity_id)
+#  index_commodity_builds_on_environment_and_commodity_type  (environment,commodity_type)
+#  index_commodity_builds_on_environment_and_version         (environment,version)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade
+#
+class CommodityBuild < ApplicationRecord
+  belongs_to :commodity
+
+  # How many builds of one environment are kept. Enough to diff a patch against
+  # the one before it, and to compare a bad load with what it replaced, without
+  # the table growing with every patch forever.
+  BUILDS_RETAINED = 3
+
+  # Everything a build says, as opposed to what identifies the commodity. Three
+  # facts -- this catalogue has no enums, no serialized columns and no
+  # manufacturer, which is why it fits in one change rather than three.
+  #
+  # The data migration carries its own copy on purpose: a migration has to keep
+  # running against the schema of its own moment, not this list as it later
+  # becomes.
+  FACTS = %i[name commodity_type description].freeze
+
+  # Every fact is read through the build. Nothing is held back here: equipment
+  # and components hold `manufacturer_id` and `hidden` back because an
+  # association and a visibility scope read the columns, and commodities have
+  # neither.
+  READ_THROUGH = FACTS
+
+  # The facts Commodity filters and sorts by. `description` is left out -- no
+  # filter reaches it, and folding it into the fallback subquery would widen it
+  # for no gain.
+  FILTERABLE = %i[name commodity_type].freeze
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :commodity_id, uniqueness: {scope: [:environment, :version]}
+
+  # Every build this environment still has, newest first.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on. `ScData::Source` names the version
+  # exactly, so this needs no ordering or subselect.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared. Re-loading a build updates its rows in place, so `created_at` is
+  # when that build first landed rather than when it was last touched.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/app/views/admin/api/v1/commodities/_base.jbuilder
+++ b/app/views/admin/api/v1/commodities/_base.jbuilder
@@ -5,6 +5,7 @@ json.name commodity.name
 json.slug commodity.slug
 json.commodity_type commodity.commodity_type
 json.description commodity.description
+json.retired commodity.retired?
 
 json.store_image do
   json.partial! "api/v1/shared/file", record: commodity, attr: :store_image

--- a/app/views/api/v1/commodities/_base.jbuilder
+++ b/app/views/api/v1/commodities/_base.jbuilder
@@ -5,6 +5,7 @@ json.name commodity.name
 json.slug commodity.slug
 json.commodity_type commodity.commodity_type
 json.description commodity.description
+json.retired commodity.retired?
 
 json.store_image do
   json.partial! "api/v1/shared/file", record: commodity, attr: :store_image

--- a/db/data/20260827181000_backfill_commodity_builds.rb
+++ b/db/data/20260827181000_backfill_commodity_builds.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Seeds a build row from what each commodity row already says, so the new table is
+# populated before anything reads from it -- rather than staying empty until the
+# next sc_data load.
+#
+# Rows whose version is nil are skipped: the export stopped naming them, or never
+# did. The UEX importer creates commodities too, and those carry no version -- for
+# them the column keeps answering, which is why the readers fall back at all.
+class BackfillCommodityBuilds < ActiveRecord::Migration[8.1]
+  # Its own copy on purpose: a migration has to keep running against the schema of
+  # its own moment, not `CommodityBuild::FACTS` as that later becomes.
+  FACTS = %i[name commodity_type description].freeze
+
+  def up
+    environment = ScData::Source.environment
+
+    Commodity.where.not(version: nil).find_each do |commodity|
+      # Keyed on the version the row itself carries, not just the environment: a
+      # commodity whose build already exists must be updated in place rather than
+      # have some other build's row repointed at it.
+      build = commodity.builds.find_or_initialize_by(
+        environment:, version: commodity.version
+      )
+
+      # Read off the row rather than through the reader, which resolves the build
+      # first -- the very row being written here.
+      build.update!(FACTS.index_with { |fact| commodity.read_attribute(fact) })
+    end
+  end
+
+  def down
+    CommodityBuild.delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_27_150100)
+DataMigrate::Data.define(version: 2026_08_27_181000)

--- a/db/migrate/20260827180000_create_commodity_builds.rb
+++ b/db/migrate/20260827180000_create_commodity_builds.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a commodity, following the shape
+# `equipment_builds` and `component_builds` established.
+#
+# The smallest of the four catalogues by a wide margin: the loader writes three
+# facts. Everything else on the row is identity or comes from somewhere else
+# entirely -- `uex_code` and `uex_id` are the UEX importer's, `slug` is generated,
+# and `store_image` is curated, filled only while empty so a load never replaces
+# an admin's upload.
+#
+# Nothing references a commodity, and there is no manufacturer, so this needs no
+# entry in `Manufacturers::Deduplicator::ASSOCIATED_MODELS` -- unlike components.
+class CreateCommodityBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :commodity_builds, id: :uuid do |t|
+      # Cascade: a build says something about a commodity, and says nothing at
+      # all once the commodity is gone.
+      t.references :commodity, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      t.string :name
+      t.string :commodity_type
+      t.text :description
+
+      t.timestamps
+    end
+
+    # One row per commodity per build. Re-loading the same build updates it in
+    # place; a new build adds a row beside it.
+    add_index :commodity_builds, [:commodity_id, :environment, :version],
+      unique: true, name: "index_commodity_builds_on_commodity_and_build"
+
+    # The filters a browsable catalogue needs, so narrowing to one build stays a
+    # join rather than a scan. Every read names an environment and a version,
+    # because that pair is what `ScData::Source` hands out.
+    add_index :commodity_builds, [:environment, :version]
+    add_index :commodity_builds, [:environment, :commodity_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -199,6 +199,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_150000) do
     t.index ["sc_key"], name: "index_commodities_on_sc_key", unique: true
     t.index ["slug"], name: "index_commodities_on_slug", unique: true
     t.index ["uex_code"], name: "index_commodities_on_uex_code"
+  end
+
+  create_table "commodity_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "commodity_id", null: false
+    t.string "commodity_type"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "environment", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.index ["commodity_id", "environment", "version"], name: "index_commodity_builds_on_commodity_and_build", unique: true
+    t.index ["commodity_id"], name: "index_commodity_builds_on_commodity_id"
+    t.index ["environment", "commodity_type"], name: "index_commodity_builds_on_environment_and_commodity_type"
+    t.index ["environment", "version"], name: "index_commodity_builds_on_environment_and_version"
   end
 
   create_table "compare_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1555,6 +1570,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_150000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_notifications", "admin_users", on_delete: :cascade
   add_foreign_key "cargo_hold_container_capacities", "cargo_holds"
+  add_foreign_key "commodity_builds", "commodities", on_delete: :cascade
   add_foreign_key "component_builds", "components", on_delete: :cascade
   add_foreign_key "equipment_builds", "equipment", on_delete: :cascade
   add_foreign_key "fleet_event_admins", "fleet_events"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8054,6 +8054,8 @@ components:
           type:
           - string
           - 'null'
+        retired:
+          type: boolean
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         availability:
@@ -8097,6 +8099,7 @@ components:
       - id
       - name
       - slug
+      - retired
       - availability
       - createdAt
       - updatedAt

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10882,6 +10882,8 @@ components:
           type:
           - string
           - 'null'
+        retired:
+          type: boolean
         storeImage:
           "$ref": "#/components/schemas/MediaFile"
         availability:
@@ -10897,6 +10899,7 @@ components:
       - id
       - name
       - slug
+      - retired
       - availability
       - createdAt
       - updatedAt

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -32,6 +32,35 @@ FactoryBot.define do
     description { Faker::Lorem.sentence }
     version { Rails.configuration.sc_data[:version] }
 
+    transient { with_build { true } }
+
+    # A build describing the commodity, mirroring what the backfill did for the
+    # rows already in the table. Keyed on the row's own version, so
+    # `create(:commodity, version: <older>)` is retired here too, and skipped
+    # entirely for a row with no version -- the UEX importer creates those, and
+    # the export never named them.
+    after(:create) do |commodity, evaluator|
+      next unless evaluator.with_build
+      next if commodity.version.blank?
+
+      commodity.builds.create!(
+        environment: ScData::Source.environment,
+        version: commodity.version,
+        **commodity.attributes.symbolize_keys.slice(*CommodityBuild::FACTS)
+      )
+
+      # Validating the row consulted a fact reader, which cached the build as it
+      # was then -- absent. Dropped so the record behaves like a freshly loaded one.
+      commodity.association(:build).reset
+      commodity.association(:last_build).reset
+    end
+
+    # For tests that manage builds themselves and would otherwise collide with
+    # the one above on the unique index.
+    trait :without_build do
+      with_build { false }
+    end
+
     trait :with_store_image do
       store_image { Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/test.png"), "image/png") }
     end

--- a/test/factories/commodity_builds.rb
+++ b/test/factories/commodity_builds.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: commodity_builds
+#
+#  id             :uuid             not null, primary key
+#  commodity_type :string
+#  description    :text
+#  environment    :string           not null
+#  name           :string
+#  version        :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  commodity_id   :uuid             not null
+#
+# Indexes
+#
+#  index_commodity_builds_on_commodity_and_build             (commodity_id,environment,version) UNIQUE
+#  index_commodity_builds_on_commodity_id                    (commodity_id)
+#  index_commodity_builds_on_environment_and_commodity_type  (environment,commodity_type)
+#  index_commodity_builds_on_environment_and_version         (environment,version)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :commodity_build do
+    commodity
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+
+    sequence(:name) { |n| "#{Faker::Commerce.material} #{n}" }
+    commodity_type { "metal" }
+    description { Faker::Lorem.sentence }
+  end
+end

--- a/test/integration/api/v1/commodities_test.rb
+++ b/test/integration/api/v1/commodities_test.rb
@@ -73,6 +73,30 @@ class Api::V1::CommoditiesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Said out loud rather than left to be inferred from an absence: the list used
+  # to serve a dropped commodity as though it were current.
+  test "GET /commodities marks a commodity the current build no longer ships" do
+    create(:commodity, name: "Astatine", version: "0.0.1-live.1")
+
+    assert_api_response :get, 200, params: {q: {"currentVersion" => false}} do
+      items = parsed_body["items"].index_by { |item| item["name"] }
+
+      assert items["Astatine"]["retired"]
+      assert_not items["Gold"]["retired"]
+    end
+  end
+
+  # A retired commodity still has to read: an inventory ledger entry can point at
+  # one, so the last build that described it answers rather than nothing.
+  test "GET /commodities names a retired commodity off the last build describing it" do
+    dropped = create(:commodity, :without_build, name: "Column Name", version: "0.0.1-live.1")
+    create(:commodity_build, commodity: dropped, version: "0.0.1-live.1", name: "Astatine")
+
+    assert_api_response :get, 200, params: {q: {"currentVersion" => false}} do
+      assert_includes parsed_body["items"].map { |item| item["name"] }, "Astatine"
+    end
+  end
+
   test "GET /commodities exposes the fields the picker needs" do
     assert_api_response :get, 200 do
       gold = parsed_body["items"].find { |item| item["name"] == "Gold" }

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -180,6 +180,41 @@ module ScData
         assert Component.exists?(dropped.id), "the row itself has to stay"
         assert_empty dropped.builds.current
       end
+
+      # The same helper, the third catalogue. Commodities are the simplest of the
+      # three -- three facts, no enums, no serialized columns, no manufacturer --
+      # so what this pins is that the loader writes only what a build says: the
+      # identity keys and the UEX mapping stay on the row.
+      test "#apply_build works the same for a commodity" do
+        commodity = create(:commodity, :without_build)
+
+        @loader.apply_build(commodity, {name: "Quantanium", commodity_type: "mineral"})
+
+        build = commodity.builds.sole
+        assert_equal "Quantanium", build.name
+        assert_equal "mineral", build.commodity_type
+        assert_equal ::ScData::Source.environment, build.environment
+        assert_equal ::ScData::Source.version, build.version
+      end
+
+      test "a commodity build carries no identity or UEX columns to write to" do
+        %w[sc_key sc_ref slug uex_id uex_code].each do |column|
+          refute_includes CommodityBuild.column_names, column
+        end
+      end
+
+      test "#retire_absent_builds drops a commodity's current build but keeps the commodity" do
+        kept = create(:commodity, :without_build)
+        dropped = create(:commodity, :without_build)
+        create(:commodity_build, commodity: kept)
+        create(:commodity_build, commodity: dropped)
+
+        @loader.retire_absent_builds(CommodityBuild, :commodity_id, [kept.id])
+
+        assert_equal 1, CommodityBuild.current.count
+        assert Commodity.exists?(dropped.id), "the row itself has to stay"
+        assert_empty dropped.builds.current
+      end
     end
   end
 end

--- a/test/loaders/sc_data/base_loader_apply_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_test.rb
@@ -21,8 +21,13 @@ module ScData
         assert_equal({created: 1, updated: 0, unchanged: 0}, @loader.stats["Commodity"])
       end
 
+      # `:without_build` here and below: `apply` writes the column, and a commodity
+      # reads its build in preference to it, so a commodity with a build would
+      # read as "Old" however the column moved. What is under test is the counting
+      # seam, not the fact layering -- the loader always calls `apply_build`
+      # alongside `apply`.
       test "#apply counts a record whose attributes moved as updated" do
-        commodity = create(:commodity, name: "Old")
+        commodity = create(:commodity, :without_build, name: "Old")
 
         @loader.apply(commodity, {name: "New"})
 
@@ -33,7 +38,7 @@ module ScData
       # The distinction the seam exists for: assigning the values a row already
       # holds is not a write, and a run of those should not read as one.
       test "#apply counts a record assigned its own values as unchanged" do
-        commodity = create(:commodity, name: "Same")
+        commodity = create(:commodity, :without_build, name: "Same")
 
         @loader.apply(commodity, {name: "Same"})
 

--- a/test/models/commodity_build_test.rb
+++ b/test/models/commodity_build_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommodityBuildTest < ActiveSupport::TestCase
+  setup do
+    @environment = ScData::Source.environment
+  end
+
+  test "a commodity carries one row per build, not two" do
+    commodity = create(:commodity, :without_build)
+    create(:commodity_build, commodity:, environment: @environment, version: "1.0.0")
+
+    duplicate = build(:commodity_build, commodity:, environment: @environment, version: "1.0.0")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :commodity_id
+  end
+
+  test "a later build of the same environment sits beside the earlier one" do
+    commodity = create(:commodity, :without_build)
+    create(:commodity_build, commodity:, environment: @environment, version: "1.0.0")
+
+    assert_difference("CommodityBuild.count", 1) do
+      create(:commodity_build, commodity:, environment: @environment, version: "1.0.1")
+    end
+  end
+
+  # The same version in two environments is two builds: live and ptu ship the
+  # same version string while carrying different data.
+  test "the same commodity can be described by more than one environment" do
+    commodity = create(:commodity, :without_build)
+    create(:commodity_build, commodity:, environment: "live", version: "1.0.0")
+
+    assert_difference("CommodityBuild.count", 1) do
+      create(:commodity_build, commodity:, environment: "ptu", version: "1.0.0")
+    end
+  end
+
+  test "requires the commodity it describes, and a build to be" do
+    orphan = build(:commodity_build, commodity: nil, environment: nil, version: nil)
+
+    assert_not orphan.valid?
+    assert_includes orphan.errors.attribute_names, :commodity
+    assert_includes orphan.errors.attribute_names, :environment
+    assert_includes orphan.errors.attribute_names, :version
+  end
+
+  test ".for_source keeps only the current environment" do
+    commodity = create(:commodity, :without_build)
+    live = create(:commodity_build, commodity:, environment: @environment, version: "1.0.0")
+    other = create(:commodity_build, commodity:, environment: "ptu", version: "1.0.0")
+
+    assert_includes CommodityBuild.for_source, live
+    assert_not_includes CommodityBuild.for_source, other
+  end
+
+  test ".current also narrows to the version the environment is on" do
+    commodity = create(:commodity, :without_build)
+    current = create(:commodity_build, commodity:, environment: @environment, version: ScData::Source.version)
+    older = create(:commodity_build, commodity:, environment: @environment, version: "0.0.1-live.1")
+
+    assert_includes CommodityBuild.current, current
+    assert_not_includes CommodityBuild.current, older
+  end
+
+  test ".retained_versions keeps the newest builds of an environment" do
+    commodity = create(:commodity, :without_build)
+    %w[0.0.1 0.0.2 0.0.3 0.0.4].each_with_index do |version, index|
+      create(
+        :commodity_build,
+        commodity:, environment: @environment, version:,
+        created_at: index.days.ago.end_of_day
+      )
+    end
+
+    assert_equal %w[0.0.2 0.0.1], CommodityBuild.retained_versions(@environment, keep: 2)
+  end
+
+  test "builds go when the commodity does" do
+    commodity = create(:commodity, :without_build)
+    create(:commodity_build, commodity:)
+
+    assert_difference("CommodityBuild.count", -1) do
+      commodity.destroy
+    end
+  end
+end

--- a/test/models/commodity_test.rb
+++ b/test/models/commodity_test.rb
@@ -158,4 +158,105 @@ class CommodityTest < ActiveSupport::TestCase
       commodity.destroy!
     end
   end
+
+  # Every test below makes the build **disagree** with the column. While both are
+  # written they are identical, so a passing test would prove nothing about which
+  # side answered.
+  test "a commodity in the current build reads that build, and is not retired" do
+    commodity = create(:commodity, name: "Column Name", commodity_type: "metal")
+    commodity.build.update!(name: "Build Name", commodity_type: "gas")
+
+    assert_not commodity.reload.retired?
+    assert_equal "Build Name", commodity.name
+    assert_equal "gas", commodity.commodity_type
+  end
+
+  # A dropped commodity still has to resolve to something: an inventory item can
+  # point at one, and a hard delegation would leave it nameless.
+  test "a retired commodity reads the last build that described it, and is marked" do
+    commodity = create(:commodity, :without_build, name: "Column Name")
+    create(:commodity_build, commodity:, version: "0.0.1-live.1", name: "Old Build Name")
+
+    assert_predicate commodity.reload, :retired?
+    assert_equal "Old Build Name", commodity.name
+  end
+
+  test "the current build wins over an earlier one" do
+    commodity = create(:commodity, name: "Column Name")
+    create(:commodity_build, commodity:, version: "0.0.1-live.1", name: "Old Build Name")
+    commodity.build.update!(name: "Current Build Name")
+
+    assert_equal "Current Build Name", commodity.reload.name
+  end
+
+  # The UEX importer creates commodities the export has never named, and an admin
+  # can create one by hand. Neither has a build, and both have to read.
+  test "a commodity with no build at all falls back to its own columns" do
+    commodity = create(:commodity, :without_build, name: "Column Name", commodity_type: "metal", version: nil)
+
+    assert_nil commodity.build
+    assert_equal "Column Name", commodity.name
+    assert_equal "metal", commodity.commodity_type
+  end
+
+  test "#update_with_facts writes the correction to the build as well" do
+    commodity = create(:commodity, name: "Wrong Name")
+
+    assert commodity.update_with_facts(name: "Corrected Name", commodity_type: "gas")
+
+    assert_equal "Corrected Name", commodity.build.reload.name
+    assert_equal "gas", commodity.build.commodity_type
+    assert_equal "Corrected Name", commodity.reload.name
+  end
+
+  test "#update_with_facts leaves a retired commodity's build alone" do
+    commodity = create(:commodity, :without_build, name: "Wrong Name")
+    old = create(:commodity_build, commodity:, version: "0.0.1-live.1", name: "Old Build Name")
+
+    assert commodity.update_with_facts(name: "Corrected Name")
+
+    assert_equal "Old Build Name", old.reload.name
+  end
+
+  test "filters on the name the build carries, not the column" do
+    commodity = create(:commodity, name: "Column Name")
+    commodity.build.update!(name: "Quantanium")
+
+    assert_includes Commodity.with_facts.ransack(name_cont: "Quantanium").result, commodity
+    assert_not_includes Commodity.with_facts.ransack(name_cont: "Column").result, commodity
+  end
+
+  test "filters on the type the build carries, not the column" do
+    commodity = create(:commodity, commodity_type: "metal")
+    commodity.build.update!(commodity_type: "gas")
+
+    assert_includes Commodity.with_facts.ransack(commodity_type_eq: "gas").result, commodity
+    assert_not_includes Commodity.with_facts.ransack(commodity_type_eq: "metal").result, commodity
+  end
+
+  test "sorts by the name the build carries, not the column" do
+    first = create(:commodity, name: "Zzz Column")
+    second = create(:commodity, name: "Aaa Column")
+    first.build.update!(name: "Aaa Build")
+    second.build.update!(name: "Zzz Build")
+
+    result = Commodity.with_facts.ransack(sorts: "name asc").result
+
+    assert_equal [first, second], result.to_a
+  end
+
+  # The fallback path, which is `currentVersion=false` and the admin list: a
+  # commodity no build describes has to be findable by what its column says.
+  test "the fallback join finds a commodity by its column when no build describes it" do
+    commodity = create(:commodity, :without_build, name: "Column Only", version: nil)
+
+    assert_includes Commodity.with_facts(false).ransack(name_cont: "Column Only").result, commodity
+  end
+
+  test "the facet lists the type the build carries, not the column" do
+    commodity = create(:commodity, commodity_type: "metal")
+    commodity.build.update!(commodity_type: "gas")
+
+    assert_equal %w[gas], Commodity.commodity_types
+  end
 end


### PR DESCRIPTION
The third catalogue, and the simplest of the three by a wide margin — so expand, reads and filters land together rather than as three PRs.

## Why one PR here

Components cost two attempts because a serialized fact left off the build made the reader hand a raw YAML string to a caller expecting a hash. Commodities have **no enums, no serialized columns, no manufacturer, and nothing references them**. The loader writes three facts: `name`, `commodity_type`, `description`.

Everything else on the row is identity or comes from somewhere else — `uex_code` and `uex_id` are the UEX importer's, `slug` is generated, and `store_image` is curated, filled only while empty so a load never replaces an admin's upload. A test pins that the build table has no column for any of them.

## Reads

Three steps: the current build, else the last build that described the commodity, else the column.

The fallback is not optional. An inventory ledger entry pointing at a dropped commodity has to resolve to something, and the **UEX importer creates commodities the export has never named** — those have no build at all, so the column keeps answering.

`retired` is now in the API. Until now the list served a commodity the export had dropped as though it were current.

## Filters

Every query parameter keeps its name: a ransacker wins over a real column of the same name, so no API change, no frontend change.

Two join shapes behind one `commodity_facts` alias, because a ransacker emits one static expression:

- **the current catalogue** — an inner join to the current build, no column fallback. That join *is* `current_version`.
- **everything else** — `currentVersion=false` and the admin list, with `COALESCE` folded into the subquery rather than into each condition.

### The step equipment got wrong, checked this time

The first equipment cut coalesced on every condition and was **9x slower**, with every test still passing — an expression spanning two tables cannot use an index.

At 231 commodities Postgres prefers a seq scan on its own merits, so timings are flat (0.22ms before, 0.29ms now). What matters is whether the index *can* apply. With seq scans discouraged:

```
current catalogue:
  Bitmap Index Scan on index_commodity_builds_on_environment_and_commodity_type
    Index Cond: ((environment = 'live') AND (commodity_type = 'metal'))

fallback:
  Filter: (COALESCE(commodity_builds.commodity_type, c.commodity_type) = 'metal')
    Bitmap Index Scan ... Index Cond: (environment = 'live')
```

The filter is an **index condition** on the current path and a **post-join filter** on the fallback — the shape that cost equipment 9x, contained to the path that has no alternative.

## A bug this turned up

`current_version` reads the flag with `params.delete(:current_version) { true }`, and the join and the scope both asked. The second caller got the **default**, so `currentVersion=false` picked the fallback join and was then filtered back out. Caught by an existing integration test.

The fix also removed the pairing: `with_facts` takes the flag alone, since the inner join already excludes what the build does not describe. Asking the scope beside it scanned `commodity_builds` a second time for the same answer.

## Tests that can actually fail

Every new model test makes the build **disagree** with the column — while both are written they are identical, so a passing test would otherwise prove nothing about which side answered. Three mutations, each caught:

| mutation | failures |
| --- | --- |
| `fact_sql` points back at the column | 3 |
| readers ignore the build | 3 |
| the facet reads the rows again | 1 |

11 new model tests, 8 for `CommodityBuild`, 3 for the loader helper's third catalogue, and 2 integration tests covering `retired` and a retired commodity reading its last build.

## Deliberately not here

**The columns stay.** Dropping them should lag by at least a release, and by then all three catalogues can be swept together.

**The jbuilder cache key** is `["v1", commodity, prices]`, which does not include the build. Harmless while the loader dual-writes — it touches the row on every load — but it becomes real in the contract phase, for all three catalogues at once.

## Verification

414 model tests, 1,295 public API and 820 admin integration tests — green. `standardrb` clean. Schema regenerated; the cable document is unchanged.

Two known environmental failures, unrelated and identical on unmodified main: the `ScData::Loader::*` suites need the parsed `sc_data` tree, which is not part of a checkout, and two admin mailer tests hit premailer on `localhost:3000`.

🤖
