### PR TITLE
feat(sc_data): carry fuel consumption on the model build

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -78,9 +78,10 @@ module ScData
 
         ModelPosition.generate_for_model!(model)
 
-        model.set_fuel_consumption_from_hardpoints
-
         update_params = {}
+
+        # Computed here because it reads the loadout `update_loadout` just wrote.
+        update_params[:fuel_consumption] = model.fuel_consumption_from_hardpoints
 
         update_params = update_metrics(model, model_data, update_params)
         update_params = update_personal_inventory(model_data, update_params)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -571,14 +571,17 @@ class Model < ApplicationRecord
     end
   end
 
-  def set_fuel_consumption_from_hardpoints
+  # Returns rather than assigns, so the loader can put it through `update_params`
+  # like every other game-file fact and it reaches the build as well as the row.
+  # Assigning it here is what kept it out of both.
+  def fuel_consumption_from_hardpoints
     thrusters = hardpoints.includes(:component).where(group: :thruster).filter_map do |hardpoint|
       next if hardpoint.component.blank?
 
       hardpoint.component.type_data
     end
 
-    self.fuel_consumption = thrusters.sum do |thruster|
+    thrusters.sum do |thruster|
       thruster.dig("fuel_burn_rate_per10_k_newton").to_f
     end
   end

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -14,6 +14,7 @@
 #  cargo_holds             :string
 #  environment             :string           not null
 #  external_fuel_tanks     :string
+#  fuel_consumption        :decimal(15, 2)
 #  ground                  :boolean          default(FALSE)
 #  ground_acceleration     :decimal(15, 2)
 #  ground_decceleration    :decimal(15, 2)
@@ -69,7 +70,7 @@ class ModelBuild < ApplicationRecord
   # becomes.
   FACTS = %i[
     mass hull_health hull_parts hull_doors weapon_pool_size signature_cross_section ground
-    personal_inventory
+    personal_inventory fuel_consumption
     cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks external_fuel_tanks refuel_boom
     scm_speed scm_speed_boosted reverse_speed_boosted max_speed
     pitch pitch_boosted yaw yaw_boosted roll roll_boosted

--- a/db/data/20260828141000_backfill_model_build_fuel_consumption.rb
+++ b/db/data/20260828141000_backfill_model_build_fuel_consumption.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Fills in the fact the build table was created without. Every model build of
+# every environment gets the value its row carries, which is what the loader
+# wrote there.
+#
+# Only rows that have none: a build written since the column landed already
+# carries its own value, and overwriting it with the row's would undo a later
+# load.
+class BackfillModelBuildFuelConsumption < ActiveRecord::Migration[8.1]
+  def up
+    ModelBuild.where(fuel_consumption: nil).includes(:model).find_each do |build|
+      value = build.model&.read_attribute(:fuel_consumption)
+      next if value.blank?
+
+      build.update_columns(fuel_consumption: value)
+    end
+  end
+
+  def down
+    ModelBuild.update_all(fuel_consumption: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_27_201000)
+DataMigrate::Data.define(version: 2026_08_28_141000)

--- a/db/migrate/20260828140000_add_fuel_consumption_to_model_builds.rb
+++ b/db/migrate/20260828140000_add_fuel_consumption_to_model_builds.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# `fuel_consumption` is a game-file fact like the other 27 -- summed from the
+# `fuel_burn_rate_per10_k_newton` of every thruster the loadout fits.
+#
+# It was missed when the table was created because it never went through
+# `update_params`: the loader assigned it to the record directly, so a grep for
+# what the loader writes did not find it.
+class AddFuelConsumptionToModelBuilds < ActiveRecord::Migration[8.1]
+  def change
+    add_column :model_builds, :fuel_consumption, :decimal, precision: 15, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -983,6 +983,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_120000) do
     t.datetime "created_at", null: false
     t.string "environment", null: false
     t.string "external_fuel_tanks"
+    t.decimal "fuel_consumption", precision: 15, scale: 2
     t.boolean "ground", default: false
     t.decimal "ground_acceleration", precision: 15, scale: 2
     t.decimal "ground_decceleration", precision: 15, scale: 2

--- a/test/factories/model_builds.rb
+++ b/test/factories/model_builds.rb
@@ -8,6 +8,7 @@
 #  cargo_holds             :string
 #  environment             :string           not null
 #  external_fuel_tanks     :string
+#  fuel_consumption        :decimal(15, 2)
 #  ground                  :boolean          default(FALSE)
 #  ground_acceleration     :decimal(15, 2)
 #  ground_decceleration    :decimal(15, 2)

--- a/test/models/model_build_test.rb
+++ b/test/models/model_build_test.rb
@@ -10,6 +10,7 @@ require "test_helper"
 #  cargo_holds             :string
 #  environment             :string           not null
 #  external_fuel_tanks     :string
+#  fuel_consumption        :decimal(15, 2)
 #  ground                  :boolean          default(FALSE)
 #  ground_acceleration     :decimal(15, 2)
 #  ground_decceleration    :decimal(15, 2)
@@ -164,6 +165,11 @@ class ModelBuildTest < ActiveSupport::TestCase
 
   test "a build carries nothing the ship matrix supplies" do
     assert_empty ModelBuild.column_names.grep(/\Arsi_/)
+  end
+
+  test "carries every fact the loader writes, fuel consumption included" do
+    assert_includes ModelBuild::FACTS, :fuel_consumption
+    assert_includes ModelBuild.column_names, "fuel_consumption"
   end
 
   test ".retained_versions keeps the newest builds of an environment" do

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -334,4 +334,44 @@ class ModelTest < ActiveSupport::TestCase
 
     assert_includes user.vehicles.ransack(model_mass_gteq: 500_000).result, vehicle
   end
+
+  # `fuel_consumption` is a game-file fact like the rest -- summed from every
+  # thruster the loadout fits. It was missed when the build table was created
+  # because the loader assigned it to the record instead of putting it through
+  # `update_params`, so a grep for what the loader writes did not find it.
+  test "reads fuel consumption off the build" do
+    model = create(:model, fuel_consumption: 1.0)
+    create(:model_build, model:, fuel_consumption: 42.5)
+
+    assert_equal 42.5, model.reload.fuel_consumption
+  end
+
+  test "falls back to the column for a model with no build" do
+    model = create(:model, fuel_consumption: 1.0)
+
+    assert_nil model.build
+    assert_equal 1.0, model.fuel_consumption
+  end
+
+  # Returning rather than assigning is the point, and the column is the only place
+  # it shows: an assignment here is shadowed by the reader, which answers from the
+  # build, so it would never be noticed.
+  test "#fuel_consumption_from_hardpoints returns the sum without assigning it" do
+    model = create(:model, fuel_consumption: 1.0)
+    create(:model_build, model:, fuel_consumption: 42.5)
+    model.reload
+
+    assert_equal 0.0, model.fuel_consumption_from_hardpoints, "no thrusters fitted"
+    assert_equal 1.0, model.read_attribute(:fuel_consumption), "the column was not touched"
+    assert_not model.changed?, "nothing was assigned"
+  end
+
+  test "#update_with_facts carries a fuel consumption correction to the build" do
+    model = create(:model, fuel_consumption: 1.0)
+    create(:model_build, model:, fuel_consumption: 42.5)
+
+    assert model.reload.update_with_facts(fuel_consumption: 7.5)
+
+    assert_equal 7.5, model.build.reload.fuel_consumption
+  end
 end


### PR DESCRIPTION
The twenty-eighth fact, and the one the build table was created without.

`fuel_consumption` is a game-file value like the other 27 — summed from the `fuel_burn_rate_per10_k_newton` of every thruster the loadout fits. It was missed for a mechanical reason worth naming: **the loader never put it through `update_params`.** It called `set_fuel_consumption_from_hardpoints`, which assigned straight to the record, so reading off what the loader writes did not find it.

## The rename is not cosmetic

`set_fuel_consumption_from_hardpoints` → `fuel_consumption_from_hardpoints`, returning the sum instead of assigning it. That lets the loader treat it like every other fact: one value, written to the row and to the build from the same place.

It also removes a trap. Once the reader answers from the build, **an assignment there is shadowed** — `model.fuel_consumption` returns the build's value and the assigned one is never seen. That is invisible to any test that goes through the reader: put the assignment back and every such test still passes.

So the test pins it through `read_attribute` and `changed?` instead. Found while mutation-checking — the first version of that test used `reload`, which discarded the assignment before it could be observed, and the mutation survived.

## Scope

Neither ransackable nor sortable, so no filter moves and `FILTERABLE` is unchanged. No API or schema change.

The backfill fills **only rows that have none**, so a build written since the column landed keeps its own value rather than having the row's put back over it.

## Verification

Full local dataset: 215 builds, all with a value, **none whose value failed to round-trip**.

20 model tests and 13 model-build tests green. `test/loaders`: **160 tests, 0 failures** with the parsed tree in place. Two mutations, both caught: dropping it from `FACTS` (4 failures), and restoring the assignment (1).

## What this leaves

The four acceleration columns — `scm_speed_acceleration`, `scm_speed_decceleration`, `max_speed_acceleration`, `max_speed_decceleration` — are still column-only, on 147 models, and **paper_trail says the archived `sc_loader` wrote them last, on 2024-05-24.** Nothing updates them any more, and they are still reachable through `ransackable_attributes`.

The question was whether the export carries them, since they can go if it does not. **It does, indirectly.** The raw `IFCSParams` block carries `positiveLinearTimeToFullSpeed` and `negativeLinearTimeToFullSpeed` per axis, and the parsed thruster `type_data` carries `thrust_capacity` on 1,265 thrusters. Neither is an acceleration, but `mass` is already a build fact, so thrust over mass is.

Which of the two the old loader used is settled: `scm_speed / scm_speed_acceleration` scatters across 27–152 with no clustering at the uniform 3-second time-to-full-speed, and the stored values sit at 1.75–6 m/s², which is the magnitude of thrust over mass for a ship that size. So they are derivable, and deleting them is not the right call — extending the parser is.

🤖
