### PR TITLE
feat(sc_data): find and decide the ships the game files describe

### DIFF
--- a/app/api_components/admin/v1/schemas/enums/unlisted_model_comparison_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/unlisted_model_comparison_enum.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class UnlistedModelComparisonEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: [:string, :null],
+            enum: ::ScDataUnlistedModel::COMPARISONS + [nil]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/enums/unlisted_model_decision_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/unlisted_model_decision_enum.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class UnlistedModelDecisionEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: [:string, :null],
+            enum: ::ScDataUnlistedModel::DECISIONS + [nil]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/sc_data_unlisted_model_link_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/sc_data_unlisted_model_link_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ScDataUnlistedModelLinkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              # Which ship in the catalogue this game-file entry already is. The
+              # detected match is only a suggestion, so the admin names it.
+              modelId: {type: :string, format: :uuid}
+            },
+            additionalProperties: false,
+            required: %w[modelId]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/sc_data_unlisted_model_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/sc_data_unlisted_model_query.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class ScDataUnlistedModelQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              identifierCont: {type: :string},
+              nameCont: {type: :string},
+              comparisonEq: ::Admin::V1::Schemas::Enums::UnlistedModelComparisonEnum,
+              manufacturerCodeEq: {type: :string},
+
+              # The list is the undecided ones unless one of these asks
+              # otherwise: `decisionEq` for a single kind, `decisionNull=false`
+              # for everything already dealt with.
+              decisionEq: ::Admin::V1::Schemas::Enums::UnlistedModelDecisionEnum,
+              decisionNull: {type: :boolean},
+
+              sorts: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum]}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/sc_data_unlisted_model.rb
+++ b/app/api_components/admin/v1/schemas/sc_data_unlisted_model.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class ScDataUnlistedModel
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            identifier: {type: :string},
+            name: {type: [:string, :null]},
+
+            # How the export's version compares to the ship it extends.
+            # Descriptive rather than a verdict: the game files never say whether
+            # a player can own something, which is the only question that
+            # decides whether this becomes a model.
+            comparison: ::Admin::V1::Schemas::Enums::UnlistedModelComparisonEnum,
+            decision: ::Admin::V1::Schemas::Enums::UnlistedModelDecisionEnum,
+            decidedAt: {type: [:string, :null], format: "date-time"},
+
+            firstSeenVersion: {type: :string},
+            lastSeenVersion: {type: :string},
+            environment: {type: :string},
+
+            # Blank when the identifier names a prefix no ship in the catalogue
+            # uses -- a new company, or a file that is not a ship at all.
+            manufacturerCode: {type: [:string, :null]},
+            manufacturer: {oneOf: [::Admin::V1::Schemas::ScDataUnlistedModels::ManufacturerRef, {type: :null}]},
+
+            baseModel: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
+            model: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
+
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id identifier firstSeenVersion lastSeenVersion environment createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/sc_data_unlisted_model.rb
+++ b/app/api_components/admin/v1/schemas/sc_data_unlisted_model.rb
@@ -13,6 +13,10 @@ module Admin
             identifier: {type: :string},
             name: {type: [:string, :null]},
 
+            # What a model made from this entry would be called: the export
+            # prefixes the manufacturer and Fleetyards does not.
+            suggestedName: {type: :string},
+
             # How the export's version compares to the ship it extends.
             # Descriptive rather than a verdict: the game files never say whether
             # a player can own something, which is the only question that
@@ -31,13 +35,19 @@ module Admin
             manufacturer: {oneOf: [::Admin::V1::Schemas::ScDataUnlistedModels::ManufacturerRef, {type: :null}]},
 
             baseModel: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
+
+            # A ship of that name already in the catalogue, and a livery of that
+            # name already on the ship this extends. Either means the work is
+            # done and the entry only needs a decision, not a creation.
+            existingModel: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
+            existingPaint: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
             model: {oneOf: [::Admin::V1::Schemas::Models::ModelRef, {type: :null}]},
 
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id identifier firstSeenVersion lastSeenVersion environment createdAt updatedAt]
+          required: %w[id identifier suggestedName firstSeenVersion lastSeenVersion environment createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/admin/v1/schemas/sc_data_unlisted_models/manufacturer_ref.rb
+++ b/app/api_components/admin/v1/schemas/sc_data_unlisted_models/manufacturer_ref.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module ScDataUnlistedModels
+        # Enough to name the company the identifier prefix resolved to. The full
+        # manufacturer payload carries logos and counts a row in this list has
+        # no use for.
+        class ManufacturerRef
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              name: {type: [:string, :null]},
+              code: {type: [:string, :null]},
+              slug: {type: [:string, :null]}
+            },
+            additionalProperties: false,
+            required: %w[id]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/sc_data_unlisted_models/sc_data_unlisted_models.rb
+++ b/app/api_components/admin/v1/schemas/sc_data_unlisted_models/sc_data_unlisted_models.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module ScDataUnlistedModels
+        class ScDataUnlistedModels < ::Shared::V1::Schemas::BaseList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            properties: {
+              items: {type: :array, items: {"$ref": "#/components/schemas/ScDataUnlistedModel"}}
+            },
+            required: %w[items]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/sorts/sc_data_unlisted_model_sort_enum.rb
+++ b/app/api_components/admin/v1/schemas/sorts/sc_data_unlisted_model_sort_enum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Sorts
+        class ScDataUnlistedModelSortEnum
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :string,
+            enum: ::ScDataUnlistedModel::ALLOWED_SORTING_PARAMS,
+            "x-enumNames": ::ScDataUnlistedModel::ALLOWED_SORTING_PARAMS.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
+++ b/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
@@ -8,7 +8,7 @@ module Admin
       # The rows are written by the sc_data load, never by hand, so there is no
       # create, update or destroy here -- only listing them and deciding.
       class ScDataUnlistedModelsController < ::Admin::Api::BaseController
-        before_action :set_entry, only: %i[ignore create_model mark_as_paint reset]
+        before_action :set_entry, only: %i[ignore create_model mark_as_paint link reset]
 
         def index
           authorize! with: ::Admin::ScDataUnlistedModelPolicy
@@ -27,9 +27,10 @@ module Admin
             .per(per_page(ScDataUnlistedModel))
         end
 
-        # Not a ship somebody owns: an NPC copy the marker filter missed, a prop,
-        # a template. It stops being reported and stays recorded, so the next
-        # load does not raise it again.
+        # Nothing the catalogue should carry, for whatever reason -- an NPC copy
+        # the marker filter missed, a prop, a template, or a ship that simply
+        # does not belong in it. The reason is the admin's; this only records
+        # that one was reached, so the next load does not raise the entry again.
         def ignore
           @sc_data_unlisted_model.decide!("ignored")
         end
@@ -39,6 +40,19 @@ module Admin
         # an admin supplies, which is what the paints import already handles.
         def mark_as_paint
           @sc_data_unlisted_model.mark_as_paint!
+        end
+
+        # Already in the catalogue, under an identifier the game files spell
+        # differently. The detected match is only a suggestion -- the admin says
+        # which ship it is, because the export never gives enough to be sure.
+        def link
+          @sc_data_unlisted_model.link_to_model!(Model.find(params[:model_id]))
+        rescue ArgumentError => e
+          @sc_data_unlisted_model.errors.add(:base, e.message)
+
+          render json: ValidationError.new(
+            "sc_data_unlisted_model.link", errors: @sc_data_unlisted_model.errors
+          ), status: :bad_request
         end
 
         def create_model

--- a/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
+++ b/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      # Ships the game files describe that Fleetyards has no model for.
+      #
+      # The rows are written by the sc_data load, never by hand, so there is no
+      # create, update or destroy here -- only listing them and deciding.
+      class ScDataUnlistedModelsController < ::Admin::Api::BaseController
+        before_action :set_entry, only: %i[ignore create_model mark_as_paint reset]
+
+        def index
+          authorize! with: ::Admin::ScDataUnlistedModelPolicy
+
+          query_params["sorts"] = sorting_params(ScDataUnlistedModel, query_params[:sorts])
+
+          # Undecided by default, because that is the working list. An explicit
+          # `decision` filter is what reaches the ones already dealt with.
+          scope = ScDataUnlistedModel.includes(:base_model, :model)
+          scope = scope.undecided if query_params[:decision_eq].blank? && query_params[:decision_null].blank?
+
+          @q = authorized_scope(scope).ransack(query_params)
+
+          @sc_data_unlisted_models = @q.result
+            .page(params[:page])
+            .per(per_page(ScDataUnlistedModel))
+        end
+
+        # Not a ship somebody owns: an NPC copy the marker filter missed, a prop,
+        # a template. It stops being reported and stays recorded, so the next
+        # load does not raise it again.
+        def ignore
+          @sc_data_unlisted_model.decide!("ignored")
+        end
+
+        # It belongs on an existing model as a livery rather than as a model of
+        # its own. Records the decision only -- a paint needs a name and artwork
+        # an admin supplies, which is what the paints import already handles.
+        def mark_as_paint
+          @sc_data_unlisted_model.mark_as_paint!
+        end
+
+        def create_model
+          @sc_data_unlisted_model.create_model!
+        rescue ArgumentError => e
+          # Put on the record rather than raised as a bare hash: `ValidationError`
+          # reads `errors` off whatever it is given, so the two failure paths
+          # below produce the same shape in the payload.
+          @sc_data_unlisted_model.errors.add(:base, e.message)
+
+          render json: ValidationError.new(
+            "sc_data_unlisted_model.create_model", errors: @sc_data_unlisted_model.errors
+          ), status: :bad_request
+        rescue ActiveRecord::RecordInvalid => e
+          render json: ValidationError.new(
+            "sc_data_unlisted_model.create_model", errors: e.record.errors
+          ), status: :bad_request
+        end
+
+        # For a decision made in error. The model a `create_model` left behind
+        # stays: deleting a ship is its own action, and a hangar entry may
+        # already point at it.
+        def reset
+          @sc_data_unlisted_model.reset!
+        end
+
+        private def set_entry
+          @sc_data_unlisted_model = ScDataUnlistedModel.find(params[:id])
+
+          authorize! @sc_data_unlisted_model, with: ::Admin::ScDataUnlistedModelPolicy
+        end
+
+        private def query_params
+          @query_params ||= params.permit(q: [
+            :sorts, :identifier_cont, :name_cont, :comparison_eq, :decision_eq,
+            :decision_null, :manufacturer_code_eq
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
+++ b/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
@@ -17,7 +17,7 @@ module Admin
 
           # Undecided by default, because that is the working list. An explicit
           # `decision` filter is what reaches the ones already dealt with.
-          scope = ScDataUnlistedModel.includes(:base_model, :model)
+          scope = ScDataUnlistedModel.includes(:model, base_model: :paints)
           scope = scope.undecided if query_params[:decision_eq].blank? && query_params[:decision_null].blank?
 
           @q = authorized_scope(scope).ransack(query_params)

--- a/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
+++ b/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
@@ -16,6 +16,7 @@ import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useQueryClient } from "@tanstack/vue-query";
+import { useComlink } from "@/shared/composables/useComlink";
 
 type Props = {
   unlistedModel: ScDataUnlistedModel;
@@ -28,6 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { t } = useI18n();
 const { displayConfirm } = useAppNotifications();
+const comlink = useComlink();
 const queryClient = useQueryClient();
 
 const invalidate = () =>
@@ -79,6 +81,17 @@ const markAsPaint = async () => {
   await paintMutation.mutateAsync({ id: props.unlistedModel.id });
 };
 
+// The other answer to "why is this still here": the catalogue already has it,
+// under an identifier the game files spell differently. Prefilled with what was
+// detected, confirmed by a person, because the export never says enough.
+const openLinkModal = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/admin/components/UnlistedModels/LinkModal/index.vue"),
+    props: { unlistedModel: props.unlistedModel },
+  });
+};
+
 const ignore = async () => {
   await ignoreMutation.mutateAsync({ id: props.unlistedModel.id });
 };
@@ -95,6 +108,13 @@ const ignore = async () => {
   >
     <i class="fa-duotone fa-starship" />
     <span v-if="withLabels">{{ t("actions.unlistedModel.createModel") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.unlistedModel.link')"
+    @click="openLinkModal"
+  >
+    <i class="fa-duotone fa-link" />
+    <span v-if="withLabels">{{ t("actions.unlistedModel.link") }}</span>
   </Btn>
   <Btn
     v-tooltip="!withLabels && t('actions.unlistedModel.markAsPaint')"

--- a/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
+++ b/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
@@ -1,0 +1,101 @@
+<script lang="ts">
+export default {
+  name: "UnlistedModelActionItems",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  type ScDataUnlistedModel,
+  useScDataUnlistedModelIgnore,
+  useScDataUnlistedModelMarkAsPaint,
+  useScDataUnlistedModelCreateModel,
+  getScDataUnlistedModelsQueryKey,
+} from "@/services/fyAdminApi";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  unlistedModel: ScDataUnlistedModel;
+  withLabels?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  withLabels: false,
+});
+
+const { t } = useI18n();
+const { displayConfirm } = useAppNotifications();
+const queryClient = useQueryClient();
+
+const invalidate = () =>
+  queryClient.invalidateQueries({
+    queryKey: getScDataUnlistedModelsQueryKey(),
+  });
+
+const ignoreMutation = useScDataUnlistedModelIgnore({
+  mutation: { onSettled: invalidate },
+});
+const paintMutation = useScDataUnlistedModelMarkAsPaint({
+  mutation: { onSettled: invalidate },
+});
+const createMutation = useScDataUnlistedModelCreateModel({
+  mutation: { onSettled: invalidate },
+});
+
+// `belongs_to :manufacturer` is required on a model, and an identifier whose
+// prefix resolves to nothing is either a new company or not a ship at all.
+const canCreate = computed(() => !!props.unlistedModel.manufacturer);
+
+const createModel = () => {
+  displayConfirm({
+    text: t("messages.confirm.unlistedModel.createModel", {
+      name: props.unlistedModel.name ?? props.unlistedModel.identifier,
+    }),
+    onConfirm: async () => {
+      await createMutation.mutateAsync({ id: props.unlistedModel.id });
+    },
+  });
+};
+
+const markAsPaint = async () => {
+  await paintMutation.mutateAsync({ id: props.unlistedModel.id });
+};
+
+const ignore = async () => {
+  await ignoreMutation.mutateAsync({ id: props.unlistedModel.id });
+};
+</script>
+
+<template>
+  <Btn
+    v-tooltip="
+      !withLabels &&
+      (canCreate
+        ? t('actions.unlistedModel.createModel')
+        : t('actions.unlistedModel.noManufacturer'))
+    "
+    :disabled="!canCreate"
+    @click="createModel"
+  >
+    <i class="fa-duotone fa-starship" />
+    <span v-if="withLabels">{{ t("actions.unlistedModel.createModel") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.unlistedModel.markAsPaint')"
+    @click="markAsPaint"
+  >
+    <i class="fa-duotone fa-palette" />
+    <span v-if="withLabels">{{ t("actions.unlistedModel.markAsPaint") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.unlistedModel.ignore')"
+    :tone="BtnTonesEnum.DANGER"
+    @click="ignore"
+  >
+    <i class="fa-duotone fa-eye-slash" />
+    <span v-if="withLabels">{{ t("actions.unlistedModel.ignore") }}</span>
+  </Btn>
+</template>

--- a/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
+++ b/app/frontend/admin/components/UnlistedModels/Actions/Items.vue
@@ -45,14 +45,29 @@ const createMutation = useScDataUnlistedModelCreateModel({
   mutation: { onSettled: invalidate },
 });
 
-// `belongs_to :manufacturer` is required on a model, and an identifier whose
-// prefix resolves to nothing is either a new company or not a ship at all.
-const canCreate = computed(() => !!props.unlistedModel.manufacturer);
+// A model needs a manufacturer, and an identifier whose prefix resolves to
+// nothing is either a new company or not a ship. A ship of that name already in
+// the catalogue is the other half: only a quarter of models carry an `sc_key`,
+// so an existing one lands in this list anyway, and creating would duplicate it.
+const canCreate = computed(
+  () =>
+    !!props.unlistedModel.manufacturer && !props.unlistedModel.existingModel,
+);
+
+const createBlockedReason = computed(() => {
+  if (props.unlistedModel.existingModel) {
+    return t("actions.unlistedModel.alreadyExists", {
+      name: props.unlistedModel.existingModel.name ?? "",
+    });
+  }
+
+  return t("actions.unlistedModel.noManufacturer");
+});
 
 const createModel = () => {
   displayConfirm({
     text: t("messages.confirm.unlistedModel.createModel", {
-      name: props.unlistedModel.name ?? props.unlistedModel.identifier,
+      name: props.unlistedModel.suggestedName,
     }),
     onConfirm: async () => {
       await createMutation.mutateAsync({ id: props.unlistedModel.id });
@@ -73,9 +88,7 @@ const ignore = async () => {
   <Btn
     v-tooltip="
       !withLabels &&
-      (canCreate
-        ? t('actions.unlistedModel.createModel')
-        : t('actions.unlistedModel.noManufacturer'))
+      (canCreate ? t('actions.unlistedModel.createModel') : createBlockedReason)
     "
     :disabled="!canCreate"
     @click="createModel"

--- a/app/frontend/admin/components/UnlistedModels/Actions/index.vue
+++ b/app/frontend/admin/components/UnlistedModels/Actions/index.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "UnlistedModelActions",
+};
+</script>
+
+<script lang="ts" setup>
+import Items from "@/admin/components/UnlistedModels/Actions/Items.vue";
+import { useMobile } from "@/shared/composables/useMobile";
+import { type ScDataUnlistedModel } from "@/services/fyAdminApi";
+
+type Props = {
+  unlistedModel: ScDataUnlistedModel;
+};
+
+const props = defineProps<Props>();
+
+const mobile = useMobile();
+</script>
+
+<template>
+  <BtnDropdown v-if="mobile">
+    <Items :unlisted-model="props.unlistedModel" with-labels />
+  </BtnDropdown>
+  <BtnGroup v-else>
+    <Items :unlisted-model="props.unlistedModel" />
+  </BtnGroup>
+</template>

--- a/app/frontend/admin/components/UnlistedModels/LinkModal/index.vue
+++ b/app/frontend/admin/components/UnlistedModels/LinkModal/index.vue
@@ -1,0 +1,103 @@
+<script lang="ts">
+export default {
+  name: "UnlistedModelLinkModal",
+};
+</script>
+
+<script lang="ts" setup>
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import ModelFilterGroup from "@/admin/components/base/ModelFilterGroup/index.vue";
+import {
+  type ScDataUnlistedModel,
+  useScDataUnlistedModelLink,
+  getScDataUnlistedModelsQueryKey,
+} from "@/services/fyAdminApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  unlistedModel: ScDataUnlistedModel;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const comlink = useComlink();
+const queryClient = useQueryClient();
+
+// Prefilled with what the export lets us work out — the ship of that name, else
+// the one this extends. Both are suggestions; the export never says enough to be
+// sure, so the admin confirms.
+const modelId = ref<string | undefined>(
+  props.unlistedModel.existingModel?.id ?? props.unlistedModel.baseModel?.id,
+);
+const submitting = ref(false);
+const error = ref<string | undefined>();
+
+const linkMutation = useScDataUnlistedModelLink();
+
+const submit = async () => {
+  if (!modelId.value || submitting.value) return;
+
+  submitting.value = true;
+  error.value = undefined;
+
+  try {
+    await linkMutation.mutateAsync({
+      id: props.unlistedModel.id,
+      data: { modelId: modelId.value },
+    });
+
+    await queryClient.invalidateQueries({
+      queryKey: getScDataUnlistedModelsQueryKey(),
+    });
+
+    comlink.emit("close-modal");
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <Modal :title="t('headlines.admin.unlistedModels.link')">
+    <p class="hint">
+      <i class="fa-light fa-info-circle" />
+      {{
+        t("labels.unlistedModel.linkHint", {
+          identifier: props.unlistedModel.identifier,
+        })
+      }}
+    </p>
+
+    <form id="unlisted-model-link" @submit.prevent="submit">
+      <ModelFilterGroup
+        v-model="modelId"
+        :no-label="false"
+        value-attr="id"
+        :multiple="false"
+        name="model"
+      />
+
+      <p v-if="error" class="text-danger">{{ error }}</p>
+    </form>
+
+    <template #footer>
+      <div class="modal-actions">
+        <Btn
+          :loading="submitting"
+          :disabled="!modelId || submitting"
+          :size="BtnSizesEnum.LG"
+          @click="submit"
+        >
+          {{ t("actions.unlistedModel.link") }}
+        </Btn>
+      </div>
+    </template>
+  </Modal>
+</template>

--- a/app/frontend/admin/pages/models/routes.ts
+++ b/app/frontend/admin/pages/models/routes.ts
@@ -17,6 +17,19 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "unlisted/",
+    name: "admin-unlisted-models",
+    component: () => import("@/admin/pages/models/unlisted.vue"),
+    strict: true,
+    meta: {
+      needsAuthentication: true,
+      title: "admin.unlistedModels.index",
+      icon: "fa-duotone fa-magnifying-glass-plus",
+      activeRoute: "admin-models",
+      access: ["models"],
+    },
+  },
+  {
     path: "modules/",
     component: () => import("@/admin/pages/models.vue"),
     children: modelModulesRoutes,

--- a/app/frontend/admin/pages/models/unlisted.vue
+++ b/app/frontend/admin/pages/models/unlisted.vue
@@ -88,6 +88,11 @@ const columns: BaseTableCol<ScDataUnlistedModel>[] = [
     mobile: false,
   },
   {
+    name: "alreadyThere",
+    label: "Already in the catalogue",
+    mobile: false,
+  },
+  {
     name: "manufacturer",
     label: "Manufacturer",
     mobile: false,
@@ -136,7 +141,7 @@ const { t } = useI18n();
           <code>{{ record.identifier }}</code>
         </template>
         <template #col-name="{ record }">
-          {{ record.name }}
+          {{ record.suggestedName }}
         </template>
         <template #col-comparison="{ record }">
           {{ record.comparison ? comparisonLabels[record.comparison] : "" }}
@@ -151,6 +156,20 @@ const { t } = useI18n();
           >
             {{ record.baseModel.name }}
           </router-link>
+        </template>
+        <template #col-alreadyThere="{ record }">
+          <router-link
+            v-if="record.existingModel"
+            :to="{
+              name: 'admin-models',
+              query: { q: record.existingModel.name },
+            }"
+          >
+            {{ record.existingModel.name }}
+          </router-link>
+          <span v-else-if="record.existingPaint">
+            {{ record.existingPaint.name }}
+          </span>
         </template>
         <template #col-manufacturer="{ record }">
           {{ record.manufacturer?.name ?? record.manufacturerCode }}

--- a/app/frontend/admin/pages/models/unlisted.vue
+++ b/app/frontend/admin/pages/models/unlisted.vue
@@ -1,0 +1,178 @@
+<script lang="ts">
+export default {
+  name: "AdminUnlistedModelsPage",
+};
+</script>
+
+<script lang="ts" setup>
+import Heading from "@/shared/components/base/Heading/index.vue";
+import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { usePagination } from "@/shared/composables/usePagination";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useScDataUnlistedModels,
+  getScDataUnlistedModelsQueryKey,
+  type ScDataUnlistedModel,
+  type ScDataUnlistedModelSortEnum,
+} from "@/services/fyAdminApi";
+import UnlistedModelActions from "@/admin/components/UnlistedModels/Actions/index.vue";
+
+const route = useRoute();
+
+const sorts = computed((): ScDataUnlistedModelSortEnum[] => {
+  return route.query.s ? [route.query.s as ScDataUnlistedModelSortEnum] : [];
+});
+
+const queryKey = computed(() => {
+  return getScDataUnlistedModelsQueryKey(queryParams.value);
+});
+
+const { perPage, page, updatePerPage } = usePagination(queryKey);
+
+const queryParams = computed(() => {
+  return {
+    page: page.value,
+    perPage: perPage.value,
+    q: {
+      sorts: sorts.value,
+    },
+  };
+});
+
+const {
+  data: unlistedModels,
+  refetch,
+  ...asyncStatus
+} = useScDataUnlistedModels(queryParams);
+
+watch(
+  () => sorts.value,
+  async () => {
+    await refetch();
+  },
+);
+
+// What the export lets us work out. Not a verdict on whether the ship belongs
+// in the catalogue -- the game files never say whether a player can own one.
+const comparisonLabels: Record<string, string> = {
+  identical: "Identical to the ship it extends",
+  refitted: "Same hull, different stock loadout",
+  structural: "A different machine",
+  unrelated: "No base ship",
+};
+
+const columns: BaseTableCol<ScDataUnlistedModel>[] = [
+  {
+    name: "identifier",
+    label: "Game-file identifier",
+    sortable: true,
+  },
+  {
+    name: "name",
+    label: "Name in the export",
+    sortable: true,
+  },
+  {
+    name: "comparison",
+    label: "Compared to its base ship",
+    sortable: true,
+    mobile: false,
+  },
+  {
+    name: "baseModel",
+    label: "Variant of",
+    mobile: false,
+  },
+  {
+    name: "manufacturer",
+    label: "Manufacturer",
+    mobile: false,
+  },
+  {
+    name: "firstSeenVersion",
+    label: "First seen",
+    sortable: true,
+    mobile: false,
+  },
+];
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.unlistedModels.index") }}
+    <HeadingSmall v-if="unlistedModels">
+      {{
+        t("headlines.pagination.count", {
+          current: unlistedModels?.items.length,
+          total: unlistedModels?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <FilteredList
+    name="admin-unlisted-models"
+    :records="unlistedModels?.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+  >
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="unlistedModels?.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+        default-sort="identifier asc"
+      >
+        <template #col-identifier="{ record }">
+          <code>{{ record.identifier }}</code>
+        </template>
+        <template #col-name="{ record }">
+          {{ record.name }}
+        </template>
+        <template #col-comparison="{ record }">
+          {{ record.comparison ? comparisonLabels[record.comparison] : "" }}
+        </template>
+        <template #col-baseModel="{ record }">
+          <router-link
+            v-if="record.baseModel"
+            :to="{
+              name: 'admin-model-edit',
+              params: { id: record.baseModel.id },
+            }"
+          >
+            {{ record.baseModel.name }}
+          </router-link>
+        </template>
+        <template #col-manufacturer="{ record }">
+          {{ record.manufacturer?.name ?? record.manufacturerCode }}
+        </template>
+        <template #col-firstSeenVersion="{ record }">
+          {{ record.firstSeenVersion }}
+        </template>
+        <template #actions="{ record }">
+          <UnlistedModelActions
+            :unlisted-model="record"
+            :on-decided="refetch"
+          />
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="unlistedModels"
+        :query-result-ref="unlistedModels"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -273,7 +273,8 @@
         "createModel": "Schiff anlegen",
         "markAsPaint": "Ist eine Lackierung",
         "ignore": "Kein Schiff",
-        "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen"
+        "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen",
+        "alreadyExists": "%{name} ist bereits im Katalog"
       }
     }
   }

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -268,6 +268,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "Fracht leeren"
+      },
+      "unlistedModel": {
+        "createModel": "Schiff anlegen",
+        "markAsPaint": "Ist eine Lackierung",
+        "ignore": "Kein Schiff",
+        "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen"
       }
     }
   }

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -272,9 +272,10 @@
       "unlistedModel": {
         "createModel": "Schiff anlegen",
         "markAsPaint": "Ist eine Lackierung",
-        "ignore": "Kein Schiff",
+        "ignore": "Ignorieren",
         "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen",
-        "alreadyExists": "%{name} ist bereits im Katalog"
+        "alreadyExists": "%{name} ist bereits im Katalog",
+        "link": "Schon im Katalog"
       }
     }
   }

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -67,7 +67,8 @@
           "prices": "Preise"
         },
         "unlistedModels": {
-          "index": "Schiffe in den Spieldateien ohne Model"
+          "index": "Schiffe in den Spieldateien ohne Model",
+          "link": "Mit einem Schiff im Katalog verknüpfen"
         },
         "manufacturers": {
           "index": "Hersteller",

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -66,6 +66,9 @@
           "models": "Verknüpfte Modelle",
           "prices": "Preise"
         },
+        "unlistedModels": {
+          "index": "Schiffe in den Spieldateien ohne Model"
+        },
         "manufacturers": {
           "index": "Hersteller",
           "new": "Neuer Hersteller",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1429,6 +1429,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "Welches Schiff im Katalog ist %{identifier}? Der Vorschlag stammt aus dem Export und kann falsch sein."
       }
     }
   }

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -403,6 +403,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "Ein Schiff aus %{name} anlegen? Der nächste sc_data-Load ergänzt die Mechanik."
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -138,6 +138,9 @@
             "prices": "Preise"
           }
         },
+        "unlistedModels": {
+          "index": "Nicht gelistete Schiffe"
+        },
         "modelModulePackages": {
           "index": "Modulpakete",
           "create": "Modulpaket erstellen"

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -211,6 +211,9 @@
             "prices": "%{name} Preise bearbeiten"
           }
         },
+        "unlistedModels": {
+          "index": "Nicht gelistete Schiffe"
+        },
         "modelModulePackages": {
           "index": "Modell Modul Pakete"
         },

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -361,6 +361,12 @@
         "sortOldest": "Oldest first",
         "sortNewest": "Newest first",
         "openCenter": "Notifications"
+      },
+      "unlistedModel": {
+        "createModel": "Create ship",
+        "markAsPaint": "It is a paint",
+        "ignore": "Not a ship",
+        "noManufacturer": "No manufacturer resolves from this identifier"
       }
     }
   }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -366,7 +366,8 @@
         "createModel": "Create ship",
         "markAsPaint": "It is a paint",
         "ignore": "Not a ship",
-        "noManufacturer": "No manufacturer resolves from this identifier"
+        "noManufacturer": "No manufacturer resolves from this identifier",
+        "alreadyExists": "%{name} is already in the catalogue"
       }
     }
   }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -365,9 +365,10 @@
       "unlistedModel": {
         "createModel": "Create ship",
         "markAsPaint": "It is a paint",
-        "ignore": "Not a ship",
+        "ignore": "Ignore",
         "noManufacturer": "No manufacturer resolves from this identifier",
-        "alreadyExists": "%{name} is already in the catalogue"
+        "alreadyExists": "%{name} is already in the catalogue",
+        "link": "Already in the catalogue"
       }
     }
   }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -72,6 +72,9 @@
           "hardpoints": "Hardpoints",
           "cargoHolds": "Cargo Holds"
         },
+        "unlistedModels": {
+          "index": "Ships in the game files with no model"
+        },
         "manufacturers": {
           "index": "Manufacturers",
           "new": "New Manufacturer",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -73,7 +73,8 @@
           "cargoHolds": "Cargo Holds"
         },
         "unlistedModels": {
-          "index": "Ships in the game files with no model"
+          "index": "Ships in the game files with no model",
+          "link": "Link to a ship in the catalogue"
         },
         "manufacturers": {
           "index": "Manufacturers",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2182,6 +2182,9 @@
         "noBody": "This notification carries no further details.",
         "archivesOn": "Moves to the archive",
         "deletesOn": "Deleted"
+      },
+      "unlistedModel": {
+        "linkHint": "Which ship in the catalogue is %{identifier}? The suggestion comes from the export and may be wrong."
       }
     }
   }

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -458,6 +458,9 @@
         },
         "notifications": {
           "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "Create a ship from %{name}? The next sc_data load fills in its mechanics."
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -173,6 +173,9 @@
             "cargoHolds": "Cargo Holds"
           }
         },
+        "unlistedModels": {
+          "index": "Unlisted Ships"
+        },
         "modelModulePackages": {
           "index": "Module Packages",
           "create": "Create Module Package"

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -249,6 +249,9 @@
             "cargoHolds": "Edit %{name} Cargo Holds"
           }
         },
+        "unlistedModels": {
+          "index": "Unlisted Ships"
+        },
         "modelModulePackages": {
           "index": "Model Module Packages"
         },

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -263,7 +263,8 @@
         "createModel": "Crear nave",
         "markAsPaint": "Es una pintura",
         "ignore": "No es una nave",
-        "noManufacturer": "Este identificador no resuelve ningún fabricante"
+        "noManufacturer": "Este identificador no resuelve ningún fabricante",
+        "alreadyExists": "%{name} ya está en el catálogo"
       }
     }
   }

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -262,9 +262,10 @@
       "unlistedModel": {
         "createModel": "Crear nave",
         "markAsPaint": "Es una pintura",
-        "ignore": "No es una nave",
+        "ignore": "Ignorar",
         "noManufacturer": "Este identificador no resuelve ningún fabricante",
-        "alreadyExists": "%{name} ya está en el catálogo"
+        "alreadyExists": "%{name} ya está en el catálogo",
+        "link": "Ya está en el catálogo"
       }
     }
   }

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -258,6 +258,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "Vaciar carga"
+      },
+      "unlistedModel": {
+        "createModel": "Crear nave",
+        "markAsPaint": "Es una pintura",
+        "ignore": "No es una nave",
+        "noManufacturer": "Este identificador no resuelve ningún fabricante"
       }
     }
   }

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -67,7 +67,8 @@
           "prices": "Precios"
         },
         "unlistedModels": {
-          "index": "Naves en los archivos del juego sin modelo"
+          "index": "Naves en los archivos del juego sin modelo",
+          "link": "Vincular con una nave del catálogo"
         },
         "manufacturers": {
           "index": "Fabricantes",

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -66,6 +66,9 @@
           "models": "Modelos vinculados",
           "prices": "Precios"
         },
+        "unlistedModels": {
+          "index": "Naves en los archivos del juego sin modelo"
+        },
         "manufacturers": {
           "index": "Fabricantes",
           "new": "Nuevo fabricante",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1314,6 +1314,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "¿Qué nave del catálogo es %{identifier}? La sugerencia viene del export y puede estar equivocada."
       }
     }
   }

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -369,6 +369,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "¿Crear una nave a partir de %{name}? La próxima carga de sc_data rellenará su mecánica."
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -137,6 +137,9 @@
             "prices": "Precios"
           }
         },
+        "unlistedModels": {
+          "index": "Naves no listadas"
+        },
         "modelModulePackages": {
           "index": "Paquetes de Módulos",
           "create": "Crear Paquete de Módulos"

--- a/app/frontend/translations/es/title.json
+++ b/app/frontend/translations/es/title.json
@@ -197,6 +197,9 @@
             "prices": "Editar %{name} Precios"
           }
         },
+        "unlistedModels": {
+          "index": "Naves no listadas"
+        },
         "modelModulePackages": {
           "index": "Paquetes de Módulos de Modelos"
         },

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -263,7 +263,8 @@
         "createModel": "Créer le vaisseau",
         "markAsPaint": "C'est une peinture",
         "ignore": "Pas un vaisseau",
-        "noManufacturer": "Aucun constructeur ne correspond à cet identifiant"
+        "noManufacturer": "Aucun constructeur ne correspond à cet identifiant",
+        "alreadyExists": "%{name} est déjà dans le catalogue"
       }
     }
   }

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -258,6 +258,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "Vider la cargaison"
+      },
+      "unlistedModel": {
+        "createModel": "Créer le vaisseau",
+        "markAsPaint": "C'est une peinture",
+        "ignore": "Pas un vaisseau",
+        "noManufacturer": "Aucun constructeur ne correspond à cet identifiant"
       }
     }
   }

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -262,9 +262,10 @@
       "unlistedModel": {
         "createModel": "Créer le vaisseau",
         "markAsPaint": "C'est une peinture",
-        "ignore": "Pas un vaisseau",
+        "ignore": "Ignorer",
         "noManufacturer": "Aucun constructeur ne correspond à cet identifiant",
-        "alreadyExists": "%{name} est déjà dans le catalogue"
+        "alreadyExists": "%{name} est déjà dans le catalogue",
+        "link": "Déjà dans le catalogue"
       }
     }
   }

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -66,6 +66,9 @@
           "models": "Modèles liés",
           "prices": "Prix"
         },
+        "unlistedModels": {
+          "index": "Vaisseaux des fichiers de jeu sans modèle"
+        },
         "manufacturers": {
           "index": "Fabricants",
           "new": "Nouveau fabricant",

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -67,7 +67,8 @@
           "prices": "Prix"
         },
         "unlistedModels": {
-          "index": "Vaisseaux des fichiers de jeu sans modèle"
+          "index": "Vaisseaux des fichiers de jeu sans modèle",
+          "link": "Lier à un vaisseau du catalogue"
         },
         "manufacturers": {
           "index": "Fabricants",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1319,6 +1319,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "Quel vaisseau du catalogue est %{identifier} ? La suggestion vient de l'export et peut être fausse."
       }
     }
   }

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -369,6 +369,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "Créer un vaisseau à partir de %{name} ? Le prochain chargement sc_data complétera ses caractéristiques."
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -137,6 +137,9 @@
             "prices": "Prix"
           }
         },
+        "unlistedModels": {
+          "index": "Vaisseaux non listés"
+        },
         "modelModulePackages": {
           "index": "Paquets de Modules",
           "create": "Créer un Paquet de Modules"

--- a/app/frontend/translations/fr/title.json
+++ b/app/frontend/translations/fr/title.json
@@ -197,6 +197,9 @@
             "prices": "Éditer %{name} Prix"
           }
         },
+        "unlistedModels": {
+          "index": "Vaisseaux non listés"
+        },
         "modelModulePackages": {
           "index": "Paquets de Modules de Modèles"
         },

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -262,9 +262,10 @@
       "unlistedModel": {
         "createModel": "Crea nave",
         "markAsPaint": "È una livrea",
-        "ignore": "Non è una nave",
+        "ignore": "Ignora",
         "noManufacturer": "Nessun produttore corrisponde a questo identificatore",
-        "alreadyExists": "%{name} è già nel catalogo"
+        "alreadyExists": "%{name} è già nel catalogo",
+        "link": "Già nel catalogo"
       }
     }
   }

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -258,6 +258,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "Svuota carico"
+      },
+      "unlistedModel": {
+        "createModel": "Crea nave",
+        "markAsPaint": "È una livrea",
+        "ignore": "Non è una nave",
+        "noManufacturer": "Nessun produttore corrisponde a questo identificatore"
       }
     }
   }

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -263,7 +263,8 @@
         "createModel": "Crea nave",
         "markAsPaint": "È una livrea",
         "ignore": "Non è una nave",
-        "noManufacturer": "Nessun produttore corrisponde a questo identificatore"
+        "noManufacturer": "Nessun produttore corrisponde a questo identificatore",
+        "alreadyExists": "%{name} è già nel catalogo"
       }
     }
   }

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -66,6 +66,9 @@
           "models": "Modelli collegati",
           "prices": "Prezzi"
         },
+        "unlistedModels": {
+          "index": "Navi nei file di gioco senza modello"
+        },
         "manufacturers": {
           "index": "Produttori",
           "new": "Nuovo produttore",

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -67,7 +67,8 @@
           "prices": "Prezzi"
         },
         "unlistedModels": {
-          "index": "Navi nei file di gioco senza modello"
+          "index": "Navi nei file di gioco senza modello",
+          "link": "Collega a una nave del catalogo"
         },
         "manufacturers": {
           "index": "Produttori",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1315,6 +1315,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "Quale nave del catalogo è %{identifier}? Il suggerimento viene dall'export e può essere sbagliato."
       }
     }
   }

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -368,6 +368,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "Creare una nave da %{name}? Il prossimo caricamento sc_data completerà le sue meccaniche."
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -137,6 +137,9 @@
             "prices": "Prezzi"
           }
         },
+        "unlistedModels": {
+          "index": "Navi non elencate"
+        },
         "modelModulePackages": {
           "index": "Pacchetti Moduli",
           "create": "Crea Pacchetto Moduli"

--- a/app/frontend/translations/it/title.json
+++ b/app/frontend/translations/it/title.json
@@ -197,6 +197,9 @@
             "prices": "Modifica %{name} Prezzi"
           }
         },
+        "unlistedModels": {
+          "index": "Navi non elencate"
+        },
         "modelModulePackages": {
           "index": "Pacchetti Moduli Modelli"
         },

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -258,6 +258,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "清空货物"
+      },
+      "unlistedModel": {
+        "createModel": "创建飞船",
+        "markAsPaint": "这是涂装",
+        "ignore": "不是飞船",
+        "noManufacturer": "此标识符无法解析出制造商"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -262,9 +262,10 @@
       "unlistedModel": {
         "createModel": "创建飞船",
         "markAsPaint": "这是涂装",
-        "ignore": "不是飞船",
+        "ignore": "忽略",
         "noManufacturer": "此标识符无法解析出制造商",
-        "alreadyExists": "%{name} 已在目录中"
+        "alreadyExists": "%{name} 已在目录中",
+        "link": "已在目录中"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -263,7 +263,8 @@
         "createModel": "创建飞船",
         "markAsPaint": "这是涂装",
         "ignore": "不是飞船",
-        "noManufacturer": "此标识符无法解析出制造商"
+        "noManufacturer": "此标识符无法解析出制造商",
+        "alreadyExists": "%{name} 已在目录中"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -67,7 +67,8 @@
           "prices": "价格"
         },
         "unlistedModels": {
-          "index": "游戏文件中没有对应条目的飞船"
+          "index": "游戏文件中没有对应条目的飞船",
+          "link": "关联到目录中的飞船"
         },
         "manufacturers": {
           "index": "制造商",

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -66,6 +66,9 @@
           "models": "关联型号",
           "prices": "价格"
         },
+        "unlistedModels": {
+          "index": "游戏文件中没有对应条目的飞船"
+        },
         "manufacturers": {
           "index": "制造商",
           "new": "新制造商",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1310,6 +1310,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "%{identifier} 对应目录中的哪艘飞船？建议来自导出数据，可能有误。"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -368,6 +368,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "根据 %{name} 创建飞船？下次 sc_data 载入会补齐其数据。"
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -137,6 +137,9 @@
             "prices": "价格"
           }
         },
+        "unlistedModels": {
+          "index": "未收录的飞船"
+        },
         "modelModulePackages": {
           "index": "模块包",
           "create": "创建模块包"

--- a/app/frontend/translations/zh-CN/title.json
+++ b/app/frontend/translations/zh-CN/title.json
@@ -197,6 +197,9 @@
             "prices": "编辑 %{name} 价格"
           }
         },
+        "unlistedModels": {
+          "index": "未收录的飞船"
+        },
         "modelModulePackages": {
           "index": "模型模块包"
         },

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -258,6 +258,12 @@
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
         "clearCargo": "清空貨物"
+      },
+      "unlistedModel": {
+        "createModel": "建立飛船",
+        "markAsPaint": "這是塗裝",
+        "ignore": "不是飛船",
+        "noManufacturer": "此識別碼無法解析出製造商"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -262,9 +262,10 @@
       "unlistedModel": {
         "createModel": "建立飛船",
         "markAsPaint": "這是塗裝",
-        "ignore": "不是飛船",
+        "ignore": "忽略",
         "noManufacturer": "此識別碼無法解析出製造商",
-        "alreadyExists": "%{name} 已在目錄中"
+        "alreadyExists": "%{name} 已在目錄中",
+        "link": "已在目錄中"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -263,7 +263,8 @@
         "createModel": "建立飛船",
         "markAsPaint": "這是塗裝",
         "ignore": "不是飛船",
-        "noManufacturer": "此識別碼無法解析出製造商"
+        "noManufacturer": "此識別碼無法解析出製造商",
+        "alreadyExists": "%{name} 已在目錄中"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -66,6 +66,9 @@
           "models": "關聯型號",
           "prices": "價格"
         },
+        "unlistedModels": {
+          "index": "遊戲檔案中沒有對應條目的飛船"
+        },
         "manufacturers": {
           "index": "製造商",
           "new": "新製造商",

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -67,7 +67,8 @@
           "prices": "價格"
         },
         "unlistedModels": {
-          "index": "遊戲檔案中沒有對應條目的飛船"
+          "index": "遊戲檔案中沒有對應條目的飛船",
+          "link": "關聯到目錄中的飛船"
         },
         "manufacturers": {
           "index": "製造商",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1310,6 +1310,9 @@
         "scKey": "SC Key",
         "scRef": "SC Ref",
         "storeImage": "Store Image"
+      },
+      "unlistedModel": {
+        "linkHint": "%{identifier} 對應目錄中的哪艘飛船？建議來自匯出資料，可能有誤。"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -368,6 +368,9 @@
         },
         "equipment": {
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
+        },
+        "unlistedModel": {
+          "createModel": "根據 %{name} 建立飛船？下次 sc_data 載入會補齊其資料。"
         }
       },
       "oauthAuthorize": {

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -137,6 +137,9 @@
             "prices": "價格"
           }
         },
+        "unlistedModels": {
+          "index": "未收錄的飛船"
+        },
         "modelModulePackages": {
           "index": "模組包",
           "create": "建立模組包"

--- a/app/frontend/translations/zh-TW/title.json
+++ b/app/frontend/translations/zh-TW/title.json
@@ -197,6 +197,9 @@
             "prices": "編輯 %{name} 價格"
           }
         },
+        "unlistedModels": {
+          "index": "未收錄的飛船"
+        },
         "modelModulePackages": {
           "index": "模型模組套件"
         },

--- a/app/jobs/loaders/sc_data/models_job.rb
+++ b/app/jobs/loaders/sc_data/models_job.rb
@@ -20,12 +20,31 @@ module Loaders
 
         import.update!(output: {"ModelsLoader" => loader.stats})
 
+        report_unlisted_models(import)
+
         import.finish!
       rescue => e
         import.fail!
         import.update!(info: e.message)
 
         raise e
+      end
+
+      # The load only ever iterates models that already exist, so a ship in the
+      # game files with no row is invisible to it. This is what says so.
+      #
+      # Only a genuinely new entry is actionable, so the pile that has been
+      # sitting undecided does not reopen an issue on every patch.
+      private def report_unlisted_models(import)
+        result = ::ScData::UnlistedModels.new.run
+
+        AdminReport.deliver(
+          task_type: "sc_data_unlisted_models",
+          title: "Ships in the game files with no model (#{result[:new].size} new)",
+          body: ::ScData::UnlistedModels.report_body(result),
+          actionable: ::ScData::UnlistedModels.actionable?(result),
+          record: import
+        )
       end
     end
   end

--- a/app/lib/sc_data/manufacturer_mapping.rb
+++ b/app/lib/sc_data/manufacturer_mapping.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module ScData
+  # Which manufacturer a game-file identifier belongs to.
+  #
+  # Nothing in the export says. The parsed model record carries a name, a
+  # description, a career and a role, but no manufacturer -- and
+  # `belongs_to :manufacturer` on Model is required, so anything that creates a
+  # model from the game files needs this first.
+  #
+  # The identifier's prefix is the signal: `drak_caterpillar` is Drake. Both
+  # tables below were derived from the 215 models already matched to a parsed
+  # file rather than from a reading of the naming scheme, so they are evidence.
+  # Only 20 prefixes exist across the whole catalogue.
+  class ManufacturerMapping
+    # Eighteen resolve on the prefix alone. Two of them do not spell their own
+    # code: Aopoa files under `xian`, Grey's Market under `glsn`.
+    PREFIXES = {
+      "aegs" => "AEGS", "anvl" => "ANVL", "argo" => "ARGO", "banu" => "BANU",
+      "cnou" => "CNOU", "crus" => "CRUS", "drak" => "DRAK", "espr" => "ESPR",
+      "gama" => "GAMA", "glsn" => "GREY", "grin" => "GRIN", "krig" => "KRIG",
+      "mrai" => "MRAI", "misc" => "MISC", "orig" => "ORIG", "rsi" => "RSI",
+      "tmbl" => "TMBL", "vncl" => "VNCL", "xian" => "XNAA", "xnaa" => "XNAA"
+    }.freeze
+
+    # Where the prefix names the wrong company, because the export files a ship
+    # under the parent brand or under what the ship is a copy of.
+    #
+    # Mirai is MISC's sub-brand, so the Fury and the Razor ship as `misc_*`.
+    # Esperia builds replicas of Vanduul hulls, so the Blade, Glaive and Stinger
+    # ship as `vncl_*` -- while the Scythe under the same prefix really is
+    # Vanduul.
+    #
+    # Matched on the stem, so `misc_fury_lx` and `misc_fury_miru` both resolve
+    # through `misc_fury`. No stem may be a prefix of another -- a test pins
+    # that, because two overlapping stems would need an order this does not
+    # define.
+    FAMILIES = {
+      "misc_fury" => "MRAI",
+      "misc_razor" => "MRAI",
+      "vncl_blade" => "ESPR",
+      "vncl_glaive" => "ESPR",
+      "vncl_stinger" => "ESPR"
+    }.freeze
+
+    # The manufacturer code, or nil for a prefix nothing in the catalogue has
+    # used yet. Nil is a finding rather than a failure: it means the export has
+    # introduced a company, which is worth reporting rather than guessing at.
+    def self.code_for(identifier)
+      identifier = identifier.to_s.downcase
+      return if identifier.blank?
+
+      family = FAMILIES.keys.find { |stem| identifier == stem || identifier.start_with?("#{stem}_") }
+      return FAMILIES.fetch(family) if family
+
+      PREFIXES[identifier.split("_").first]
+    end
+
+    # The manufacturer itself, when we already have it. A code the export names
+    # and the catalogue does not carry resolves to nil for the same reason.
+    def self.for(identifier)
+      code = code_for(identifier)
+
+      Manufacturer.find_by(code:) if code.present?
+    end
+
+    def self.known_prefix?(identifier)
+      code_for(identifier).present?
+    end
+  end
+end

--- a/app/lib/sc_data/unlisted_models.rb
+++ b/app/lib/sc_data/unlisted_models.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+module ScData
+  # Which ships the game files describe that Fleetyards has no model for.
+  #
+  # Run at the end of a models load. Nothing here creates anything -- it records
+  # what the export showed and reports what nobody has decided about yet.
+  #
+  # There is no rule that decides these. The export says what exists and what it
+  # is made of, never whether a player can own it, and that is the only question
+  # the catalogue cares about: `aegs_idris_p_collector_military` is mechanically
+  # identical to the Idris-P and is an ownable collector version, while
+  # `aegs_reclaimer_pu_hijacked` is mechanically identical to the Reclaimer and is
+  # a mission prop. So this narrows the pile and describes each entry; a person
+  # decides.
+  class UnlistedModels
+    # What the export names an NPC copy, a wreck or a template. 733 of the 894
+    # unlisted files in the live tree carry one of these -- a single
+    # `aegs_avenger_stalker` ships seven `_pu_ai_` variants. The same idea as
+    # `WEAPON_VARIANT_KEYS`, which trims the weapon list from 175 to 133.
+    MARKERS = %w[
+      _pu_ai_ _ai_ _unmanned _template _derelict _wreck _dead _swarm _test _modifiers
+    ].freeze
+
+    def initialize(source = ::ScData::Source.current, base_folder: nil)
+      @source = source
+      @base_folder = base_folder || Rails.root.join("data/sc_data")
+    end
+
+    attr_reader :source
+
+    # Upserts a row per unlisted identifier and returns what a person still has
+    # to look at. Seeing an identifier again only moves `last_seen_*`, so a
+    # decision survives every later load.
+    def run
+      identifiers = unlisted_identifiers
+
+      identifiers.each { |identifier| record(identifier) }
+
+      {
+        seen: identifiers.size,
+        new: ScDataUnlistedModel.undecided.first_seen_in(source).where(identifier: identifiers).order(:identifier).to_a,
+        undecided: ScDataUnlistedModel.undecided.order(:identifier).to_a
+      }
+    end
+
+    # Only a genuinely new entry is worth interrupting somebody for. The pile that
+    # has been sitting undecided is reported as a count, not as a list.
+    def self.actionable?(result)
+      result[:new].present?
+    end
+
+    def self.report_body(result, source = ::ScData::Source.current)
+      lines = ["## New in #{source.environment} #{source.version} (#{result[:new].size})", ""]
+
+      if result[:new].empty?
+        lines << "Nothing the export shows is new to us."
+      else
+        result[:new].first(LISTED).each { |entry| lines << "- #{describe(entry)}" }
+        lines << "- …and #{result[:new].size - LISTED} more" if result[:new].size > LISTED
+      end
+
+      lines << ""
+      lines << "## Still undecided (#{result[:undecided].size})"
+      lines << ""
+
+      result[:undecided].group_by(&:comparison).sort_by { |_, list| -list.size }.each do |comparison, list|
+        lines << "- #{COMPARISON_LABELS.fetch(comparison, comparison)}: #{list.size}"
+      end
+
+      unknown = result[:undecided].count(&:unknown_manufacturer?)
+      if unknown.positive?
+        lines << ""
+        lines << "#{unknown} name a prefix no ship in the catalogue uses — a new company, or not a ship."
+      end
+
+      lines.join("\n")
+    end
+
+    LISTED = 25
+
+    COMPARISON_LABELS = {
+      "identical" => "identical to the ship they extend",
+      "refitted" => "same hull, different stock loadout",
+      "structural" => "a different machine",
+      "unrelated" => "no base ship in the catalogue"
+    }.freeze
+
+    def self.describe(entry)
+      parts = ["**#{entry.identifier}**"]
+      parts << entry.name if entry.name.present?
+      parts << (entry.base_model ? "#{COMPARISON_LABELS.fetch(entry.comparison, entry.comparison)} — #{entry.base_model.name}" : "no base ship")
+      parts << (entry.manufacturer_code.presence || "unknown manufacturer")
+
+      parts.join(" · ")
+    end
+
+    private
+
+    def export_path
+      Pathname(@base_folder).join("parsed", source.environment.to_s)
+    end
+
+    def parsed_identifiers
+      Dir.glob(export_path.join("models", "*.json")).map { |file| File.basename(file, ".json") }
+    end
+
+    # Everything the export ships, less what the catalogue already has and less
+    # what announces itself as not a ship.
+    def unlisted_identifiers
+      known = Model.all.filter_map(&:sc_data_identifier).to_set
+
+      parsed_identifiers.reject do |identifier|
+        known.include?(identifier) || MARKERS.any? { |marker| identifier.include?(marker) }
+      end
+    end
+
+    def record(identifier)
+      entry = ScDataUnlistedModel.find_or_initialize_by(identifier:)
+
+      if entry.new_record?
+        entry.first_seen_version = source.version
+        entry.first_seen_environment = source.environment
+      end
+
+      entry.last_seen_version = source.version
+      entry.last_seen_environment = source.environment
+
+      # Refreshed on every run rather than only on creation: a base ship the
+      # catalogue gained since, or a manufacturer the mapping learned, should
+      # show up without the row having to be deleted.
+      data = load(identifier)
+      base = base_model_for(identifier)
+
+      entry.name = data&.dig("name")
+      entry.manufacturer_code = ::ScData::ManufacturerMapping.code_for(identifier)
+      entry.base_model = base
+      entry.comparison = compare(data, base)
+
+      entry.save!
+    end
+
+    def load(identifier)
+      path = export_path.join("models", "#{identifier}.json")
+
+      JSON.parse(path.read) if path.exist?
+    end
+
+    # The longest model identifier this one extends. `anvl_ballista_ea_outlaw`
+    # resolves to the Ballista.
+    def base_model_for(identifier)
+      stem = models_by_identifier.keys.select { |known| identifier.start_with?("#{known}_") }.max_by(&:length)
+
+      models_by_identifier[stem] if stem
+    end
+
+    def models_by_identifier
+      @models_by_identifier ||= Model.all.index_by(&:sc_data_identifier).except(nil)
+    end
+
+    # Descriptive, not a verdict. `refitted` is the same hull with different
+    # components in the same ports -- which is what both a referral bonus and an
+    # in-game-only special look like.
+    def compare(data, base)
+      return "unrelated" if base.nil?
+      return if data.nil?
+
+      base_data = load(base.sc_data_identifier)
+      return if base_data.nil?
+
+      a = ports(base_data)
+      b = ports(data)
+
+      return "structural" if a.keys.sort != b.keys.sort ||
+        base_data["mass"] != data["mass"] ||
+        base_data["min_crew"] != data["min_crew"] ||
+        base_data["hull_health"] != data["hull_health"]
+
+      (a == b) ? "identical" : "refitted"
+    end
+
+    def ports(data)
+      Array(data["loadout"]).to_h { |port| [port["name"], port["ref"]] }
+    end
+  end
+end

--- a/app/lib/sc_data/unlisted_models.rb
+++ b/app/lib/sc_data/unlisted_models.rb
@@ -22,6 +22,21 @@ module ScData
       _pu_ai_ _ai_ _unmanned _template _derelict _wreck _dead _swarm _test _modifiers
     ].freeze
 
+    # The in-game vendors that sell a loadout rather than a hull. What you earn
+    # from Wikelo's Emporium or PYAM is the base ship carrying that fitting --
+    # measured across the live tree, every one of these has the same mass, crew,
+    # hull health and port list as the ship it extends, and changes only which
+    # off-the-shelf component sits in each port. Nobody owns one either: across
+    # 400 hangar syncs not a single vendor name appears.
+    #
+    # Matched on the export's display name rather than the identifier, because
+    # that is where the vendor is written -- `mrai_guardian_military` ships as
+    # "Mirai Guardian Wikelo War Special".
+    #
+    # **Only when a base ship resolves.** A vendor selling a hull the catalogue
+    # does not have would have none, and has to stay reported.
+    VENDOR_VARIANTS = /\b(wikelo|pyam)\b/i
+
     def initialize(source = ::ScData::Source.current, base_folder: nil)
       @source = source
       @base_folder = base_folder || Rails.root.join("data/sc_data")
@@ -33,9 +48,13 @@ module ScData
     # to look at. Seeing an identifier again only moves `last_seen_*`, so a
     # decision survives every later load.
     def run
-      identifiers = unlisted_identifiers
+      identifiers = unlisted_identifiers.reject { |identifier| vendor_variant?(identifier) }
 
       identifiers.each { |identifier| record(identifier) }
+
+      # A row the rule now covers stops being reported. Only undecided ones go:
+      # a decision that was already made is the record of it.
+      ScDataUnlistedModel.undecided.where.not(identifier: identifiers).delete_all
 
       {
         seen: identifiers.size,
@@ -113,6 +132,15 @@ module ScData
       parsed_identifiers.reject do |identifier|
         known.include?(identifier) || MARKERS.any? { |marker| identifier.include?(marker) }
       end
+    end
+
+    # A loadout an in-game vendor sells, on a hull the catalogue already has.
+    def vendor_variant?(identifier)
+      data = load(identifier)
+      return false if data.nil?
+      return false unless data["name"].to_s.match?(VENDOR_VARIANTS)
+
+      base_model_for(identifier).present?
     end
 
     def record(identifier)

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -53,6 +53,7 @@ class AdminNotification < ApplicationRecord
     weekly_stats: "weekly_stats",
     ship_matrix_import: "ship_matrix_import",
     sc_data_import: "sc_data_import",
+    sc_data_unlisted_models: "sc_data_unlisted_models",
     import_run: "import_run"
   }
 
@@ -117,6 +118,14 @@ class AdminNotification < ApplicationRecord
       retention: 30.days,
       access: [:models],
       icon: "fa-duotone fa-database"
+    },
+    # Ships the game files describe that we have no model for. Kept longer than
+    # the import reports around it: an undecided entry is a to-do, not a status
+    # line, and it stays true until somebody acts on it.
+    sc_data_unlisted_models: {
+      retention: 90.days,
+      access: [:models],
+      icon: "fa-duotone fa-rocket"
     },
     # The status line every other import leaves behind, at info when it
     # finished and at error when it did not.

--- a/app/models/sc_data_unlisted_model.rb
+++ b/app/models/sc_data_unlisted_model.rb
@@ -51,9 +51,10 @@ class ScDataUnlistedModel < ApplicationRecord
   # collector version and a mission prop can be mechanically identical.
   COMPARISONS = %w[identical refitted structural unrelated].freeze
 
-  # `ignored` covers everything that is not a ship somebody owns -- NPC copies
-  # the marker filter missed, props, templates. `paint` means it belongs on an
-  # existing model as a livery instead.
+  # `ignored` is for anything the catalogue should not carry, whatever the
+  # reason -- an NPC copy the marker filter missed, a prop, a template, or a ship
+  # that simply does not belong in it. `paint` means it belongs on an existing
+  # model as a livery instead.
   DECISIONS = %w[ignored model paint].freeze
 
   validates :identifier, presence: true, uniqueness: true
@@ -153,6 +154,21 @@ class ScDataUnlistedModel < ApplicationRecord
 
       created
     end
+  end
+
+  # The catalogue already has this ship, under an identifier the game files spell
+  # differently. Records which one, so the entry stops being reported and the
+  # answer is kept rather than being worked out again next patch.
+  #
+  # The model's `sc_key` is deliberately not claimed here. Only a fifth of the
+  # entries that match an existing ship *are* that ship -- the rest are variants
+  # whose export name is simply the base ship's -- and repointing a ship's
+  # identifier at a variant's file would make the loader read the wrong one.
+  def link_to_model!(target)
+    raise ArgumentError, "already decided" if decision.present?
+    raise ArgumentError, "no model given" if target.blank?
+
+    update!(decision: "model", model: target, decided_at: Time.current)
   end
 
   def decide!(decision)

--- a/app/models/sc_data_unlisted_model.rb
+++ b/app/models/sc_data_unlisted_model.rb
@@ -48,4 +48,58 @@ class ScDataUnlistedModel < ApplicationRecord
   def manufacturer
     Manufacturer.find_by(code: manufacturer_code) if manufacturer_code.present?
   end
+
+  # Turns the entry into a real model. The export gives a name; the identifier
+  # gives a manufacturer, which `belongs_to :manufacturer` requires. Nothing else
+  # is guessed -- the next sc_data load fills in the mechanics and flips
+  # `in_game`, because a parsed file exists for it by definition.
+  #
+  # Created hidden, which is the column default: an admin still has to give it
+  # images, a classification and a production status before it belongs in the
+  # public catalogue.
+  def create_model!
+    raise ArgumentError, "already decided" if decision.present?
+    raise ArgumentError, "no manufacturer for #{identifier}" if manufacturer.blank?
+
+    transaction do
+      created = Model.create!(name: name.presence || identifier, manufacturer:, sc_key: identifier)
+
+      update!(decision: "model", model: created, decided_at: Time.current)
+
+      created
+    end
+  end
+
+  def decide!(decision)
+    update!(decision:, decided_at: Time.current)
+  end
+
+  def mark_as_paint!
+    decide!("paint")
+  end
+
+  # Back to undecided, for a decision made in error. The model a `create_model`
+  # left behind is not deleted here -- deleting a ship is its own action, and a
+  # hangar entry may already point at it.
+  def reset!
+    update!(decision: nil, model: nil, decided_at: nil)
+  end
+
+  DEFAULT_SORTING_PARAMS = ["identifier asc"]
+  ALLOWED_SORTING_PARAMS = [
+    "identifier asc", "identifier desc",
+    "name asc", "name desc",
+    "comparison asc", "comparison desc",
+    "firstSeenVersion asc", "firstSeenVersion desc",
+    "createdAt asc", "createdAt desc"
+  ]
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id identifier name comparison decision manufacturer_code first_seen_version
+      last_seen_version created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[base_model model]
+  end
 end

--- a/app/models/sc_data_unlisted_model.rb
+++ b/app/models/sc_data_unlisted_model.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# A ship the game files describe that Fleetyards has no model for.
+#
+# See the migration for why these exist at all. The short version: the RSI ship
+# matrix is the only thing that creates a `Model`, so anything in the game and
+# not on the matrix is invisible, and until now nothing said so.
+class ScDataUnlistedModel < ApplicationRecord
+  # The ship it appears to be a variant of, where the identifier extends one we
+  # already carry.
+  belongs_to :base_model, class_name: "Model", optional: true
+
+  # Set once a decision turns into a model.
+  belongs_to :model, optional: true
+
+  # How the export's version compares to that base ship. Descriptive rather than
+  # a verdict: the game files never say whether a player can own something, and
+  # that is the only question the catalogue cares about. An in-game-only
+  # collector version and a mission prop can be mechanically identical.
+  COMPARISONS = %w[identical refitted structural unrelated].freeze
+
+  # `ignored` covers everything that is not a ship somebody owns -- NPC copies
+  # the marker filter missed, props, templates. `paint` means it belongs on an
+  # existing model as a livery instead.
+  DECISIONS = %w[ignored model paint].freeze
+
+  validates :identifier, presence: true, uniqueness: true
+  validates :comparison, inclusion: {in: COMPARISONS}, allow_nil: true
+  validates :decision, inclusion: {in: DECISIONS}, allow_nil: true
+
+  scope :undecided, -> { where(decision: nil) }
+  scope :decided, -> { where.not(decision: nil) }
+
+  # Everything this build showed for the first time, which is what a person
+  # actually wants to see -- as opposed to the pile that has been sitting
+  # undecided since the table was created.
+  scope :first_seen_in, ->(source = ::ScData::Source.current) {
+    where(first_seen_environment: source.environment, first_seen_version: source.version)
+  }
+
+  # The export named a prefix no ship in the catalogue uses. Either a new
+  # company, or the file is not a ship -- every unresolved identifier in the live
+  # tree today is a world object.
+  def unknown_manufacturer?
+    manufacturer_code.blank?
+  end
+
+  def manufacturer
+    Manufacturer.find_by(code: manufacturer_code) if manufacturer_code.present?
+  end
+end

--- a/app/models/sc_data_unlisted_model.rb
+++ b/app/models/sc_data_unlisted_model.rb
@@ -5,6 +5,38 @@
 # See the migration for why these exist at all. The short version: the RSI ship
 # matrix is the only thing that creates a `Model`, so anything in the game and
 # not on the matrix is invisible, and until now nothing said so.
+# == Schema Information
+#
+# Table name: sc_data_unlisted_models
+#
+#  id                     :uuid             not null, primary key
+#  comparison             :string
+#  decided_at             :datetime
+#  decision               :string
+#  first_seen_environment :string           not null
+#  first_seen_version     :string           not null
+#  identifier             :string           not null
+#  last_seen_environment  :string           not null
+#  last_seen_version      :string           not null
+#  manufacturer_code      :string
+#  name                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  base_model_id          :uuid
+#  model_id               :uuid
+#
+# Indexes
+#
+#  index_sc_data_unlisted_models_on_base_model_id  (base_model_id)
+#  index_sc_data_unlisted_models_on_decision       (decision)
+#  index_sc_data_unlisted_models_on_identifier     (identifier) UNIQUE
+#  index_sc_data_unlisted_models_on_model_id       (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (base_model_id => models.id) ON DELETE => nullify
+#  fk_rails_...  (model_id => models.id) ON DELETE => nullify
+#
 class ScDataUnlistedModel < ApplicationRecord
   # The ship it appears to be a variant of, where the identifier extends one we
   # already carry.
@@ -49,6 +81,53 @@ class ScDataUnlistedModel < ApplicationRecord
     Manufacturer.find_by(code: manufacturer_code) if manufacturer_code.present?
   end
 
+  # The name to give a model made from this entry. The export prefixes the
+  # manufacturer and Fleetyards does not -- it ships "Esperia Prowler" and
+  # "Argo MOLE" where the catalogue says "Prowler" and "MOLE". Taking the export
+  # name as-is would both break the convention and slip past Model's name
+  # uniqueness, which is scoped to the manufacturer.
+  def suggested_name
+    export_name = name.presence || identifier
+    return export_name if manufacturer.blank?
+
+    # The export writes whichever form of the company name is shortest to say --
+    # "Kruger S-65 Stingray" for Kruger Intergalactic, "Argo MOLE" for Argo
+    # Astronautics -- so the first word of the name is tried alongside the whole
+    # of it and the long form.
+    prefixes = [manufacturer.long_name, manufacturer.name, manufacturer.name.to_s.split.first]
+      .compact_blank.uniq.sort_by { |prefix| -prefix.length }
+
+    prefixes.each do |prefix|
+      stripped = export_name.sub(/\A#{Regexp.escape(prefix)}\s+/i, "")
+
+      return stripped if stripped != export_name
+    end
+
+    export_name
+  end
+
+  # A ship of that name already in the catalogue. Only 64 of 247 models carry an
+  # `sc_key`, so an existing ship whose identifier is derived from its slug never
+  # matches a game-file identifier and lands in this list anyway -- this is what
+  # stops a second one being made from it.
+  def existing_model
+    return if manufacturer.blank?
+
+    Model.find_by(manufacturer:, name: suggested_name)
+  end
+
+  # A livery of that name already on the ship this extends. Nine entries in the
+  # live tree have one -- Dunlevy, Heartseeker, Carrack Expedition, Snowblind --
+  # so the work is already done and the entry only needs marking.
+  def existing_paint
+    return if base_model.blank?
+
+    token = identifier.sub("#{base_model.sc_data_identifier}_", "").split("_").first
+    return if token.blank? || token == identifier
+
+    base_model.paints.find { |paint| paint.name.to_s.downcase.include?(token.downcase) }
+  end
+
   # Turns the entry into a real model. The export gives a name; the identifier
   # gives a manufacturer, which `belongs_to :manufacturer` requires. Nothing else
   # is guessed -- the next sc_data load fills in the mechanics and flips
@@ -61,8 +140,14 @@ class ScDataUnlistedModel < ApplicationRecord
     raise ArgumentError, "already decided" if decision.present?
     raise ArgumentError, "no manufacturer for #{identifier}" if manufacturer.blank?
 
+    # Refused rather than silently duplicated: an existing ship of this name
+    # means the entry is a variant, a livery, or the same ship under a slug the
+    # game files spell differently. Which of those it is, only a person knows.
+    existing = existing_model
+    raise ArgumentError, "#{existing.name} already exists" if existing.present?
+
     transaction do
-      created = Model.create!(name: name.presence || identifier, manufacturer:, sc_key: identifier)
+      created = Model.create!(name: suggested_name, manufacturer:, sc_key: identifier)
 
       update!(decision: "model", model: created, decided_at: Time.current)
 

--- a/app/policies/admin/sc_data_unlisted_model_policy.rb
+++ b/app/policies/admin/sc_data_unlisted_model_policy.rb
@@ -1,0 +1,7 @@
+module Admin
+  class ScDataUnlistedModelPolicy < BasePolicy
+    private def resource_access
+      [:models]
+    end
+  end
+end

--- a/app/views/admin/api/v1/sc_data_unlisted_models/_base.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/_base.jbuilder
@@ -6,6 +6,10 @@ json.id entry.id
 json.identifier entry.identifier
 json.name entry.name
 
+# The export prefixes the manufacturer and Fleetyards does not, so this is what
+# a model made from the entry would actually be called.
+json.suggested_name entry.suggested_name
+
 # How the export's version compares to the ship it extends. Descriptive rather
 # than a verdict: the game files never say whether a player can own something.
 json.comparison entry.comparison
@@ -40,6 +44,32 @@ if entry.base_model.present?
   end
 else
   json.base_model nil
+end
+
+# A ship of that name already in the catalogue. Only a quarter of models carry an
+# `sc_key`, so one whose identifier comes from its slug lands in this list even
+# though it exists -- this is what stops a second being made from it.
+existing_model = entry.existing_model
+if existing_model.present?
+  json.existing_model do
+    json.id existing_model.id
+    json.name existing_model.name
+    json.slug existing_model.slug
+  end
+else
+  json.existing_model nil
+end
+
+# The livery is already on the ship this extends, so the entry only needs marking.
+existing_paint = entry.existing_paint
+if existing_paint.present?
+  json.existing_paint do
+    json.id existing_paint.id
+    json.name existing_paint.name
+    json.slug existing_paint.slug
+  end
+else
+  json.existing_paint nil
 end
 
 if entry.model.present?

--- a/app/views/admin/api/v1/sc_data_unlisted_models/_base.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/_base.jbuilder
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+entry = sc_data_unlisted_model
+
+json.id entry.id
+json.identifier entry.identifier
+json.name entry.name
+
+# How the export's version compares to the ship it extends. Descriptive rather
+# than a verdict: the game files never say whether a player can own something.
+json.comparison entry.comparison
+json.decision entry.decision
+json.decided_at entry.decided_at
+
+json.first_seen_version entry.first_seen_version
+json.last_seen_version entry.last_seen_version
+json.environment entry.last_seen_environment
+
+json.manufacturer_code entry.manufacturer_code
+
+# Blank when the identifier names a prefix no ship in the catalogue uses -- a
+# new company, or a file that is not a ship at all.
+manufacturer = entry.manufacturer
+if manufacturer.present?
+  json.manufacturer do
+    json.id manufacturer.id
+    json.name manufacturer.name
+    json.code manufacturer.code
+    json.slug manufacturer.slug
+  end
+else
+  json.manufacturer nil
+end
+
+if entry.base_model.present?
+  json.base_model do
+    json.id entry.base_model.id
+    json.name entry.base_model.name
+    json.slug entry.base_model.slug
+  end
+else
+  json.base_model nil
+end
+
+if entry.model.present?
+  json.model do
+    json.id entry.model.id
+    json.name entry.model.name
+    json.slug entry.model.slug
+  end
+else
+  json.model nil
+end
+
+json.partial! "api/shared/dates", record: entry

--- a/app/views/admin/api/v1/sc_data_unlisted_models/_sc_data_unlisted_model.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/_sc_data_unlisted_model.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: sc_data_unlisted_model
+)

--- a/app/views/admin/api/v1/sc_data_unlisted_models/create_model.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/create_model.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: @sc_data_unlisted_model
+)

--- a/app/views/admin/api/v1/sc_data_unlisted_models/ignore.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/ignore.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: @sc_data_unlisted_model
+)

--- a/app/views/admin/api/v1/sc_data_unlisted_models/index.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/index.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array!(
+    @sc_data_unlisted_models,
+    partial: "admin/api/v1/sc_data_unlisted_models/sc_data_unlisted_model",
+    as: :sc_data_unlisted_model
+  )
+end
+json.partial! "api/shared/meta", result: @sc_data_unlisted_models

--- a/app/views/admin/api/v1/sc_data_unlisted_models/link.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/link.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: @sc_data_unlisted_model
+)

--- a/app/views/admin/api/v1/sc_data_unlisted_models/mark_as_paint.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/mark_as_paint.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: @sc_data_unlisted_model
+)

--- a/app/views/admin/api/v1/sc_data_unlisted_models/reset.jbuilder
+++ b/app/views/admin/api/v1/sc_data_unlisted_models/reset.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial!(
+  "admin/api/v1/sc_data_unlisted_models/base",
+  sc_data_unlisted_model: @sc_data_unlisted_model
+)

--- a/asyncapi/cable/admin/v1/schema.yaml
+++ b/asyncapi/cable/admin/v1/schema.yaml
@@ -125,6 +125,7 @@ components:
       - weekly_stats
       - ship_matrix_import
       - sc_data_import
+      - sc_data_unlisted_models
       - import_run
       x-enumNames:
       - PAINTS_IMPORT
@@ -138,6 +139,7 @@ components:
       - WEEKLY_STATS
       - SHIP_MATRIX_IMPORT
       - SC_DATA_IMPORT
+      - SC_DATA_UNLISTED_MODELS
       - IMPORT_RUN
     Import:
       type: object

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -2,6 +2,7 @@
 de:
   validation_error:
     sc_data_unlisted_model:
+      link: Schiff konnte nicht mit dem Katalog verknüpft werden.
       create_model: Schiff konnte nicht aus den Spieldateien angelegt werden.
     change_pasword: Passwortänderung fehlgeschlagen.
     confirmation: Bestätigung fehlgeschlagen.

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -1,6 +1,8 @@
 ---
 de:
   validation_error:
+    sc_data_unlisted_model:
+      create_model: Schiff konnte nicht aus den Spieldateien angelegt werden.
     change_pasword: Passwortänderung fehlgeschlagen.
     confirmation: Bestätigung fehlgeschlagen.
     vehicle:

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -1,6 +1,8 @@
 ---
 en:
   validation_error:
+    sc_data_unlisted_model:
+      create_model: Ship could not be created from the game files.
     change_pasword: Password Change failed.
     confirmation: Confirmation failed.
     vehicle:

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -2,6 +2,7 @@
 en:
   validation_error:
     sc_data_unlisted_model:
+      link: Ship could not be linked to the catalogue.
       create_model: Ship could not be created from the game files.
     change_pasword: Password Change failed.
     confirmation: Confirmation failed.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -1,6 +1,8 @@
 ---
 es:
   validation_error:
+    sc_data_unlisted_model:
+      create_model: No se pudo crear la nave a partir de los archivos del juego.
     change_pasword: Cambio de contraseña fallido.
     confirmation: Confirmación fallida.
     vehicle:

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -2,6 +2,7 @@
 es:
   validation_error:
     sc_data_unlisted_model:
+      link: No se pudo vincular la nave con el catálogo.
       create_model: No se pudo crear la nave a partir de los archivos del juego.
     change_pasword: Cambio de contraseña fallido.
     confirmation: Confirmación fallida.

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -98,6 +98,17 @@ v1_admin_api_routes = lambda do
     get :type_filters, on: :collection
   end
 
+  # Ships the game files describe that we have no model for. Only listed and
+  # decided on -- the rows are written by the sc_data load, never by hand.
+  resources :sc_data_unlisted_models, path: "unlisted-models", only: %i[index] do
+    member do
+      post :ignore
+      post "create-model", to: "sc_data_unlisted_models#create_model"
+      post "mark-as-paint", to: "sc_data_unlisted_models#mark_as_paint"
+      post :reset
+    end
+  end
+
   resources :fleets, only: %i[index show create update destroy] do
     collection do
       get :options

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -105,6 +105,7 @@ v1_admin_api_routes = lambda do
       post :ignore
       post "create-model", to: "sc_data_unlisted_models#create_model"
       post "mark-as-paint", to: "sc_data_unlisted_models#mark_as_paint"
+      post :link
       post :reset
     end
   end

--- a/data_link_tmp
+++ b/data_link_tmp
@@ -1,0 +1,1 @@
+/Users/mortik/dev/fleetyards/data/sc_data

--- a/db/migrate/20260828120000_create_sc_data_unlisted_models.rb
+++ b/db/migrate/20260828120000_create_sc_data_unlisted_models.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# A ship the game files describe that Fleetyards has no model for.
+#
+# The RSI ship matrix is the only thing that creates a `Model`, and the sc_data
+# loader only iterates rows that already exist. So a ship that is in the game and
+# not on the matrix -- a referral bonus, an in-game-only variant, a new hull --
+# is invisible, and nothing says so. This is the record that says so.
+#
+# A row per identifier rather than per build: the same file reappears every
+# patch, and a decision about it should only be made once.
+class CreateScDataUnlistedModels < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sc_data_unlisted_models, id: :uuid do |t|
+      t.string :identifier, null: false
+      t.string :name
+
+      # Which build first showed it, so a later run can tell a genuinely new
+      # ship from one that has been sitting undecided for months.
+      t.string :first_seen_version, null: false
+      t.string :first_seen_environment, null: false
+      t.string :last_seen_version, null: false
+      t.string :last_seen_environment, null: false
+
+      # What the export lets us work out on its own: the manufacturer from the
+      # identifier prefix, and the ship it appears to be a variant of.
+      t.string :manufacturer_code
+      t.references :base_model, type: :uuid, null: true,
+        foreign_key: {to_table: :models, on_delete: :nullify}
+
+      # How it compares to that base ship -- identical, a different stock
+      # loadout, or a different machine. Descriptive, not a verdict: the export
+      # never says whether a player can own something, which is the only
+      # question the catalogue cares about.
+      t.string :comparison
+
+      # Null while undecided. A decided row stops being reported.
+      t.string :decision
+      t.references :model, type: :uuid, null: true,
+        foreign_key: {on_delete: :nullify}
+      t.datetime :decided_at
+
+      t.timestamps
+    end
+
+    add_index :sc_data_unlisted_models, :identifier, unique: true
+    # The report asks for undecided rows on every load.
+    add_index :sc_data_unlisted_models, :decision
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1389,6 +1389,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_200000) do
     t.string "url"
   end
 
+  create_table "sc_data_unlisted_models", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "base_model_id"
+    t.string "comparison"
+    t.datetime "created_at", null: false
+    t.datetime "decided_at"
+    t.string "decision"
+    t.string "first_seen_environment", null: false
+    t.string "first_seen_version", null: false
+    t.string "identifier", null: false
+    t.string "last_seen_environment", null: false
+    t.string "last_seen_version", null: false
+    t.string "manufacturer_code"
+    t.uuid "model_id"
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.index ["base_model_id"], name: "index_sc_data_unlisted_models_on_base_model_id"
+    t.index ["decision"], name: "index_sc_data_unlisted_models_on_decision"
+    t.index ["identifier"], name: "index_sc_data_unlisted_models_on_identifier", unique: true
+    t.index ["model_id"], name: "index_sc_data_unlisted_models_on_model_id"
+  end
+
   create_table "star_citizen_updates", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "news_sub_type"
@@ -1664,6 +1685,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_200000) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "omniauth_connections", "users"
+  add_foreign_key "sc_data_unlisted_models", "models", column: "base_model_id", on_delete: :nullify
+  add_foreign_key "sc_data_unlisted_models", "models", on_delete: :nullify
   add_foreign_key "supporter_contributions", "users"
   add_foreign_key "vehicle_loadout_hardpoints", "components"
   add_foreign_key "vehicle_loadout_hardpoints", "model_hardpoints"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6629,6 +6629,57 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/unlisted-models/{id}/link":
+    parameters:
+    - name: id
+      in: path
+      description: Unlisted model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Link to a model already in the catalogue
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelLink
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ScDataUnlistedModelLinkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModel"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/unlisted-models/{id}/mark-as-paint":
     parameters:
     - name: id
@@ -14231,6 +14282,16 @@ components:
       - createdAt
       - updatedAt
       title: ScDataUnlistedModel
+    ScDataUnlistedModelLinkInput:
+      type: object
+      properties:
+        modelId:
+          type: string
+          format: uuid
+      additionalProperties: false
+      required:
+      - modelId
+      title: ScDataUnlistedModelLinkInput
     ScDataUnlistedModelQuery:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6496,6 +6496,229 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/unlisted-models":
+    get:
+      summary: Unlisted models list
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModels
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+          default: 25
+        required: false
+      - "$ref": "#/components/parameters/SortingParameter"
+      - name: q
+        in: query
+        schema:
+          "$ref": "#/components/schemas/ScDataUnlistedModelQuery"
+        style: deepObject
+        explode: true
+        required: false
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModels"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/unlisted-models/{id}/create-model":
+    parameters:
+    - name: id
+      in: path
+      description: Unlisted model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Create Model
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelCreateModel
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModel"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/unlisted-models/{id}/ignore":
+    parameters:
+    - name: id
+      in: path
+      description: Unlisted model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Ignore
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelIgnore
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModel"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/unlisted-models/{id}/mark-as-paint":
+    parameters:
+    - name: id
+      in: path
+      description: Unlisted model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Mark As Paint
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelMarkAsPaint
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModel"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/unlisted-models/{id}/reset":
+    parameters:
+    - name: id
+      in: path
+      description: Unlisted model id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    post:
+      summary: Reset
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelReset
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataUnlistedModel"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/users":
     get:
       summary: Users list
@@ -7596,6 +7819,7 @@ components:
       - weekly_stats
       - ship_matrix_import
       - sc_data_import
+      - sc_data_unlisted_models
       - import_run
       x-enumNames:
       - PAINTS_IMPORT
@@ -7609,6 +7833,7 @@ components:
       - WEEKLY_STATS
       - SHIP_MATRIX_IMPORT
       - SC_DATA_IMPORT
+      - SC_DATA_UNLISTED_MODELS
       - IMPORT_RUN
       title: AdminNotificationTypeEnum
     AdminNotificationUnreadCount:
@@ -11084,6 +11309,28 @@ components:
       additionalProperties: false
       example: {}
       title: ManufacturerQuery
+    ManufacturerRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type:
+          - string
+          - 'null'
+        code:
+          type:
+          - string
+          - 'null'
+        slug:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      required:
+      - id
+      title: ManufacturerRef
     ManufacturerSortEnum:
       type: string
       enum:
@@ -13914,6 +14161,128 @@ components:
       - meta
       - items
       title: RsiRequestLogs
+    ScDataUnlistedModel:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+        name:
+          type:
+          - string
+          - 'null'
+        comparison:
+          "$ref": "#/components/schemas/UnlistedModelComparisonEnum"
+        decision:
+          "$ref": "#/components/schemas/UnlistedModelDecisionEnum"
+        decidedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        firstSeenVersion:
+          type: string
+        lastSeenVersion:
+          type: string
+        environment:
+          type: string
+        manufacturerCode:
+          type:
+          - string
+          - 'null'
+        manufacturer:
+          oneOf:
+          - "$ref": "#/components/schemas/ManufacturerRef"
+          - type: 'null'
+        baseModel:
+          oneOf:
+          - "$ref": "#/components/schemas/ModelRef"
+          - type: 'null'
+        model:
+          oneOf:
+          - "$ref": "#/components/schemas/ModelRef"
+          - type: 'null'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - identifier
+      - firstSeenVersion
+      - lastSeenVersion
+      - environment
+      - createdAt
+      - updatedAt
+      title: ScDataUnlistedModel
+    ScDataUnlistedModelQuery:
+      type: object
+      properties:
+        identifierCont:
+          type: string
+        nameCont:
+          type: string
+        comparisonEq:
+          "$ref": "#/components/schemas/UnlistedModelComparisonEnum"
+        manufacturerCodeEq:
+          type: string
+        decisionEq:
+          "$ref": "#/components/schemas/UnlistedModelDecisionEnum"
+        decisionNull:
+          type: boolean
+        sorts:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ScDataUnlistedModelSortEnum"
+          - "$ref": "#/components/schemas/ScDataUnlistedModelSortEnum"
+      additionalProperties: false
+      example: {}
+      title: ScDataUnlistedModelQuery
+    ScDataUnlistedModelSortEnum:
+      type: string
+      enum:
+      - identifier asc
+      - identifier desc
+      - name asc
+      - name desc
+      - comparison asc
+      - comparison desc
+      - firstSeenVersion asc
+      - firstSeenVersion desc
+      - createdAt asc
+      - createdAt desc
+      x-enumNames:
+      - IDENTIFIER_ASC
+      - IDENTIFIER_DESC
+      - NAME_ASC
+      - NAME_DESC
+      - COMPARISON_ASC
+      - COMPARISON_DESC
+      - FIRST_SEEN_VERSION_ASC
+      - FIRST_SEEN_VERSION_DESC
+      - CREATED_AT_ASC
+      - CREATED_AT_DESC
+      title: ScDataUnlistedModelSortEnum
+    ScDataUnlistedModels:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ScDataUnlistedModel"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: ScDataUnlistedModels
     SessionInput:
       type: object
       properties:
@@ -14216,6 +14585,27 @@ components:
       - VTOL
       - MAV
       title: ThrusterClassEnum
+    UnlistedModelComparisonEnum:
+      type:
+      - string
+      - 'null'
+      enum:
+      - identical
+      - refitted
+      - structural
+      - unrelated
+      -
+      title: UnlistedModelComparisonEnum
+    UnlistedModelDecisionEnum:
+      type:
+      - string
+      - 'null'
+      enum:
+      - ignored
+      - model
+      - paint
+      -
+      title: UnlistedModelDecisionEnum
     User:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -14173,6 +14173,8 @@ components:
           type:
           - string
           - 'null'
+        suggestedName:
+          type: string
         comparison:
           "$ref": "#/components/schemas/UnlistedModelComparisonEnum"
         decision:
@@ -14200,6 +14202,14 @@ components:
           oneOf:
           - "$ref": "#/components/schemas/ModelRef"
           - type: 'null'
+        existingModel:
+          oneOf:
+          - "$ref": "#/components/schemas/ModelRef"
+          - type: 'null'
+        existingPaint:
+          oneOf:
+          - "$ref": "#/components/schemas/ModelRef"
+          - type: 'null'
         model:
           oneOf:
           - "$ref": "#/components/schemas/ModelRef"
@@ -14214,6 +14224,7 @@ components:
       required:
       - id
       - identifier
+      - suggestedName
       - firstSeenVersion
       - lastSeenVersion
       - environment

--- a/test/factories/sc_data_unlisted_models.rb
+++ b/test/factories/sc_data_unlisted_models.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sc_data_unlisted_models
+#
+#  id                     :uuid             not null, primary key
+#  comparison             :string
+#  decided_at             :datetime
+#  decision               :string
+#  first_seen_environment :string           not null
+#  first_seen_version     :string           not null
+#  identifier             :string           not null
+#  last_seen_environment  :string           not null
+#  last_seen_version      :string           not null
+#  manufacturer_code      :string
+#  name                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  base_model_id          :uuid
+#  model_id               :uuid
+#
+# Indexes
+#
+#  index_sc_data_unlisted_models_on_base_model_id  (base_model_id)
+#  index_sc_data_unlisted_models_on_decision       (decision)
+#  index_sc_data_unlisted_models_on_identifier     (identifier) UNIQUE
+#  index_sc_data_unlisted_models_on_model_id       (model_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (base_model_id => models.id) ON DELETE => nullify
+#  fk_rails_...  (model_id => models.id) ON DELETE => nullify
+#
 FactoryBot.define do
   factory :sc_data_unlisted_model do
     sequence(:identifier) { |n| "drak_newhull_#{n}" }

--- a/test/factories/sc_data_unlisted_models.rb
+++ b/test/factories/sc_data_unlisted_models.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :sc_data_unlisted_model do
+    sequence(:identifier) { |n| "drak_newhull_#{n}" }
+    name { "Drake Newhull" }
+    manufacturer_code { "DRAK" }
+    comparison { "unrelated" }
+
+    first_seen_version { ScData::Source.version }
+    first_seen_environment { ScData::Source.environment }
+    last_seen_version { ScData::Source.version }
+    last_seen_environment { ScData::Source.environment }
+
+    trait :decided do
+      decision { "ignored" }
+      decided_at { Time.current }
+    end
+  end
+end

--- a/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
+++ b/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
@@ -37,6 +37,40 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  api_path "/unlisted-models/{id}/link" do
+    parameter name: "id", in: :path, description: "Unlisted model id",
+      schema: {type: :string, format: :uuid}, required: true
+
+    post("Link to a model already in the catalogue") do
+      operationId "scDataUnlistedModelLink"
+      tags "ScDataUnlistedModels"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::ScDataUnlistedModelLinkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::ScDataUnlistedModel
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
   %w[ignore mark-as-paint create-model reset].each do |action|
     api_path "/unlisted-models/{id}/#{action}" do
       parameter name: "id", in: :path, description: "Unlisted model id",
@@ -252,5 +286,58 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     assert_api_response :post, 404, path_params: {id: SecureRandom.uuid}, api_path: "/unlisted-models/{id}/ignore"
+  end
+
+  # The answer to "it is already in the catalogue, under a name the game files
+  # spell differently". Without it the entry comes back every patch.
+  test "POST link records which ship in the catalogue it already is" do
+    existing = create(:model, name: "S-65 Stingray")
+
+    sign_in @user
+
+    assert_no_difference("Model.count") do
+      assert_api_response :post, 200,
+        path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/link",
+        body: {modelId: existing.id} do
+        assert_equal "model", parsed_body["decision"]
+        assert_equal "S-65 Stingray", parsed_body.dig("model", "name")
+      end
+    end
+
+    assert_equal existing, @entry.reload.model
+    assert_empty ScDataUnlistedModel.undecided
+  end
+
+  # Repointing a ship's identifier at a variant's file would make the loader read
+  # the wrong one, so linking records the answer and leaves `sc_key` alone.
+  test "POST link leaves the linked ship's own identifier alone" do
+    existing = create(:model, name: "S-65 Stingray", sc_key: nil)
+
+    sign_in @user
+
+    assert_api_response :post, 200,
+      path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/link",
+      body: {modelId: existing.id}
+
+    assert_nil existing.reload.sc_key
+  end
+
+  test "POST link refuses a second decision" do
+    existing = create(:model, name: "S-65 Stingray")
+    @entry.decide!("ignored")
+
+    sign_in @user
+
+    assert_api_response :post, 400,
+      path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/link",
+      body: {modelId: existing.id}
+  end
+
+  test "POST link reports a model that is not there" do
+    sign_in @user
+
+    assert_api_response :post, 404,
+      path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/link",
+      body: {modelId: SecureRandom.uuid}
   end
 end

--- a/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
+++ b/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
@@ -137,7 +137,7 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     assert_difference("Model.count", 1) do
       assert_api_response :post, 200, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/create-model" do
         assert_equal "model", parsed_body["decision"]
-        assert_equal "Kruger S-65 Stingray", parsed_body.dig("model", "name")
+        assert_equal "S-65 Stingray", parsed_body.dig("model", "name")
       end
     end
 
@@ -145,6 +145,60 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     assert_equal "krig_s65_stingray", model.sc_key
     assert_equal "KRIG", model.manufacturer.code
     assert_predicate model, :hidden?, "a new ship stays out of the catalogue until an admin fills it in"
+  end
+
+  # The export writes "Kruger S-65 Stingray" where the catalogue says
+  # "S-65 Stingray". Taking the export name as-is would break the convention and
+  # slip past Model's name uniqueness, which is scoped to the manufacturer.
+  test "the suggested name drops the manufacturer the export prefixes" do
+    create(:manufacturer, code: "KRIG", name: "Kruger Intergalactic")
+
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      entry = parsed_body["items"].find { |item| item["identifier"] == "krig_s65_stingray" }
+
+      assert_equal "S-65 Stingray", entry["suggestedName"]
+    end
+  end
+
+  # Only a quarter of models carry an `sc_key`, so a ship whose identifier comes
+  # from its slug lands in this list even though the catalogue has it.
+  test "POST create-model refuses when a ship of that name already exists" do
+    manufacturer = create(:manufacturer, code: "KRIG", name: "Kruger Intergalactic")
+    existing = create(:model, manufacturer:, name: "S-65 Stingray")
+
+    assert_no_difference("Model.count") do
+      sign_in @user
+
+      assert_api_response :post, 400,
+        path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/create-model"
+    end
+
+    assert_predicate @entry.reload.decision, :blank?
+    assert_equal existing, @entry.existing_model
+  end
+
+  test "the list names the ship and the paint already in the catalogue" do
+    manufacturer = create(:manufacturer, code: "KRIG", name: "Kruger Intergalactic")
+    create(:model, manufacturer:, name: "S-65 Stingray")
+
+    base = create(:model, name: "Gladius", sc_key: "aegs_gladius")
+    paint = create(:model_paint, model: base, name: "Dunlevy")
+    create(
+      :sc_data_unlisted_model,
+      identifier: "aegs_gladius_dunlevy", name: "Aegis Gladius Dunlevy",
+      manufacturer_code: "AEGS", base_model: base, comparison: "refitted"
+    )
+
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      items = parsed_body["items"].index_by { |item| item["identifier"] }
+
+      assert_equal "S-65 Stingray", items["krig_s65_stingray"].dig("existingModel", "name")
+      assert_equal paint.name, items["aegs_gladius_dunlevy"].dig("existingPaint", "name")
+    end
   end
 
   # `belongs_to :manufacturer` is required, and an unresolved prefix means either

--- a/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
+++ b/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/unlisted-models" do
+    get("Unlisted models list") do
+      operationId "scDataUnlistedModels"
+      tags "ScDataUnlistedModels"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query,
+        schema: {type: :string, default: ScDataUnlistedModel.default_per_page}, required: false
+      parameter "$ref": "#/components/parameters/SortingParameter"
+      parameter name: "q", in: :query,
+        schema: ::Admin::V1::Schemas::Queries::ScDataUnlistedModelQuery,
+        style: :deepObject,
+        explode: true,
+        required: false
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::ScDataUnlistedModels::ScDataUnlistedModels
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  %w[ignore mark-as-paint create-model reset].each do |action|
+    api_path "/unlisted-models/{id}/#{action}" do
+      parameter name: "id", in: :path, description: "Unlisted model id",
+        schema: {type: :string, format: :uuid}, required: true
+
+      post(action.tr("-", " ").titleize) do
+        operationId "scDataUnlistedModel#{action.tr("-", "_").camelize}"
+        tags "ScDataUnlistedModels"
+        produces "application/json"
+
+        response(200, "successful") do
+          schema ::Admin::V1::Schemas::ScDataUnlistedModel
+        end
+
+        response(400, "bad request") do
+          schema ::Shared::V1::Schemas::ValidationError
+        end
+
+        response(404, "not found") do
+          schema ::Shared::V1::Schemas::StandardError
+        end
+
+        response(403, "forbidden") do
+          schema ::Shared::V1::Schemas::StandardError
+        end
+
+        response(401, "unauthorized") do
+          schema ::Shared::V1::Schemas::StandardError
+        end
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:models])
+    @entry = create(
+      :sc_data_unlisted_model,
+      identifier: "krig_s65_stingray", name: "Kruger S-65 Stingray", manufacturer_code: "KRIG"
+    )
+  end
+
+  test "GET /unlisted-models lists what nobody has decided about" do
+    decided = create(:sc_data_unlisted_model, :decided)
+
+    sign_in @user
+
+    assert_api_response :get, 200 do
+      identifiers = parsed_body["items"].map { |item| item["identifier"] }
+
+      assert_includes identifiers, "krig_s65_stingray"
+      assert_not_includes identifiers, decided.identifier
+    end
+  end
+
+  test "GET /unlisted-models reaches the decided ones when asked" do
+    decided = create(:sc_data_unlisted_model, :decided)
+
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"decisionEq" => "ignored"}} do
+      assert_equal [decided.identifier], parsed_body["items"].map { |item| item["identifier"] }
+    end
+  end
+
+  test "GET /unlisted-models needs the models privilege" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403
+  end
+
+  test "GET /unlisted-models is not public" do
+    assert_api_response :get, 401
+  end
+
+  test "POST ignore records the decision and drops it from the list" do
+    sign_in @user
+    assert_api_response :post, 200, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/ignore" do
+      assert_equal "ignored", parsed_body["decision"]
+    end
+
+    assert_predicate @entry.reload.decision, :present?
+    assert_empty ScDataUnlistedModel.undecided
+  end
+
+  test "POST mark-as-paint records that it belongs on an existing model" do
+    sign_in @user
+    assert_api_response :post, 200, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/mark-as-paint" do
+      assert_equal "paint", parsed_body["decision"]
+    end
+  end
+
+  # The export gives a name, the identifier gives a manufacturer, and nothing
+  # else is guessed -- the next load fills in the mechanics.
+  test "POST create-model creates the ship and links it" do
+    sign_in @user
+    create(:manufacturer, code: "KRIG", name: "Kruger Intergalactic")
+
+    assert_difference("Model.count", 1) do
+      assert_api_response :post, 200, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/create-model" do
+        assert_equal "model", parsed_body["decision"]
+        assert_equal "Kruger S-65 Stingray", parsed_body.dig("model", "name")
+      end
+    end
+
+    model = @entry.reload.model
+    assert_equal "krig_s65_stingray", model.sc_key
+    assert_equal "KRIG", model.manufacturer.code
+    assert_predicate model, :hidden?, "a new ship stays out of the catalogue until an admin fills it in"
+  end
+
+  # `belongs_to :manufacturer` is required, and an unresolved prefix means either
+  # a new company or a file that is not a ship.
+  test "POST create-model refuses when the prefix resolves to no manufacturer" do
+    sign_in @user
+    orphan = create(:sc_data_unlisted_model, identifier: "orbital_sentry_pu_uee", manufacturer_code: nil)
+
+    assert_no_difference("Model.count") do
+      assert_api_response :post, 400, path_params: {id: orphan.id}, api_path: "/unlisted-models/{id}/create-model"
+    end
+  end
+
+  test "POST create-model refuses a second time" do
+    sign_in @user
+    create(:manufacturer, code: "KRIG")
+    @entry.create_model!
+
+    assert_no_difference("Model.count") do
+      assert_api_response :post, 400, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/create-model"
+    end
+  end
+
+  # The model a create left behind stays: deleting a ship is its own action, and
+  # a hangar entry may already point at it.
+  test "POST reset returns it to the list without deleting the model" do
+    sign_in @user
+    create(:manufacturer, code: "KRIG")
+    @entry.create_model!
+
+    assert_no_difference("Model.count") do
+      assert_api_response :post, 200, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/reset" do
+        assert_nil parsed_body["decision"]
+      end
+    end
+
+    assert_includes ScDataUnlistedModel.undecided, @entry.reload
+  end
+
+  test "POST ignore needs the models privilege" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :post, 403, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/ignore"
+  end
+
+  test "POST ignore is not public" do
+    assert_api_response :post, 401, path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/ignore"
+  end
+
+  test "POST ignore reports a missing entry" do
+    sign_in @user
+
+    assert_api_response :post, 404, path_params: {id: SecureRandom.uuid}, api_path: "/unlisted-models/{id}/ignore"
+  end
+end

--- a/test/jobs/loaders/sc_data/models_job_test.rb
+++ b/test/jobs/loaders/sc_data/models_job_test.rb
@@ -20,6 +20,57 @@ module Loaders
         )
       end
 
+      # The load only iterates models that already exist, so a ship in the game
+      # files with no row is invisible to it. These pin that the job says so.
+      test "#perform reports the ships the game files describe and we have no model for" do
+        @admin_user = create(:admin_user, resource_access: [:models])
+        AdminNotificationsChannel.stubs(:broadcast_to)
+        SC_DATA_STUB.call
+        ::ScData::Loader::ModelsLoader.any_instance.stubs(:all)
+        ::ScData::Loader::ModelsLoader.any_instance.stubs(:stats).returns({})
+        ::Loaders::ScData::ModelsJob.any_instance.stubs(:fetch_parsed_tree!)
+
+        entry = create(:sc_data_unlisted_model, identifier: "krig_s65_stingray", name: "Kruger S-65 Stingray")
+        ::ScData::UnlistedModels.any_instance.stubs(:run)
+          .returns({seen: 1, new: [entry], undecided: [entry]})
+
+        creator = mock("GithubIssueCreator")
+        creator.expects(:run)
+        GithubIssueCreator.stubs(:new).returns(creator)
+
+        ::Loaders::ScData::ModelsJob.new.perform
+
+        notification = AdminNotification.find_by(
+          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
+        )
+        assert_not_nil notification
+        assert_equal "warning", notification.severity
+        assert_includes notification.body, "krig_s65_stingray"
+      end
+
+      # Only a genuinely new entry is worth an issue, or a pile that has been
+      # sitting undecided would reopen one on every patch.
+      test "#perform opens no issue when nothing is new" do
+        @admin_user = create(:admin_user, resource_access: [:models])
+        AdminNotificationsChannel.stubs(:broadcast_to)
+        SC_DATA_STUB.call
+        ::ScData::Loader::ModelsLoader.any_instance.stubs(:all)
+        ::ScData::Loader::ModelsLoader.any_instance.stubs(:stats).returns({})
+        ::Loaders::ScData::ModelsJob.any_instance.stubs(:fetch_parsed_tree!)
+
+        entry = create(:sc_data_unlisted_model)
+        ::ScData::UnlistedModels.any_instance.stubs(:run)
+          .returns({seen: 1, new: [], undecided: [entry]})
+        GithubIssueCreator.expects(:new).never
+
+        ::Loaders::ScData::ModelsJob.new.perform
+
+        notification = AdminNotification.find_by(
+          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
+        )
+        assert_equal "info", notification.severity
+      end
+
       test "#perform marks import as failed on error" do
         assert_import_wrapping_job_failure(
           job_class: ::Loaders::ScData::ModelsJob,

--- a/test/lib/sc_data/manufacturer_mapping_test.rb
+++ b/test/lib/sc_data/manufacturer_mapping_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ScData::ManufacturerMappingTest < ActiveSupport::TestCase
+  test "resolves a manufacturer from the identifier prefix" do
+    assert_equal "DRAK", ScData::ManufacturerMapping.code_for("drak_caterpillar")
+    assert_equal "AEGS", ScData::ManufacturerMapping.code_for("aegs_gladius_dunlevy")
+    assert_equal "RSI", ScData::ManufacturerMapping.code_for("rsi_apollo_medivac_tier_1")
+  end
+
+  # Two prefixes do not spell their own code, which is the whole reason a table
+  # exists rather than an upcase of the prefix.
+  test "resolves the two prefixes that do not spell their own code" do
+    assert_equal "XNAA", ScData::ManufacturerMapping.code_for("xian_scout")
+    assert_equal "GREY", ScData::ManufacturerMapping.code_for("glsn_shiv")
+  end
+
+  # Mirai is MISC's sub-brand, so the Fury files under `misc_`.
+  test "a family wins over the prefix" do
+    assert_equal "MRAI", ScData::ManufacturerMapping.code_for("misc_fury")
+    assert_equal "MISC", ScData::ManufacturerMapping.code_for("misc_freelancer")
+  end
+
+  test "a family covers the variants beneath it" do
+    assert_equal "MRAI", ScData::ManufacturerMapping.code_for("misc_fury_lx")
+    assert_equal "MRAI", ScData::ManufacturerMapping.code_for("misc_fury_miru")
+    assert_equal "MRAI", ScData::ManufacturerMapping.code_for("misc_razor_ex")
+  end
+
+  # Esperia builds replicas of Vanduul hulls under the Vanduul prefix -- but the
+  # Scythe under that same prefix really is Vanduul.
+  test "a family does not capture its prefix siblings" do
+    assert_equal "ESPR", ScData::ManufacturerMapping.code_for("vncl_glaive")
+    assert_equal "VNCL", ScData::ManufacturerMapping.code_for("vncl_scythe")
+  end
+
+  test "a prefix the family only resembles is not a match" do
+    assert_equal "MISC", ScData::ManufacturerMapping.code_for("misc_furyx")
+  end
+
+  # An unknown prefix is a finding, not a failure: the export has introduced a
+  # company, or the file is not a ship at all. Every unresolved identifier in the
+  # live tree is a world object -- orbital sentries, comm probes, a satellite.
+  test "an unknown prefix resolves to nothing rather than a guess" do
+    assert_nil ScData::ManufacturerMapping.code_for("orbital_sentry_pu_uee")
+    assert_nil ScData::ManufacturerMapping.code_for("probe_comms_1_a")
+    assert_nil ScData::ManufacturerMapping.code_for("newco_wonderfulship")
+  end
+
+  test "handles a blank identifier" do
+    assert_nil ScData::ManufacturerMapping.code_for(nil)
+    assert_nil ScData::ManufacturerMapping.code_for("")
+  end
+
+  test ".for returns the manufacturer itself" do
+    manufacturer = create(:manufacturer, code: "DRAK")
+
+    assert_equal manufacturer, ScData::ManufacturerMapping.for("drak_caterpillar")
+  end
+
+  test ".for returns nothing for a code the catalogue does not carry" do
+    assert_nil ScData::ManufacturerMapping.for("banu_defender")
+  end
+
+  # A family whose code matches what its prefix already gives is dead weight, and
+  # one whose prefix is missing from the table would resolve by accident.
+  test "every family earns its entry" do
+    ScData::ManufacturerMapping::FAMILIES.each do |stem, code|
+      prefix = stem.split("_").first
+
+      assert_includes ScData::ManufacturerMapping::PREFIXES, prefix,
+        "#{stem} names a prefix the table does not carry"
+      assert_not_equal ScData::ManufacturerMapping::PREFIXES[prefix], code,
+        "#{stem} resolves to what its prefix already gives"
+    end
+  end
+
+  # The lookup takes the first stem that matches, which is only unambiguous while
+  # no stem sits beneath another. If that ever stops being true, the lookup needs
+  # an order before the new entry can be trusted.
+  test "no family stem sits beneath another" do
+    stems = ScData::ManufacturerMapping::FAMILIES.keys
+
+    stems.combination(2).each do |a, b|
+      assert_not a.start_with?("#{b}_"), "#{a} sits beneath #{b}"
+      assert_not b.start_with?("#{a}_"), "#{b} sits beneath #{a}"
+    end
+  end
+end

--- a/test/lib/sc_data/unlisted_models_test.rb
+++ b/test/lib/sc_data/unlisted_models_test.rb
@@ -110,6 +110,61 @@ class ScData::UnlistedModelsTest < ActiveSupport::TestCase
     assert_equal "structural", ScDataUnlistedModel.find_by(identifier: "argo_atls_ikti").comparison
   end
 
+  # What you earn from Wikelo's Emporium or PYAM is the base ship carrying that
+  # fitting, not a second ship. The vendor is written in the display name rather
+  # than the identifier.
+  test "leaves out a loadout an in-game vendor sells on a hull we already have" do
+    create(:model, sc_key: "mrai_guardian", name: "Guardian")
+    write_ship("mrai_guardian")
+    write_ship("mrai_guardian_military", name: "Mirai Guardian Wikelo War Special")
+    write_ship("drak_corsair_exec_military", name: "Corsair PYAM Exec")
+    create(:model, sc_key: "drak_corsair", name: "Corsair")
+    write_ship("drak_corsair")
+
+    result = run_detector
+
+    assert_equal 0, result[:seen]
+    assert_empty ScDataUnlistedModel.all
+  end
+
+  # The safety valve: a vendor selling a hull the catalogue does not have has no
+  # base ship, and has to stay reported.
+  test "still reports a vendor ship with no base ship in the catalogue" do
+    write_ship("krig_newhull_collector_mod", name: "Kruger Newhull Wikelo Special")
+
+    assert_equal 1, run_detector[:seen]
+    assert_equal "krig_newhull_collector_mod", ScDataUnlistedModel.sole.identifier
+  end
+
+  test "a row the vendor rule now covers stops being reported" do
+    create(:model, sc_key: "mrai_guardian", name: "Guardian")
+    write_ship("mrai_guardian")
+    write_ship("mrai_guardian_military", name: "Mirai Guardian")
+    run_detector
+
+    assert_equal 1, ScDataUnlistedModel.count
+
+    write_ship("mrai_guardian_military", name: "Mirai Guardian Wikelo War Special")
+
+    assert_empty run_detector[:undecided]
+    assert_empty ScDataUnlistedModel.all
+  end
+
+  # A decision already made is the record of it, whatever a later rule says.
+  test "a decided row survives a rule that would now exclude it" do
+    create(:model, sc_key: "mrai_guardian", name: "Guardian")
+    write_ship("mrai_guardian")
+    write_ship("mrai_guardian_military", name: "Mirai Guardian")
+    run_detector
+    ScDataUnlistedModel.sole.decide!("ignored")
+
+    write_ship("mrai_guardian_military", name: "Mirai Guardian Wikelo War Special")
+    run_detector
+
+    assert_equal 1, ScDataUnlistedModel.count
+    assert_equal "ignored", ScDataUnlistedModel.sole.decision
+  end
+
   # Every unresolved identifier in the live tree today is a world object -- an
   # orbital sentry, a comm probe, a satellite.
   test "records no manufacturer for a prefix no ship in the catalogue uses" do

--- a/test/lib/sc_data/unlisted_models_test.rb
+++ b/test/lib/sc_data/unlisted_models_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ScData::UnlistedModelsTest < ActiveSupport::TestCase
+  setup do
+    @dir = Dir.mktmpdir
+    @source = ScData::Source.new(version: "1.0.0", environment: "live")
+    FileUtils.mkdir_p(models_path)
+  end
+
+  teardown do
+    FileUtils.remove_entry(@dir)
+  end
+
+  def models_path
+    File.join(@dir, "parsed", "live", "models")
+  end
+
+  def write_ship(identifier, name: identifier.titleize, mass: 1_000.0, crew: "1", ports: {})
+    File.write(
+      File.join(models_path, "#{identifier}.json"),
+      JSON.dump(
+        "name" => name, "mass" => mass, "min_crew" => crew, "hull_health" => 500.0,
+        "loadout" => ports.map { |port, ref| {"name" => port, "ref" => ref} }
+      )
+    )
+  end
+
+  def run_detector
+    ScData::UnlistedModels.new(@source, base_folder: @dir).run
+  end
+
+  test "reports a ship the export describes and the catalogue has no model for" do
+    write_ship("drak_newhull", name: "Drake Newhull")
+
+    result = run_detector
+
+    assert_equal 1, result[:seen]
+    entry = ScDataUnlistedModel.sole
+    assert_equal "drak_newhull", entry.identifier
+    assert_equal "Drake Newhull", entry.name
+    assert_equal "DRAK", entry.manufacturer_code
+    assert_equal "unrelated", entry.comparison
+    assert_equal "1.0.0", entry.first_seen_version
+  end
+
+  test "leaves out a ship the catalogue already has" do
+    create(:model, sc_key: "drak_caterpillar")
+    write_ship("drak_caterpillar")
+
+    assert_equal 0, run_detector[:seen]
+    assert_empty ScDataUnlistedModel.all
+  end
+
+  # 733 of the 894 unlisted files in the live tree carry one of these.
+  test "leaves out what the export names an NPC copy or a template" do
+    %w[aegs_avenger_pu_ai_civ aegs_avenger_ai_template drak_cutlass_unmanned_ff rsi_x_wreck].each do |identifier|
+      write_ship(identifier)
+    end
+
+    assert_equal 0, run_detector[:seen]
+  end
+
+  test "resolves the ship a variant extends, and how it compares" do
+    create(:model, sc_key: "aegs_gladius", name: "Gladius")
+    write_ship("aegs_gladius", ports: {"powerplant" => "a", "cooler" => "b"})
+    write_ship("aegs_gladius_dunlevy", ports: {"powerplant" => "z", "cooler" => "b"})
+
+    run_detector
+
+    entry = ScDataUnlistedModel.find_by(identifier: "aegs_gladius_dunlevy")
+    assert_equal "Gladius", entry.base_model.name
+    assert_equal "refitted", entry.comparison
+  end
+
+  # A base ship can itself sit beneath another: `misc_freelancer` and
+  # `misc_freelancer_dur` are both models, so a variant of the DUR must not
+  # resolve to the plain Freelancer.
+  test "resolves the most specific base ship, not the first that fits" do
+    create(:model, sc_key: "aegs_gladius", name: "Gladius")
+    create(:model, sc_key: "aegs_gladius_valiant", name: "Gladius Valiant")
+    write_ship("aegs_gladius")
+    write_ship("aegs_gladius_valiant")
+    write_ship("aegs_gladius_valiant_showdown")
+
+    run_detector
+
+    entry = ScDataUnlistedModel.find_by(identifier: "aegs_gladius_valiant_showdown")
+    assert_equal "Gladius Valiant", entry.base_model.name
+  end
+
+  test "calls a variant identical when every port carries the same item" do
+    create(:model, sc_key: "aegs_gladius", name: "Gladius")
+    write_ship("aegs_gladius", ports: {"powerplant" => "a"})
+    write_ship("aegs_gladius_showdown", ports: {"powerplant" => "a"})
+
+    run_detector
+
+    assert_equal "identical", ScDataUnlistedModel.find_by(identifier: "aegs_gladius_showdown").comparison
+  end
+
+  test "calls a variant structural when a port or a number moved" do
+    create(:model, sc_key: "argo_atls", name: "ATLS")
+    write_ship("argo_atls", mass: 1_440.0, ports: {"seat" => "a"})
+    write_ship("argo_atls_ikti", mass: 1_800.0, ports: {"seat" => "a", "radar" => "b"})
+
+    run_detector
+
+    assert_equal "structural", ScDataUnlistedModel.find_by(identifier: "argo_atls_ikti").comparison
+  end
+
+  # Every unresolved identifier in the live tree today is a world object -- an
+  # orbital sentry, a comm probe, a satellite.
+  test "records no manufacturer for a prefix no ship in the catalogue uses" do
+    write_ship("orbital_sentry_pu_uee", name: "Orbital Sentry")
+
+    run_detector
+
+    entry = ScDataUnlistedModel.sole
+    assert_nil entry.manufacturer_code
+    assert_predicate entry, :unknown_manufacturer?
+  end
+
+  test "seeing the same ship again neither duplicates it nor makes it new" do
+    write_ship("drak_newhull")
+    run_detector
+
+    later = ScData::UnlistedModels.new(
+      ScData::Source.new(version: "1.0.1", environment: "live"), base_folder: @dir
+    )
+    # The tree is read per environment, so the newer build reads the same files.
+    result = later.run
+
+    entry = ScDataUnlistedModel.sole
+    assert_equal "1.0.0", entry.first_seen_version
+    assert_equal "1.0.1", entry.last_seen_version
+    assert_empty result[:new], "a ship seen in an earlier build is not new"
+    assert_equal 1, result[:undecided].size
+  end
+
+  test "a decided ship stops being reported" do
+    write_ship("drak_newhull")
+    run_detector
+
+    ScDataUnlistedModel.sole.update!(decision: "ignored", decided_at: Time.current)
+
+    result = run_detector
+    assert_empty result[:undecided]
+    assert_equal 1, ScDataUnlistedModel.count
+  end
+
+  test "refreshes the base ship when the catalogue gains one" do
+    write_ship("aegs_gladius", ports: {"powerplant" => "a"})
+    write_ship("aegs_gladius_dunlevy", ports: {"powerplant" => "a"})
+    run_detector
+
+    assert_nil ScDataUnlistedModel.find_by(identifier: "aegs_gladius_dunlevy").base_model
+
+    create(:model, sc_key: "aegs_gladius", name: "Gladius")
+    run_detector
+
+    assert_equal "Gladius", ScDataUnlistedModel.find_by(identifier: "aegs_gladius_dunlevy").base_model.name
+  end
+
+  test "only a new ship makes the report actionable" do
+    write_ship("drak_newhull")
+    result = run_detector
+
+    assert ScData::UnlistedModels.actionable?(result)
+    assert_includes ScData::UnlistedModels.report_body(result, @source), "drak_newhull"
+
+    ScDataUnlistedModel.sole.update!(decision: "ignored", decided_at: Time.current)
+
+    assert_not ScData::UnlistedModels.actionable?(run_detector)
+  end
+end


### PR DESCRIPTION
Nothing creates a `Model` except the RSI ship matrix, and the sc_data loader only iterates rows that already exist. So a ship that is in the game and not on the matrix — a referral bonus, an in-game-only variant, a genuinely new hull — is invisible, and nothing said so.

This finds them, describes them, and gives them somewhere to be decided.

## The funnel

| | |
| --- | --- |
| parsed model files, live tree | 1,109 |
| already a model | 215 |
| NPC copy, unmanned, wreck, template — filtered by filename | 733 |
| loadouts an in-game vendor sells on a hull we have | 41 |
| **left for a person** | **~120** |

Worked through on a real dataset while building this, that last number came down to **7**: the S-65 Stingray, the F8A Lightning, Grey's Basher, the two ATLS IKTI, the Drake Command Module, and the Gladius Dunlevy.

## Manufacturer from an identifier

Nothing in the export says which company built a ship — and `belongs_to :manufacturer` is required, so nothing downstream can create a model without this. Twenty prefixes cover the whole catalogue, derived from the 215 models already matched to a parsed file.

Two prefixes don't spell their own code (Aopoa files under `xian`, Grey's Market under `glsn`), and two name the wrong company outright: Mirai is MISC's sub-brand so the Fury and Razor ship as `misc_*`, and Esperia builds Vanduul replicas so the Blade, Glaive and Stinger ship as `vncl_*` — while the Scythe under that prefix really is Vanduul.

**All 215 in-game models resolve to the manufacturer their row carries, none wrong.** Across the whole tree, 1,095 of 1,109 resolve; the 14 that don't are every world object in the export plus a template — which fell out of the table rather than being designed for.

## Described, not judged

Each entry records the ship it extends and how it compares: identical, same hull with a different stock loadout, or a different machine.

**No rule decides these.** The export says what exists and what it is made of, never whether a player can own it — and that is the only question the catalogue cares about. `aegs_idris_p_collector_military` is mechanically identical to the Idris-P and is an ownable collector version; `aegs_reclaimer_pu_hijacked` is mechanically identical to the Reclaimer and is a mission prop.

Three rules were tried and dropped before settling on describing: item-port count (separates props in one group, then collapses — the accepted Argo ATLS has 13 ports, the mining laser 14), filename pattern-matching (misplaced 49 entries), and mechanical difference used as a verdict rather than a description.

## The vendor rule, and its safety valve

What you earn from Wikelo's Emporium or PYAM is the base ship carrying that fitting. Checked before the rule was written: every one has the same mass, crew, hull health and port list as the ship it extends, and 63 of 64 refitted entries touch only ports holding components the catalogue already carries. The sets are reusable product lines, not per-ship kits — and the Asgard collector version is fitted *worse* than its base. Nor does anyone own one: across 400 hangar syncs not a single vendor name appears, while the eight Edition-style names that do are already Models or ModelPaints.

Matched on the display name, since that is where the vendor is written — `mrai_guardian_military` ships as "Mirai Guardian Wikelo War Special".

**Only when a base ship resolves.** One of the 41 has none, and a vendor selling a hull we don't have is exactly what this list exists to catch.

## The admin page

Under **Models**, with five actions, each recording a decision that survives every later load.

| action | what it does |
| --- | --- |
| **Create ship** | name from the export, manufacturer from the identifier, created hidden |
| **Already in the catalogue** | links to the ship it already is — prefilled with the detected match |
| **It is a paint** | records that it belongs on an existing model as a livery |
| **Ignore** | anything the catalogue should not carry |
| **Reset** | back to the list, without deleting a model a create left behind |

**Create ship** guesses nothing beyond those two fields — the next load fills in the mechanics and flips `in_game`, because a parsed file exists by definition.

## Two collisions this turned up

**The export prefixes the manufacturer and Fleetyards does not** — "Kruger S-65 Stingray" against our "S-65 Stingray", "Argo MOLE" against "MOLE". Taking the name as-is would break the convention *and* slip past Model's name uniqueness, which is scoped to the manufacturer. With the prefix stripped, **43 of 161 entries resolve to a ship already in the catalogue** — only 64 of 247 models carry an `sc_key`, so an existing ship lands in this list anyway. `create-model` refuses rather than duplicating; a person says which it is.

**A `ModelRef` schema component already existed.** The first cut declared its own, which silently replaced it and loosened `name` and `slug` to nullable for every consumer. No test fails on that — it was caught by reading the generated diff. The existing component is reused.

## A decision is made once

A row per identifier rather than per build. Seeing a file again only moves `last_seen_*`, so the report separates a genuinely new ship from the backlog, and **only a new entry is actionable** — an undecided pile doesn't reopen a GitHub issue every patch. A run also drops rows a tightened rule has come to cover, undecided ones only: a decision already made is the record of it.

## Verification

875 admin integration tests, 160 loader, 112 job, 77 across the touched libs — green. `standardrb`, `eslint`, `prettier` and `tsc` clean. Translated into all seven languages, with a check that walks every key the new files ask for against every locale — which is what caught the route's meta title, resolved through a third namespace beside `nav` and `headlines`.

Mutation-checked throughout: the vendor rule (4 mutations), the detector (5), the manufacturer mapping (3). Each caught. One survived and got a test written for it rather than removed — the base-ship match has to be the longest one, because `misc_freelancer` and `misc_freelancer_dur` are both models.

Two known environmental failures, identical on main: two admin mailer tests hit premailer on `localhost:3000`.

## Not here

**No bulk action.** Working the backlog down one row at a time is fine at seven; it was tedious at 161. The table already supports selection if that turns out to matter.

**No model-level loadout presets.** The five vendor component sets — military, stealth, industrial — would make good named presets appliable to any hull, and the ignored rows are the source list since nothing is deleted. Fleetyards has `VehicleLoadout` per vehicle and nothing at model level.

🤖
