### PR TITLE
feat(admin): report import runs in the notification center

### DIFF
--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1909,7 +1909,10 @@
           "new_supporter": "New Supporter",
           "rsi_api_blocked": "RSI API Blocked",
           "rsi_api_unblocked": "RSI API Restored",
-          "weekly_stats": "Weekly Report"
+          "weekly_stats": "Weekly Report",
+          "ship_matrix_import": "Ship Matrix Import",
+          "sc_data_import": "sc_data Import",
+          "import_run": "Import"
         }
       },
       "optional": "optional",

--- a/app/jobs/loaders/models_job.rb
+++ b/app/jobs/loaders/models_job.rb
@@ -7,7 +7,21 @@ module Loaders
 
       import.start!
 
+      started_at = Time.current
+
       ::Rsi::ModelsLoader.new.all
+
+      AdminReport.deliver(
+        task_type: "ship_matrix_import",
+        title: "Ship Matrix Import Results",
+        body: results_body(started_at),
+        # A run that changes nothing is the normal case for a matrix that moves
+        # a few times a month, so it never opens an issue. A run that breaks
+        # raises, and the import's own notification carries that.
+        actionable: false,
+        link: "/models",
+        record: import
+      )
 
       import.finish!
     rescue => e
@@ -15,6 +29,26 @@ module Loaders
       import.update!(info: e.message)
 
       raise e
+    end
+
+    # `Rsi::ModelsLoader` returns nothing countable, so the run is measured on
+    # either side of it. New models are named because that is the part of the
+    # report worth reading; an update is a field nobody can name from here.
+    private def results_body(started_at)
+      added = Model.where(created_at: started_at..).order(:name)
+      updated = Model.where(updated_at: started_at..).where(created_at: ...started_at).count
+
+      lines = [
+        "## Ship Matrix Import",
+        "",
+        "- **Models added**: #{added.count}",
+        "- **Models updated**: #{updated}",
+        "- **Models in total**: #{Model.count}"
+      ]
+
+      return lines.join("\n") if added.empty?
+
+      (lines + ["", "### Added", "", *added.map { |model| "- **#{model.name}**" }]).join("\n")
     end
   end
 end

--- a/app/jobs/loaders/sc_data/all_job.rb
+++ b/app/jobs/loaders/sc_data/all_job.rb
@@ -14,10 +14,23 @@ module Loaders
 
         fetch_parsed_tree!(version)
 
+        # `to_h` rather than the bare return: a loader set that produced
+        # nothing hands back nil, and the report still has to render.
+        stats = ::ScData::Loader::BaseLoader.all.to_h
+
         # Kept on the import so the admin view of a load says what it did.
         # Otherwise the only record of a build that rewrote the catalogue, versus
         # one that changed nothing, is a log line nobody goes looking for.
-        import.update!(output: ::ScData::Loader::BaseLoader.all)
+        import.update!(output: stats)
+
+        AdminReport.deliver(
+          task_type: "sc_data_import",
+          title: "sc_data Import Results (#{version})",
+          body: results_body(version, stats),
+          actionable: empty_catalogue?(stats),
+          link: "/maintenance/imports",
+          record: import
+        )
 
         import.finish!
       rescue => e
@@ -25,6 +38,36 @@ module Loaders
         import.update!(info: e.message)
 
         raise e
+      end
+
+      private def results_body(version, stats)
+        lines = ["## sc_data #{version}", ""]
+
+        stats.each do |loader, counts|
+          lines << "### #{loader}"
+          lines << ""
+
+          if counts.blank?
+            lines << "- nothing written"
+          else
+            counts.sort.each do |name, buckets|
+              lines << "- **#{name}**: #{buckets.map { |bucket, count| "#{bucket} #{count}" }.join(", ")}"
+            end
+          end
+
+          lines << ""
+        end
+
+        lines.join("\n").strip
+      end
+
+      # A loader that wrote nothing and left nothing unchanged never saw its
+      # catalogue - the failure that left Commodity and Equipment empty for a
+      # week. Worth a human, unlike a build that simply changed little.
+      private def empty_catalogue?(stats)
+        stats.any? do |_loader, counts|
+          counts.blank? || counts.values.all? { |buckets| buckets.values.sum.zero? }
+        end
       end
     end
   end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -50,7 +50,10 @@ class AdminNotification < ApplicationRecord
     new_supporter: "new_supporter",
     rsi_api_blocked: "rsi_api_blocked",
     rsi_api_unblocked: "rsi_api_unblocked",
-    weekly_stats: "weekly_stats"
+    weekly_stats: "weekly_stats",
+    ship_matrix_import: "ship_matrix_import",
+    sc_data_import: "sc_data_import",
+    import_run: "import_run"
   }
 
   enum :severity, {
@@ -104,6 +107,23 @@ class AdminNotification < ApplicationRecord
       retention: 30.days,
       access: [:stats],
       icon: "fa-duotone fa-chart-line"
+    },
+    ship_matrix_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-list-tree"
+    },
+    sc_data_import: {
+      retention: 30.days,
+      access: [:models],
+      icon: "fa-duotone fa-database"
+    },
+    # The status line every other import leaves behind, at info when it
+    # finished and at error when it did not.
+    import_run: {
+      retention: 30.days,
+      access: [:imports],
+      icon: "fa-duotone fa-file-import"
     }
   }.freeze
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -70,9 +70,46 @@ class Import < ApplicationRecord
     end
   end
 
+  # Imports whose job files its own report, with the detail a status line
+  # cannot carry. Reporting both would put every paints run into the center
+  # twice - once with the missing models, once saying it finished.
+  SELF_REPORTED_TYPES = %w[
+    Imports::ModelsImport
+    Imports::ModulesImport
+    Imports::PaintsImport
+    Imports::UexPricesImport
+    Imports::UexCommodityPricesImport
+    Imports::ScData::AllImport
+  ].freeze
+
   def notify_admin
     AdminUser.find_each do |admin_user|
       ::ImportsChannel.broadcast_to(admin_user, to_jbuilder_hash)
     end
+
+    report_run
+  end
+
+  def label
+    type.to_s.demodulize.underscore.humanize
+  end
+
+  # The cable broadcast reaches whoever has the imports page open; this is for
+  # everyone who does not, which is the point of the notification center.
+  private def report_run
+    # A user's import belongs to that user - they ran it, they get told in
+    # their own center, and thousands of syncs a week are not admin news.
+    return if user_id.present?
+    return unless finished? || failed?
+    return if finished? && SELF_REPORTED_TYPES.include?(type.to_s)
+
+    AdminNotification.notify!(
+      type: :import_run,
+      title: "#{label} #{aasm_state}",
+      body: info.presence,
+      severity: failed? ? :error : :info,
+      link: "/maintenance/imports",
+      record: self
+    )
   end
 end

--- a/asyncapi/cable/admin/v1/schema.yaml
+++ b/asyncapi/cable/admin/v1/schema.yaml
@@ -123,6 +123,9 @@ components:
       - rsi_api_blocked
       - rsi_api_unblocked
       - weekly_stats
+      - ship_matrix_import
+      - sc_data_import
+      - import_run
       x-enumNames:
       - PAINTS_IMPORT
       - MODULES_IMPORT
@@ -133,6 +136,9 @@ components:
       - RSI_API_BLOCKED
       - RSI_API_UNBLOCKED
       - WEEKLY_STATS
+      - SHIP_MATRIX_IMPORT
+      - SC_DATA_IMPORT
+      - IMPORT_RUN
     Import:
       type: object
       properties:

--- a/docs/exec-plans/admin-import-notifications.md
+++ b/docs/exec-plans/admin-import-notifications.md
@@ -1,0 +1,81 @@
+# Admin Import Notifications
+
+Five of the recurring loaders report every run into the admin notification center through `AdminReport`: paints, modules, loaner, UEX prices, UEX commodities. The ship matrix import and the sc_data loaders do not, and a failed import of any kind is only visible as a row in the imports list and a cable broadcast nobody was watching — the center, which exists so an operator can find out afterwards what happened overnight, never hears about either.
+
+## What is missing
+
+| Run | Record | Today | Plan |
+|---|---|---|---|
+| `Loaders::ModelsJob` (ship matrix) | `Imports::ModelsImport` | cable only | `ship_matrix_import` report per run |
+| `Loaders::ScData::AllJob` | `Imports::ScData::AllImport` | cable only, stats on the import | `sc_data_import` report per run |
+| Any import that fails | every `Import` | cable only | `import_run` at error severity |
+| Any admin import that finishes without its own report | `Imports::ModelImport`, `Imports::ScData::{Models,Model}Import` | cable only | `import_run` at info severity |
+| A user's hangar import or sync | `Imports::HangarImport`, `Imports::HangarSync` | cable only | stays out — see D2 |
+
+## Decisions
+
+### D1 — One generic type, severity tells the outcome
+
+`import_run` covers both the finished and the failed case rather than a type per outcome. The center already filters by severity, and a reader looking for "what did the imports do last night" wants one filter, not two. The two named types stay separate because they carry a report body, not a status line.
+
+### D2 — A user's import is not admin news
+
+`Imports::HangarImport` and `Imports::HangarSync` belong to a user and run whenever that user presses sync. Reporting them would put thousands of rows a week into every admin's inbox, and the user already gets `hangar_sync_finished` in their own center. The gate is `user_id.present?`, not a type list, so a user-owned import added later is excluded by default.
+
+### D3 — A job that reports its own run silences the generic one
+
+Otherwise every paints run lands twice: once as the report with the missing-model list, once as "Paints Import finished". The import knows which types those are, and the generic notification skips them on success — but never on failure, because a report that never ran is exactly what the failure notification is for.
+
+### D4 — Actionable means "a catalogue came back empty"
+
+`AdminReport` opens a GitHub issue when a report is actionable, so the bar is a run that needs a human. For sc_data that is a loader whose counts are all zero — the failure mode that left Commodity and Equipment empty for a week. For the ship matrix, a run that touches nothing is normal (the matrix rarely changes), so it never marks itself actionable; a broken run raises, and D1 covers it.
+
+---
+
+## Progress
+
+- [x] Phase 1 — Notification types
+- [x] Phase 2 — Ship matrix report
+- [x] Phase 3 — sc_data report
+- [x] Phase 4 — Generic import notifications
+- [x] Phase 5 — Tests, lint, schema
+
+---
+
+## Phase 1: Notification types
+
+`AdminNotification` gains three enum values and their `TYPES` entries:
+
+- `ship_matrix_import` — access `[:models]`, 30 days
+- `sc_data_import` — access `[:models]`, 30 days
+- `import_run` — access `[:imports]`, 30 days
+
+Plus `labels.adminNotifications.types.*` in `en`, and a regenerated admin schema (the enum component reads the model).
+
+## Phase 2: Ship matrix report
+
+`Loaders::ModelsJob` reports what the run changed. `Rsi::ModelsLoader#all` returns nothing countable, so the job measures either side of it: models created since the run started, and models updated but not created. New models are listed by name — that is the part worth reading.
+
+## Phase 3: sc_data report
+
+`Loaders::ScData::AllJob` already collects `BaseLoader.all`, a hash of per-loader `{created, updated, unchanged}` counts, and stores it on the import. The same hash becomes the report body, and a loader with three zeroes makes the run actionable (D4).
+
+## Phase 4: Generic import notifications
+
+`Import#notify_admin` keeps its cable broadcast and adds a center notification, gated by D2 and D3. Failure carries `info` (the exception message) as the body at error severity.
+
+## Phase 5: Tests, lint, schema
+
+Job tests for both reports, model tests for the gates, `standardrb`, `./bin/generate-schema`.
+
+## Not in scope
+
+- **RSI news and YouTube feeds** — one entry per run would be noise; they post to Discord and a failure raises
+- **Per-model sc_data loads** (`Loaders::ScData::ModelJob`) — covered by the generic notification
+- **Retiring `ImportsChannel`** — the live progress view still uses it
+
+## Discovery Log
+
+- **2026-08-27** `BaseLoader.all` hands back nil when nothing ran, which the
+  existing job test stubs — the report has to render either way.
+- **2026-08-27** Written after the notification center landed (#4562). `hangar_sync_finished` already exists on the user side and needed nothing.

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7594,6 +7594,9 @@ components:
       - rsi_api_blocked
       - rsi_api_unblocked
       - weekly_stats
+      - ship_matrix_import
+      - sc_data_import
+      - import_run
       x-enumNames:
       - PAINTS_IMPORT
       - MODULES_IMPORT
@@ -7604,6 +7607,9 @@ components:
       - RSI_API_BLOCKED
       - RSI_API_UNBLOCKED
       - WEEKLY_STATS
+      - SHIP_MATRIX_IMPORT
+      - SC_DATA_IMPORT
+      - IMPORT_RUN
       title: AdminNotificationTypeEnum
     AdminNotificationUnreadCount:
       type: object

--- a/test/jobs/loaders/models_job_test.rb
+++ b/test/jobs/loaders/models_job_test.rb
@@ -7,6 +7,49 @@ module Loaders
   class ModelsJobTest < ActiveJob::TestCase
     include ImportWrappingJobTests
 
+    setup do
+      @admin_user = create(:admin_user, resource_access: [:models])
+      AdminNotificationsChannel.stubs(:broadcast_to)
+    end
+
+    test "#perform reports what the run changed" do
+      Rsi::ModelsLoader.any_instance.stubs(:all).returns(nil)
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_not_nil notification
+      assert_equal "info", notification.severity
+      assert_includes notification.body, "Models added"
+    end
+
+    # A quiet run is the normal case for a matrix that moves a few times a
+    # month, so it must not open an issue nobody can close.
+    test "#perform never opens an issue" do
+      Rsi::ModelsLoader.any_instance.stubs(:all).returns(nil)
+      GithubIssueCreator.expects(:new).never
+
+      ::Loaders::ModelsJob.new.perform
+    end
+
+    test "#perform names the models the run added" do
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        create(:model, name: "Spirit C1")
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "Spirit C1"
+    end
+
     test "#perform creates an import, runs the loader, and finishes the import" do
       assert_import_wrapping_job_success(
         job_class: ::Loaders::ModelsJob,

--- a/test/jobs/loaders/sc_data/all_job_test.rb
+++ b/test/jobs/loaders/sc_data/all_job_test.rb
@@ -7,6 +7,12 @@ module Loaders
     class AllJobTest < ActiveJob::TestCase
       setup do
         Rails.configuration.stubs(:sc_data).returns({version: "3.24.0"})
+        @admin_user = create(:admin_user, resource_access: [:models])
+        AdminNotificationsChannel.stubs(:broadcast_to)
+      end
+
+      def notification
+        AdminNotification.find_by(admin_user: @admin_user, notification_type: "sc_data_import")
       end
 
       test "#perform creates an import, runs the loader, and finishes the import" do
@@ -34,6 +40,35 @@ module Loaders
 
         assert_equal({"created" => 2, "updated" => 1, "unchanged" => 4818},
           output.dig("EquipmentLoader", "Equipment"))
+      end
+
+      test "#perform reports the counts each loader produced" do
+        ::ScData::Loader::BaseLoader.expects(:all).returns({
+          "EquipmentLoader" => {"Equipment" => {created: 2, updated: 1, unchanged: 4818}}
+        })
+
+        ::Loaders::ScData::AllJob.new.perform
+
+        assert_not_nil notification
+        assert_equal "info", notification.severity
+        assert_includes notification.title, "3.24.0"
+        assert_includes notification.body, "created 2"
+      end
+
+      # The failure that left Commodity and Equipment empty for a week: the
+      # loader ran, wrote nothing, and left nothing unchanged either.
+      test "#perform asks for a human when a catalogue came back empty" do
+        ::ScData::Loader::BaseLoader.expects(:all).returns({
+          "EquipmentLoader" => {"Equipment" => {created: 0, updated: 0, unchanged: 0}}
+        })
+
+        creator = mock("GithubIssueCreator")
+        creator.expects(:run)
+        GithubIssueCreator.expects(:new).returns(creator)
+
+        ::Loaders::ScData::AllJob.new.perform
+
+        assert_equal "warning", notification.severity
       end
 
       test "#perform marks import as failed on error" do

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -68,6 +68,76 @@ class ImportTest < ActiveSupport::TestCase
     end
   end
 
+  test "a finished import tells the notification center" do
+    admin_user = create(:admin_user, resource_access: [:imports])
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    ImportsChannel.stubs(:broadcast_to)
+
+    record = create(:import, type: "Imports::ModelImport")
+    record.start!
+    record.finish!
+
+    notification = AdminNotification.find_by(admin_user:, notification_type: "import_run")
+
+    assert_not_nil notification
+    assert_equal "info", notification.severity
+    assert_includes notification.title, "finished"
+  end
+
+  test "a failed import carries its error at error severity" do
+    admin_user = create(:admin_user, resource_access: [:imports])
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    ImportsChannel.stubs(:broadcast_to)
+
+    record = create(:import, type: "Imports::ModelImport")
+    record.start!
+    record.update!(info: "RSI returned 502")
+    record.fail!
+
+    notification = AdminNotification.find_by(admin_user:, notification_type: "import_run")
+
+    assert_equal "error", notification.severity
+    assert_equal "RSI returned 502", notification.body
+  end
+
+  # Otherwise every paints run lands twice: once as the report with the missing
+  # models in it, once as a line saying it finished.
+  test "an import whose job files its own report stays quiet on success" do
+    create(:admin_user, resource_access: [:imports])
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    ImportsChannel.stubs(:broadcast_to)
+
+    record = create(:import, type: "Imports::PaintsImport")
+    record.start!
+    record.finish!
+
+    assert_equal 0, AdminNotification.where(notification_type: "import_run").count
+  end
+
+  test "an import whose job files its own report still reports a failure" do
+    create(:admin_user, resource_access: [:imports])
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    ImportsChannel.stubs(:broadcast_to)
+
+    record = create(:import, type: "Imports::PaintsImport")
+    record.start!
+    record.fail!
+
+    assert_equal 1, AdminNotification.where(notification_type: "import_run").count
+  end
+
+  test "an import a user owns is not admin news" do
+    create(:admin_user, resource_access: [:imports])
+    AdminNotificationsChannel.stubs(:broadcast_to)
+    ImportsChannel.stubs(:broadcast_to)
+
+    record = create(:import, type: "Imports::ModelImport", user: create(:user))
+    record.start!
+    record.finish!
+
+    assert_equal 0, AdminNotification.where(notification_type: "import_run").count
+  end
+
   test "notify_admin broadcasts a renderable payload to admins" do
     create(:admin_user)
     record = create(:import, :modules_import)


### PR DESCRIPTION
Five of the recurring loaders already report every run into the admin notification center through `AdminReport` — paints, modules, loaner, UEX prices, UEX commodities. The ship matrix import and the sc_data load do not, and a failed import of any kind is only visible as a row in the imports list plus a cable broadcast to whoever had that page open. For a job that runs at night, that is nobody, which is the gap the center exists to close.

## Ship matrix

`Loaders::ModelsJob` files a report per run. `Rsi::ModelsLoader#all` returns nothing countable, so the job measures either side of it — models created since it started, and models updated but not created — and names the new ones, since that is the part worth reading.

It never opens a GitHub issue: a run that changes nothing is the normal case for a matrix that moves a few times a month. A run that breaks raises, and the generic notification below carries it.

## sc_data

`Loaders::ScData::AllJob` already collected per-loader created/updated/unchanged counts and kept them on the import, where the only reader is somebody who already suspects something. The same counts become the report body.

A loader that wrote nothing *and* left nothing unchanged never saw its catalogue — the failure mode that left Commodity and Equipment empty for a week. That marks the run actionable, so it opens an issue; a build that simply changed little does not.

## Every other import

`Import#notify_admin` keeps its cable broadcast and adds a line in the center, at error severity when the import failed, carrying the exception message it already stored.

Two gates:

- **An import a user owns stays out.** They ran it, they are told in their own center, and thousands of hangar syncs a week are not admin news. The gate is `user_id.present?`, so a user-owned import added later is excluded by default.
- **An import whose job files its own report stays quiet on success**, or every paints run lands twice — once with the missing models in it, once saying it finished. On failure it reports either way: a report that never ran is exactly what the failure line is for.

## Types

Three new `AdminNotification` types: `ship_matrix_import` and `sc_data_import` behind the models privilege, next to the reports they sit with, and `import_run` behind imports. The generic one covers both outcomes rather than splitting into finished and failed — the center filters by severity already.

Not in scope: the RSI news and YouTube feeds (one entry per run is noise, and a failure raises), and `ImportsChannel`, which the live progress view still needs.

## Verification

98 tests across the import model, the admin notification model, every loader job and the admin request specs. `standardrb` and `./bin/generate-schema` clean.

Plan: `docs/exec-plans/admin-import-notifications.md`

🤖