### PR TITLE
feat(sc_data): read model mechanics off the build

### DIFF
--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -63,7 +63,7 @@ module Admin
         end
 
         def update
-          return if @model.update(model_params.merge(author_id: current_user.id, update_reason: :custom))
+          return if @model.update_with_facts(model_params.merge(author_id: current_user.id, update_reason: :custom))
 
           render json: ValidationError.new("model.update", errors: @model.errors), status: :bad_request
         end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -155,13 +155,7 @@ class Model < ApplicationRecord
 
   belongs_to :manufacturer
 
-  # What each build of the game says about this model's mechanics. Written
-  # alongside the columns; nothing reads through them yet.
-  #
-  # Models differ from the other three catalogues in having three sources rather
-  # than one -- the game files, the RSI ship matrix in the `rsi_*` columns, and
-  # whatever an admin has curated -- so which layer wins per field is a decision
-  # the step that moves the readers has to make, not this one.
+  # What each build of the game says about this model's mechanics.
   has_many :builds, class_name: "ModelBuild", dependent: :destroy
   has_one :build, -> { current }, class_name: "ModelBuild", inverse_of: :model
 
@@ -171,6 +165,73 @@ class Model < ApplicationRecord
   has_one :last_build,
     -> { for_source.order(created_at: :desc) },
     class_name: "ModelBuild", inverse_of: :model
+
+  # A mechanics fact resolves the build first, then the column: the build we are
+  # on, else the last build of this environment that described the model, else
+  # what the row itself says.
+  #
+  # **The RSI ship matrix is deliberately not a layer here**, though the design
+  # sketch had it sitting between the two. Measured before writing it: reading
+  # `rsi_mass` and its five siblings above the column changes exactly one value
+  # across 246 models, and that one change is a regression. For 30 of the 31
+  # ships with no build the column already *holds* the matrix value, because
+  # `Rsi::ModelsLoader` writes both. The 31st is the Retaliator Bomber, whose
+  # column carries a game-file mass the sc_data loader wrote in April from a
+  # build that still shipped it -- promoting the matrix there would replace a
+  # real value with a staler one.
+  #
+  # The matrix earns a layer when it stops being copied into the column, which is
+  # the change that moves `rsi_*` out of Model's columns entirely. Until then it
+  # is the same value read twice.
+  #
+  # Build existence also cannot become this catalogue's filter the way it did for
+  # equipment and components: 31 of 246 models are concept ships the matrix
+  # carries and no build ever will, and filtering on a build row would hide every
+  # one of them. `in_game` stays the flag.
+
+  # The build we are on, or the last one that described the model. A hangar entry
+  # pointing at a ship the export dropped still has to resolve to something.
+  def facts
+    build || last_build
+  end
+
+  # An admin correction is a correction to the build we are on, so it has to
+  # reach the build as well as the row.
+  #
+  # Deliberately the same rule the other three catalogues use, rather than the
+  # curated-wins layer the design sketched. Measured over the whole paper_trail
+  # history: an admin has edited **none** of these 27 facts. What they do curate
+  # -- images, `sales_page_url`, dimensions, `pledge_price`, `production_status`,
+  # `size`, `cargo` -- is outside the build entirely, dimensions included and
+  # deliberately so.
+  def update_with_facts(attributes)
+    transaction do
+      return false unless update(attributes)
+
+      # Sliced to `FACTS`, which is also what keeps `author_id` and
+      # `update_reason` off the build: both are `attr_accessor`s for
+      # paper_trail's meta rather than columns, and the admin controller merges
+      # them into the same hash.
+      facts_attributes = attributes.to_h.symbolize_keys.slice(*ModelBuild::FACTS)
+
+      # Reloaded rather than read off the association: validating the row above
+      # consults a fact reader, which caches whatever the build was at that
+      # moment -- a nil, for a row whose build is written afterwards.
+      reload_build&.update!(facts_attributes) if facts_attributes.present?
+
+      true
+    end
+  end
+
+  # The column still answers for a model no build describes -- every concept ship,
+  # and every ship the export dropped before this table existed.
+  ModelBuild::FACTS.each do |fact|
+    define_method(fact) do
+      value = facts&.public_send(fact)
+
+      value.nil? ? super() : value
+    end
+  end
 
   has_many :hardpoints, as: :parent, dependent: :destroy, autosave: true
   has_many :components, through: :hardpoints
@@ -243,6 +304,10 @@ class Model < ApplicationRecord
   # manufacturer brings its own pictures, because its partial renders them.
   def self.rendered_associations
     [
+      # Both, because every mechanics reader consults `build || last_build`.
+      # Without them a ship list is two extra queries per row rather than two
+      # for the page -- and the ships and hangar endpoints are the slow ones.
+      :build, :last_build,
       :item_prices, :loaners, :cargo_holds_db,
       {manufacturer: Manufacturer.attachment_preloads},
       {model_loaners: :loaner_model}

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -165,4 +165,112 @@ class ModelTest < ActiveSupport::TestCase
 
     assert_nil model.personal_inventory_label
   end
+
+  # Every test here makes the build **disagree** with the column. While the
+  # loader writes both they are identical, so a passing test would otherwise
+  # prove nothing about which side answered.
+  test "a model in the current build reads that build's mechanics" do
+    model = create(:model, mass: 100.0, scm_speed: 50.0)
+    create(:model_build, model:, mass: 999.0, scm_speed: 111.0)
+
+    assert_equal 999.0, model.reload.mass
+    assert_equal 111.0, model.scm_speed
+  end
+
+  # A hangar entry pointing at a ship the export dropped still has to resolve, so
+  # the last build of this environment answers rather than nothing.
+  test "a model the current build dropped reads the last build that described it" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, version: "0.0.1-live.1", mass: 777.0)
+
+    assert_nil model.reload.build
+    assert_equal 777.0, model.mass
+  end
+
+  test "the current build wins over an earlier one" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, version: "0.0.1-live.1", mass: 777.0)
+    create(:model_build, model:, mass: 999.0)
+
+    assert_equal 999.0, model.reload.mass
+  end
+
+  # Every concept ship, and every ship the export dropped before the build table
+  # existed. 31 of 246 models in a full dataset have no build at all.
+  test "a model with no build at all falls back to its own columns" do
+    model = create(:model, mass: 100.0, scm_speed: 50.0)
+
+    assert_nil model.build
+    assert_equal 100.0, model.mass
+    assert_equal 50.0, model.scm_speed
+  end
+
+  # The build carries no `rsi_*` column, and the matrix is deliberately not a
+  # read layer: for a ship with no build the column already holds the matrix
+  # value, and for one the export dropped it holds a real game-file value.
+  test "the ship matrix does not override what a build says" do
+    model = create(:model, mass: 100.0, rsi_mass: 555.0)
+    create(:model_build, model:, mass: 999.0)
+
+    assert_equal 999.0, model.reload.mass
+  end
+
+  test "the ship matrix does not override the column when there is no build" do
+    model = create(:model, mass: 100.0, rsi_mass: 555.0)
+
+    assert_equal 100.0, model.mass
+  end
+
+  # All five, because the reader falls through to the column only on nil and a
+  # raw YAML string is not nil -- the shape that broke the components loader.
+  test "a serialized fact read off the build keeps its structure" do
+    cargo_holds = [{"capacity" => 6, "dimensions" => {"x" => 1.25}}]
+    refuel_boom = {"name" => "refuel_boom", "rate" => 5.0}
+    model = create(:model, cargo_holds: [{"capacity" => 1}])
+    create(:model_build, model:, cargo_holds:, refuel_boom:)
+
+    model.reload
+
+    assert_equal cargo_holds, model.cargo_holds
+    assert_equal refuel_boom, model.refuel_boom
+  end
+
+  test "a jsonb fact read off the build keeps its structure" do
+    hull_parts = [{"name" => "hull_front", "health" => 12_000.0}]
+    model = create(:model)
+    create(:model_build, model:, hull_parts:)
+
+    assert_equal hull_parts, model.reload.hull_parts
+  end
+
+  test "#update_with_facts writes the correction to the build as well" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, mass: 999.0)
+
+    assert model.reload.update_with_facts(mass: 250.0)
+
+    assert_equal 250.0, model.build.reload.mass
+    assert_equal 250.0, model.reload.mass
+  end
+
+  # `author_id` and `update_reason` are `attr_accessor`s for paper_trail's meta,
+  # and the admin controller merges them into the same hash the build is sliced
+  # from.
+  test "#update_with_facts keeps paper_trail's meta off the build" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, mass: 999.0)
+
+    assert model.reload.update_with_facts(mass: 250.0, update_reason: :custom, author_id: nil)
+
+    assert_equal 250.0, model.build.reload.mass
+  end
+
+  test "#update_with_facts leaves a dropped model's build alone" do
+    model = create(:model, mass: 100.0)
+    old = create(:model_build, model:, version: "0.0.1-live.1", mass: 777.0)
+
+    assert model.reload.update_with_facts(mass: 250.0)
+
+    assert_equal 777.0, old.reload.mass
+  end
 end


### PR DESCRIPTION
> **Stacked on #4566** — base is `feat/model-builds`. That one adds the table and the dual-write; this one moves the readers.

Models stop reading their own columns for the 27 mechanics facts: the build we are on, else the last build of this environment that described the model, else the column.

**Across the full local dataset, no displayed value changes — on any of 246 models, for any of the 27 facts.** That is the property to want from a refactor this size, and it is checked rather than hoped: the script reads every fact through the new reader and against `read_attribute`, which is what shipped before.

## Two things the design called for, and measuring said no to

I wrote the layering design down some sessions ago as *curated > game files > ship matrix*. Both of the parts that make models different from the other three catalogues turn out not to survive contact with the data.

### The RSI ship matrix is not a read layer

Six of the 27 facts have an `rsi_` column: `mass`, `scm_speed`, `max_speed`, `pitch`, `yaw`, `roll`. Reading them above the column changes **exactly one value across 246 models — and that one change is a regression.**

| | |
| --- | --- |
| ships with no build | 31 |
| …where the column already *is* the matrix value | 30 |
| …where it is not | 1 — the Retaliator Bomber |

`Rsi::ModelsLoader` writes both the shadow and the column, so for a concept ship the matrix layer reads the same number twice. The Retaliator Bomber is `in_game: false` with `production_status: flight-ready`, and paper_trail says its mass, scm speed, pitch, yaw and roll were all written by `sc_data_loader` on 2026-04-04 — real game-file values from a build that still shipped it. Promoting the matrix there swaps a real value for a staler one.

It also had a trap in it: `rsi_mass` is `null: false, default: 0.0`, so **23 models carry a zero that means "the matrix never said"**. A plain nil check would have handed back `0.0` as a ship's mass.

The matrix earns a layer when it stops being copied into the column — the change that moves `rsi_*` out of Model's columns. Until then it is the same value read twice.

### Curation does not outrank the build

The sketch had curated values winning permanently, which is the opposite of equipment and components, where a correction *is* a correction to the build and the next load overwrites it deliberately.

Over the entire paper_trail history, an admin has edited **none** of the 27 build facts:

```
front_view 102   top_view 101   angled_view 101   side_view 100
sales_page_url 89   pledge_price 43   production_status 27   size 27
length 13   height 13   beam 12   cargo 8   focus 5   price 5
```

All outside the build — **dimensions included, which is the group #4566 deliberately left out**. So `update_with_facts` follows the other three catalogues, and the curated-wins layer is not built for a case that does not exist.

## Build existence is not the catalogue filter

For equipment and components, "is it in the current build?" became the catalogue filter. For models it cannot: 31 of 246 are concept ships no build will ever describe, and filtering on a build row would hide every one of them. `in_game` stays the flag.

## The N+1 this would have shipped

Every reader consults `build || last_build`, so a ship list pays two queries per row unless they are preloaded.

| 50 models, all 27 facts read | queries |
| --- | --- |
| no preload | 60 |
| `rendered_associations` before | 103 |
| **`rendered_associations` now** | **46** |

The hangar inherits it through `{model: Model.rendered_associations}`, which matters given how much of that endpoint is model rendering.

## Tests

11 new model tests, all built by making the build **disagree** with the column — while the loader writes both they are identical, so a passing test would otherwise prove nothing about which side answered. Four mutations, each caught:

| mutation | failures |
| --- | --- |
| readers ignore the build | 6 |
| no `last_build` fallback | 1 |
| corrections never reach the build | 2 |
| no `FACTS` slice in `update_with_facts` | 1 error |

That last one is `author_id` and `update_reason` — `attr_accessor`s for paper_trail's meta that the admin controller merges into the same hash the build is sliced from.

## Verification

460 model tests, 1,310 public API and 820 admin integration tests — green. No API or schema change: no field is added or removed. `standardrb` clean.

`test/loaders` needs the parsed `sc_data` tree, which is not part of a checkout — 19 failures / 18 errors, identical against the base branch. Two admin mailer tests hit premailer on `localhost:3000`, also unchanged.

🤖
