### PR TITLE
feat(sc_data): filter and sort models through the build

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -223,6 +223,44 @@ class Model < ApplicationRecord
     end
   end
 
+  # One fact, for a query rather than a reader.
+  #
+  # A correlated subquery rather than the joined alias the other three catalogues
+  # use, because Model is the one whose facts are reached **without** a join:
+  # `Vehicle` sorts by `modelMass`, `modelScmSpeed`, `modelMaxSpeed` and
+  # `modelGroundMaxSpeed` through its `model` association, and ransack builds
+  # that join itself. An expression naming an alias nobody joined raises
+  # `PG::UndefinedTable` -- measured, on the hangar.
+  #
+  # The `COALESCE` the other catalogues avoid is unavoidable here for the same
+  # reason build existence cannot be this catalogue's filter: 31 of 246 models
+  # are concept ships no build describes, and a filter that dropped them would
+  # empty the catalogue of everything not yet flying.
+  #
+  # It is affordable because the subquery resolves at most one row per *model*,
+  # not per result row -- Postgres memoizes on `vehicles.model_id`. Measured
+  # against the columns on the largest sets in the database: the biggest hangar
+  # (5,992 vehicles) 0.69ms against 1.09ms, the biggest fleet (9,598) 1.32ms
+  # against 0.56ms, the models list 0.48ms against 0.30ms.
+  def self.fact_sql(fact, source = ::ScData::Source.current)
+    sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+      COALESCE(
+        (SELECT model_facts.#{fact} FROM model_builds model_facts
+          WHERE model_facts.model_id = models.id
+            AND model_facts.environment = ?
+            AND model_facts.version = ?),
+        models.#{fact}
+      )
+    SQL
+  end
+
+  # Filtering and sorting read the build. Each shadows a real column of the same
+  # name -- a ransacker wins over a column -- so every query parameter keeps
+  # working untouched, with no API and no frontend change.
+  ModelBuild::FILTERABLE.each do |fact|
+    ransacker(fact) { Arel.sql(Model.fact_sql(fact)) }
+  end
+
   # The column still answers for a model no build describes -- every concept ship,
   # and every ship the export dropped before this table existed.
   ModelBuild::FACTS.each do |fact|

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -87,6 +87,15 @@ class ModelBuild < ApplicationRecord
   serialize :external_fuel_tanks, coder: YAML
   serialize :refuel_boom, coder: YAML
 
+  # The facts Model filters and sorts by, which is every one of them that
+  # `Model.ransackable_attributes` lists. The other twelve nothing queries.
+  FILTERABLE = %i[
+    mass scm_speed max_speed personal_inventory ground
+    pitch yaw roll
+    ground_max_speed ground_reverse_speed ground_acceleration ground_decceleration
+    cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks
+  ].freeze
+
   validates :environment, presence: true
   validates :version, presence: true
   validates :model_id, uniqueness: {scope: [:environment, :version]}

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -273,4 +273,65 @@ class ModelTest < ActiveSupport::TestCase
 
     assert_equal 777.0, old.reload.mass
   end
+
+  # Filtering and sorting, made to disagree with the column -- while the loader
+  # writes both they are identical, so a passing test would prove nothing.
+  test "filters on the mass the build carries, not the column" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, mass: 999_999.0)
+
+    assert_includes Model.ransack(mass_gteq: 500_000).result, model
+    assert_not_includes Model.ransack(mass_lteq: 500).result, model
+  end
+
+  test "sorts by the speed the build carries, not the column" do
+    slow = create(:model, name: "Zzz", scm_speed: 900.0)
+    fast = create(:model, name: "Aaa", scm_speed: 10.0)
+    create(:model_build, model: slow, scm_speed: 10.0)
+    create(:model_build, model: fast, scm_speed: 900.0)
+
+    assert_equal [fast, slow], Model.where(id: [slow.id, fast.id]).ransack(sorts: "scm_speed desc").result.to_a
+  end
+
+  # 31 of 246 models in a full dataset are concept ships no build describes. A
+  # filter that dropped them would empty the catalogue of everything not flying.
+  test "a model with no build is still found by what its column says" do
+    model = create(:model, mass: 4_242.0)
+
+    assert_nil model.build
+    assert_includes Model.ransack(mass_gteq: 4_000).result, model
+  end
+
+  test "an older build does not answer a filter" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, version: "0.0.1-live.1", mass: 999_999.0)
+
+    assert_not_includes Model.ransack(mass_gteq: 500_000).result, model,
+      "only the build we are on decides a filter"
+    assert_includes Model.ransack(mass_lteq: 500).result, model
+  end
+
+  # The reason this uses a subquery rather than the joined alias the other three
+  # catalogues use: ransack builds the association join itself, so an expression
+  # naming an alias nobody joined raises PG::UndefinedTable.
+  test "a vehicle sorts by a model fact through its association" do
+    slow = create(:model, name: "Zzz", mass: 900.0)
+    fast = create(:model, name: "Aaa", mass: 10.0)
+    create(:model_build, model: slow, mass: 10.0)
+    create(:model_build, model: fast, mass: 900.0)
+    user = create(:user)
+    a = create(:vehicle, model: slow, user:)
+    b = create(:vehicle, model: fast, user:)
+
+    assert_equal [b, a], user.vehicles.ransack(sorts: "model_mass desc").result.to_a
+  end
+
+  test "a vehicle filters on a model fact through its association" do
+    model = create(:model, mass: 100.0)
+    create(:model_build, model:, mass: 999_999.0)
+    user = create(:user)
+    vehicle = create(:vehicle, model:, user:)
+
+    assert_includes user.vehicles.ransack(model_mass_gteq: 500_000).result, vehicle
+  end
 end


### PR DESCRIPTION
The last of the four catalogues — and the one that could not use the shape the other three did.

## Why models needed a different shape

Equipment, components and commodities alias two joins as `<table>_facts` and let a ransacker name that alias. Model cannot.

`Vehicle` sorts by `modelMass`, `modelScmSpeed`, `modelMaxSpeed` and `modelGroundMaxSpeed` **through its `model` association**, and ransack builds that join itself. An expression naming an alias nobody joined raises `PG::UndefinedTable` — confirmed against the real hangar before anything else was written:

```
ActiveRecord::StatementInvalid: PG::UndefinedTable:
  missing FROM-clause entry for table "model_facts"
  ... FROM "vehicles" WHERE "vehicles"."user_id" = $1
      ORDER BY COALESCE(model_facts.mass, models.mass) ...
```

That is the hangar: **1,573,370 vehicles**. So the fact had to be an expression that needs nothing from the caller — a correlated subquery.

## The COALESCE the other three avoid

Unavoidable here, for the same reason build existence cannot be this catalogue's filter: **31 of 246 models are concept ships no build will ever describe**, and a filter that dropped them would empty the catalogue of everything not yet flying.

It is affordable because the subquery resolves one row per *model*, not per result row — Postgres memoizes on `vehicles.model_id`, and the subplan is an index scan on `index_model_builds_on_model_id`:

```
Sort Key: (COALESCE((SubPlan 1), models.mass)) DESC NULLS LAST
  ->  Nested Loop Left Join
        ->  Bitmap Index Scan on index_vehicles_on_user_id
        ->  Memoize   Cache Key: vehicles.model_id
              ->  Index Scan using ships_pkey on models
```

## Measured, on the largest sets in the database

| | column | build |
| --- | ---: | ---: |
| models list, sorted by mass | 0.40ms | **0.30ms** |
| models list, filtered by mass | 0.29ms | **0.29ms** |
| biggest hangar (5,992 vehicles), by model mass | 0.59ms | **0.55ms** |
| biggest fleet (9,598 vehicles), by model mass | 0.38ms | **0.60ms** |

The fleet case is the one that costs anything, and it costs 0.22ms.

The models-list filter is a seq scan over 246 rows — no index can serve a COALESCE over a subquery, and at that size none is wanted. That is inherent to keeping concept ships visible, not an oversight.

## Scope

**Fifteen facts move** — every one `Model.ransackable_attributes` lists. The other twelve nothing queries.

Worth naming, because it made this much smaller than the other three: **no query schema exposes a build fact as a filter.** Neither the public nor the admin `ModelQuery` permits one. What actually reaches these facts is the four sorts — `mass`, `scmSpeed`, `maxSpeed`, `groundMaxSpeed` — and two of those come through the hangar. The scopes that looked like candidates do not touch a build fact either: `with_cargo` reads the derived `cargo` column, `with_cargo_grids` an association, `will_it_fit` the dimensions, which the build deliberately does not carry.

**No API or schema change.** A ransacker wins over a same-named column, so every query parameter keeps its name — `bin/generate-schema` produces an empty diff.

## Tests

Six, all built by making the build **disagree** with the column, since the loader writes both and they are otherwise identical. Two go through `Vehicle`'s association, because that is the path that would have broken.

They cover the filter, the sort, a model with no build falling back to its column, and an older build not answering a filter.

Four mutations, each caught:

| mutation | failures |
| --- | --- |
| the expression points back at the column | 4 |
| the column fallback is dropped | 2 |
| any build answers, not the one we are on | 1 |
| the ransackers are never defined | 4 |

## Verification

466 model tests, 1,310 public API, 820 admin integration — green. `standardrb` clean. Two known environmental failures, identical on main: two admin mailer tests hit premailer on `localhost:3000`.

With this, all four catalogues filter and sort through their build.

🤖
