### PR TITLE
feat(sc_data): give models a row per build

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -42,9 +42,19 @@ module ScData
       def all
         update_in_game_flags
 
+        loaded = []
+
         Model.where(in_game: true).find_each do |model|
-          load_model(model)
+          loaded << model.id if load_model(model)
         end
+
+        # A model the export dropped loses its current build and keeps the row.
+        # `in_game` already went false above, but a build row is the thing that
+        # says which patch last described the ship, and a hangar entry pointing
+        # at a retired ship still has to resolve.
+        retire_absent_builds(ModelBuild, :model_id, loaded)
+
+        prune_builds(ModelBuild)
 
         Hardpoint.find_each(&:save) # hack to generate correct group_keys
       end
@@ -84,6 +94,11 @@ module ScData
         update_params = update_ground_speeds(model_data, update_params)
 
         apply(model, update_params.merge(update_reason: :sc_data_loader))
+
+        # Dual-write. Built from `update_params` before the reason is merged in:
+        # `update_reason` is an `attr_accessor` on Model for paper_trail's meta,
+        # not a column, so it has nowhere to land here.
+        apply_build(model, update_params.slice(*ModelBuild::FACTS))
       end
 
       private def update_in_game_flags

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -155,6 +155,23 @@ class Model < ApplicationRecord
 
   belongs_to :manufacturer
 
+  # What each build of the game says about this model's mechanics. Written
+  # alongside the columns; nothing reads through them yet.
+  #
+  # Models differ from the other three catalogues in having three sources rather
+  # than one -- the game files, the RSI ship matrix in the `rsi_*` columns, and
+  # whatever an admin has curated -- so which layer wins per field is a decision
+  # the step that moves the readers has to make, not this one.
+  has_many :builds, class_name: "ModelBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "ModelBuild", inverse_of: :model
+
+  # The newest build of this environment that still describes the model, which is
+  # what a model the export dropped falls back to. A hangar entry pointing at a
+  # retired ship has to resolve to something.
+  has_one :last_build,
+    -> { for_source.order(created_at: :desc) },
+    class_name: "ModelBuild", inverse_of: :model
+
   has_many :hardpoints, as: :parent, dependent: :destroy, autosave: true
   has_many :components, through: :hardpoints
 

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a model.
+#
+# The columns here are exactly the ones `ScData::Loader::ModelsLoader` writes,
+# minus dimensions and minus `in_game` -- see the migration for why. Everything
+# curated, everything the RSI ship matrix supplies, and everything that
+# identifies the model stays on Model.
+# == Schema Information
+#
+# Table name: model_builds
+#
+#  id                      :uuid             not null, primary key
+#  cargo_holds             :string
+#  environment             :string           not null
+#  external_fuel_tanks     :string
+#  ground                  :boolean          default(FALSE)
+#  ground_acceleration     :decimal(15, 2)
+#  ground_decceleration    :decimal(15, 2)
+#  ground_max_speed        :decimal(15, 2)
+#  ground_reverse_speed    :decimal(15, 2)
+#  hull_doors              :jsonb
+#  hull_health             :decimal(15, 2)
+#  hull_parts              :jsonb
+#  hydrogen_fuel_tanks     :string
+#  mass                    :decimal(15, 2)
+#  max_speed               :decimal(15, 2)
+#  personal_inventory      :decimal(15, 2)
+#  pitch                   :decimal(15, 2)
+#  pitch_boosted           :decimal(15, 2)
+#  quantum_fuel_tanks      :string
+#  refuel_boom             :string
+#  reverse_speed_boosted   :decimal(15, 2)
+#  roll                    :decimal(15, 2)
+#  roll_boosted            :decimal(15, 2)
+#  scm_speed               :decimal(15, 2)
+#  scm_speed_boosted       :decimal(15, 2)
+#  signature_cross_section :jsonb
+#  version                 :string           not null
+#  weapon_pool_size        :integer
+#  yaw                     :decimal(15, 2)
+#  yaw_boosted             :decimal(15, 2)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  model_id                :uuid             not null
+#
+# Indexes
+#
+#  index_model_builds_on_environment_and_version  (environment,version)
+#  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
+#  index_model_builds_on_model_id                 (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class ModelBuild < ApplicationRecord
+  belongs_to :model
+
+  # How many builds of one environment are kept. Enough to diff a patch against
+  # the one before it, and to compare a bad load with what it replaced, without
+  # the table growing with every patch forever.
+  BUILDS_RETAINED = 3
+
+  # Everything a build says about a model's mechanics.
+  #
+  # The data migration carries its own copy on purpose: a migration has to keep
+  # running against the schema of its own moment, not this list as it later
+  # becomes.
+  FACTS = %i[
+    mass hull_health hull_parts hull_doors weapon_pool_size signature_cross_section ground
+    personal_inventory
+    cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks external_fuel_tanks refuel_boom
+    scm_speed scm_speed_boosted reverse_speed_boosted max_speed
+    pitch pitch_boosted yaw yaw_boosted roll roll_boosted
+    ground_max_speed ground_reverse_speed ground_acceleration ground_decceleration
+  ].freeze
+
+  # All five of Model's serialized columns that a build carries, declared
+  # together. Missing one is not a quiet loss: `Component` serializes six and I
+  # matched one, and the reader handed a raw YAML string to a caller that called
+  # `dig` on it. A reader falls through to the column only on nil, and a string
+  # is not nil.
+  serialize :cargo_holds, coder: YAML
+  serialize :quantum_fuel_tanks, coder: YAML
+  serialize :hydrogen_fuel_tanks, coder: YAML
+  serialize :external_fuel_tanks, coder: YAML
+  serialize :refuel_boom, coder: YAML
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :model_id, uniqueness: {scope: [:environment, :version]}
+
+  # Every build this environment still has.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on. `ScData::Source` names the version
+  # exactly, so this needs no ordering or subselect.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared. Re-loading a build updates its rows in place, so `created_at` is
+  # when that build first landed rather than when it was last touched.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/db/data/20260827201000_backfill_model_builds.rb
+++ b/db/data/20260827201000_backfill_model_builds.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Seeds a build row from what each model row already says, so the new table is
+# populated before anything reads from it -- rather than staying empty until the
+# next sc_data load.
+#
+# Models have no `version` column, unlike the other three catalogues, so there is
+# no per-row version to key on. `in_game` stands in for it: it is set by the very
+# check a build row expresses -- a parsed model file existing for this
+# environment -- so a model that is in the game gets a build for the version the
+# app is configured on, and one that is not gets none.
+#
+# The values seeded here are the game files' in all but a handful of cases: the
+# sc_data loader writes these columns on every load, after the RSI loader. Where
+# an admin has curated one, the curated value is what lands in the build, and the
+# next load overwrites it. That is the same trade the other three catalogues
+# made, and the layering question -- curated over game files over ship matrix --
+# belongs to the step that moves the readers.
+class BackfillModelBuilds < ActiveRecord::Migration[8.1]
+  # Its own copy on purpose: a migration has to keep running against the schema of
+  # its own moment, not `ModelBuild::FACTS` as that later becomes.
+  FACTS = %i[
+    mass hull_health hull_parts hull_doors weapon_pool_size signature_cross_section ground
+    personal_inventory
+    cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks external_fuel_tanks refuel_boom
+    scm_speed scm_speed_boosted reverse_speed_boosted max_speed
+    pitch pitch_boosted yaw yaw_boosted roll roll_boosted
+    ground_max_speed ground_reverse_speed ground_acceleration ground_decceleration
+  ].freeze
+
+  def up
+    environment = ScData::Source.environment
+    version = ScData::Source.version
+
+    Model.where(in_game: true).find_each do |model|
+      build = model.builds.find_or_initialize_by(environment:, version:)
+
+      # `read_attribute` would hand back the raw YAML for the five serialized
+      # columns, so these go through the readers -- which at this point still
+      # answer from the columns, because nothing reads the build yet.
+      build.update!(FACTS.index_with { |fact| model.public_send(fact) })
+    end
+  end
+
+  def down
+    ModelBuild.delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_27_181000)
+DataMigrate::Data.define(version: 2026_08_27_201000)

--- a/db/migrate/20260827200000_create_model_builds.rb
+++ b/db/migrate/20260827200000_create_model_builds.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a model, following the shape
+# `equipment_builds`, `component_builds` and `commodity_builds` established.
+#
+# The columns are exactly the ones `ScData::Loader::ModelsLoader` writes, minus
+# two groups:
+#
+# **Dimensions.** `sc_length`, `sc_beam` and `sc_height` stay off. A ship ships up
+# to three unlabelled size sets -- flight, landed, and for some a deployed cargo
+# grid or a combat configuration -- and no source says which one a number belongs
+# to. A build row would enshrine one of them as *the* dimension, and there is no
+# read path to layer it behind yet.
+#
+# **`in_game` and `production_status`.** The loader writes those through
+# `apply_columns`, and `in_game` is already the thing a build row expresses: a
+# parsed model file existing for this environment. Duplicating it here would give
+# the same fact two homes.
+class CreateModelBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :model_builds, id: :uuid do |t|
+      # Cascade: a build says something about a model, and says nothing at all
+      # once the model is gone.
+      t.references :model, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      # Hull and mass.
+      t.decimal :mass, precision: 15, scale: 2
+      t.decimal :hull_health, precision: 15, scale: 2
+      t.jsonb :hull_parts
+      t.jsonb :hull_doors
+      t.integer :weapon_pool_size
+      t.jsonb :signature_cross_section
+      t.boolean :ground, default: false
+
+      t.decimal :personal_inventory, precision: 15, scale: 2
+
+      # Serialized as YAML on Model, so the same type here or a round trip loses
+      # the structure. This is the shape that broke the components loader: a
+      # reader falls through to the column only on nil, and a raw YAML string is
+      # not nil, so a caller expecting a hash got the string.
+      t.string :cargo_holds
+      t.string :quantum_fuel_tanks
+      t.string :hydrogen_fuel_tanks
+      t.string :external_fuel_tanks
+      t.string :refuel_boom
+
+      # Flight, off the ship's IFCS.
+      t.decimal :scm_speed, precision: 15, scale: 2
+      t.decimal :scm_speed_boosted, precision: 15, scale: 2
+      t.decimal :reverse_speed_boosted, precision: 15, scale: 2
+      t.decimal :max_speed, precision: 15, scale: 2
+      t.decimal :pitch, precision: 15, scale: 2
+      t.decimal :pitch_boosted, precision: 15, scale: 2
+      t.decimal :yaw, precision: 15, scale: 2
+      t.decimal :yaw_boosted, precision: 15, scale: 2
+      t.decimal :roll, precision: 15, scale: 2
+      t.decimal :roll_boosted, precision: 15, scale: 2
+
+      # Ground vehicles only -- 27 of 215 models in game carry any of these.
+      t.decimal :ground_max_speed, precision: 15, scale: 2
+      t.decimal :ground_reverse_speed, precision: 15, scale: 2
+      t.decimal :ground_acceleration, precision: 15, scale: 2
+      t.decimal :ground_decceleration, precision: 15, scale: 2
+
+      t.timestamps
+    end
+
+    # One row per model per build. Re-loading the same build updates it in place;
+    # a new build adds a row beside it.
+    add_index :model_builds, [:model_id, :environment, :version],
+      unique: true, name: "index_model_builds_on_model_and_build"
+
+    # Every read names an environment and a version, because that pair is what
+    # `ScData::Source` hands out. No fact index yet: which of these the ship list
+    # filters and sorts by is a question for the step that moves the filters,
+    # and an index guessed now is one nothing measured.
+    add_index :model_builds, [:environment, :version]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -978,6 +978,44 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_180000) do
     t.index ["fleet_id", "slug"], name: "index_missions_on_fleet_id_and_slug", unique: true
   end
 
+  create_table "model_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "cargo_holds"
+    t.datetime "created_at", null: false
+    t.string "environment", null: false
+    t.string "external_fuel_tanks"
+    t.boolean "ground", default: false
+    t.decimal "ground_acceleration", precision: 15, scale: 2
+    t.decimal "ground_decceleration", precision: 15, scale: 2
+    t.decimal "ground_max_speed", precision: 15, scale: 2
+    t.decimal "ground_reverse_speed", precision: 15, scale: 2
+    t.jsonb "hull_doors"
+    t.decimal "hull_health", precision: 15, scale: 2
+    t.jsonb "hull_parts"
+    t.string "hydrogen_fuel_tanks"
+    t.decimal "mass", precision: 15, scale: 2
+    t.decimal "max_speed", precision: 15, scale: 2
+    t.uuid "model_id", null: false
+    t.decimal "personal_inventory", precision: 15, scale: 2
+    t.decimal "pitch", precision: 15, scale: 2
+    t.decimal "pitch_boosted", precision: 15, scale: 2
+    t.string "quantum_fuel_tanks"
+    t.string "refuel_boom"
+    t.decimal "reverse_speed_boosted", precision: 15, scale: 2
+    t.decimal "roll", precision: 15, scale: 2
+    t.decimal "roll_boosted", precision: 15, scale: 2
+    t.decimal "scm_speed", precision: 15, scale: 2
+    t.decimal "scm_speed_boosted", precision: 15, scale: 2
+    t.jsonb "signature_cross_section"
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.integer "weapon_pool_size"
+    t.decimal "yaw", precision: 15, scale: 2
+    t.decimal "yaw_boosted", precision: 15, scale: 2
+    t.index ["environment", "version"], name: "index_model_builds_on_environment_and_version"
+    t.index ["model_id", "environment", "version"], name: "index_model_builds_on_model_and_build", unique: true
+    t.index ["model_id"], name: "index_model_builds_on_model_id"
+  end
+
   create_table "model_hardpoint_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "component_id"
     t.datetime "created_at", null: false
@@ -1614,6 +1652,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_180000) do
   add_foreign_key "mission_teams", "missions"
   add_foreign_key "missions", "fleets"
   add_foreign_key "missions", "users", column: "created_by_id"
+  add_foreign_key "model_builds", "models", on_delete: :cascade
   add_foreign_key "model_paints", "components", on_delete: :nullify
   add_foreign_key "model_positions", "hardpoints", on_delete: :nullify
   add_foreign_key "model_positions", "models"

--- a/test/factories/model_builds.rb
+++ b/test/factories/model_builds.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: model_builds
+#
+#  id                      :uuid             not null, primary key
+#  cargo_holds             :string
+#  environment             :string           not null
+#  external_fuel_tanks     :string
+#  ground                  :boolean          default(FALSE)
+#  ground_acceleration     :decimal(15, 2)
+#  ground_decceleration    :decimal(15, 2)
+#  ground_max_speed        :decimal(15, 2)
+#  ground_reverse_speed    :decimal(15, 2)
+#  hull_doors              :jsonb
+#  hull_health             :decimal(15, 2)
+#  hull_parts              :jsonb
+#  hydrogen_fuel_tanks     :string
+#  mass                    :decimal(15, 2)
+#  max_speed               :decimal(15, 2)
+#  personal_inventory      :decimal(15, 2)
+#  pitch                   :decimal(15, 2)
+#  pitch_boosted           :decimal(15, 2)
+#  quantum_fuel_tanks      :string
+#  refuel_boom             :string
+#  reverse_speed_boosted   :decimal(15, 2)
+#  roll                    :decimal(15, 2)
+#  roll_boosted            :decimal(15, 2)
+#  scm_speed               :decimal(15, 2)
+#  scm_speed_boosted       :decimal(15, 2)
+#  signature_cross_section :jsonb
+#  version                 :string           not null
+#  weapon_pool_size        :integer
+#  yaw                     :decimal(15, 2)
+#  yaw_boosted             :decimal(15, 2)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  model_id                :uuid             not null
+#
+# Indexes
+#
+#  index_model_builds_on_environment_and_version  (environment,version)
+#  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
+#  index_model_builds_on_model_id                 (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :model_build do
+    model
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+
+    mass { 1_500.0 }
+    scm_speed { 210.0 }
+    max_speed { 1_200.0 }
+    ground { false }
+  end
+end

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -215,6 +215,60 @@ module ScData
         assert Commodity.exists?(dropped.id), "the row itself has to stay"
         assert_empty dropped.builds.current
       end
+
+      # The same helper, the fourth catalogue and the awkward one. Models carry
+      # three sources rather than one -- the game files, the RSI ship matrix in
+      # the `rsi_*` columns, and whatever an admin curated -- so what this pins is
+      # the boundary: a build holds the mechanics the game files describe, and
+      # nothing from the other two.
+      test "#apply_build works the same for a model" do
+        model = create(:model)
+
+        @loader.apply_build(model, {mass: 1_234.5, scm_speed: 210.0, ground: true})
+
+        build = model.builds.sole
+        assert_equal 1_234.5, build.mass
+        assert_equal 210.0, build.scm_speed
+        assert_predicate build, :ground
+        assert_equal ::ScData::Source.environment, build.environment
+        assert_equal ::ScData::Source.version, build.version
+      end
+
+      # The five YAML columns through the helper rather than the factory, because
+      # the loader hands it real structures and a coder missing on either side
+      # turns one into a string somewhere in between.
+      test "#apply_build round-trips a model's serialized facts" do
+        model = create(:model)
+        cargo_holds = [{"capacity" => 6, "dimensions" => {"x" => 1.25}}]
+        refuel_boom = {"name" => "refuel_boom", "rate" => 5.0}
+
+        @loader.apply_build(model, {cargo_holds:, refuel_boom:})
+
+        build = model.builds.sole.reload
+        assert_equal cargo_holds, build.cargo_holds
+        assert_equal refuel_boom, build.refuel_boom
+      end
+
+      # `update_reason` is an `attr_accessor` for paper_trail's meta rather than a
+      # column, so the loader has to keep it off the build -- and `FACTS` is what
+      # does that.
+      test "a model build has nowhere to put the loader's update reason" do
+        refute_includes ModelBuild.column_names, "update_reason"
+        refute_includes ModelBuild::FACTS, :update_reason
+      end
+
+      test "#retire_absent_builds drops a model's current build but keeps the model" do
+        kept = create(:model)
+        dropped = create(:model)
+        create(:model_build, model: kept)
+        create(:model_build, model: dropped)
+
+        @loader.retire_absent_builds(ModelBuild, :model_id, [kept.id])
+
+        assert_equal 1, ModelBuild.current.count
+        assert Model.exists?(dropped.id), "the row itself has to stay"
+        assert_empty dropped.builds.current
+      end
     end
   end
 end

--- a/test/models/model_build_test.rb
+++ b/test/models/model_build_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: model_builds
+#
+#  id                      :uuid             not null, primary key
+#  cargo_holds             :string
+#  environment             :string           not null
+#  external_fuel_tanks     :string
+#  ground                  :boolean          default(FALSE)
+#  ground_acceleration     :decimal(15, 2)
+#  ground_decceleration    :decimal(15, 2)
+#  ground_max_speed        :decimal(15, 2)
+#  ground_reverse_speed    :decimal(15, 2)
+#  hull_doors              :jsonb
+#  hull_health             :decimal(15, 2)
+#  hull_parts              :jsonb
+#  hydrogen_fuel_tanks     :string
+#  mass                    :decimal(15, 2)
+#  max_speed               :decimal(15, 2)
+#  personal_inventory      :decimal(15, 2)
+#  pitch                   :decimal(15, 2)
+#  pitch_boosted           :decimal(15, 2)
+#  quantum_fuel_tanks      :string
+#  refuel_boom             :string
+#  reverse_speed_boosted   :decimal(15, 2)
+#  roll                    :decimal(15, 2)
+#  roll_boosted            :decimal(15, 2)
+#  scm_speed               :decimal(15, 2)
+#  scm_speed_boosted       :decimal(15, 2)
+#  signature_cross_section :jsonb
+#  version                 :string           not null
+#  weapon_pool_size        :integer
+#  yaw                     :decimal(15, 2)
+#  yaw_boosted             :decimal(15, 2)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  model_id                :uuid             not null
+#
+# Indexes
+#
+#  index_model_builds_on_environment_and_version  (environment,version)
+#  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
+#  index_model_builds_on_model_id                 (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class ModelBuildTest < ActiveSupport::TestCase
+  setup do
+    @environment = ScData::Source.environment
+  end
+
+  test "a model carries one row per build, not two" do
+    model = create(:model)
+    create(:model_build, model:, environment: @environment, version: "1.0.0")
+
+    duplicate = build(:model_build, model:, environment: @environment, version: "1.0.0")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :model_id
+  end
+
+  test "a later build of the same environment sits beside the earlier one" do
+    model = create(:model)
+    create(:model_build, model:, environment: @environment, version: "1.0.0")
+
+    assert_difference("ModelBuild.count", 1) do
+      create(:model_build, model:, environment: @environment, version: "1.0.1")
+    end
+  end
+
+  # The same version in two environments is two builds: live and ptu ship the
+  # same version string while carrying different data.
+  test "the same model can be described by more than one environment" do
+    model = create(:model)
+    create(:model_build, model:, environment: "live", version: "1.0.0")
+
+    assert_difference("ModelBuild.count", 1) do
+      create(:model_build, model:, environment: "ptu", version: "1.0.0")
+    end
+  end
+
+  test "requires the model it describes, and a build to be" do
+    orphan = build(:model_build, model: nil, environment: nil, version: nil)
+
+    assert_not orphan.valid?
+    assert_includes orphan.errors.attribute_names, :model
+    assert_includes orphan.errors.attribute_names, :environment
+    assert_includes orphan.errors.attribute_names, :version
+  end
+
+  test ".for_source keeps only the current environment" do
+    model = create(:model)
+    live = create(:model_build, model:, environment: @environment, version: "1.0.0")
+    other = create(:model_build, model:, environment: "ptu", version: "1.0.0")
+
+    assert_includes ModelBuild.for_source, live
+    assert_not_includes ModelBuild.for_source, other
+  end
+
+  test ".current also narrows to the version the environment is on" do
+    model = create(:model)
+    current = create(:model_build, model:, environment: @environment, version: ScData::Source.version)
+    older = create(:model_build, model:, environment: @environment, version: "0.0.1-live.1")
+
+    assert_includes ModelBuild.current, current
+    assert_not_includes ModelBuild.current, older
+  end
+
+  # All five of them, together. Declaring one and assuming the rest is what broke
+  # the components expand: the reader falls through to the column only on nil, and
+  # a raw YAML string is not nil, so a caller calling `dig` on it got the string.
+  test "every serialized fact comes back as the structure it went in as" do
+    cargo_holds = [{"dimensions" => {"x" => 1.25, "y" => 7.5, "z" => 1.25}, "capacity" => 6}]
+    quantum = [{"name" => "quantum_fuel_tank", "capacity" => 3_000.0}]
+    hydrogen = [{"name" => "hydrogen_fuel_tank", "capacity" => 660_000.0}]
+    external = [{"name" => "external_fuel_tank", "capacity" => 12_000.0}]
+    refuel_boom = {"name" => "refuel_boom", "rate" => 5.0}
+
+    build = create(
+      :model_build,
+      cargo_holds:, quantum_fuel_tanks: quantum, hydrogen_fuel_tanks: hydrogen,
+      external_fuel_tanks: external, refuel_boom:
+    )
+
+    build.reload
+
+    assert_equal cargo_holds, build.cargo_holds
+    assert_equal quantum, build.quantum_fuel_tanks
+    assert_equal hydrogen, build.hydrogen_fuel_tanks
+    assert_equal external, build.external_fuel_tanks
+    assert_equal refuel_boom, build.refuel_boom
+  end
+
+  # The jsonb facts are native rather than serialized, so this pins that they were
+  # not given a coder they do not need.
+  test "the jsonb facts keep their structure without a coder" do
+    hull_parts = [{"name" => "hull_front", "health" => 12_000.0}]
+    hull_doors = [{"name" => "door_cargo", "health" => 900.0}]
+    cross_section = {"x" => 1.0, "y" => 0.5, "z" => 0.75}
+
+    build = create(:model_build, hull_parts:, hull_doors:, signature_cross_section: cross_section)
+
+    build.reload
+
+    assert_equal hull_parts, build.hull_parts
+    assert_equal hull_doors, build.hull_doors
+    assert_equal cross_section, build.signature_cross_section
+  end
+
+  # Dimensions are deliberately absent: a ship ships up to three unlabelled size
+  # sets and no source says which a number belongs to, so a build row would
+  # enshrine one of them as the dimension.
+  test "a build carries no dimensions and no in-game flag" do
+    %w[length beam height sc_length sc_beam sc_height in_game production_status].each do |column|
+      refute_includes ModelBuild.column_names, column
+    end
+  end
+
+  test "a build carries nothing the ship matrix supplies" do
+    assert_empty ModelBuild.column_names.grep(/\Arsi_/)
+  end
+
+  test ".retained_versions keeps the newest builds of an environment" do
+    model = create(:model)
+    %w[0.0.1 0.0.2 0.0.3 0.0.4].each_with_index do |version, index|
+      create(
+        :model_build,
+        model:, environment: @environment, version:,
+        created_at: index.days.ago.end_of_day
+      )
+    end
+
+    assert_equal %w[0.0.2 0.0.1], ModelBuild.retained_versions(@environment, keep: 2)
+  end
+
+  test "builds go when the model does" do
+    model = create(:model)
+    create(:model_build, model:)
+
+    assert_difference("ModelBuild.count", -1) do
+      model.destroy
+    end
+  end
+end


### PR DESCRIPTION
The fourth catalogue, and the awkward one — so **expand only**. The loader dual-writes; nothing reads through the build yet.

## Why the reads are a separate PR

The other three catalogues have one source. Models have three:

| layer | where it lives today |
| --- | --- |
| curated | the bare column, indistinguishable from a loader write |
| game files | the bare column, written last on every sc_data load |
| RSI ship matrix | the `rsi_*` columns |

Which layer wins per field is a real decision, and it is the opposite ordering from equipment and components — there an admin correction *is* a correction to the build, and the next load overwrites it deliberately. For models, curation has to survive a load. That needs its own PR, and it needs measuring first: paper_trail already records an update reason per version (`sc_data_loader`, `rsi_loader`, `custom`), so which fields an admin actually curated is answerable from the history rather than guessable.

## The 27 facts

Exactly what `ScData::Loader::ModelsLoader` writes, minus two groups.

**Dimensions stay off.** A ship ships up to three unlabelled size sets — flight, landed, and for some a deployed cargo grid or a combat configuration — and neither the game files nor the ship matrix says which one a number belongs to. A build row would enshrine one of them as *the* dimension, and there is no read path to layer it behind yet.

**`in_game` and `production_status` stay off.** The loader writes those through `apply_columns`, and `in_game` is already the thing a build row expresses: a parsed model file existing for this environment. Duplicating it would give one fact two homes.

## No version column

Models are the one catalogue without a `version` column, so the backfill cannot key on what a row itself carries. `in_game` stands in — it is set by the very check a build row expresses. A model in the game gets a build for the configured version; one that is not gets none.

Verified against a full local dataset: **215 in-game models, 215 builds, every fact round-trips**, the serialized structures included.

## The components trap, caught up front

Model YAML-serializes **five** columns — `cargo_holds`, `quantum_fuel_tanks`, `hydrogen_fuel_tanks`, `external_fuel_tanks`, `refuel_boom` — and three more facts are native jsonb.

The components expand cost a second attempt because I matched one of six serialized columns and moved on. A reader falls through to the column only on `nil`, and a raw YAML string is not `nil`, so the weapons endpoint called `dig` on a string.

So this time it was checked mechanically before any test was written: every fact exists on both sides, every SQL type matches, and the set of serialized attributes is **identical on both classes**. Two tests pin it — one round-tripping all five YAML facts, one pinning that the three jsonb facts do *not* have a coder they don't need.

Three further tests pin the boundary rather than the behaviour: no dimensions, no `in_game`, no `rsi_*` column on the build.

## One thing the loader needed

`update_reason` is an `attr_accessor` for paper_trail's meta, not a column, so the build params are sliced from `update_params` **before** the reason is merged in — otherwise `apply_build` gets an attribute with nowhere to land.

## Deliberately not here

**No factory hook.** Equipment and components grew one because `current_version` became row existence, which made a build mandatory for a record to be visible at all. Nothing reads the build here, so a hook would churn hundreds of tests for no benefit. It belongs in the reads PR, where it is forced.

**No fact indexes** beyond the structural two. Which of these the ship list filters and sorts by is a question for the step that moves the filters, and an index guessed now is one nothing measured.

## Verification

416 model tests, 1,294 public API and 820 admin integration tests — green. `standardrb` clean. No API or schema change, because nothing reads yet.

The `ScData::Loader::*` suites need the parsed `sc_data` tree, which is not part of a checkout. Failure counts compared against unmodified main: **19 failures / 18 errors on both**. Two admin mailer tests hit premailer on `localhost:3000`, also identical on main.

Touches `base_loader_apply_build_test.rb`, which #4563 also appends to — a trivial conflict for whichever lands second.

🤖
