### PR TITLE
feat(notifications): call-to-actions in the notification center

### DIFF
--- a/app/api_components/v1/schemas/enums/notification_record_type_enum.rb
+++ b/app/api_components/v1/schemas/enums/notification_record_type_enum.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Enums
+      class NotificationRecordTypeEnum
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :string,
+          enum: ::NotificationRecordReference::TYPES,
+          "x-enumNames": ::NotificationRecordReference::TYPES.map { |v| transform_enum_key(v) }
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/notification.rb
+++ b/app/api_components/v1/schemas/notification.rb
@@ -14,6 +14,7 @@ module V1
           body: {type: :string},
           link: {type: :string},
           icon: {type: :string},
+          record: ::V1::Schemas::NotificationRecord,
           read: {type: :boolean},
           readAt: {type: :string, format: "date-time"},
           archived: {type: :boolean},

--- a/app/api_components/v1/schemas/notification_record.rb
+++ b/app/api_components/v1/schemas/notification_record.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class NotificationRecord
+      include OpenapiRuby::Components::Base
+
+      # Identifiers only - enough to fetch the record the notification is about
+      # and read its current state. Which fields are set depends on the type,
+      # and which endpoint they belong to is decided by the notification type.
+      schema({
+        type: :object,
+        properties: {
+          type: ::V1::Schemas::Enums::NotificationRecordTypeEnum,
+          id: {type: :string, format: :uuid},
+          fleetSlug: {type: :string},
+          username: {type: :string},
+          eventSlug: {type: :string},
+          inventorySlug: {type: :string}
+        },
+        additionalProperties: false,
+        required: %w[type id]
+      })
+    end
+  end
+end

--- a/app/controllers/api/v1/fleet_members_controller.rb
+++ b/app/controllers/api/v1/fleet_members_controller.rb
@@ -14,13 +14,13 @@ module Api
       before_action :authenticate_user!, only: []
       before_action -> { doorkeeper_authorize! "fleet", "fleet:read" },
         unless: :user_signed_in?,
-        only: %i[index]
+        only: %i[index show]
       before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
         unless: :user_signed_in?,
         only: %i[create accept_request decline_request promote demote destroy]
 
-      before_action :set_fleet, only: %i[index create accept_request decline_request promote demote destroy]
-      before_action :set_member, only: %i[accept_request decline_request promote demote destroy]
+      before_action :set_fleet, only: %i[index show create accept_request decline_request promote demote destroy]
+      before_action :set_member, only: %i[show accept_request decline_request promote demote destroy]
 
       def index
         authorize! with: FleetMembershipPolicy, context: {fleet: @fleet}
@@ -38,6 +38,13 @@ module Api
           .joins(:user)
 
         @members = result_with_pagination(result, per_page(FleetMembership))
+      end
+
+      # `set_member` has already found and authorized it. Reading one member on
+      # its own is what a notification about a membership needs: it links to a
+      # request that may long since have been answered, and the answer is the
+      # member's state.
+      def show
       end
 
       def create

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -27,8 +27,13 @@ module Api
         # No distinct: nothing here joins, and SELECT DISTINCT cannot order by
         # the computed `unread` expression.
         @notifications = @q.result
+          .includes(:record)
           .page(params[:page])
           .per(per_page(Notification))
+
+        # `includes` stops at the polymorphic record; the reference reads a slug
+        # or two off it, which without this is a query per row.
+        NotificationRecordReference.preload(@notifications)
       end
 
       def unread_count

--- a/app/frontend/frontend/components/Notifications/Detail/index.vue
+++ b/app/frontend/frontend/components/Notifications/Detail/index.vue
@@ -6,7 +6,14 @@ export default {
 
 <script lang="ts" setup>
 import Btn from "@/shared/components/base/Btn/index.vue";
-import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import {
+  BtnTonesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
+import {
+  actionTestId,
+  useNotificationActions,
+} from "@/frontend/composables/useNotificationActions";
 import Panel from "@/shared/components/base/Panel/index.vue";
 import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
 import Markdown from "@/shared/components/Markdown/index.vue";
@@ -30,6 +37,12 @@ const emit = defineEmits<{
 }>();
 
 const { t, l } = useI18n();
+
+const { linksFor } = useNotificationActions();
+
+const links = computed(() =>
+  props.notification ? linksFor(props.notification) : [],
+);
 
 const body = ref<HTMLElement>();
 
@@ -83,14 +96,6 @@ watch(
         </div>
         <div class="notification-detail__actions">
           <Btn
-            v-if="notification.link"
-            :to="notification.link"
-            data-test="notification-detail-open"
-          >
-            <i class="fa-duotone fa-arrow-up-right-from-square" />
-            {{ t("actions.open") }}
-          </Btn>
-          <Btn
             v-if="notification.read"
             v-tooltip="t('actions.notifications.unread')"
             :aria-label="t('actions.notifications.unread')"
@@ -141,6 +146,27 @@ watch(
       >
         {{ t("labels.notifications.noBody") }}
       </p>
+
+      <!-- The way on. A row of its own rather than another icon beside archive
+           and delete: what the notification is asking for should not have to
+           compete with the housekeeping. -->
+      <div
+        v-if="links.length"
+        class="notification-detail__cta"
+        data-test="notification-detail-actions"
+      >
+        <Btn
+          v-for="action in links"
+          :key="action.key"
+          :to="action.to"
+          :href="action.href"
+          :variant="action.primary ? undefined : BtnVariantsEnum.GHOST"
+          :data-test="actionTestId(action.key)"
+        >
+          <i :class="action.icon" />
+          {{ t(`labels.notificationActions.${action.key}`) }}
+        </Btn>
+      </div>
 
       <!-- Retention files a notification into the archive; the archive is what
            eventually deletes it. Each state names the date it is heading for. -->
@@ -259,6 +285,13 @@ watch(
 .notification-detail__body--empty {
   color: $gray-lighter;
   font-style: italic;
+}
+
+.notification-detail__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
 }
 
 .notification-detail__facts {

--- a/app/frontend/frontend/components/Notifications/Detail/index.vue
+++ b/app/frontend/frontend/components/Notifications/Detail/index.vue
@@ -17,6 +17,7 @@ import {
 import Panel from "@/shared/components/base/Panel/index.vue";
 import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
 import Markdown from "@/shared/components/Markdown/index.vue";
+import RecordActions from "@/frontend/components/Notifications/RecordActions/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type Notification } from "@/services/fyApi";
 
@@ -34,6 +35,7 @@ const emit = defineEmits<{
   archive: [];
   unarchive: [];
   destroy: [];
+  refresh: [];
 }>();
 
 const { t, l } = useI18n();
@@ -151,10 +153,15 @@ watch(
            and delete: what the notification is asking for should not have to
            compete with the housekeeping. -->
       <div
-        v-if="links.length"
+        v-if="links.length || notification.record"
         class="notification-detail__cta"
         data-test="notification-detail-actions"
       >
+        <RecordActions
+          v-if="notification.record"
+          :notification="notification"
+          @done="emit('refresh')"
+        />
         <Btn
           v-for="action in links"
           :key="action.key"

--- a/app/frontend/frontend/components/Notifications/ListItem/index.vue
+++ b/app/frontend/frontend/components/Notifications/ListItem/index.vue
@@ -9,6 +9,7 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useNotificationActions } from "@/frontend/composables/useNotificationActions";
 import { type Notification } from "@/services/fyApi";
 
 type Props = {
@@ -35,6 +36,10 @@ const emit = defineEmits<{
 }>();
 
 const { t, l } = useI18n();
+
+const { primaryLink } = useNotificationActions();
+
+const primary = computed(() => primaryLink(props.notification));
 
 const select = ref<HTMLButtonElement>();
 
@@ -94,6 +99,18 @@ defineExpose({ focus: () => select.value?.focus() });
       </span>
     </button>
     <div class="notification-item__actions">
+      <!-- Only the way on, and only as an icon: the row has to survive on a
+           phone, and anything the reader has to weigh up belongs in the
+           reading pane, which is the surface that knows the current state. -->
+      <Btn
+        v-if="primary"
+        v-tooltip="t(`labels.notificationActions.${primary.key}`)"
+        :aria-label="t(`labels.notificationActions.${primary.key}`)"
+        :to="primary.to"
+        data-test="notification-item-open"
+      >
+        <i :class="primary.icon" />
+      </Btn>
       <Btn
         v-if="notification.archived"
         v-tooltip="t('actions.notifications.unarchive')"

--- a/app/frontend/frontend/components/Notifications/RecordActions/index.vue
+++ b/app/frontend/frontend/components/Notifications/RecordActions/index.vue
@@ -1,0 +1,100 @@
+<script lang="ts">
+export default {
+  name: "NotificationsRecordActions",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { BtnVariantsEnum } from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { actionTestId } from "@/frontend/composables/useNotificationActions";
+import {
+  useNotificationRecordActions,
+  type NotificationAction,
+} from "@/frontend/composables/useNotificationRecordActions";
+import { type Notification } from "@/services/fyApi";
+
+type Props = {
+  notification: Notification;
+};
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  done: [];
+}>();
+
+const { t } = useI18n();
+const { displaySuccess, displayAlert } = useAppNotifications();
+
+const notification = computed(() => props.notification);
+
+const { actions, externalLink, isLoading, isUnavailable, refresh } =
+  useNotificationRecordActions(notification);
+
+const running = ref<string>();
+
+const run = async (action: NotificationAction) => {
+  running.value = action.key;
+
+  try {
+    await action.run();
+    displaySuccess({ text: t("messages.notifications.actionDone") });
+    emit("done");
+  } catch {
+    // Most likely the record moved on between the load and the click, so the
+    // honest response is to re-read it - the buttons then disappear on their
+    // own rather than inviting a second failure.
+    displayAlert({ text: t("messages.notifications.actionFailed") });
+  } finally {
+    running.value = undefined;
+    await refresh();
+  }
+};
+</script>
+
+<template>
+  <p
+    v-if="isUnavailable"
+    class="notification-record-actions__gone"
+    data-test="notification-record-unavailable"
+  >
+    {{ t("labels.notificationActions.unavailable") }}
+  </p>
+  <template v-else-if="!isLoading">
+    <Btn
+      v-for="action in actions"
+      :key="action.key"
+      :tone="action.tone"
+      :loading="running === action.key"
+      :disabled="!!running"
+      :data-test="actionTestId(action.key)"
+      @click="run(action)"
+    >
+      <i :class="action.icon" />
+      {{ t(`labels.notificationActions.${action.key}`) }}
+    </Btn>
+    <Btn
+      v-if="externalLink"
+      :href="externalLink.href"
+      target="_blank"
+      :variant="BtnVariantsEnum.GHOST"
+      :data-test="actionTestId(externalLink.key)"
+    >
+      <i :class="externalLink.icon" />
+      {{ t(`labels.notificationActions.${externalLink.key}`) }}
+    </Btn>
+  </template>
+</template>
+
+<style lang="scss" scoped>
+.notification-record-actions__gone {
+  margin: 0;
+  align-self: center;
+  color: $gray-lighter;
+  font-size: 0.85em;
+  font-style: italic;
+}
+</style>

--- a/app/frontend/frontend/composables/useNotificationActions.spec.ts
+++ b/app/frontend/frontend/composables/useNotificationActions.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { useNotificationActions } from "./useNotificationActions";
+import {
+  NotificationRecordTypeEnum,
+  NotificationTypeEnum,
+  type Notification,
+  type NotificationRecord,
+  type NotificationTypeEnum as NotificationType,
+} from "@/services/fyApi";
+
+window.API_ENDPOINT = "https://api.fleetyards.test/v1";
+
+const notification = (
+  notificationType: `${NotificationType}`,
+  attributes: { link?: string; record?: NotificationRecord } = {},
+): Notification =>
+  ({
+    id: "notification-1",
+    notificationType,
+    title: "A notification",
+    read: false,
+    archived: false,
+    expiresAt: "2026-09-01T00:00:00Z",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    ...attributes,
+  }) as Notification;
+
+const keysFor = (input: Notification) =>
+  useNotificationActions()
+    .linksFor(input)
+    .map((link) => link.key);
+
+describe("useNotificationActions", () => {
+  it("names the target rather than saying 'open'", () => {
+    expect(
+      keysFor(notification(NotificationTypeEnum.FLEET_INVITE, { link: "/x" })),
+    ).toEqual(["openInvite"]);
+
+    expect(
+      keysFor(notification(NotificationTypeEnum.HANGAR_CREATE, { link: "/x" })),
+    ).toEqual(["openHangar"]);
+
+    expect(
+      keysFor(
+        notification(NotificationTypeEnum.FLEET_MEMBER_REQUESTED, {
+          link: "/x",
+        }),
+      ),
+    ).toEqual(["reviewRequest"]);
+  });
+
+  it("offers nothing when the notification carries no link", () => {
+    expect(keysFor(notification(NotificationTypeEnum.HANGAR_CREATE))).toEqual(
+      [],
+    );
+  });
+
+  it("adds the calendar file for an event, off the reference alone", () => {
+    const links = useNotificationActions().linksFor(
+      notification(NotificationTypeEnum.FLEET_EVENT_PUBLISHED, {
+        link: "/fleets/test-fleet/events/mining-run",
+        record: {
+          type: NotificationRecordTypeEnum.FLEET_EVENT,
+          id: "event-1",
+          fleetSlug: "test-fleet",
+          eventSlug: "mining-run",
+        },
+      }),
+    );
+
+    expect(links.map((link) => link.key)).toEqual([
+      "openEvent",
+      "addToCalendar",
+      "openFleet",
+    ]);
+
+    expect(links[1].href).toBe(
+      "https://api.fleetyards.test/v1/fleets/test-fleet/events/mining-run/event.ics",
+    );
+  });
+
+  it("does not send an invited user to a fleet they are not in yet", () => {
+    expect(
+      keysFor(
+        notification(NotificationTypeEnum.FLEET_INVITE, {
+          link: "/fleets/invites",
+          record: {
+            type: NotificationRecordTypeEnum.FLEET_MEMBERSHIP,
+            id: "membership-1",
+            fleetSlug: "test-fleet",
+            username: "someone",
+          },
+        }),
+      ),
+    ).toEqual(["openInvite"]);
+  });
+
+  it("does not repeat the fleet when the fleet is already the target", () => {
+    expect(
+      keysFor(
+        notification(NotificationTypeEnum.FLEET_REQUEST_ACCEPTED, {
+          link: "/fleets/test-fleet",
+          record: {
+            type: NotificationRecordTypeEnum.FLEET_MEMBERSHIP,
+            id: "membership-1",
+            fleetSlug: "test-fleet",
+            username: "someone",
+          },
+        }),
+      ),
+    ).toEqual(["openFleet"]);
+  });
+});

--- a/app/frontend/frontend/composables/useNotificationActions.ts
+++ b/app/frontend/frontend/composables/useNotificationActions.ts
@@ -1,0 +1,136 @@
+import {
+  NotificationRecordTypeEnum,
+  type Notification,
+  type NotificationTypeEnum,
+} from "@/services/fyApi";
+
+export type NotificationLink = {
+  key: string;
+  icon: string;
+  to?: string;
+  href?: string;
+  primary?: boolean;
+};
+
+/*
+ * What a notification's link actually leads to. Every type used to wear the
+ * same "Open", so a fleet invite and a ship added to the hangar were told apart
+ * only by the title above the button.
+ *
+ * Typed against the full enum on purpose: a new notification type then fails
+ * the build here rather than quietly falling back to "Open" in production.
+ */
+const PRIMARY_ACTIONS: Record<`${NotificationTypeEnum}`, string> = {
+  hangar_create: "openHangar",
+  hangar_destroy: "openHangar",
+  wishlist_create: "openWishlist",
+  wishlist_destroy: "openWishlist",
+  model_on_sale: "openModel",
+  new_model: "openModel",
+  hangar_sync_finished: "openHangar",
+  hangar_sync_failed: "openHangar",
+  fleet_invite: "openInvite",
+  fleet_member_requested: "reviewRequest",
+  fleet_member_accepted: "openMembers",
+  fleet_request_accepted: "openFleet",
+  fleet_inventory_item_added: "openInventory",
+  fleet_event_published: "openEvent",
+  fleet_event_locked: "openEvent",
+  fleet_event_starting_soon: "openEvent",
+  fleet_event_started: "openEvent",
+  fleet_event_completed: "openEvent",
+  fleet_event_cancelled: "openEvent",
+  fleet_event_signup_added: "openRoster",
+  fleet_event_signup_withdrawn: "openRoster",
+  fleet_event_signup_confirmed: "openEvent",
+  fleet_event_signup_assigned: "openEvent",
+  fleet_event_signup_kicked: "openEvent",
+};
+
+const ACTION_ICONS: Record<string, string> = {
+  openHangar: "fa-duotone fa-warehouse",
+  openWishlist: "fa-duotone fa-heart",
+  openModel: "fa-duotone fa-starship",
+  openInvite: "fa-duotone fa-envelope-open",
+  reviewRequest: "fa-duotone fa-user-check",
+  openMembers: "fa-duotone fa-users",
+  openFleet: "fa-duotone fa-shield",
+  openInventory: "fa-duotone fa-boxes-stacked",
+  openEvent: "fa-duotone fa-calendar-day",
+  openRoster: "fa-duotone fa-list-check",
+  addToCalendar: "fa-duotone fa-calendar-plus",
+  open: "fa-duotone fa-arrow-up-right-from-square",
+};
+
+// Where the shortcut to the fleet would either repeat the primary target or
+// send the reader somewhere they cannot go yet - an invite is answered before
+// its fleet is readable.
+const NO_FLEET_SHORTCUT = ["openFleet", "openInvite"];
+
+const icon = (key: string) => ACTION_ICONS[key] || ACTION_ICONS.open;
+
+// The keys are camelCase because they are translation keys; the test ids the
+// rest of the app hands out are kebab-case.
+export const actionTestId = (key: string) =>
+  `notification-action-${key.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()}`;
+
+export const useNotificationActions = () => {
+  const primaryLink = (
+    notification: Notification,
+  ): NotificationLink | undefined => {
+    if (!notification.link) {
+      return undefined;
+    }
+
+    const key = PRIMARY_ACTIONS[notification.notificationType] || "open";
+
+    return { key, icon: icon(key), to: notification.link, primary: true };
+  };
+
+  /*
+   * The side doors: the calendar file an event already serves, and the fleet
+   * behind whatever the notification is about. Both come off the record
+   * reference the payload carries, so neither costs a request.
+   */
+  const secondaryLinks = (notification: Notification): NotificationLink[] => {
+    const record = notification.record;
+
+    if (!record) {
+      return [];
+    }
+
+    const links: NotificationLink[] = [];
+
+    if (
+      record.type === NotificationRecordTypeEnum.FLEET_EVENT &&
+      record.fleetSlug &&
+      record.eventSlug
+    ) {
+      links.push({
+        key: "addToCalendar",
+        icon: icon("addToCalendar"),
+        href: `${window.API_ENDPOINT}/fleets/${record.fleetSlug}/events/${record.eventSlug}/event.ics`,
+      });
+    }
+
+    const primaryKey = PRIMARY_ACTIONS[notification.notificationType];
+
+    if (record.fleetSlug && !NO_FLEET_SHORTCUT.includes(primaryKey)) {
+      links.push({
+        key: "openFleet",
+        icon: icon("openFleet"),
+        to: `/fleets/${record.fleetSlug}`,
+      });
+    }
+
+    return links;
+  };
+
+  const linksFor = (notification: Notification): NotificationLink[] => {
+    const primary = primaryLink(notification);
+
+    return [...(primary ? [primary] : []), ...secondaryLinks(notification)];
+  };
+
+  return { primaryLink, secondaryLinks, linksFor };
+};

--- a/app/frontend/frontend/composables/useNotificationRecordActions.spec.ts
+++ b/app/frontend/frontend/composables/useNotificationRecordActions.spec.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+type QueryStub = {
+  data: ReturnType<typeof ref>;
+  isLoading: ReturnType<typeof ref<boolean>>;
+  isError: ReturnType<typeof ref<boolean>>;
+  refetch: ReturnType<typeof vi.fn>;
+};
+
+const stub = (): QueryStub => ({
+  data: ref(undefined),
+  isLoading: ref(false),
+  isError: ref(false),
+  refetch: vi.fn(),
+});
+
+const queries = {
+  ownMembership: stub(),
+  member: stub(),
+  event: stub(),
+  vehicle: stub(),
+  sync: stub(),
+};
+
+const mutations = {
+  acceptFleetMembership: vi.fn(),
+  declineFleetMembership: vi.fn(),
+  acceptFleetMember: vi.fn(),
+  declineFleetMember: vi.fn(),
+  signupFleetEvent: vi.fn(),
+  syncRsiHangar: vi.fn(),
+  updateVehicle: vi.fn(),
+};
+
+vi.mock("@/services/fyApi", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useFleetMembership: () => queries.ownMembership,
+  useFleetMember: () => queries.member,
+  useFleetEvent: () => queries.event,
+  useShowVehicle: () => queries.vehicle,
+  useSyncRsiHangarStatus: () => queries.sync,
+  ...mutations,
+}));
+
+const { useNotificationRecordActions } =
+  await import("./useNotificationRecordActions");
+const {
+  NotificationRecordTypeEnum,
+  NotificationTypeEnum,
+  FleetEventSignupStatusEnum,
+} = await import("@/services/fyApi");
+
+type AnyRecord = Record<string, unknown>;
+
+const notificationRef = (notificationType: string, record: AnyRecord) =>
+  ref({
+    id: "notification-1",
+    notificationType,
+    title: "A notification",
+    read: false,
+    archived: false,
+    expiresAt: "2026-09-01T00:00:00Z",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    record,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+const membershipRecord = {
+  type: NotificationRecordTypeEnum.FLEET_MEMBERSHIP,
+  id: "membership-1",
+  fleetSlug: "test-fleet",
+  username: "newcomer",
+};
+
+const eventRecord = {
+  type: NotificationRecordTypeEnum.FLEET_EVENT,
+  id: "event-1",
+  fleetSlug: "test-fleet",
+  eventSlug: "mining-run",
+};
+
+beforeEach(() => {
+  Object.values(queries).forEach((query) => {
+    query.data.value = undefined;
+    query.isLoading.value = false;
+    query.isError.value = false;
+  });
+  Object.values(mutations).forEach((mutation) => mutation.mockReset());
+});
+
+describe("useNotificationRecordActions", () => {
+  it("offers an answer while the invite is still open", async () => {
+    queries.ownMembership.data.value = { status: "invited" };
+
+    const { actions } = useNotificationRecordActions(
+      notificationRef(NotificationTypeEnum.FLEET_INVITE, membershipRecord),
+    );
+
+    expect(actions.value.map((action) => action.key)).toEqual([
+      "accept",
+      "decline",
+    ]);
+
+    await actions.value[0].run();
+
+    expect(mutations.acceptFleetMembership).toHaveBeenCalledWith("test-fleet");
+  });
+
+  it("offers nothing once the invite has been answered elsewhere", () => {
+    queries.ownMembership.data.value = { status: "accepted" };
+
+    const { actions } = useNotificationRecordActions(
+      notificationRef(NotificationTypeEnum.FLEET_INVITE, membershipRecord),
+    );
+
+    expect(actions.value).toEqual([]);
+  });
+
+  it("answers a join request through the member endpoint", async () => {
+    queries.member.data.value = { status: "requested" };
+
+    const { actions } = useNotificationRecordActions(
+      notificationRef(
+        NotificationTypeEnum.FLEET_MEMBER_REQUESTED,
+        membershipRecord,
+      ),
+    );
+
+    await actions.value[1].run();
+
+    expect(mutations.declineFleetMember).toHaveBeenCalledWith(
+      "test-fleet",
+      "newcomer",
+    );
+  });
+
+  it("only offers a sign-up while sign-ups are open and the event is ahead", async () => {
+    const notification = notificationRef(
+      NotificationTypeEnum.FLEET_EVENT_PUBLISHED,
+      eventRecord,
+    );
+
+    const { actions } = useNotificationRecordActions(notification);
+
+    queries.event.data.value = { signupsOpen: false, past: false };
+    expect(actions.value).toEqual([]);
+
+    queries.event.data.value = { signupsOpen: true, past: true };
+    expect(actions.value).toEqual([]);
+
+    queries.event.data.value = { signupsOpen: true, past: false };
+    expect(actions.value.map((action) => action.key)).toEqual(["signUp"]);
+
+    await actions.value[0].run();
+
+    expect(mutations.signupFleetEvent).toHaveBeenCalledWith(
+      "test-fleet",
+      "mining-run",
+      { status: FleetEventSignupStatusEnum.CONFIRMED },
+    );
+  });
+
+  it("withdraws through the same upsert rather than hunting for the slot", async () => {
+    queries.event.data.value = { signupsOpen: true, past: false };
+
+    const { actions } = useNotificationRecordActions(
+      notificationRef(
+        NotificationTypeEnum.FLEET_EVENT_SIGNUP_CONFIRMED,
+        eventRecord,
+      ),
+    );
+
+    await actions.value[0].run();
+
+    expect(mutations.signupFleetEvent).toHaveBeenCalledWith(
+      "test-fleet",
+      "mining-run",
+      { status: FleetEventSignupStatusEnum.WITHDRAWN },
+    );
+  });
+
+  it("does not offer a second sync while one is running", () => {
+    const notification = notificationRef(
+      NotificationTypeEnum.HANGAR_SYNC_FAILED,
+      { type: NotificationRecordTypeEnum.HANGAR_SYNC, id: "import-1" },
+    );
+
+    const { actions } = useNotificationRecordActions(notification);
+
+    queries.sync.data.value = { active: true };
+    expect(actions.value).toEqual([]);
+
+    queries.sync.data.value = { active: false };
+    expect(actions.value.map((action) => action.key)).toEqual(["syncAgain"]);
+  });
+
+  it("moves a wished-for ship into the hangar and links the store", async () => {
+    queries.vehicle.data.value = {
+      id: "vehicle-1",
+      wanted: true,
+      model: { links: { storeUrl: "https://robertsspaceindustries.com/x" } },
+    };
+
+    const { actions, externalLink } = useNotificationRecordActions(
+      notificationRef(NotificationTypeEnum.MODEL_ON_SALE, {
+        type: NotificationRecordTypeEnum.VEHICLE,
+        id: "vehicle-1",
+      }),
+    );
+
+    await actions.value[0].run();
+
+    expect(mutations.updateVehicle).toHaveBeenCalledWith("vehicle-1", {
+      wanted: false,
+    });
+    expect(externalLink.value?.href).toBe(
+      "https://robertsspaceindustries.com/x",
+    );
+  });
+
+  it("says the record is gone rather than offering buttons that cannot work", () => {
+    queries.ownMembership.isError.value = true;
+
+    const { actions, isUnavailable } = useNotificationRecordActions(
+      notificationRef(NotificationTypeEnum.FLEET_INVITE, membershipRecord),
+    );
+
+    expect(isUnavailable.value).toBe(true);
+    expect(actions.value).toEqual([]);
+  });
+});

--- a/app/frontend/frontend/composables/useNotificationRecordActions.ts
+++ b/app/frontend/frontend/composables/useNotificationRecordActions.ts
@@ -1,0 +1,251 @@
+import {
+  acceptFleetMember,
+  acceptFleetMembership,
+  declineFleetMember,
+  declineFleetMembership,
+  FleetEventSignupStatusEnum,
+  FleetMembershipStatusEnum,
+  NotificationTypeEnum,
+  signupFleetEvent,
+  syncRsiHangar,
+  updateVehicle,
+  useFleetEvent,
+  useFleetMember,
+  useFleetMembership,
+  useShowVehicle,
+  useSyncRsiHangarStatus,
+  type Notification,
+} from "@/services/fyApi";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+
+export type NotificationAction = {
+  key: string;
+  icon: string;
+  tone?: `${BtnTonesEnum}`;
+  run: () => Promise<unknown>;
+};
+
+/*
+ * Which record a notification's actions depend on. A type that is not in here
+ * has nothing to do beyond its link - most notifications report something that
+ * has already happened.
+ */
+const LOOKUPS = {
+  fleet_invite: "ownMembership",
+  fleet_member_requested: "member",
+  fleet_event_published: "event",
+  fleet_event_starting_soon: "event",
+  fleet_event_signup_confirmed: "event",
+  fleet_event_signup_assigned: "event",
+  hangar_sync_finished: "sync",
+  hangar_sync_failed: "sync",
+  model_on_sale: "vehicle",
+} as const satisfies Partial<Record<`${NotificationTypeEnum}`, string>>;
+
+type Lookup = (typeof LOOKUPS)[keyof typeof LOOKUPS];
+
+const lookupFor = (notification?: Notification): Lookup | undefined =>
+  notification
+    ? LOOKUPS[notification.notificationType as keyof typeof LOOKUPS]
+    : undefined;
+
+/*
+ * The actions a notification can still offer, decided by the record as it is
+ * now rather than as it was when the notification was written. An invite
+ * answered on the fleet page half an hour ago leaves nothing here, which is
+ * the point: a button that would only produce a 422 is worse than no button.
+ */
+export const useNotificationRecordActions = (
+  notification: Ref<Notification | undefined>,
+) => {
+  const record = computed(() => notification.value?.record);
+  const lookup = computed(() => lookupFor(notification.value));
+
+  const fleetSlug = computed(() => record.value?.fleetSlug || "");
+  const username = computed(() => record.value?.username || "");
+  const eventSlug = computed(() => record.value?.eventSlug || "");
+  const recordId = computed(() => record.value?.id || "");
+
+  // A query cannot be created conditionally, so all five exist and only the
+  // one the notification calls for is ever enabled.
+  const enabledFor = (kind: Lookup, ...required: Ref<string>[]) =>
+    computed(
+      () => lookup.value === kind && required.every((value) => !!value.value),
+    );
+
+  const queries = {
+    ownMembership: useFleetMembership(fleetSlug, {
+      query: { enabled: enabledFor("ownMembership", fleetSlug), retry: false },
+    }),
+    member: useFleetMember(fleetSlug, username, {
+      query: {
+        enabled: enabledFor("member", fleetSlug, username),
+        retry: false,
+      },
+    }),
+    event: useFleetEvent(fleetSlug, eventSlug, undefined, {
+      query: {
+        enabled: enabledFor("event", fleetSlug, eventSlug),
+        retry: false,
+      },
+    }),
+    vehicle: useShowVehicle(recordId, {
+      query: { enabled: enabledFor("vehicle", recordId), retry: false },
+    }),
+    sync: useSyncRsiHangarStatus({
+      query: { enabled: computed(() => lookup.value === "sync"), retry: false },
+    }),
+  };
+
+  const active = computed(() =>
+    lookup.value ? queries[lookup.value] : undefined,
+  );
+
+  const isLoading = computed(() => !!active.value?.isLoading.value);
+
+  // The record is gone, or was never the reader's to see. Nothing to act on,
+  // and saying so beats a row of buttons that cannot work.
+  const isUnavailable = computed(() => !!active.value?.isError.value);
+
+  const refresh = async () => {
+    await active.value?.refetch();
+  };
+
+  const membershipActions = (
+    status: FleetMembershipStatusEnum | undefined,
+    expected: FleetMembershipStatusEnum,
+    accept: () => Promise<unknown>,
+    decline: () => Promise<unknown>,
+  ): NotificationAction[] => {
+    if (status !== expected) {
+      return [];
+    }
+
+    return [
+      { key: "accept", icon: "fa-duotone fa-check", run: accept },
+      {
+        key: "decline",
+        icon: "fa-duotone fa-xmark",
+        tone: BtnTonesEnum.DANGER,
+        run: decline,
+      },
+    ];
+  };
+
+  const actions = computed<NotificationAction[]>(() => {
+    switch (notification.value?.notificationType) {
+      case NotificationTypeEnum.FLEET_INVITE:
+        return membershipActions(
+          queries.ownMembership.data.value?.status,
+          FleetMembershipStatusEnum.INVITED,
+          () => acceptFleetMembership(fleetSlug.value),
+          () => declineFleetMembership(fleetSlug.value),
+        );
+
+      case NotificationTypeEnum.FLEET_MEMBER_REQUESTED:
+        return membershipActions(
+          queries.member.data.value?.status,
+          FleetMembershipStatusEnum.REQUESTED,
+          () => acceptFleetMember(fleetSlug.value, username.value),
+          () => declineFleetMember(fleetSlug.value, username.value),
+        );
+
+      case NotificationTypeEnum.FLEET_EVENT_PUBLISHED:
+      case NotificationTypeEnum.FLEET_EVENT_STARTING_SOON: {
+        const event = queries.event.data.value;
+
+        if (!event?.signupsOpen || event.past) {
+          return [];
+        }
+
+        // Only the plain yes. The event page carries the three-way status and
+        // the ship picker; repeating them here would be a form, not a call to
+        // action.
+        return [
+          {
+            key: "signUp",
+            icon: "fa-duotone fa-check",
+            run: () =>
+              signupFleetEvent(fleetSlug.value, eventSlug.value, {
+                status: FleetEventSignupStatusEnum.CONFIRMED,
+              }),
+          },
+        ];
+      }
+
+      case NotificationTypeEnum.FLEET_EVENT_SIGNUP_CONFIRMED:
+      case NotificationTypeEnum.FLEET_EVENT_SIGNUP_ASSIGNED: {
+        const event = queries.event.data.value;
+
+        if (!event || event.past) {
+          return [];
+        }
+
+        return [
+          {
+            key: "withdraw",
+            icon: "fa-duotone fa-arrow-right-from-bracket",
+            tone: BtnTonesEnum.DANGER,
+            run: () =>
+              signupFleetEvent(fleetSlug.value, eventSlug.value, {
+                status: FleetEventSignupStatusEnum.WITHDRAWN,
+              }),
+          },
+        ];
+      }
+
+      case NotificationTypeEnum.HANGAR_SYNC_FINISHED:
+      case NotificationTypeEnum.HANGAR_SYNC_FAILED: {
+        if (queries.sync.data.value?.active !== false) {
+          return [];
+        }
+
+        return [
+          {
+            key: "syncAgain",
+            icon: "fa-duotone fa-rotate",
+            run: () => syncRsiHangar({}),
+          },
+        ];
+      }
+
+      case NotificationTypeEnum.MODEL_ON_SALE: {
+        const vehicle = queries.vehicle.data.value;
+
+        if (!vehicle?.wanted) {
+          return [];
+        }
+
+        return [
+          {
+            key: "markAsBought",
+            icon: "fa-duotone fa-cart-shopping",
+            run: () => updateVehicle(vehicle.id, { wanted: false }),
+          },
+        ];
+      }
+
+      default:
+        return [];
+    }
+  });
+
+  // The pledge store sits behind the ship, so it only becomes offerable once
+  // the vehicle has been loaded.
+  const externalLink = computed(() => {
+    if (
+      notification.value?.notificationType !==
+      NotificationTypeEnum.MODEL_ON_SALE
+    ) {
+      return undefined;
+    }
+
+    const storeUrl = queries.vehicle.data.value?.model?.links?.storeUrl;
+
+    return storeUrl
+      ? { key: "openStore", icon: "fa-duotone fa-store", href: storeUrl }
+      : undefined;
+  });
+
+  return { actions, externalLink, isLoading, isUnavailable, refresh };
+};

--- a/app/frontend/frontend/pages/notifications.vue
+++ b/app/frontend/frontend/pages/notifications.vue
@@ -506,6 +506,7 @@ const destroySelected = () =>
           @archive="selected && archiveOne(selected)"
           @unarchive="selected && unarchiveOne(selected)"
           @destroy="selected && destroy(selected)"
+          @refresh="invalidate()"
         />
       </div>
     </template>

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1931,7 +1931,15 @@
         "openInventory": "Open inventory",
         "openEvent": "Open event",
         "openRoster": "Show sign-ups",
-        "addToCalendar": "Add to calendar"
+        "addToCalendar": "Add to calendar",
+        "openStore": "Pledge store",
+        "accept": "Accept",
+        "decline": "Decline",
+        "signUp": "Sign up",
+        "withdraw": "Withdraw",
+        "syncAgain": "Sync again",
+        "markAsBought": "Mark as bought",
+        "unavailable": "This is no longer available."
       },
       "notificationTypes": {
         "channels": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1919,6 +1919,20 @@
         }
       },
       "optional": "optional",
+      "notificationActions": {
+        "open": "Open",
+        "openHangar": "Open hangar",
+        "openWishlist": "Open wishlist",
+        "openModel": "Show ship",
+        "openInvite": "View invite",
+        "reviewRequest": "Review request",
+        "openMembers": "Show members",
+        "openFleet": "Open fleet",
+        "openInventory": "Open inventory",
+        "openEvent": "Open event",
+        "openRoster": "Show sign-ups",
+        "addToCalendar": "Add to calendar"
+      },
       "notificationTypes": {
         "channels": {
           "app": "App",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -830,6 +830,8 @@
         "readAll": "All notifications marked as read",
         "destroyed": "Notification deleted",
         "destroyedAll": "All notifications deleted",
+        "actionDone": "Done",
+        "actionFailed": "That did not work - the notification may be out of date",
         "error": "Something went wrong",
         "bulk": {
           "read": {

--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -84,7 +84,8 @@ class HangarSync < HangarImporter
       type: :hangar_sync_finished,
       title: I18n.t("notifications.hangar_sync_finished.title"),
       body: sync_notification_body(output),
-      link: Rails.application.routes.url_helpers.frontend_hangar_path
+      link: Rails.application.routes.url_helpers.frontend_hangar_path,
+      record: import
     )
 
     output
@@ -99,7 +100,8 @@ class HangarSync < HangarImporter
         type: :hangar_sync_failed,
         title: I18n.t("notifications.hangar_sync_failed.title"),
         body: I18n.t("notifications.hangar_sync_failed.body", error: e.message),
-        link: Rails.application.routes.url_helpers.frontend_hangar_path
+        link: Rails.application.routes.url_helpers.frontend_hangar_path,
+        record: import
       )
     end
 

--- a/app/lib/notification_examples.rb
+++ b/app/lib/notification_examples.rb
@@ -7,7 +7,13 @@
 module NotificationExamples
   module_function
 
-  def create_for(user)
+  # `records` attaches a real record to the examples that name one. Without it
+  # the fixtures show the links and nothing else: the actions that answer an
+  # invite or sign up for an event are decided by the record's current state,
+  # so a notification pointing at nothing has none of them. The caller builds
+  # the records - this module is loaded in production and does not know
+  # FactoryBot.
+  def create_for(user, records: {})
     examples.each do |example|
       occurred_at = example[:age].ago
 
@@ -18,6 +24,7 @@ module NotificationExamples
         body: example[:body],
         link: example[:link],
         icon: example[:icon],
+        record: records[example[:type]],
         read_at: example[:read] ? occurred_at + 1.minute : nil,
         archived_at: example[:archived] ? occurred_at + 2.minutes : nil,
         created_at: occurred_at,
@@ -32,7 +39,7 @@ module NotificationExamples
         type: :fleet_invite,
         title: "You were invited to Test Fleet",
         body: "Accept the invite to see the fleet's hangar and events.",
-        link: "/fleets",
+        link: "/fleets/invites",
         icon: "fa-duotone fa-users",
         age: 6.minutes
       },

--- a/app/lib/notification_examples.rb
+++ b/app/lib/notification_examples.rb
@@ -61,6 +61,7 @@ module NotificationExamples
       {
         type: :hangar_create,
         title: "Aurora MR added to your hangar",
+        link: "/hangar",
         icon: "fa-duotone fa-warehouse",
         age: 3.hours
       },
@@ -84,6 +85,7 @@ module NotificationExamples
       {
         type: :wishlist_create,
         title: "Carrack added to your wishlist",
+        link: "/hangar",
         icon: "fa-duotone fa-heart",
         read: true,
         age: 2.days

--- a/app/lib/notification_record_reference.rb
+++ b/app/lib/notification_record_reference.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# What a notification points at, cut down to what a client needs to fetch that
+# record again.
+#
+# It deliberately carries no state. The notification payload is
+# fragment-cached, so a status served alongside it would be a lie the moment
+# the record moves on - an invite answered elsewhere would still read as open.
+# The client loads the record itself and decides from there which actions still
+# apply.
+#
+# Which endpoint a reference belongs to is not encoded here either: the same
+# FleetMembership is read through `/fleets/:slug/membership` when it is the
+# reader's own and through `/fleets/:slug/members/:username` when it is not,
+# and the notification type is what tells the two apart.
+class NotificationRecordReference
+  # The associations a reference reads, so a page of notifications can preload
+  # them instead of walking into one query per row. Keyed by the polymorphic
+  # `record_type`, which for an STI record is the base class.
+  PRELOADS = {
+    "FleetMembership" => %i[fleet user],
+    "FleetEvent" => %i[fleet],
+    "FleetInventory" => %i[fleet]
+  }.freeze
+
+  TYPES = %w[fleet_membership fleet_event fleet_inventory vehicle hangar_sync].freeze
+
+  def self.for(notification)
+    new(notification).to_h
+  end
+
+  def self.preload(notifications)
+    records = notifications.filter_map(&:record)
+
+    PRELOADS.each do |record_type, associations|
+      scoped = records.select { |record| record.class.base_class.name == record_type }
+
+      next if scoped.empty?
+
+      ActiveRecord::Associations::Preloader.new(records: scoped, associations:).call
+    end
+  end
+
+  def initialize(notification)
+    @record = notification.record
+  end
+
+  def to_h
+    case record
+    when FleetMembership
+      {type: "fleet_membership", id: record.id, fleet_slug: record.fleet&.slug, username: record.user&.username}
+    when FleetEvent
+      {type: "fleet_event", id: record.id, fleet_slug: record.fleet&.slug, event_slug: record.slug}
+    when FleetInventory
+      {type: "fleet_inventory", id: record.id, fleet_slug: record.fleet&.slug, inventory_slug: record.slug}
+    when Vehicle
+      {type: "vehicle", id: record.id}
+    when Imports::HangarSync
+      {type: "hangar_sync", id: record.id}
+    end
+  end
+
+  private attr_reader :record
+end

--- a/app/models/fleet_inventory_item.rb
+++ b/app/models/fleet_inventory_item.rb
@@ -69,7 +69,7 @@ class FleetInventoryItem < ApplicationRecord
         user: recipient,
         type: :fleet_inventory_item_added,
         title: I18n.t("notifications.fleet_inventory_item_added.title", item_name: name, fleet: fleet.name),
-        link: Rails.application.routes.url_helpers.frontend_fleet_path(fleet.slug),
+        link: "/fleets/#{fleet.slug}/logistics/inventories/#{fleet_inventory.slug}",
         record: fleet_inventory
       )
     end

--- a/app/views/api/v1/fleet_members/show.jbuilder
+++ b/app/views/api/v1/fleet_members/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_members/fleet_member", member: @member

--- a/app/views/api/v1/notifications/_base.jbuilder
+++ b/app/views/api/v1/notifications/_base.jbuilder
@@ -12,4 +12,17 @@ json.archived notification.archived?
 json.archived_at notification.archived_at&.utc&.iso8601
 json.deletes_at notification.deletes_at&.utc&.iso8601
 json.expires_at notification.expires_at.utc.iso8601
+
+# A reference to the record the notification is about, so the reader can load
+# it and see what state it is in now. Nothing about that state is written here:
+# this partial is fragment-cached, and a status cached alongside the
+# notification would still read as open long after the invite was answered.
+reference = NotificationRecordReference.for(notification)
+
+if reference.present?
+  json.record do
+    reference.each { |key, value| json.set!(key, value) }
+  end
+end
+
 json.partial! "api/shared/dates", record: notification

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -2827,6 +2827,8 @@ components:
           type: string
         icon:
           type: string
+        record:
+          "$ref": "#/components/schemas/NotificationRecord"
         read:
           type: boolean
         readAt:
@@ -2859,6 +2861,40 @@ components:
       - expiresAt
       - createdAt
       - updatedAt
+    NotificationRecord:
+      type: object
+      properties:
+        type:
+          "$ref": "#/components/schemas/NotificationRecordTypeEnum"
+        id:
+          type: string
+          format: uuid
+        fleetSlug:
+          type: string
+        username:
+          type: string
+        eventSlug:
+          type: string
+        inventorySlug:
+          type: string
+      additionalProperties: false
+      required:
+      - type
+      - id
+    NotificationRecordTypeEnum:
+      type: string
+      enum:
+      - fleet_membership
+      - fleet_event
+      - fleet_inventory
+      - vehicle
+      - hangar_sync
+      x-enumNames:
+      - FLEET_MEMBERSHIP
+      - FLEET_EVENT
+      - FLEET_INVENTORY
+      - VEHICLE
+      - HANGAR_SYNC
     NotificationTypeEnum:
       type: string
       enum:

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -15,7 +15,7 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
     end
   end
 
-  resources :fleet_members, path: "members", param: :username, only: %i[index create destroy] do
+  resources :fleet_members, path: "members", param: :username, only: %i[index show create destroy] do
     member do
       put :demote
       put :promote

--- a/docs/exec-plans/notification-call-to-actions.md
+++ b/docs/exec-plans/notification-call-to-actions.md
@@ -1,0 +1,92 @@
+# Notification Call-to-Actions
+
+Every one of the 24 notification types renders the same generic "Open" button in the reading pane, and nothing at all in the list rows. A fleet invite — which asks the reader for an answer — looks exactly like "Aurora MR added to your hangar", which asks for nothing. This plan gives each notification an action that fits its occasion, in three tiers: an honest label, secondary targets (calendar, store), and real mutations (accept an invite, decline a request, retry a sync).
+
+## The problem with mutations
+
+An invite may have been answered elsewhere, an event may have started, sign-ups may be locked. A button that then throws a 422 is worse than no button.
+
+So the notification carries a **reference to its record**, and the reading pane loads that record when the notification is opened. The fetched state — not the notification — decides which actions appear.
+
+`Notification` already has `record_type`/`record_id` (polymorphic). The API exposes neither.
+
+## Payload
+
+New `record` block in `app/views/api/v1/notifications/_base.jbuilder`:
+
+```ruby
+json.record do
+  json.type ...        # fleet_membership | fleet_event | fleet_inventory | vehicle | hangar_sync
+  json.id ...
+  json.fleet_slug ...  # only what the matching endpoint needs to load it
+  json.event_slug ...
+  json.username ...
+end
+```
+
+A flat object with optional fields rather than a `oneOf` discriminator: the OpenAPI components in this repo are hand-written, and a union costs more than it carries.
+
+`_notification.jbuilder` caches on `["v1", notification]`, so this block must carry **no live state** — a cached row would serve a stale status. Reference only.
+
+## Record lookups
+
+| `record.type` | Endpoint | State read |
+|---|---|---|
+| `fleet_membership` (own) | `GET /fleets/:slug/membership` | `status` |
+| `fleet_membership` (someone else's) | `GET /fleets/:slug/members/:username` **(new)** | `status` |
+| `fleet_event` | `GET /fleets/:slug/events/:slug` | `status`, `signups_open`, `past` |
+| `vehicle` | `GET /vehicles/:id` | `wanted` |
+| `hangar_sync` | `GET /hangar/sync-rsi-hangar/status` | `active` |
+
+Three render states: **loading** → link CTA only; **resolved** → the actions the state allows; **gone/403** → a "no longer available" note plus the link. On success the record query and the notification list are invalidated and the notification is marked read; archiving stays a deliberate act.
+
+## Backend work
+
+| Change | File |
+|---|---|
+| `record` block + OpenAPI component | `app/views/api/v1/notifications/_base.jbuilder` |
+| `GET /fleets/:slug/members/:username` | `config/routes/api/fleets_routes.rb`, `app/controllers/api/v1/fleet_members_controller.rb` |
+| Attach the import as the sync record | `app/lib/hangar_sync.rb` |
+| Point the inventory link at the inventory | `app/models/fleet_inventory_item.rb` |
+
+`fleet_members` currently exposes `index create destroy` plus the member actions; `set_member` and the doorkeeper scopes already exist, so `show` is a route, an action with `authorize!`, and a jbuilder reusing `_base`.
+
+## Frontend
+
+A registry — `notification_type → { labelKey, record?, actions(state) }` — in `frontend/composables/useNotificationActions.ts`. The reading pane and the list row render from it generically, which keeps the state logic unit-testable without mounting Vue.
+
+Labels under `labels.notificationActions.*` in all seven locales.
+
+### Tier 1 — label and link (all types)
+
+"Open" becomes type-specific; list rows get the same link button. For the twelve pure statements of fact (`hangar_create`, `wishlist_*`, `fleet_event_started/completed/cancelled`, `fleet_event_signup_kicked`, …) that is the whole change — there is nothing to do about them.
+
+Not affected: `NotificationsNav/index.vue` is a nav item with a badge, not a dropdown. There is no place for a CTA there.
+
+### Tier 2 — mutations, reading pane only
+
+List rows stay out: one record fetch per row would be N requests.
+
+| Type | Action | Condition | Endpoint |
+|---|---|---|---|
+| `fleet_invite` | Accept / Decline | `status == invited` | `PUT /fleets/:slug/membership/accept\|decline` |
+| `fleet_member_requested` | Accept / Decline | `status == requested` | `PUT /fleets/:slug/members/:username/accept\|decline` |
+| `fleet_event_published`, `…_starting_soon` | Sign up | `signups_open && !past` | `POST /fleets/:slug/events/:slug/signup` |
+| `fleet_event_signup_confirmed`, `…_assigned` | Withdraw | signup active | `DELETE /fleet-event-slots/:id/signup` |
+| `hangar_sync_finished`, `…_failed` | Sync again | `!active` | `PUT /hangar/sync-rsi-hangar` |
+| `model_on_sale` | Mark as bought | `wanted` | `PATCH /vehicles/:id` |
+
+`EventSignupCta` carries three statuses and a vehicle picker. The notification offers only "Sign up" (`CONFIRMED`, no vehicle); anyone who wants more follows the link. The generated mutation clients are reused as-is.
+
+### Tier 3 — secondary actions
+
+- Calendar for every event type: `GET /fleets/:slug/events/:slug/event.ics` already exists.
+- Store link for `model_on_sale`: `model.store_url` is already in the vehicle payload.
+- A second target: event → fleet, admin sign-up notices → the roster rather than the event overview.
+
+## Verification
+
+- Integration tests (`openapi-ruby`) for the `record` block and for `fleet_members#show` including the policy case, then `./bin/generate-schema`.
+- Vitest for `useNotificationActions`: state in, expected buttons out — including the expired cases (invite already answered, event past, sync running).
+- `test/playwright/e2e/Notifications.spec.ts`. This needs `app/lib/notification_examples.rb` to create real records for the first time; none of its eight examples passes a `record:` today, and without one tier 2 is invisible to the e2e run.
+- By hand: trigger an invite in a test fleet, accept it from the notification center, reopen the same notification — the actions must be gone.

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -3433,7 +3433,7 @@ paths:
       in: path
       schema:
         type: string
-      description: username
+      description: Username
       required: true
     delete:
       summary: Remove Fleet Member
@@ -3453,6 +3453,48 @@ paths:
           description: successful
         '401':
           description: Without authentication
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    get:
+      summary: Show Member
+      tags:
+      - FleetMembers
+      operationId: fleetMember
+      description: A single membership, so a notification about it can show what state
+        it is in now
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:read
+      - OpenId:
+        - fleet
+        - fleet:read
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetMember"
+        '401':
+          description: unauthorized
           content:
             application/json:
               schema:
@@ -18798,6 +18840,8 @@ components:
           type: string
         icon:
           type: string
+        record:
+          "$ref": "#/components/schemas/NotificationRecord"
         read:
           type: boolean
         readAt:
@@ -18916,6 +18960,42 @@ components:
       additionalProperties: false
       example: {}
       title: NotificationQuery
+    NotificationRecord:
+      type: object
+      properties:
+        type:
+          "$ref": "#/components/schemas/NotificationRecordTypeEnum"
+        id:
+          type: string
+          format: uuid
+        fleetSlug:
+          type: string
+        username:
+          type: string
+        eventSlug:
+          type: string
+        inventorySlug:
+          type: string
+      additionalProperties: false
+      required:
+      - type
+      - id
+      title: NotificationRecord
+    NotificationRecordTypeEnum:
+      type: string
+      enum:
+      - fleet_membership
+      - fleet_event
+      - fleet_inventory
+      - vehicle
+      - hangar_sync
+      x-enumNames:
+      - FLEET_MEMBERSHIP
+      - FLEET_EVENT
+      - FLEET_INVENTORY
+      - VEHICLE
+      - HANGAR_SYNC
+      title: NotificationRecordTypeEnum
     NotificationSortEnum:
       type: string
       enum:

--- a/test/integration/api/v1/fleets_members_show_test.rb
+++ b/test/integration/api/v1/fleets_members_show_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMembersShowTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/members/{username}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+    parameter name: "username", in: :path, schema: {type: :string}, description: "Username"
+
+    get("Show Member") do
+      operationId "fleetMember"
+      description "A single membership, so a notification about it can show what state it is in now"
+      tags "FleetMembers"
+      produces "application/json"
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:read"]},
+        {OpenId: ["fleet", "fleet:read"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Fleets::FleetMember
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:user)
+    @member = create(:user)
+    @outsider = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+  end
+
+  test "GET /fleets/:slug/members/:username returns the member" do
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug, username: @member.username} do
+      assert_equal @member.username, parsed_body["username"]
+      assert_equal "accepted", parsed_body["status"]
+    end
+  end
+
+  test "GET /fleets/:slug/members/:username reports a request that is still open" do
+    requester = create(:user)
+    membership = @fleet.fleet_memberships.create!(user: requester, fleet_role: @fleet.default_member_role)
+    membership.request!
+
+    sign_in @admin
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug, username: requester.username} do
+      assert_equal "requested", parsed_body["status"]
+    end
+  end
+
+  test "GET /fleets/:slug/members/:username returns 404 for an unknown member" do
+    sign_in @admin
+
+    assert_api_response :get, 404, path_params: {fleetSlug: @fleet.slug, username: "unknown"}
+  end
+
+  # An outsider gets a 404 rather than a 403 - the fleet is out of their scope,
+  # so there is nothing to be forbidden from. 403 is for someone who is in the
+  # fleet but whose role may not read its memberships.
+  test "GET /fleets/:slug/members/:username returns 403 without membership read access" do
+    @fleet.default_member_role.update!(resource_access: [])
+
+    sign_in @member
+
+    assert_api_response :get, 403, path_params: {fleetSlug: @fleet.slug, username: @admin.username}
+  end
+
+  test "GET /fleets/:slug/members/:username lets a member read their own membership" do
+    @fleet.default_member_role.update!(resource_access: [])
+
+    sign_in @member
+
+    assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug, username: @member.username}
+  end
+
+  test "GET /fleets/:slug/members/:username returns 404 for an outsider" do
+    sign_in @outsider
+
+    assert_api_response :get, 404, path_params: {fleetSlug: @fleet.slug, username: @member.username}
+  end
+
+  test "GET /fleets/:slug/members/:username returns 401 when not signed in" do
+    assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug, username: @member.username}
+  end
+
+  test "GET /fleets/:slug/members/:username with OAuth bearer token" do
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:read"])
+  end
+end

--- a/test/integration/api/v1/notifications_record_behaviour_test.rb
+++ b/test/integration/api/v1/notifications_record_behaviour_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::NotificationsRecordBehaviourTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    sign_in @user
+  end
+
+  def notification_record
+    get "/api/v1/notifications", as: :json
+
+    assert_response :ok
+
+    JSON.parse(response.body)["items"].first["record"]
+  end
+
+  test "a membership notification points at the membership with the slugs to load it" do
+    fleet = create(:fleet, admins: [create(:user)])
+    membership = fleet.fleet_memberships.create!(user: @user, fleet_role: fleet.default_member_role)
+
+    create(:notification, user: @user, notification_type: "fleet_invite", record: membership)
+
+    record = notification_record
+
+    assert_equal "fleet_membership", record["type"]
+    assert_equal membership.id, record["id"]
+    assert_equal fleet.slug, record["fleetSlug"]
+    assert_equal @user.username, record["username"]
+  end
+
+  test "an event notification carries both slugs" do
+    fleet = create(:fleet, admins: [@user])
+    event = create(:fleet_event, fleet:, created_by: @user)
+
+    create(:notification, user: @user, notification_type: "fleet_event_published", record: event)
+
+    record = notification_record
+
+    assert_equal "fleet_event", record["type"]
+    assert_equal fleet.slug, record["fleetSlug"]
+    assert_equal event.slug, record["eventSlug"]
+  end
+
+  test "a hangar sync notification points at the import" do
+    import = Imports::HangarSync.create!(user: @user)
+
+    create(:notification, user: @user, notification_type: "hangar_sync_failed", record: import)
+
+    record = notification_record
+
+    assert_equal "hangar_sync", record["type"]
+    assert_equal import.id, record["id"]
+  end
+
+  # `Jbuilder.ignore_nil` is on for the whole API, so a notification about
+  # nothing in particular leaves the key out rather than sending a null.
+  test "a notification without a record carries no reference" do
+    create(:notification, user: @user, notification_type: "hangar_create", record: nil)
+
+    get "/api/v1/notifications", as: :json
+
+    refute JSON.parse(response.body)["items"].first.key?("record")
+  end
+
+  test "a page of notifications does not query per row for its references" do
+    fleet = create(:fleet, admins: [create(:user)])
+
+    3.times do
+      membership = fleet.fleet_memberships.create!(user: create(:user), fleet_role: fleet.default_member_role)
+      create(:notification, user: @user, notification_type: "fleet_member_requested", record: membership)
+    end
+
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      queries << payload[:sql] unless payload[:name].in?(["SCHEMA", "TRANSACTION"])
+    end
+
+    get "/api/v1/notifications", as: :json
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    # One for the memberships, one for their fleets, one for their users -
+    # three rows must not cost three of each.
+    fleet_queries = queries.count { |sql| sql.include?('FROM "fleets"') }
+
+    assert_operator fleet_queries, :<=, 1, "expected the fleets to be preloaded, got #{fleet_queries} queries"
+  end
+end

--- a/test/playwright/app_commands/scenarios/notifications.rb
+++ b/test/playwright/app_commands/scenarios/notifications.rb
@@ -10,6 +10,18 @@ user = User.find_or_create_by!(username: "notifications") do |u|
   u.confirmed_at = Time.current
 end
 
-NotificationExamples.create_for(user)
+# A real, still-open invite behind the invite example. The reading pane decides
+# its actions from the membership's current state, so without this the fixture
+# would only ever show the link.
+fleet = FactoryBot.create(:fleet, name: "Test Fleet", admins: [FactoryBot.create(:user)])
+invite = FactoryBot.create(
+  :fleet_membership,
+  fleet: fleet,
+  user: user,
+  fleet_role: fleet.fleet_roles.ranked.last,
+  aasm_state: :invited
+)
+
+NotificationExamples.create_for(user, records: {fleet_invite: invite})
 
 Rails.logger.info "E2E: Created notifications scenario test data"

--- a/test/playwright/e2e/Notifications.spec.ts
+++ b/test/playwright/e2e/Notifications.spec.ts
@@ -164,6 +164,40 @@ test.describe("Notifications", () => {
     await expect(page.getByTestId("notification-detail-no-body")).toBeVisible();
   });
 
+  test("Names what the link leads to instead of a bare 'Open'", async ({
+    page,
+  }) => {
+    await row(page, "Aurora MR added to your hangar")
+      .getByTestId("notification-select")
+      .click();
+
+    await expect(
+      page.getByTestId("notification-action-open-hangar"),
+    ).toBeVisible();
+  });
+
+  test("Answers a fleet invite from the reading pane", async ({
+    page,
+    notification,
+  }) => {
+    await row(page, "You were invited to Test Fleet")
+      .getByTestId("notification-select")
+      .click();
+
+    const accept = page.getByTestId("notification-action-accept");
+
+    await expect(accept).toBeVisible();
+    await expect(page.getByTestId("notification-action-decline")).toBeVisible();
+
+    await accept.click();
+
+    await notification.success("Done");
+
+    // The membership is no longer an open invite, so re-reading it leaves
+    // nothing to answer.
+    await expect(page.getByTestId("notification-action-accept")).toHaveCount(0);
+  });
+
   test("Counts the unread notifications in the navigation", async ({
     page,
   }) => {


### PR DESCRIPTION
Notifications now carry an action that fits their occasion. Until now every one of the 24 types wore the same generic "Open" in the reading pane, and nothing at all in the list rows — a fleet invite, which asks the reader for an answer, looked exactly like "Aurora MR added to your hangar", which asks for nothing.

## The mechanism

A notification now exposes a **reference to its record** — the type plus the slugs the matching endpoint needs. Deliberately no state: the payload is fragment-cached, and a status served alongside it would still read as open long after the invite was answered. The reading pane loads the record itself, and the fetched state decides which buttons exist.

`record_type`/`record_id` have been on the model since the notification center landed; the API just never showed them.

## Three tiers

**Naming the link.** "Open" becomes "View invite", "Review request", "Open event". The map is typed against the full notification enum, so a new type fails the build rather than quietly falling back to "Open". List rows get the same link as an icon.

**Acting on it.** Accept/decline an invite or a join request, sign up for or withdraw from an event, retry a hangar sync, mark a wished-for ship as bought. Each appears only while the loaded record still allows it — an invite answered on the fleet page half an hour ago leaves nothing behind. When the record is gone or was never the reader's to see, the pane says so instead of offering buttons that cannot work.

**Side doors.** The calendar file an event already serves, the fleet behind whatever the notification is about, the pledge store behind a ship on sale.

## Along the way

- `GET /fleets/:slug/members/:username` — a membership was only reachable through the member list, so nothing could ask what state one particular membership is in.
- The hangar sync notifications attached no record at all; the inventory notification linked to the fleet's front page rather than the inventory the item landed in.
- `includes(:record)` stops at the polymorphic record, so the slugs behind it are preloaded separately — without that a page of 25 is a query per row. A test pins that down.

## Decisions worth flagging

- **Sign-up offers the plain yes only.** The event page carries the three-way status and the ship picker; repeating them in a notification would be a form, not a call to action. Withdrawing goes through the same upsert, which saves hunting through the event for the reader's own slot.
- **List rows get no record-driven actions.** One fetch per row would be N requests for a page of 25.
- **Labels are English only**, matching the rest of the notification center — the other six locales already fall back to `en` for `notificationTypes`.
- **The navigation is untouched** — it is a nav item with a badge, not a dropdown, so there is no place for a CTA there.

## Testing

- 133 Ruby tests green: the record reference, `fleet_members#show` including the policy cases, hangar sync, the existing fleet member and notification suites.
- 13 Vitest cases across both composables, including the expired states — invite already answered, event past, sync already running.
- **The e2e specs are written but unrun**: port 8280 was held by another worktree's server, and Playwright would have adopted it and tested foreign code. The two new specs and the fixture that puts a real membership behind the invite example need a CI run to count.

## Found, not fixed

`new_model` is declared in `Notification::TYPES` with a mailer and a retention, but `NewModelJob` only posts to Discord and sets `notified: true` — it never calls `notify!`. The type exists in the sample data and nowhere else.

🤖
