### PR TITLE
feat(notifications): summarise the hangar sync result in the notification

### DIFF
--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -12,6 +12,28 @@ class HangarSync < HangarImporter
     "slug = :normalized_name"
   ].freeze
 
+  SUMMARY_KEYS = %i[
+    imported_vehicles
+    found_vehicles
+    moved_vehicles_to_wanted
+    imported_components
+    found_components
+    imported_upgrades
+    found_upgrades
+  ].freeze
+
+  WARNING_KEYS = %i[
+    missing_models
+    missing_components
+    missing_component_vehicles
+    missing_upgrades
+    missing_upgrade_vehicles
+  ].freeze
+
+  # A hangar can miss dozens of items at once, and the notification body is read
+  # in a narrow reading pane.
+  MAX_LISTED_ITEMS = 10
+
   def initialize(data)
     @data = data.map { |item| item.deep_transform_keys { |key| key.to_s.underscore.to_sym } }
     @ships = @data.select { |item| item[:type] == "ship" }
@@ -61,7 +83,7 @@ class HangarSync < HangarImporter
       user: import.user,
       type: :hangar_sync_finished,
       title: I18n.t("notifications.hangar_sync_finished.title"),
-      body: I18n.t("notifications.hangar_sync_finished.body"),
+      body: sync_notification_body(output),
       link: Rails.application.routes.url_helpers.frontend_hangar_path
     )
 
@@ -82,6 +104,39 @@ class HangarSync < HangarImporter
     end
 
     raise e
+  end
+
+  # The sync modal is gone as soon as the user closes it, so the notification is
+  # the only lasting record of what a sync actually did.
+  private def sync_notification_body(output)
+    counts = SUMMARY_KEYS.filter_map do |key|
+      count = output[key].size
+      next if count.zero?
+
+      "- #{I18n.t("notifications.hangar_sync_finished.summary.#{key}")}: **#{count}**"
+    end
+
+    warnings = WARNING_KEYS.filter_map do |key|
+      items = output[key]
+      next if items.empty?
+
+      "- #{I18n.t("notifications.hangar_sync_finished.summary.#{key}")}: **#{items.size}** (#{listed_items(items)})"
+    end
+
+    lines = [I18n.t("notifications.hangar_sync_finished.body")]
+    lines += ["", *counts] if counts.present?
+    lines += ["", "#### #{I18n.t("notifications.hangar_sync_finished.warnings")}", "", *warnings] if warnings.present?
+
+    lines.join("\n")
+  end
+
+  private def listed_items(items)
+    listed = items.first(MAX_LISTED_ITEMS)
+    remaining = items.size - listed.size
+
+    return listed.join(", ") if remaining.zero?
+
+    "#{listed.join(", ")}, #{I18n.t("notifications.hangar_sync_finished.more_items", count: remaining)}"
   end
 
   def sync_vehicles(user_id)

--- a/config/locales/de/notifications.yml
+++ b/config/locales/de/notifications.yml
@@ -15,6 +15,21 @@ de:
     hangar_sync_finished:
       title: Hangar-Synchronisierung abgeschlossen
       body: Ihr RSI-Hangar wurde erfolgreich synchronisiert.
+      warnings: Warnungen
+      more_items: "und %{count} weitere"
+      summary:
+        imported_vehicles: Schiffe hinzugefügt
+        found_vehicles: Schiffe gefunden
+        moved_vehicles_to_wanted: Schiffe zur Wunschliste verschoben
+        imported_components: Komponenten hinzugefügt
+        found_components: Komponenten gefunden
+        imported_upgrades: Upgrades hinzugefügt
+        found_upgrades: Upgrades gefunden
+        missing_models: Schiffe nicht gefunden
+        missing_components: Komponenten nicht gefunden
+        missing_component_vehicles: Kein passendes Schiff für Komponenten
+        missing_upgrades: Upgrades nicht gefunden
+        missing_upgrade_vehicles: Kein passendes Schiff für Upgrades
     hangar_sync_failed:
       title: Hangar-Synchronisierung fehlgeschlagen
       body: 'Ihre RSI-Hangar-Synchronisierung ist fehlgeschlagen: %{error}'

--- a/config/locales/en/notifications.yml
+++ b/config/locales/en/notifications.yml
@@ -15,6 +15,21 @@ en:
     hangar_sync_finished:
       title: Hangar sync completed
       body: Your RSI hangar has been synced successfully.
+      warnings: Warnings
+      more_items: "and %{count} more"
+      summary:
+        imported_vehicles: Added ships
+        found_vehicles: Found ships
+        moved_vehicles_to_wanted: Ships moved to wishlist
+        imported_components: Added components
+        found_components: Found components
+        imported_upgrades: Added upgrades
+        found_upgrades: Found upgrades
+        missing_models: Ships not found
+        missing_components: Components not found
+        missing_component_vehicles: No matching ship for components
+        missing_upgrades: Upgrades not found
+        missing_upgrade_vehicles: No matching ship for upgrades
     hangar_sync_failed:
       title: Hangar sync failed
       body: "Your RSI hangar sync failed: %{error}"

--- a/config/locales/es/notifications.yml
+++ b/config/locales/es/notifications.yml
@@ -15,6 +15,21 @@ es:
     hangar_sync_finished:
       title: Sincronización del hangar completada
       body: Su hangar RSI ha sido sincronizado exitosamente.
+      warnings: Advertencias
+      more_items: "y %{count} más"
+      summary:
+        imported_vehicles: Naves agregadas
+        found_vehicles: Naves encontradas
+        moved_vehicles_to_wanted: Naves movidas a la lista de deseos
+        imported_components: Componentes agregados
+        found_components: Componentes encontrados
+        imported_upgrades: Mejoras agregadas
+        found_upgrades: Mejoras encontradas
+        missing_models: Naves no encontradas
+        missing_components: Componentes no encontrados
+        missing_component_vehicles: No se encontró una nave para los componentes
+        missing_upgrades: Mejoras no encontradas
+        missing_upgrade_vehicles: No se encontró una nave para las mejoras
     hangar_sync_failed:
       title: Sincronización del hangar fallida
       body: 'La sincronización de su hangar RSI falló: %{error}'

--- a/config/locales/fr/notifications.yml
+++ b/config/locales/fr/notifications.yml
@@ -15,6 +15,21 @@ fr:
     hangar_sync_finished:
       title: Synchronisation du hangar terminée
       body: Votre hangar RSI a été synchronisé avec succès.
+      warnings: Avertissements
+      more_items: "et %{count} de plus"
+      summary:
+        imported_vehicles: Vaisseaux ajoutés
+        found_vehicles: Vaisseaux trouvés
+        moved_vehicles_to_wanted: Vaisseaux déplacés vers la liste de souhaits
+        imported_components: Composants ajoutés
+        found_components: Composants trouvés
+        imported_upgrades: Améliorations ajoutées
+        found_upgrades: Améliorations trouvées
+        missing_models: Vaisseaux introuvables
+        missing_components: Composants introuvables
+        missing_component_vehicles: Aucun vaisseau correspondant pour les composants
+        missing_upgrades: Améliorations introuvables
+        missing_upgrade_vehicles: Aucun vaisseau correspondant pour les améliorations
     hangar_sync_failed:
       title: Échec de la synchronisation du hangar
       body: 'La synchronisation de votre hangar RSI a échoué : %{error}'

--- a/config/locales/it/notifications.yml
+++ b/config/locales/it/notifications.yml
@@ -15,6 +15,21 @@ it:
     hangar_sync_finished:
       title: Sincronizzazione hangar completata
       body: Il tuo hangar RSI è stato sincronizzato con successo.
+      warnings: Avvisi
+      more_items: "e altri %{count}"
+      summary:
+        imported_vehicles: Navi aggiunte
+        found_vehicles: Navi trovate
+        moved_vehicles_to_wanted: Navi spostate nella lista dei desideri
+        imported_components: Componenti aggiunti
+        found_components: Componenti trovati
+        imported_upgrades: Upgrade aggiunti
+        found_upgrades: Upgrade trovati
+        missing_models: Navi non trovate
+        missing_components: Componenti non trovati
+        missing_component_vehicles: Nessuna nave corrispondente per i componenti
+        missing_upgrades: Upgrade non trovati
+        missing_upgrade_vehicles: Nessuna nave corrispondente per gli upgrade
     hangar_sync_failed:
       title: Sincronizzazione hangar fallita
       body: 'La sincronizzazione del tuo hangar RSI è fallita: %{error}'

--- a/config/locales/zh-CN/notifications.yml
+++ b/config/locales/zh-CN/notifications.yml
@@ -15,6 +15,21 @@ zh-CN:
     hangar_sync_finished:
       title: 机库同步完成
       body: 您的 RSI 机库已成功同步。
+      warnings: 警告
+      more_items: "以及另外 %{count} 项"
+      summary:
+        imported_vehicles: 已添加的飞船
+        found_vehicles: 已找到的飞船
+        moved_vehicles_to_wanted: 已移至愿望清单的飞船
+        imported_components: 已添加的组件
+        found_components: 已找到的组件
+        imported_upgrades: 已添加的升级
+        found_upgrades: 已找到的升级
+        missing_models: 未找到的飞船
+        missing_components: 未找到的组件
+        missing_component_vehicles: 没有与组件匹配的飞船
+        missing_upgrades: 未找到的升级
+        missing_upgrade_vehicles: 没有与升级匹配的飞船
     hangar_sync_failed:
       title: 机库同步失败
       body: '您的 RSI 机库同步失败: %{error}'

--- a/config/locales/zh-TW/notifications.yml
+++ b/config/locales/zh-TW/notifications.yml
@@ -15,6 +15,21 @@ zh-TW:
     hangar_sync_finished:
       title: 機庫同步完成
       body: 您的 RSI 機庫已成功同步。
+      warnings: 警告
+      more_items: "以及另外 %{count} 項"
+      summary:
+        imported_vehicles: 已新增的飛船
+        found_vehicles: 已找到的飛船
+        moved_vehicles_to_wanted: 已移至願望清單的飛船
+        imported_components: 已新增的元件
+        found_components: 已找到的元件
+        imported_upgrades: 已新增的升級
+        found_upgrades: 已找到的升級
+        missing_models: 未找到的飛船
+        missing_components: 未找到的元件
+        missing_component_vehicles: 沒有與元件相符的飛船
+        missing_upgrades: 未找到的升級
+        missing_upgrade_vehicles: 沒有與升級相符的飛船
     hangar_sync_failed:
       title: 機庫同步失敗
       body: '您的 RSI 機庫同步失敗: %{error}'

--- a/test/loaders/hangar_sync_test.rb
+++ b/test/loaders/hangar_sync_test.rb
@@ -98,4 +98,40 @@ class HangarSyncTest < ActiveSupport::TestCase
       end
     end
   end
+
+  class NotificationTest < HangarSyncTest
+    test "summarises the sync in the notification body" do
+      result = ::HangarSync.new(@input).run(@user.id)
+
+      body = Notification.find_by!(user: @user, notification_type: :hangar_sync_finished).body
+
+      assert_includes body, I18n.t("notifications.hangar_sync_finished.body")
+      assert_includes body, "- Added ships: **#{result[:imported_vehicles].size}**"
+      refute_includes body, "Found ships"
+      refute_includes body, I18n.t("notifications.hangar_sync_finished.warnings")
+    end
+
+    test "lists the items a sync could not match" do
+      input = @input + [{"id" => "1", "type" => "ship", "name" => "Mystery Ship"}]
+
+      ::HangarSync.new(input).run(@user.id)
+
+      body = Notification.find_by!(user: @user, notification_type: :hangar_sync_finished).body
+
+      assert_includes body, I18n.t("notifications.hangar_sync_finished.warnings")
+      assert_includes body, "- Ships not found: **1** (Mystery Ship)"
+    end
+
+    test "caps the listed items and counts the rest" do
+      missing = (1..12).map { |index| {"id" => index.to_s, "type" => "ship", "name" => "Mystery Ship #{index}"} }
+
+      ::HangarSync.new(@input + missing).run(@user.id)
+
+      body = Notification.find_by!(user: @user, notification_type: :hangar_sync_finished).body
+
+      assert_includes body, "Mystery Ship 10"
+      refute_includes body, "Mystery Ship 11"
+      assert_includes body, I18n.t("notifications.hangar_sync_finished.more_items", count: 2)
+    end
+  end
 end


### PR DESCRIPTION
The `hangar_sync_finished` notification carried a fixed sentence — "Your RSI hangar has been synced successfully." — so once the sync modal was closed, nothing recorded what the sync had actually done.

The body now summarises the same `output` the sync already returns: counts for the categories that had any hits, and a warnings section listing the items that could not be matched, by name.

```
Your RSI hangar has been synced successfully.

- Added ships: **49**

#### Warnings

- Ships not found: **1** (Mystery Ship)
- Upgrades not found: **1** (Weird Upgrade)
```

Notes:

- Empty categories are left out, so a quiet sync still reads as one sentence.
- Name lists are capped at 10 with an "and N more" tail — a hangar can miss dozens of items at once and this renders in a narrow reading pane.
- Markdown stays inside what `shared/components/Markdown` supports: headings, flat lists, bold. No nested lists.
- Labels follow the wording the sync modal already uses (`labels.syncExtension.importedItems`), translated across all seven locales.

Three tests in `test/loaders/hangar_sync_test.rb` cover the counts, the named warnings, and the cap.

🤖