### PR TITLE
fix(paints): stop targeted paint imports from hiding missing mappings

### DIFF
--- a/app/lib/paints_importer.rb
+++ b/app/lib/paints_importer.rb
@@ -144,7 +144,7 @@ class PaintsImporter
       existing_paint = ModelPaint.find_by(model_id: model.id, name: paint_name)
 
       if existing_paint.present?
-        return {
+        next {
           new: false,
           paint_id: existing_paint.id,
           model_id: model.id,

--- a/app/lib/paints_importer.rb
+++ b/app/lib/paints_importer.rb
@@ -101,7 +101,25 @@ class PaintsImporter
   end
 
   private def paint_for_target?(paint)
-    Array(models_mapping(paint[:model_name])).include?(@model.name)
+    model_names = Array(models_mapping(paint[:model_name]))
+
+    return true if model_names.include?(@model.name)
+    return false unless resembles_target?(paint[:model_name])
+
+    # A source name that resolves to no model at all belongs in the report as a
+    # missing model -- dropping it here is what hides a gap in the mapping.
+    Model.where(name: model_names).none?
+  end
+
+  private def resembles_target?(source_name)
+    source = comparable_name(source_name)
+    target = comparable_name(@model.name)
+
+    source.present? && (target.include?(source) || source.include?(target))
+  end
+
+  private def comparable_name(name)
+    name.to_s.downcase.gsub(/[^a-z0-9]/, "")
   end
 
   private def extract_paints(import)

--- a/app/lib/paints_importer.rb
+++ b/app/lib/paints_importer.rb
@@ -493,6 +493,7 @@ class PaintsImporter
       "Zeus" => zeus,
       "Zeus Mk II" => zeus,
       "Starlancer" => ["Starlancer MAX", "Starlancer TAC", "Starlancer BLD"],
+      "Stingray" => ["S-65 Stingray"],
       "Gladius Series" => gladius,
       "Gladius" => gladius,
       "Aegis Gladius" => gladius,

--- a/test/lib/paints_importer_test.rb
+++ b/test/lib/paints_importer_test.rb
@@ -79,4 +79,35 @@ class PaintsImporterTest < ActiveSupport::TestCase
     assert_equal 1, results[:existing][:count]
   end
 
+  test "#run for a single model reports an unmapped source name as a missing model" do
+    nova = create(:model, name: "Nova Tank")
+    hangar_sync("Nova - Sandstorm Paint")
+
+    results = PaintsImporter.new(model: nova).run
+
+    assert_equal 1, results[:model_not_found][:count]
+    assert_empty nova.paints
+  end
+
+  test "#run for a single model ignores unmapped source names of other models" do
+    nova = create(:model, name: "Nova Tank")
+    hangar_sync("Sunburst - Sandstorm Paint")
+
+    results = PaintsImporter.new(model: nova).run
+
+    assert_equal 0, results[:model_not_found][:count]
+    assert_empty nova.paints
+  end
+
+  test "#run for a single model ignores a source name that resolves to another model" do
+    nova_tank = create(:model, name: "Nova Tank")
+    nova = create(:model, name: "Nova")
+    hangar_sync("Nova - Sandstorm Paint")
+
+    results = PaintsImporter.new(model: nova_tank).run
+
+    assert_equal 0, results[:model_not_found][:count]
+    assert_empty nova_tank.paints
+    assert_empty nova.paints
+  end
 end

--- a/test/lib/paints_importer_test.rb
+++ b/test/lib/paints_importer_test.rb
@@ -65,4 +65,18 @@ class PaintsImporterTest < ActiveSupport::TestCase
     assert_equal 0, results[:new][:count]
     assert_equal ["Twilight"], arrow.paints.pluck(:name)
   end
+
+  test "#run imports a series paint into the models that are still missing it" do
+    aurora_cl = create(:model, name: "Aurora Mk I CL")
+    aurora_es = create(:model, name: "Aurora Mk I ES")
+    create(:model_paint, model: aurora_cl, name: "Dread Pirate")
+    hangar_sync("Aurora Mk I - Dread Pirate Paint")
+
+    results = PaintsImporter.new.run
+
+    assert_equal ["Dread Pirate"], aurora_es.paints.pluck(:name)
+    assert_equal 1, results[:new][:count]
+    assert_equal 1, results[:existing][:count]
+  end
+
 end


### PR DESCRIPTION
## Why

A hangar sync contained `Stingray - Domain Camo Paint`, but a paints import targeted at the S-65 Stingray reported "No new Paints found" — with no hint that anything was wrong.

Three separate causes, one per commit:

1. **No mapping for `Stingray`.** The source names the skins after the series, the model is `S-65 Stingray`, so the name resolved to no model and the paints were never imported.
2. **`return` inside the `models.map` block.** It left the whole method, so a paint that one member of a series already had was never created for the remaining members.
3. **A targeted run dropped unresolvable names.** `paint_for_target?` filtered before `import_paint` ever saw the paint, so it could not land in `model_not_found`. The report came back empty and `actionable?` was `false` — a full run would have listed the same paint under "Missing Models". That is what made the Stingray gap invisible.

## What changed

- `"Stingray" => ["S-65 Stingray"]` in `models_mapping`.
- `next` instead of `return` when a model already has the paint.
- A targeted run now also keeps paints whose source name resembles the target model and resolves to no model at all, so they surface as "Missing Models". Names that resolve to a different, existing model stay filtered out, so a per-model report does not fill up with the rest of the hangar.

## Tests

Four new tests in `test/lib/paints_importer_test.rb`, covering the series case and the three branches of the targeted filter (reported / unrelated / belongs elsewhere). Both fixes were checked to fail without the change.

🤖
