### PR TITLE
feat(notifications): bulk operations on both notification centers

### DIFF
--- a/app/api_components/admin/v1/schemas/admin_notification_bulk_result.rb
+++ b/app/api_components/admin/v1/schemas/admin_notification_bulk_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminNotificationBulkResult
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            count: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[count]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/admin_notification_bulk_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/admin_notification_bulk_input.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class AdminNotificationBulkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              ids: {type: :array, items: {type: :string, format: :uuid}},
+              all: {
+                type: :boolean,
+                default: false,
+                description: "Apply to every notification matching `q` instead of `ids`."
+              },
+              q: ::Admin::V1::Schemas::Queries::AdminNotificationQuery
+            },
+            additionalProperties: false,
+            description: "Naming neither `ids` nor `all` selects nothing."
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/notification_bulk_input.rb
+++ b/app/api_components/v1/schemas/inputs/notification_bulk_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class NotificationBulkInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            ids: {type: :array, items: {type: :string, format: :uuid}},
+            all: {
+              type: :boolean,
+              default: false,
+              description: "Apply to every notification matching `q` instead of `ids`."
+            },
+            q: ::V1::Schemas::Queries::NotificationQuery
+          },
+          additionalProperties: false,
+          description: "Naming neither `ids` nor `all` selects nothing."
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/notification_bulk_result.rb
+++ b/app/api_components/v1/schemas/notification_bulk_result.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class NotificationBulkResult
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          count: {type: :integer}
+        },
+        additionalProperties: false,
+        required: %w[count]
+      })
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/notifications_controller.rb
+++ b/app/controllers/admin/api/v1/notifications_controller.rb
@@ -89,6 +89,68 @@ module Admin
           head :no_content
         end
 
+        def read_bulk
+          authorize! with: ::Admin::NotificationPolicy
+
+          bulk(:unread, read_at: Time.current)
+        end
+
+        def unread_bulk
+          authorize! with: ::Admin::NotificationPolicy
+
+          bulk(:read, read_at: nil)
+        end
+
+        def archive_bulk
+          authorize! with: ::Admin::NotificationPolicy
+
+          bulk(:inbox, archived_at: Time.current)
+        end
+
+        def unarchive_bulk
+          authorize! with: ::Admin::NotificationPolicy
+
+          bulk(:archived, archived_at: nil)
+        end
+
+        def destroy_bulk
+          authorize! with: ::Admin::NotificationPolicy
+
+          @count = bulk_selection.delete_all
+
+          render :bulk
+        end
+
+        # Only the rows the action has something to do to: marking an already read
+        # notification read again would move its `read_at` to now for nothing,
+        # and the count that comes back is then what actually changed.
+        private def bulk(narrow, attributes)
+          @count = bulk_selection.public_send(narrow)
+            .update_all(**attributes, updated_at: Time.current)
+
+          render :bulk
+        end
+
+        # The reader either ticked rows or asked for everything the current
+        # filter matches, and `all` has to say so out loud. A body naming
+        # neither selects nothing rather than everything: the other reading of
+        # it is `destroy_all` by accident.
+        private def bulk_selection
+          return filtered_scope if ActiveModel::Type::Boolean.new.cast(params[:all])
+
+          scope.where(id: Array(params[:ids]))
+        end
+
+        # The list the index would return, without the paging and without the
+        # ordering - PostgreSQL refuses an ORDER BY in an UPDATE, and it means
+        # nothing there anyway.
+        private def filtered_scope
+          query = notification_query_params.except("sorts")
+          query["archived_at_null"] = true unless query.key?("archived_at_null")
+
+          scope.ransack(query).result.reorder(nil)
+        end
+
         private def scope
           authorized_scope(AdminNotification.all, with: ::Admin::NotificationPolicy).active
         end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -11,7 +11,8 @@ module Api
         only: %i[index unread_count]
       before_action -> { doorkeeper_authorize! "notifications", "notifications:write" },
         unless: :user_signed_in?,
-        only: %i[read unread archive unarchive read_all destroy destroy_all]
+        only: %i[read unread archive unarchive read_all destroy destroy_all
+          read_bulk unread_bulk archive_bulk unarchive_bulk destroy_bulk]
 
       before_action :set_notification, only: %i[read unread archive unarchive destroy]
 
@@ -92,6 +93,68 @@ module Api
         scope.delete_all
 
         head :no_content
+      end
+
+      def read_bulk
+        authorize! with: NotificationPolicy
+
+        bulk(:unread, read_at: Time.current)
+      end
+
+      def unread_bulk
+        authorize! with: NotificationPolicy
+
+        bulk(:read, read_at: nil)
+      end
+
+      def archive_bulk
+        authorize! with: NotificationPolicy
+
+        bulk(:inbox, archived_at: Time.current)
+      end
+
+      def unarchive_bulk
+        authorize! with: NotificationPolicy
+
+        bulk(:archived, archived_at: nil)
+      end
+
+      def destroy_bulk
+        authorize! with: NotificationPolicy
+
+        @count = bulk_selection.delete_all
+
+        render :bulk
+      end
+
+      # Only the rows the action has something to do to: marking an already read
+      # notification read again would move its `read_at` to now for nothing, and
+      # the count that comes back is then what actually changed.
+      private def bulk(narrow, attributes)
+        @count = bulk_selection.public_send(narrow)
+          .update_all(**attributes, updated_at: Time.current)
+
+        render :bulk
+      end
+
+      # The reader either ticked rows or asked for everything the current filter
+      # matches, and `all` has to say so out loud. A body naming neither selects
+      # nothing rather than everything: the other reading of it is `destroy_all`
+      # by accident.
+      private def bulk_selection
+        return filtered_scope if ActiveModel::Type::Boolean.new.cast(params[:all])
+
+        scope.where(id: Array(params[:ids]))
+      end
+
+      # The list the index would return, without the paging and without the
+      # ordering - PostgreSQL refuses an ORDER BY in an UPDATE, and it means
+      # nothing there anyway.
+      private def filtered_scope
+        tab_scope
+          .ransack(notification_query_params.except("archived_at_null", "sorts"))
+          .result
+          .reorder(nil)
       end
 
       private def scope

--- a/app/frontend/admin/components/Notifications/ListItem/index.vue
+++ b/app/frontend/admin/components/Notifications/ListItem/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import Btn from "@/shared/components/base/Btn/index.vue";
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import BasePill from "@/shared/components/base/Pill/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -18,14 +19,19 @@ import { type AdminNotification } from "@/services/fyAdminApi";
 type Props = {
   notification: AdminNotification;
   selected?: boolean;
+  selectable?: boolean;
+  checked?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   selected: false,
+  selectable: false,
+  checked: false,
 });
 
 const emit = defineEmits<{
   select: [];
+  toggle: [checked: boolean];
   archive: [];
   unarchive: [];
   destroy: [];
@@ -49,8 +55,21 @@ defineExpose({ focus: () => select.value?.focus() });
     :class="{
       'notification-item--unread': !notification.read,
       'notification-item--selected': props.selected,
+      'notification-item--selectable': props.selectable,
     }"
   >
+    <FormCheckbox
+      v-if="props.selectable"
+      v-tooltip="t('actions.adminNotifications.select')"
+      :model-value="props.checked"
+      :aria-label="t('actions.adminNotifications.select')"
+      class="notification-item__checkbox"
+      name="notification-selection"
+      data-test="notification-checkbox"
+      no-label
+      inline
+      @update:model-value="emit('toggle', $event)"
+    />
     <button
       ref="select"
       type="button"
@@ -184,6 +203,21 @@ defineExpose({ focus: () => select.value?.focus() });
   cursor: pointer;
 }
 
+// The checkbox brings a form field's bottom margin, which a row has no use
+// for, and it lines up with the first line of the title rather than the
+// middle of a row that may run to two.
+.notification-item__checkbox {
+  flex-shrink: 0;
+  margin-top: 10px;
+  margin-bottom: 0;
+  padding-left: 10px;
+}
+
+// The checkbox takes over the left inset, so the title stops carrying it.
+.notification-item--selectable .notification-item__select {
+  padding-left: 4px;
+}
+
 .notification-item__icon {
   flex-shrink: 0;
   margin-top: 2px;
@@ -262,6 +296,10 @@ defineExpose({ focus: () => select.value?.focus() });
   .notification-item__select {
     gap: 10px;
     padding-left: 10px;
+  }
+
+  .notification-item__checkbox {
+    padding-left: 6px;
   }
 
   .notification-item__actions {

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -11,11 +11,13 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import Detail from "@/admin/components/Notifications/Detail/index.vue";
 import FilterForm from "@/admin/components/Notifications/FilterForm/index.vue";
 import ListItem from "@/admin/components/Notifications/ListItem/index.vue";
 import { usePagination } from "@/shared/composables/usePagination";
+import { useBulkSelection } from "@/shared/composables/useBulkSelection";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import {
@@ -34,7 +36,14 @@ import {
   unarchiveAdminNotification,
   destroyAdminNotification,
   destroyAllAdminNotifications,
+  readBulkAdminNotifications,
+  unreadBulkAdminNotifications,
+  archiveBulkAdminNotifications,
+  unarchiveBulkAdminNotifications,
+  destroyBulkAdminNotifications,
   type AdminNotification,
+  type AdminNotificationBulkInput,
+  type AdminNotificationBulkResult,
   type AdminNotificationSortEnum,
 } from "@/services/fyAdminApi";
 
@@ -118,6 +127,25 @@ watch([sorts, archive], async () => {
 const { data: unreadCount } = useAdminNotificationsUnreadCount();
 
 const records = computed(() => notifications.value?.items || []);
+
+const totalCount = computed(
+  () => notifications.value?.meta.pagination?.totalCount,
+);
+
+const {
+  selectedIds,
+  allMatchingSelected,
+  selectedCount,
+  matchingCount,
+  pageSelected,
+  pagePartiallySelected,
+  canSelectAllMatching,
+  toggle: toggleSelection,
+  togglePage,
+  selectAllMatching,
+  clear: clearSelection,
+  payload: bulkPayload,
+} = useBulkSelection(records, () => queryParams.value.q, totalCount);
 
 const selectedId = ref<string>();
 
@@ -232,6 +260,61 @@ const destroyAll = () =>
     () => destroyAllAdminNotifications(),
     t("messages.adminNotifications.destroyedAll"),
   );
+
+// The selection is spent once the action lands: leaving it ticked invites a
+// second run over rows that have already moved on, and after "all matching"
+// it would no longer mean the same set.
+const withBulkFeedback = async (
+  action: (
+    input: AdminNotificationBulkInput,
+  ) => Promise<AdminNotificationBulkResult>,
+  key: string,
+) => {
+  try {
+    const { count } = await action(bulkPayload.value);
+
+    clearSelection();
+    invalidate();
+    displaySuccess({ text: t(key, { count }) });
+  } catch {
+    displayAlert({ text: t("messages.adminNotifications.error") });
+  }
+};
+
+const readSelected = () =>
+  withBulkFeedback(
+    readBulkAdminNotifications,
+    "messages.adminNotifications.bulk.read",
+  );
+
+// Same reason the single-record one closes the pane: an unread notification
+// left open only invites the click that marks it read again.
+const unreadSelected = () => {
+  selectedId.value = undefined;
+
+  return withBulkFeedback(
+    unreadBulkAdminNotifications,
+    "messages.adminNotifications.bulk.unread",
+  );
+};
+
+const archiveSelected = () =>
+  withBulkFeedback(
+    archiveBulkAdminNotifications,
+    "messages.adminNotifications.bulk.archived",
+  );
+
+const unarchiveSelected = () =>
+  withBulkFeedback(
+    unarchiveBulkAdminNotifications,
+    "messages.adminNotifications.bulk.unarchived",
+  );
+
+const destroySelected = () =>
+  withBulkFeedback(
+    destroyBulkAdminNotifications,
+    "messages.adminNotifications.bulk.destroyed",
+  );
 </script>
 
 <template>
@@ -321,6 +404,69 @@ const destroyAll = () =>
       </Btn>
     </template>
     <template #default="{ records: shown }">
+      <BulkSelectionBar
+        class="admin-notifications__bulk"
+        :class="{ 'admin-notifications__bulk--hidden': !!selected }"
+        :selected-count="selectedCount"
+        :matching-count="matchingCount"
+        :page-selected="pageSelected"
+        :page-partially-selected="pagePartiallySelected"
+        :can-select-all-matching="canSelectAllMatching"
+        :all-matching-selected="allMatchingSelected"
+        @toggle-page="togglePage"
+        @select-all-matching="selectAllMatching"
+        @clear="clearSelection"
+      >
+        <Btn
+          v-tooltip="t('actions.adminNotifications.readSelected')"
+          :aria-label="t('actions.adminNotifications.readSelected')"
+          data-test="bulk-read"
+          @click="readSelected"
+        >
+          <i class="fa-duotone fa-envelope-open" />
+        </Btn>
+        <Btn
+          v-tooltip="t('actions.adminNotifications.unreadSelected')"
+          :aria-label="t('actions.adminNotifications.unreadSelected')"
+          data-test="bulk-unread"
+          @click="unreadSelected"
+        >
+          <i class="fa-duotone fa-envelope-dot" />
+        </Btn>
+        <Btn
+          v-if="archive"
+          v-tooltip="t('actions.adminNotifications.unarchiveSelected')"
+          :aria-label="t('actions.adminNotifications.unarchiveSelected')"
+          data-test="bulk-unarchive"
+          @click="unarchiveSelected"
+        >
+          <i class="fa-duotone fa-inbox-in" />
+        </Btn>
+        <Btn
+          v-else
+          v-tooltip="t('actions.adminNotifications.archiveSelected')"
+          :aria-label="t('actions.adminNotifications.archiveSelected')"
+          data-test="bulk-archive"
+          @click="archiveSelected"
+        >
+          <i class="fa-duotone fa-box-archive" />
+        </Btn>
+        <Btn
+          v-tooltip="t('actions.adminNotifications.destroySelected')"
+          :aria-label="t('actions.adminNotifications.destroySelected')"
+          :tone="BtnTonesEnum.DANGER"
+          :confirm="
+            t('messages.confirm.adminNotifications.destroySelected', {
+              count: selectedCount,
+            })
+          "
+          data-test="bulk-destroy"
+          @click="destroySelected"
+        >
+          <i class="fa-duotone fa-trash" />
+        </Btn>
+      </BulkSelectionBar>
+
       <div
         class="admin-notifications"
         :class="{ 'admin-notifications--reading': !!selected }"
@@ -339,6 +485,11 @@ const destroyAll = () =>
               :ref="registerRow(notification)"
               :notification="notification"
               :selected="notification.id === selectedId"
+              :checked="
+                allMatchingSelected || selectedIds.includes(notification.id)
+              "
+              selectable
+              @toggle="toggleSelection(notification.id)"
               @select="select(notification)"
               @archive="archiveNotification(notification)"
               @unarchive="unarchiveNotification(notification)"
@@ -397,6 +548,22 @@ const destroyAll = () =>
   line-height: 1;
   background-color: var(--color-primary, #{$primary});
   border-radius: 10px;
+}
+
+.admin-notifications__bulk {
+  margin-bottom: 10px;
+}
+
+// Below the two-pane breakpoint the reading pane replaces the list, and a
+// selection toolbar over a hidden list has nothing to act on.
+.admin-notifications__bulk--hidden {
+  display: none;
+}
+
+@media (min-width: $notifications-two-pane-breakpoint) {
+  .admin-notifications__bulk--hidden {
+    display: flex;
+  }
 }
 
 .admin-notifications {

--- a/app/frontend/frontend/components/Notifications/ListItem/index.vue
+++ b/app/frontend/frontend/components/Notifications/ListItem/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import Btn from "@/shared/components/base/Btn/index.vue";
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type Notification } from "@/services/fyApi";
@@ -13,14 +14,19 @@ import { type Notification } from "@/services/fyApi";
 type Props = {
   notification: Notification;
   selected?: boolean;
+  selectable?: boolean;
+  checked?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   selected: false,
+  selectable: false,
+  checked: false,
 });
 
 const emit = defineEmits<{
   select: [];
+  toggle: [checked: boolean];
   archive: [];
   unarchive: [];
   destroy: [];
@@ -44,8 +50,21 @@ defineExpose({ focus: () => select.value?.focus() });
     :class="{
       'notification-item--unread': !notification.read,
       'notification-item--selected': props.selected,
+      'notification-item--selectable': props.selectable,
     }"
   >
+    <FormCheckbox
+      v-if="props.selectable"
+      v-tooltip="t('actions.notifications.select')"
+      :model-value="props.checked"
+      :aria-label="t('actions.notifications.select')"
+      class="notification-item__checkbox"
+      name="notification-selection"
+      data-test="notification-checkbox"
+      no-label
+      inline
+      @update:model-value="emit('toggle', $event)"
+    />
     <button
       ref="select"
       type="button"
@@ -158,6 +177,21 @@ defineExpose({ focus: () => select.value?.focus() });
   cursor: pointer;
 }
 
+// The checkbox brings a form field's bottom margin, which a row has no use
+// for, and it lines up with the first line of the title rather than the
+// middle of a row that may run to two.
+.notification-item__checkbox {
+  flex-shrink: 0;
+  margin-top: 10px;
+  margin-bottom: 0;
+  padding-left: 10px;
+}
+
+// The checkbox takes over the left inset, so the title stops carrying it.
+.notification-item--selectable .notification-item__select {
+  padding-left: 4px;
+}
+
 .notification-item__icon {
   flex-shrink: 0;
   margin-top: 2px;
@@ -231,6 +265,10 @@ defineExpose({ focus: () => select.value?.focus() });
   .notification-item__select {
     gap: 10px;
     padding-left: 10px;
+  }
+
+  .notification-item__checkbox {
+    padding-left: 6px;
   }
 
   .notification-item__actions {

--- a/app/frontend/frontend/pages/notifications.vue
+++ b/app/frontend/frontend/pages/notifications.vue
@@ -11,11 +11,13 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import Detail from "@/frontend/components/Notifications/Detail/index.vue";
 import FilterForm from "@/frontend/components/Notifications/FilterForm/index.vue";
 import ListItem from "@/frontend/components/Notifications/ListItem/index.vue";
 import { usePagination } from "@/shared/composables/usePagination";
+import { useBulkSelection } from "@/shared/composables/useBulkSelection";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import {
@@ -34,7 +36,14 @@ import {
   unarchiveNotification,
   destroyNotification,
   destroyAllNotifications,
+  readBulkNotifications,
+  unreadBulkNotifications,
+  archiveBulkNotifications,
+  unarchiveBulkNotifications,
+  destroyBulkNotifications,
   type Notification,
+  type NotificationBulkInput,
+  type NotificationBulkResult,
   type NotificationSortEnum,
 } from "@/services/fyApi";
 
@@ -116,6 +125,25 @@ watch([sorts, archive], async () => {
 const { data: unreadCount } = useNotificationsUnreadCount();
 
 const records = computed(() => notifications.value?.items || []);
+
+const totalCount = computed(
+  () => notifications.value?.meta.pagination?.totalCount,
+);
+
+const {
+  selectedIds,
+  allMatchingSelected,
+  selectedCount,
+  matchingCount,
+  pageSelected,
+  pagePartiallySelected,
+  canSelectAllMatching,
+  toggle: toggleSelection,
+  togglePage,
+  selectAllMatching,
+  clear: clearSelection,
+  payload: bulkPayload,
+} = useBulkSelection(records, () => queryParams.value.q, totalCount);
 
 const selectedId = ref<string>();
 
@@ -230,6 +258,56 @@ const destroyAll = () =>
     () => destroyAllNotifications(),
     t("messages.notifications.destroyedAll"),
   );
+
+// The selection is spent once the action lands: leaving it ticked invites a
+// second run over rows that have already moved on, and after "all matching"
+// it would no longer mean the same set.
+const withBulkFeedback = async (
+  action: (input: NotificationBulkInput) => Promise<NotificationBulkResult>,
+  key: string,
+) => {
+  try {
+    const { count } = await action(bulkPayload.value);
+
+    clearSelection();
+    invalidate();
+    displaySuccess({ text: t(key, { count }) });
+  } catch {
+    displayAlert({ text: t("messages.notifications.error") });
+  }
+};
+
+const readSelected = () =>
+  withBulkFeedback(readBulkNotifications, "messages.notifications.bulk.read");
+
+// Same reason the single-record one closes the pane: an unread notification
+// left open only invites the click that marks it read again.
+const unreadSelected = () => {
+  selectedId.value = undefined;
+
+  return withBulkFeedback(
+    unreadBulkNotifications,
+    "messages.notifications.bulk.unread",
+  );
+};
+
+const archiveSelected = () =>
+  withBulkFeedback(
+    archiveBulkNotifications,
+    "messages.notifications.bulk.archived",
+  );
+
+const unarchiveSelected = () =>
+  withBulkFeedback(
+    unarchiveBulkNotifications,
+    "messages.notifications.bulk.unarchived",
+  );
+
+const destroySelected = () =>
+  withBulkFeedback(
+    destroyBulkNotifications,
+    "messages.notifications.bulk.destroyed",
+  );
 </script>
 
 <template>
@@ -328,6 +406,69 @@ const destroyAll = () =>
       </Btn>
     </template>
     <template #default="{ records: shown }">
+      <BulkSelectionBar
+        class="notifications__bulk"
+        :class="{ 'notifications__bulk--hidden': !!selected }"
+        :selected-count="selectedCount"
+        :matching-count="matchingCount"
+        :page-selected="pageSelected"
+        :page-partially-selected="pagePartiallySelected"
+        :can-select-all-matching="canSelectAllMatching"
+        :all-matching-selected="allMatchingSelected"
+        @toggle-page="togglePage"
+        @select-all-matching="selectAllMatching"
+        @clear="clearSelection"
+      >
+        <Btn
+          v-tooltip="t('actions.notifications.readSelected')"
+          :aria-label="t('actions.notifications.readSelected')"
+          data-test="bulk-read"
+          @click="readSelected"
+        >
+          <i class="fa-duotone fa-envelope-open" />
+        </Btn>
+        <Btn
+          v-tooltip="t('actions.notifications.unreadSelected')"
+          :aria-label="t('actions.notifications.unreadSelected')"
+          data-test="bulk-unread"
+          @click="unreadSelected"
+        >
+          <i class="fa-duotone fa-envelope-dot" />
+        </Btn>
+        <Btn
+          v-if="archive"
+          v-tooltip="t('actions.notifications.unarchiveSelected')"
+          :aria-label="t('actions.notifications.unarchiveSelected')"
+          data-test="bulk-unarchive"
+          @click="unarchiveSelected"
+        >
+          <i class="fa-duotone fa-inbox-in" />
+        </Btn>
+        <Btn
+          v-else
+          v-tooltip="t('actions.notifications.archiveSelected')"
+          :aria-label="t('actions.notifications.archiveSelected')"
+          data-test="bulk-archive"
+          @click="archiveSelected"
+        >
+          <i class="fa-duotone fa-box-archive" />
+        </Btn>
+        <Btn
+          v-tooltip="t('actions.notifications.destroySelected')"
+          :aria-label="t('actions.notifications.destroySelected')"
+          :tone="BtnTonesEnum.DANGER"
+          :confirm="
+            t('messages.confirm.notifications.destroySelected', {
+              count: selectedCount,
+            })
+          "
+          data-test="bulk-destroy"
+          @click="destroySelected"
+        >
+          <i class="fa-duotone fa-trash" />
+        </Btn>
+      </BulkSelectionBar>
+
       <div
         class="notifications"
         :class="{ 'notifications--reading': !!selected }"
@@ -342,6 +483,11 @@ const destroyAll = () =>
               :ref="registerRow(notification)"
               :notification="notification"
               :selected="notification.id === selectedId"
+              :checked="
+                allMatchingSelected || selectedIds.includes(notification.id)
+              "
+              selectable
+              @toggle="toggleSelection(notification.id)"
               @select="select(notification)"
               @archive="archiveOne(notification)"
               @unarchive="unarchiveOne(notification)"
@@ -400,6 +546,22 @@ const destroyAll = () =>
   line-height: 1;
   background-color: var(--color-primary, #{$primary});
   border-radius: 10px;
+}
+
+.notifications__bulk {
+  margin-bottom: 10px;
+}
+
+// Below the two-pane breakpoint the reading pane replaces the list, and a
+// selection toolbar over a hidden list has nothing to act on.
+.notifications__bulk--hidden {
+  display: none;
+}
+
+@media (min-width: $notifications-two-pane-breakpoint) {
+  .notifications__bulk--hidden {
+    display: flex;
+  }
 }
 
 .notifications {

--- a/app/frontend/shared/components/BulkSelectionBar/index.scss
+++ b/app/frontend/shared/components/BulkSelectionBar/index.scss
@@ -1,0 +1,56 @@
+// No surface of its own: it is a header over the list, not another row in it,
+// and a filled bar above filled rows reads as a record that lost its title.
+// The left inset matches a row's checkbox so the two line up in one column.
+.bulk-selection-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-height: 34px;
+  padding: 4px 8px 4px 10px;
+
+  // The checkbox ships with a form field's bottom margin, which a toolbar row
+  // has no use for.
+  :deep(.base-checkbox) {
+    margin-bottom: 0;
+  }
+}
+
+// Kept in place rather than removed while nothing is ticked: the bar sits
+// directly above the list, and a row that grows the moment a checkbox is
+// clicked pushes the list out from under the pointer. `visibility` also takes
+// it off the tab order and out of the accessibility tree, so there is nothing
+// to reach while it is empty.
+.bulk-selection-bar__body {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-width: 0;
+}
+
+.bulk-selection-bar__body--empty {
+  visibility: hidden;
+}
+
+.bulk-selection-bar__count {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--color-primary, #{$primary});
+  white-space: nowrap;
+
+  :deep(.btn__content) {
+    color: inherit;
+  }
+}
+
+.bulk-selection-bar__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  // Pushed to the far end so the actions sit where a row's own buttons do.
+  margin-left: auto;
+}

--- a/app/frontend/shared/components/BulkSelectionBar/index.vue
+++ b/app/frontend/shared/components/BulkSelectionBar/index.vue
@@ -1,0 +1,112 @@
+<script lang="ts">
+export default {
+  name: "BulkSelectionBar",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  selectedCount: number;
+  matchingCount: number;
+  pageSelected: boolean;
+  pagePartiallySelected: boolean;
+  canSelectAllMatching: boolean;
+  allMatchingSelected: boolean;
+  disabled?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  disabled: false,
+});
+
+const emit = defineEmits<{
+  "toggle-page": [selected: boolean];
+  "select-all-matching": [];
+  clear: [];
+}>();
+
+const { t } = useI18n();
+
+const hasSelection = computed(() => props.selectedCount > 0);
+
+const pageLabel = computed(() =>
+  props.pageSelected
+    ? t("bulkSelection.actions.unselectPage")
+    : t("bulkSelection.actions.selectPage"),
+);
+</script>
+
+<template>
+  <div class="bulk-selection-bar" data-test="bulk-selection-bar">
+    <FormCheckbox
+      :model-value="props.pageSelected"
+      :partial="props.pagePartiallySelected"
+      :disabled="props.disabled"
+      v-tooltip="pageLabel"
+      :aria-label="pageLabel"
+      name="bulk-selection-page"
+      data-test="bulk-select-page"
+      no-label
+      inline
+      @update:model-value="emit('toggle-page', $event)"
+    />
+
+    <div
+      class="bulk-selection-bar__body"
+      :class="{ 'bulk-selection-bar__body--empty': !hasSelection }"
+    >
+      <span class="bulk-selection-bar__count">
+        <span data-test="bulk-selection-count">
+          {{
+            props.allMatchingSelected
+              ? t("bulkSelection.labels.allMatchingSelected", {
+                  count: props.selectedCount,
+                })
+              : t("bulkSelection.labels.selected", {
+                  count: props.selectedCount,
+                })
+          }}
+        </span>
+        <Btn
+          v-if="props.canSelectAllMatching"
+          :size="BtnSizesEnum.SM"
+          :variant="BtnVariantsEnum.BARE"
+          data-test="bulk-select-all-matching"
+          @click="emit('select-all-matching')"
+        >
+          {{
+            t("bulkSelection.actions.selectAllMatching", {
+              count: props.matchingCount,
+            })
+          }}
+        </Btn>
+        <Btn
+          v-tooltip="t('bulkSelection.actions.clear')"
+          :aria-label="t('bulkSelection.actions.clear')"
+          :size="BtnSizesEnum.SM"
+          :variant="BtnVariantsEnum.BARE"
+          data-test="bulk-selection-clear"
+          @click="emit('clear')"
+        >
+          <i class="fa-duotone fa-xmark" />
+        </Btn>
+      </span>
+
+      <div class="bulk-selection-bar__actions">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/shared/composables/useBulkSelection.spec.ts
+++ b/app/frontend/shared/composables/useBulkSelection.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { nextTick, ref } from "vue";
+
+import { useBulkSelection } from "./useBulkSelection";
+
+type Row = { id: string };
+
+const rows = (...ids: string[]): Row[] => ids.map((id) => ({ id }));
+
+const setup = (
+  ids: string[] = ["a", "b", "c"],
+  query: Record<string, unknown> = { archivedAtNull: true },
+  total: number | undefined = 3,
+) => {
+  const records = ref<Row[]>(rows(...ids));
+  const filter = ref(query);
+  const totalCount = ref<number | undefined>(total);
+
+  return {
+    records,
+    filter,
+    totalCount,
+    selection: useBulkSelection(records, filter, totalCount),
+  };
+};
+
+describe("useBulkSelection", () => {
+  it("ticks and unticks a single row", () => {
+    const { selection } = setup();
+
+    selection.toggle("a");
+
+    expect(selection.selectedIds.value).toEqual(["a"]);
+    expect(selection.selectedCount.value).toBe(1);
+    expect(selection.pagePartiallySelected.value).toBe(true);
+
+    selection.toggle("a");
+
+    expect(selection.selectedIds.value).toEqual([]);
+    expect(selection.pagePartiallySelected.value).toBe(false);
+  });
+
+  it("reports the page as selected once every row is ticked", () => {
+    const { selection } = setup();
+
+    selection.togglePage(true);
+
+    expect(selection.pageSelected.value).toBe(true);
+    expect(selection.selectedCount.value).toBe(3);
+
+    selection.togglePage(false);
+
+    expect(selection.pageSelected.value).toBe(false);
+  });
+
+  it("offers select all matching only when the filter reaches past the page", () => {
+    const { selection } = setup(["a", "b", "c"], {}, 3);
+
+    selection.togglePage(true);
+
+    expect(selection.canSelectAllMatching.value).toBe(false);
+
+    const wider = setup(["a", "b", "c"], {}, 30);
+
+    wider.selection.togglePage(true);
+
+    expect(wider.selection.canSelectAllMatching.value).toBe(true);
+  });
+
+  it("counts every match once all matching is selected", () => {
+    const { selection } = setup(["a", "b", "c"], {}, 30);
+
+    selection.selectAllMatching();
+
+    expect(selection.selectedCount.value).toBe(30);
+    expect(selection.pageSelected.value).toBe(true);
+    expect(selection.payload.value).toEqual({ all: true, q: {} });
+  });
+
+  it("falls back to the visible page when a row is unticked from all matching", () => {
+    const { selection } = setup(["a", "b", "c"], {}, 30);
+
+    selection.selectAllMatching();
+    selection.toggle("b");
+
+    expect(selection.allMatchingSelected.value).toBe(false);
+    expect(selection.selectedIds.value).toEqual(["a", "c"]);
+    expect(selection.payload.value).toEqual({ ids: ["a", "c"] });
+  });
+
+  it("drops ticks for rows that left the page", async () => {
+    const { records, selection } = setup();
+
+    selection.togglePage(true);
+
+    records.value = rows("c", "d");
+    await nextTick();
+
+    expect(selection.selectedIds.value).toEqual(["c"]);
+  });
+
+  // Turning the page hands the composable a new query object holding the same
+  // filter, which must not read as a filter change.
+  it("keeps all matching across an unchanged filter", async () => {
+    const { filter, selection } = setup(["a", "b", "c"], { sorts: [] }, 30);
+
+    selection.selectAllMatching();
+
+    filter.value = { sorts: [] };
+    await nextTick();
+
+    expect(selection.allMatchingSelected.value).toBe(true);
+  });
+
+  it("revokes all matching when the filter changes", async () => {
+    const { filter, selection } = setup(["a", "b", "c"], { sorts: [] }, 30);
+
+    selection.selectAllMatching();
+
+    filter.value = { sorts: [], searchCont: "aurora" };
+    await nextTick();
+
+    expect(selection.allMatchingSelected.value).toBe(false);
+  });
+});

--- a/app/frontend/shared/composables/useBulkSelection.ts
+++ b/app/frontend/shared/composables/useBulkSelection.ts
@@ -1,0 +1,113 @@
+type Identifiable = { id: string };
+
+// Two selections in one: the ids of the rows the reader ticked, and a flag
+// meaning "everything this filter matches". The second one never becomes a list
+// of ids - the server resolves it against the same filter - so it survives
+// paging and costs nothing on a filter with thousands of hits.
+export const useBulkSelection = <T extends Identifiable, Q>(
+  records: MaybeRefOrGetter<T[]>,
+  query: MaybeRefOrGetter<Q>,
+  totalCount: MaybeRefOrGetter<number | undefined>,
+) => {
+  const selectedIds = ref<string[]>([]);
+  const allMatchingSelected = ref(false);
+
+  const pageIds = computed(() => toValue(records).map((record) => record.id));
+
+  const matchingCount = computed(
+    () => toValue(totalCount) ?? pageIds.value.length,
+  );
+
+  // A row that left the page - deleted, filtered away, or simply on the page
+  // before this one - takes its tick with it. Without this an action could
+  // reach records the reader can no longer see.
+  watch(pageIds, (ids) => {
+    selectedIds.value = selectedIds.value.filter((id) => ids.includes(id));
+  });
+
+  // "All 143 matching" is a statement about the filter, so a different filter
+  // revokes it. Paging leaves it alone: the same filter still matches.
+  //
+  // Serialised rather than watched by reference: the caller builds its query
+  // from a computed, so turning the page hands over a new object holding the
+  // same filter, and identity alone would drop the selection for it.
+  watch(
+    () => JSON.stringify(toValue(query)),
+    () => {
+      allMatchingSelected.value = false;
+    },
+  );
+
+  const selectedCount = computed(() =>
+    allMatchingSelected.value ? matchingCount.value : selectedIds.value.length,
+  );
+
+  const pageSelected = computed(
+    () =>
+      pageIds.value.length > 0 &&
+      (allMatchingSelected.value ||
+        pageIds.value.every((id) => selectedIds.value.includes(id))),
+  );
+
+  const pagePartiallySelected = computed(
+    () => !pageSelected.value && selectedIds.value.length > 0,
+  );
+
+  // Only worth offering while there is more behind the filter than on the page.
+  const canSelectAllMatching = computed(
+    () =>
+      !allMatchingSelected.value &&
+      pageSelected.value &&
+      matchingCount.value > pageIds.value.length,
+  );
+
+  const clear = () => {
+    selectedIds.value = [];
+    allMatchingSelected.value = false;
+  };
+
+  const toggle = (id: string) => {
+    // Unticking one row is a narrower statement than "everything matching", so
+    // the selection drops back to the page it can actually show.
+    if (allMatchingSelected.value) {
+      allMatchingSelected.value = false;
+      selectedIds.value = pageIds.value.filter((pageId) => pageId !== id);
+
+      return;
+    }
+
+    selectedIds.value = selectedIds.value.includes(id)
+      ? selectedIds.value.filter((selected) => selected !== id)
+      : [...selectedIds.value, id];
+  };
+
+  const togglePage = (selected: boolean) => {
+    allMatchingSelected.value = false;
+    selectedIds.value = selected ? [...pageIds.value] : [];
+  };
+
+  const selectAllMatching = () => {
+    allMatchingSelected.value = true;
+  };
+
+  const payload = computed(() =>
+    allMatchingSelected.value
+      ? { all: true, q: toValue(query) }
+      : { ids: [...selectedIds.value] },
+  );
+
+  return {
+    selectedIds,
+    allMatchingSelected,
+    selectedCount,
+    matchingCount,
+    pageSelected,
+    pagePartiallySelected,
+    canSelectAllMatching,
+    toggle,
+    togglePage,
+    selectAllMatching,
+    clear,
+    payload,
+  };
+};

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -295,7 +295,13 @@
         "readAll": "Mark all as read",
         "destroyAll": "Delete all",
         "sortOldest": "Oldest first",
-        "sortNewest": "Newest first"
+        "sortNewest": "Newest first",
+        "select": "Select notification",
+        "readSelected": "Mark selected as read",
+        "unreadSelected": "Mark selected as unread",
+        "archiveSelected": "Archive selected",
+        "unarchiveSelected": "Move selected back to inbox",
+        "destroySelected": "Delete selected"
       },
       "account": {
         "calendarSubscription": {
@@ -360,7 +366,13 @@
         "settings": "Notification settings",
         "sortOldest": "Oldest first",
         "sortNewest": "Newest first",
-        "openCenter": "Notifications"
+        "openCenter": "Notifications",
+        "select": "Select notification",
+        "readSelected": "Mark selected as read",
+        "unreadSelected": "Mark selected as unread",
+        "archiveSelected": "Archive selected",
+        "unarchiveSelected": "Move selected back to inbox",
+        "destroySelected": "Delete selected"
       },
       "unlistedModel": {
         "createModel": "Create ship",

--- a/app/frontend/translations/en/bulkSelection.json
+++ b/app/frontend/translations/en/bulkSelection.json
@@ -1,0 +1,16 @@
+{
+  "en": {
+    "bulkSelection": {
+      "actions": {
+        "selectPage": "Select everything on this page",
+        "unselectPage": "Unselect everything on this page",
+        "selectAllMatching": "Select all %{count}",
+        "clear": "Clear selection"
+      },
+      "labels": {
+        "selected": "%{count} selected",
+        "allMatchingSelected": "All %{count} selected"
+      }
+    }
+  }
+}

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -435,7 +435,11 @@
           "destroy": "Are you sure you want to delete this fleet? This action can't be reverted."
         },
         "adminNotifications": {
-          "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted."
+          "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted.",
+          "destroySelected": {
+            "one": "Are you sure you want to delete the selected notification? This action can't be reverted.",
+            "other": "Are you sure you want to delete the %{count} selected notifications? This action can't be reverted."
+          }
         },
         "adminDestroyedFleet": {
           "restore": "Are you sure you want to restore this fleet?",
@@ -457,7 +461,11 @@
           "destroy": "Are you sure you want to delete this equipment? This action can't be reverted."
         },
         "notifications": {
-          "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted."
+          "destroyAll": "Are you sure you want to delete all notifications? This action can't be reverted.",
+          "destroySelected": {
+            "one": "Are you sure you want to delete the selected notification? This action can't be reverted.",
+            "other": "Are you sure you want to delete the %{count} selected notifications? This action can't be reverted."
+          }
         },
         "unlistedModel": {
           "createModel": "Create a ship from %{name}? The next sc_data load fills in its mechanics."
@@ -582,7 +590,29 @@
         "readAll": "All notifications marked as read",
         "destroyed": "Notification deleted",
         "destroyedAll": "All notifications deleted",
-        "error": "Something went wrong"
+        "error": "Something went wrong",
+        "bulk": {
+          "read": {
+            "one": "%{count} notification marked as read",
+            "other": "%{count} notifications marked as read"
+          },
+          "unread": {
+            "one": "%{count} notification marked as unread",
+            "other": "%{count} notifications marked as unread"
+          },
+          "archived": {
+            "one": "%{count} notification archived",
+            "other": "%{count} notifications archived"
+          },
+          "unarchived": {
+            "one": "%{count} notification moved back to the inbox",
+            "other": "%{count} notifications moved back to the inbox"
+          },
+          "destroyed": {
+            "one": "%{count} notification deleted",
+            "other": "%{count} notifications deleted"
+          }
+        }
       },
       "fleets": {
         "notifications": {
@@ -800,7 +830,29 @@
         "readAll": "All notifications marked as read",
         "destroyed": "Notification deleted",
         "destroyedAll": "All notifications deleted",
-        "error": "Something went wrong"
+        "error": "Something went wrong",
+        "bulk": {
+          "read": {
+            "one": "%{count} notification marked as read",
+            "other": "%{count} notifications marked as read"
+          },
+          "unread": {
+            "one": "%{count} notification marked as unread",
+            "other": "%{count} notifications marked as unread"
+          },
+          "archived": {
+            "one": "%{count} notification archived",
+            "other": "%{count} notifications archived"
+          },
+          "unarchived": {
+            "one": "%{count} notification moved back to the inbox",
+            "other": "%{count} notifications moved back to the inbox"
+          },
+          "destroyed": {
+            "one": "%{count} notification deleted",
+            "other": "%{count} notifications deleted"
+          }
+        }
       }
     }
   }

--- a/app/policies/admin/notification_policy.rb
+++ b/app/policies/admin/notification_policy.rb
@@ -5,7 +5,8 @@ module Admin
   # but every admin's own inbox, so access is ownership rather than a privilege.
   class NotificationPolicy < ApplicationPolicy
     alias_rule :index?, :destroy?, :update?, :read?, :unread?, :archive?, :unarchive?,
-      :unread_count?, to: :show?
+      :unread_count?, :read_bulk?, :unread_bulk?, :archive_bulk?, :unarchive_bulk?,
+      :destroy_bulk?, to: :show?
 
     def show?
       user.present?

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -2,7 +2,8 @@
 
 class NotificationPolicy < ApplicationPolicy
   alias_rule :index?, :destroy?, :update?, :read?, :unread?, :archive?, :unarchive?,
-    :unread_count?, to: :show?
+    :unread_count?, :read_bulk?, :unread_bulk?, :archive_bulk?, :unarchive_bulk?,
+    :destroy_bulk?, to: :show?
 
   def show?
     user.present?

--- a/app/views/admin/api/v1/notifications/bulk.jbuilder
+++ b/app/views/admin/api/v1/notifications/bulk.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.count @count

--- a/app/views/api/v1/notifications/bulk.jbuilder
+++ b/app/views/api/v1/notifications/bulk.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.count @count

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -177,6 +177,14 @@ v1_admin_api_routes = lambda do
       get "unread-count", to: "notifications#unread_count"
       put "read-all", to: "notifications#read_all"
       delete "destroy-all", to: "notifications#destroy_all"
+      # PUT rather than DELETE for the destructive one: the selection travels in
+      # the body, and a DELETE with a body is refused by enough proxies and
+      # clients to not be worth it. `vehicles#destroy_bulk` made the same call.
+      put "read-bulk", to: "notifications#read_bulk"
+      put "unread-bulk", to: "notifications#unread_bulk"
+      put "archive-bulk", to: "notifications#archive_bulk"
+      put "unarchive-bulk", to: "notifications#unarchive_bulk"
+      put "destroy-bulk", to: "notifications#destroy_bulk"
     end
   end
 

--- a/config/routes/api/notifications_routes.rb
+++ b/config/routes/api/notifications_routes.rb
@@ -11,5 +11,13 @@ resources :notifications, only: %i[index destroy] do
     get "unread-count", to: "notifications#unread_count"
     put "read-all", to: "notifications#read_all"
     delete "destroy-all", to: "notifications#destroy_all"
+    # PUT rather than DELETE for the destructive one: the selection travels in
+    # the body, and a DELETE with a body is refused by enough proxies and
+    # clients to not be worth it. `vehicles#destroy_bulk` made the same call.
+    put "read-bulk", to: "notifications#read_bulk"
+    put "unread-bulk", to: "notifications#unread_bulk"
+    put "archive-bulk", to: "notifications#archive_bulk"
+    put "unarchive-bulk", to: "notifications#unarchive_bulk"
+    put "destroy-bulk", to: "notifications#destroy_bulk"
   end
 end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -5585,6 +5585,33 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/archive-bulk":
+    put:
+      summary: Archive the selected Admin Notifications
+      tags:
+      - Notifications
+      operationId: archiveBulkAdminNotifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminNotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/destroy-all":
     delete:
       summary: Delete all Admin Notifications
@@ -5600,6 +5627,33 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/notifications/destroy-bulk":
+    put:
+      summary: Delete the selected Admin Notifications
+      tags:
+      - Notifications
+      operationId: destroyBulkAdminNotifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminNotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/read-all":
     put:
       summary: Mark all Admin Notifications as read
@@ -5615,6 +5669,87 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/notifications/read-bulk":
+    put:
+      summary: Mark the selected Admin Notifications as read
+      tags:
+      - Notifications
+      operationId: readBulkAdminNotifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminNotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/unarchive-bulk":
+    put:
+      summary: Move the selected Admin Notifications back to the inbox
+      tags:
+      - Notifications
+      operationId: unarchiveBulkAdminNotifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminNotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/unread-bulk":
+    put:
+      summary: Mark the selected Admin Notifications as unread
+      tags:
+      - Notifications
+      operationId: unreadBulkAdminNotifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminNotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminNotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/unread-count":
     get:
       summary: Unread Admin Notification count
@@ -7814,6 +7949,32 @@ components:
       - createdAt
       - updatedAt
       title: AdminNotification
+    AdminNotificationBulkInput:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        all:
+          type: boolean
+          default: false
+          description: Apply to every notification matching `q` instead of `ids`.
+        q:
+          "$ref": "#/components/schemas/AdminNotificationQuery"
+      additionalProperties: false
+      description: Naming neither `ids` nor `all` selects nothing.
+      title: AdminNotificationBulkInput
+    AdminNotificationBulkResult:
+      type: object
+      properties:
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - count
+      title: AdminNotificationBulkResult
     AdminNotificationQuery:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7638,6 +7638,41 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/archive-bulk":
+    put:
+      summary: Archive the selected notifications
+      tags:
+      - Notifications
+      operationId: archiveBulkNotifications
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - notifications
+        - notifications:write
+      - OpenId:
+        - notifications
+        - notifications:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/destroy-all":
     delete:
       summary: Delete all notifications
@@ -7661,6 +7696,41 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/notifications/destroy-bulk":
+    put:
+      summary: Delete the selected notifications
+      tags:
+      - Notifications
+      operationId: destroyBulkNotifications
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - notifications
+        - notifications:write
+      - OpenId:
+        - notifications
+        - notifications:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/read-all":
     put:
       summary: Mark all notifications as read
@@ -7684,6 +7754,111 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/notifications/read-bulk":
+    put:
+      summary: Mark the selected notifications as read
+      tags:
+      - Notifications
+      operationId: readBulkNotifications
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - notifications
+        - notifications:write
+      - OpenId:
+        - notifications
+        - notifications:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/unarchive-bulk":
+    put:
+      summary: Move the selected notifications back to the inbox
+      tags:
+      - Notifications
+      operationId: unarchiveBulkNotifications
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - notifications
+        - notifications:write
+      - OpenId:
+        - notifications
+        - notifications:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/notifications/unread-bulk":
+    put:
+      summary: Mark the selected notifications as unread
+      tags:
+      - Notifications
+      operationId: unreadBulkNotifications
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - notifications
+        - notifications:write
+      - OpenId:
+        - notifications
+        - notifications:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NotificationBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotificationBulkResult"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notifications/unread-count":
     get:
       summary: Unread notification count
@@ -18656,6 +18831,32 @@ components:
       - createdAt
       - updatedAt
       title: Notification
+    NotificationBulkInput:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        all:
+          type: boolean
+          default: false
+          description: Apply to every notification matching `q` instead of `ids`.
+        q:
+          "$ref": "#/components/schemas/NotificationQuery"
+      additionalProperties: false
+      description: Naming neither `ids` nor `all` selects nothing.
+      title: NotificationBulkInput
+    NotificationBulkResult:
+      type: object
+      properties:
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - count
+      title: NotificationBulkResult
     NotificationPreference:
       type: object
       properties:

--- a/test/integration/admin/api/v1/notifications_bulk_test.rb
+++ b/test/integration/admin/api/v1/notifications_bulk_test.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+# Every path here is a collection-level PUT, which the DSL cannot tell apart on
+# the verb alone, so each assertion names its `api_path`.
+class Admin::Api::V1::NotificationsBulkTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/notifications/read-bulk" do
+    put("Mark the selected Admin Notifications as read") do
+      operationId "readBulkAdminNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminNotificationBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminNotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/unread-bulk" do
+    put("Mark the selected Admin Notifications as unread") do
+      operationId "unreadBulkAdminNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminNotificationBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminNotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/archive-bulk" do
+    put("Archive the selected Admin Notifications") do
+      operationId "archiveBulkAdminNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminNotificationBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminNotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/unarchive-bulk" do
+    put("Move the selected Admin Notifications back to the inbox") do
+      operationId "unarchiveBulkAdminNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminNotificationBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminNotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/destroy-bulk" do
+    put("Delete the selected Admin Notifications") do
+      operationId "destroyBulkAdminNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminNotificationBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminNotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin_user = create(:admin_user, resource_access: [:models])
+    @other_admin = create(:admin_user, resource_access: [:models])
+  end
+
+  # PUT /notifications/read-bulk
+  test "PUT /notifications/read-bulk marks the listed notifications read" do
+    selected = create_list(:admin_notification, 2, admin_user: @admin_user)
+    untouched = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.all? { |notification| notification.reload.read? }
+      assert_not untouched.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all reaches past the first page" do
+    create_list(:admin_notification, AdminNotification.default_per_page + 5, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {all: true} do
+      assert_equal AdminNotification.default_per_page + 5, parsed_body["count"]
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all honours the filter it was given" do
+    create(:admin_notification, admin_user: @admin_user, title: "Paints Import Results")
+    spared = create(:admin_notification, admin_user: @admin_user, title: "Loaner Sync")
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      body: {all: true, q: {searchCont: "paints"}} do
+      assert_equal 1, parsed_body["count"]
+      assert_not spared.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all stays out of the archive" do
+    archived = create(:admin_notification, :archived, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {all: true} do
+      assert_equal 0, parsed_body["count"]
+      assert_not archived.reload.read?
+    end
+  end
+
+  # A body naming neither `ids` nor `all` must never be read as "everything":
+  # the endpoint next door is `destroy-all`.
+  test "PUT /notifications/read-bulk changes nothing when nothing is selected" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {} do
+      assert_equal 0, parsed_body["count"]
+      assert_not notification.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk ignores another admin's notification" do
+    stranger = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {ids: [stranger.id]} do
+      assert_equal 0, parsed_body["count"]
+      assert_not stranger.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk ignores a type the admin no longer has access to" do
+    stranger = create(:admin_notification, admin_user: @admin_user, notification_type: "new_supporter")
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {ids: [stranger.id]} do
+      assert_equal 0, parsed_body["count"]
+      assert_not stranger.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/read-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/unread-bulk
+  test "PUT /notifications/unread-bulk marks the listed notifications unread" do
+    selected = create_list(:admin_notification, 2, :read, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/unread-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.none? { |notification| notification.reload.read? }
+    end
+  end
+
+  test "PUT /notifications/unread-bulk returns 401 when not signed in" do
+    notification = create(:admin_notification, :read, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/unread-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/archive-bulk
+  test "PUT /notifications/archive-bulk archives the listed notifications" do
+    selected = create_list(:admin_notification, 2, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/archive-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.all? { |notification| notification.reload.archived? }
+    end
+  end
+
+  test "PUT /notifications/archive-bulk returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/archive-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/unarchive-bulk
+  test "PUT /notifications/unarchive-bulk moves the listed notifications back to the inbox" do
+    selected = create_list(:admin_notification, 2, :archived, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/unarchive-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.none? { |notification| notification.reload.archived? }
+    end
+  end
+
+  test "PUT /notifications/unarchive-bulk on all reads the archive tab off the filter" do
+    archived = create(:admin_notification, :archived, admin_user: @admin_user)
+    inbox = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/unarchive-bulk",
+      body: {all: true, q: {archivedAtNull: false}} do
+      assert_equal 1, parsed_body["count"]
+      assert_not archived.reload.archived?
+      assert_not inbox.reload.archived?
+    end
+  end
+
+  test "PUT /notifications/unarchive-bulk returns 401 when not signed in" do
+    notification = create(:admin_notification, :archived, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/unarchive-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/destroy-bulk
+  test "PUT /notifications/destroy-bulk deletes the listed notifications" do
+    selected = create_list(:admin_notification, 2, admin_user: @admin_user)
+    untouched = create(:admin_notification, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert_equal [untouched.id], AdminNotification.where(admin_user: @admin_user).pluck(:id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk on all deletes everything the filter matches" do
+    create_list(:admin_notification, 2, admin_user: @admin_user, title: "Paints Import Results")
+    spared = create(:admin_notification, admin_user: @admin_user, title: "Loaner Sync")
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk",
+      body: {all: true, q: {searchCont: "paints"}} do
+      assert_equal 2, parsed_body["count"]
+      assert_equal [spared.id], AdminNotification.where(admin_user: @admin_user).pluck(:id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk deletes nothing when nothing is selected" do
+    create_list(:admin_notification, 3, admin_user: @admin_user)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk", body: {} do
+      assert_equal 0, parsed_body["count"]
+      assert_equal 3, AdminNotification.where(admin_user: @admin_user).count
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk ignores another admin's notification" do
+    stranger = create(:admin_notification, admin_user: @other_admin)
+    sign_in @admin_user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk", body: {ids: [stranger.id]} do
+      assert_equal 0, parsed_body["count"]
+      assert AdminNotification.exists?(stranger.id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk returns 401 when not signed in" do
+    notification = create(:admin_notification, admin_user: @admin_user)
+
+    assert_api_response :put, 401, api_path: "/notifications/destroy-bulk", body: {ids: [notification.id]}
+  end
+end

--- a/test/integration/api/v1/notifications_bulk_test.rb
+++ b/test/integration/api/v1/notifications_bulk_test.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+# Every path here is a collection-level PUT, which the DSL cannot tell apart on
+# the verb alone, so each assertion names its `api_path`.
+class Api::V1::NotificationsBulkTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/notifications/read-bulk" do
+    put("Mark the selected notifications as read") do
+      operationId "readBulkNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::NotificationBulkInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["notifications", "notifications:write"]},
+        {OpenId: ["notifications", "notifications:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::NotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/unread-bulk" do
+    put("Mark the selected notifications as unread") do
+      operationId "unreadBulkNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::NotificationBulkInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["notifications", "notifications:write"]},
+        {OpenId: ["notifications", "notifications:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::NotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/archive-bulk" do
+    put("Archive the selected notifications") do
+      operationId "archiveBulkNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::NotificationBulkInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["notifications", "notifications:write"]},
+        {OpenId: ["notifications", "notifications:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::NotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/unarchive-bulk" do
+    put("Move the selected notifications back to the inbox") do
+      operationId "unarchiveBulkNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::NotificationBulkInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["notifications", "notifications:write"]},
+        {OpenId: ["notifications", "notifications:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::NotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/notifications/destroy-bulk" do
+    put("Delete the selected notifications") do
+      operationId "destroyBulkNotifications"
+      tags "Notifications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::NotificationBulkInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["notifications", "notifications:write"]},
+        {OpenId: ["notifications", "notifications:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::NotificationBulkResult
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @user = create(:user)
+  end
+
+  # PUT /notifications/read-bulk
+  test "PUT /notifications/read-bulk marks the listed notifications read" do
+    selected = create_list(:notification, 2, user: @user)
+    untouched = create(:notification, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.all? { |notification| notification.reload.read? }
+      assert_not untouched.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk counts only what it changed" do
+    already_read = create(:notification, :read, user: @user)
+    unread = create(:notification, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      body: {ids: [already_read.id, unread.id]} do
+      assert_equal 1, parsed_body["count"]
+    end
+  end
+
+  test "PUT /notifications/read-bulk leaves an already read notification's timestamp alone" do
+    read_at = 2.days.ago
+    notification = create(:notification, user: @user, read_at:)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {ids: [notification.id]} do
+      assert_in_delta read_at, notification.reload.read_at, 1.second
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all reaches past the first page" do
+    create_list(:notification, Notification.default_per_page + 5, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {all: true} do
+      assert_equal Notification.default_per_page + 5, parsed_body["count"]
+      assert_equal 0, @user.notifications.unread.count
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all honours the filter it was given" do
+    create(:notification, user: @user, title: "Hangar Sync finished")
+    spared = create(:notification, user: @user, title: "Ship on sale")
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      body: {all: true, q: {searchCont: "hangar"}} do
+      assert_equal 1, parsed_body["count"]
+      assert_not spared.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk on all stays out of the archive" do
+    archived = create(:notification, :archived, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {all: true} do
+      assert_equal 0, parsed_body["count"]
+      assert_not archived.reload.read?
+    end
+  end
+
+  # A body naming neither `ids` nor `all` must never be read as "everything":
+  # the endpoint next door is `destroy-all`.
+  test "PUT /notifications/read-bulk changes nothing when nothing is selected" do
+    notification = create(:notification, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {} do
+      assert_equal 0, parsed_body["count"]
+      assert_not notification.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk ignores another user's notification" do
+    stranger = create(:notification, user: create(:user))
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk", body: {ids: [stranger.id]} do
+      assert_equal 0, parsed_body["count"]
+      assert_not stranger.reload.read?
+    end
+  end
+
+  test "PUT /notifications/read-bulk returns 401 when not signed in" do
+    notification = create(:notification, user: @user)
+
+    assert_api_response :put, 401, api_path: "/notifications/read-bulk", body: {ids: [notification.id]}
+  end
+
+  test "PUT /notifications/read-bulk with OAuth bearer token" do
+    notification = create(:notification, user: @user)
+
+    assert_api_response :put, 200, api_path: "/notifications/read-bulk",
+      headers: oauth_headers_for(@user, scopes: ["notifications", "notifications:write"]),
+      body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/unread-bulk
+  test "PUT /notifications/unread-bulk marks the listed notifications unread" do
+    selected = create_list(:notification, 2, :read, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/unread-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.none? { |notification| notification.reload.read? }
+    end
+  end
+
+  test "PUT /notifications/unread-bulk returns 401 when not signed in" do
+    notification = create(:notification, :read, user: @user)
+
+    assert_api_response :put, 401, api_path: "/notifications/unread-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/archive-bulk
+  test "PUT /notifications/archive-bulk archives the listed notifications" do
+    selected = create_list(:notification, 2, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/archive-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.all? { |notification| notification.reload.archived? }
+    end
+  end
+
+  test "PUT /notifications/archive-bulk returns 401 when not signed in" do
+    notification = create(:notification, user: @user)
+
+    assert_api_response :put, 401, api_path: "/notifications/archive-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/unarchive-bulk
+  test "PUT /notifications/unarchive-bulk moves the listed notifications back to the inbox" do
+    selected = create_list(:notification, 2, :archived, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/unarchive-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert selected.none? { |notification| notification.reload.archived? }
+    end
+  end
+
+  test "PUT /notifications/unarchive-bulk on all reads the archive tab off the filter" do
+    archived = create(:notification, :archived, user: @user)
+    inbox = create(:notification, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/unarchive-bulk",
+      body: {all: true, q: {archivedAtNull: false}} do
+      assert_equal 1, parsed_body["count"]
+      assert_not archived.reload.archived?
+      assert_not inbox.reload.archived?
+    end
+  end
+
+  test "PUT /notifications/unarchive-bulk returns 401 when not signed in" do
+    notification = create(:notification, :archived, user: @user)
+
+    assert_api_response :put, 401, api_path: "/notifications/unarchive-bulk", body: {ids: [notification.id]}
+  end
+
+  # PUT /notifications/destroy-bulk
+  test "PUT /notifications/destroy-bulk deletes the listed notifications" do
+    selected = create_list(:notification, 2, user: @user)
+    untouched = create(:notification, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+      assert_equal [untouched.id], @user.notifications.pluck(:id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk on all deletes everything the filter matches" do
+    create_list(:notification, 2, user: @user, title: "Hangar Sync finished")
+    spared = create(:notification, user: @user, title: "Ship on sale")
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk",
+      body: {all: true, q: {searchCont: "hangar"}} do
+      assert_equal 2, parsed_body["count"]
+      assert_equal [spared.id], @user.notifications.pluck(:id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk deletes nothing when nothing is selected" do
+    create_list(:notification, 3, user: @user)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk", body: {} do
+      assert_equal 0, parsed_body["count"]
+      assert_equal 3, @user.notifications.count
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk ignores another user's notification" do
+    stranger = create(:notification, user: create(:user))
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk", body: {ids: [stranger.id]} do
+      assert_equal 0, parsed_body["count"]
+      assert Notification.exists?(stranger.id)
+    end
+  end
+
+  test "PUT /notifications/destroy-bulk returns 401 when not signed in" do
+    notification = create(:notification, user: @user)
+
+    assert_api_response :put, 401, api_path: "/notifications/destroy-bulk", body: {ids: [notification.id]}
+  end
+
+  test "PUT /notifications/destroy-bulk with OAuth bearer token" do
+    notification = create(:notification, user: @user)
+
+    assert_api_response :put, 200, api_path: "/notifications/destroy-bulk",
+      headers: oauth_headers_for(@user, scopes: ["notifications", "notifications:write"]),
+      body: {ids: [notification.id]}
+  end
+end

--- a/test/playwright/app_commands/scenarios/notifications_bulk.rb
+++ b/test/playwright/app_commands/scenarios/notifications_bulk.rb
@@ -1,0 +1,45 @@
+# You can setup your Rails state here
+require "factory_bot_rails"
+
+Rails.logger.info "E2E: Creating notifications_bulk scenario test data..."
+
+user = User.find_or_create_by!(username: "notifications") do |u|
+  u.email = "notifications@test.com"
+  u.password = "password123"
+  u.password_confirmation = "password123"
+  u.confirmed_at = Time.current
+end
+
+# More than one page of them on purpose: selecting the page is only half of
+# what the bulk bar does, and "select all matching" has nothing to prove until
+# there is something behind the page.
+(Notification.default_per_page + 5).times do |index|
+  occurred_at = index.minutes.ago
+
+  Notification.create!(
+    user:,
+    notification_type: :hangar_create,
+    title: format("Bulk notification %02d", index + 1),
+    icon: "fa-duotone fa-warehouse",
+    created_at: occurred_at,
+    updated_at: occurred_at
+  )
+end
+
+# So the archive tab has something to draw: an empty tab renders the placeholder
+# instead of the list, which would hide the bulk bar for the wrong reason.
+2.times do |index|
+  archived_at = (index + 1).hours.ago
+
+  Notification.create!(
+    user:,
+    notification_type: :hangar_destroy,
+    title: format("Archived notification %02d", index + 1),
+    icon: "fa-duotone fa-warehouse",
+    archived_at:,
+    created_at: archived_at,
+    updated_at: archived_at
+  )
+end
+
+Rails.logger.info "E2E: Created notifications_bulk scenario test data"

--- a/test/playwright/e2e/AdminNotifications.spec.ts
+++ b/test/playwright/e2e/AdminNotifications.spec.ts
@@ -164,4 +164,43 @@ test.describe("Admin Notifications", () => {
     );
     await expect(page.getByTestId("notification-detail-no-body")).toBeVisible();
   });
+
+  test("Archives the ticked notifications in one go", async ({
+    page,
+    notification,
+  }) => {
+    await row(page, "Modules Import Results")
+      .getByTestId("notification-checkbox")
+      .click();
+    await row(page, "Loaner Sync finished")
+      .getByTestId("notification-checkbox")
+      .click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toContainText(
+      "2 selected",
+    );
+
+    await page.getByTestId("bulk-archive").click();
+
+    await notification.success("2 notifications archived");
+
+    await expect(row(page, "Modules Import Results")).toHaveCount(0);
+
+    await page.getByTestId("notifications-tab-archive").click();
+
+    await expect(row(page, "Modules Import Results")).toHaveCount(1);
+  });
+
+  test("Marks the whole page as read from the header checkbox", async ({
+    page,
+    notification,
+  }) => {
+    await page.getByTestId("bulk-select-page").click();
+
+    await page.getByTestId("bulk-read").click();
+
+    await notification.success("notifications marked as read");
+
+    await expect(page.locator(".notification-item--unread")).toHaveCount(0);
+  });
 });

--- a/test/playwright/e2e/NotificationsBulk.spec.ts
+++ b/test/playwright/e2e/NotificationsBulk.spec.ts
@@ -1,0 +1,143 @@
+import { app, appScenario } from "../support/on-rails";
+import { test, expect } from "../support/commands";
+
+const row = (page: import("@playwright/test").Page, title: string) =>
+  page.getByTestId("notification-item").filter({ hasText: title });
+
+// The scenario fills one page and a bit: 25 rows are shown, 30 exist.
+const PER_PAGE = 25;
+const TOTAL = 30;
+
+test.describe("Notifications bulk operations", () => {
+  test.beforeEach(async ({ page }) => {
+    // Against a dev vite server the first visit compiles the route's module
+    // graph, which on its own can outrun the default timeout.
+    test.slow();
+
+    await app("clean");
+    await appScenario("notifications_bulk");
+
+    await page.goto("/login/", { waitUntil: "domcontentloaded" });
+    await page.locator("input[name='login']").fill("notifications");
+    await page.locator("input[name='password']").fill("password123");
+
+    const sessionCreated = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/v1/sessions") &&
+        response.request().method() === "POST",
+    );
+
+    await page.getByTestId("submit-login").click();
+
+    await sessionCreated;
+
+    await expect(page).not.toHaveURL(/\/login/);
+
+    await page.goto("/notifications/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("notification-item").first()).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  // Hidden rather than absent: the bar keeps its height so ticking a row does
+  // not push the list down.
+  test("Offers no actions until something is ticked", async ({ page }) => {
+    await expect(page.getByTestId("bulk-selection-bar")).toBeVisible();
+    await expect(page.getByTestId("bulk-selection-count")).toBeHidden();
+    await expect(page.getByTestId("bulk-archive")).toBeHidden();
+
+    const idle = await page.getByTestId("bulk-selection-bar").boundingBox();
+
+    await page.getByTestId("bulk-select-page").click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toBeVisible();
+
+    const selected = await page.getByTestId("bulk-selection-bar").boundingBox();
+
+    expect(selected?.height).toBe(idle?.height);
+  });
+
+  test("Archives the rows ticked one by one", async ({ page, notification }) => {
+    await row(page, "Bulk notification 01")
+      .getByTestId("notification-checkbox")
+      .click();
+    await row(page, "Bulk notification 02")
+      .getByTestId("notification-checkbox")
+      .click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toContainText(
+      "2 selected",
+    );
+
+    await page.getByTestId("bulk-archive").click();
+
+    await notification.success("2 notifications archived");
+
+    await expect(row(page, "Bulk notification 01")).toHaveCount(0);
+    await expect(row(page, "Bulk notification 02")).toHaveCount(0);
+
+    await page.getByTestId("notifications-tab-archive").click();
+
+    await expect(row(page, "Bulk notification 01")).toHaveCount(1);
+  });
+
+  test("Ticks the whole page from the header checkbox", async ({ page }) => {
+    await page.getByTestId("bulk-select-page").click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toContainText(
+      `${PER_PAGE} selected`,
+    );
+    await expect(page.getByTestId("notification-item")).toHaveCount(PER_PAGE);
+  });
+
+  test("Reaches past the page with select all", async ({
+    page,
+    notification,
+  }) => {
+    await page.getByTestId("bulk-select-page").click();
+
+    // Only on offer once the page is full and there is more behind it.
+    await page.getByTestId("bulk-select-all-matching").click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toContainText(
+      `All ${TOTAL} selected`,
+    );
+
+    await page.getByTestId("bulk-read").click();
+
+    await notification.success(`${TOTAL} notifications marked as read`);
+
+    // Nothing unread left anywhere, not just on the page that was shown.
+    await expect(page.locator(".notification-item--unread")).toHaveCount(0);
+  });
+
+  test("Drops the selection when the reader leaves the tab", async ({
+    page,
+  }) => {
+    await page.getByTestId("bulk-select-page").click();
+
+    await expect(page.getByTestId("bulk-selection-count")).toBeVisible();
+
+    await page.getByTestId("notifications-tab-archive").click();
+
+    await expect(row(page, "Archived notification 01")).toHaveCount(1);
+    await expect(page.getByTestId("bulk-selection-count")).toBeHidden();
+  });
+
+  test("Deletes the selected rows after confirming", async ({
+    page,
+    notification,
+  }) => {
+    await row(page, "Bulk notification 01")
+      .getByTestId("notification-checkbox")
+      .click();
+
+    await page.getByTestId("bulk-destroy").click();
+    await page.getByTestId("confirm-ok").click();
+
+    await notification.success("1 notification deleted");
+
+    await expect(row(page, "Bulk notification 01")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Both notification centers — the user's and the admin's — could only act on one notification at a time, or on all of them at once via "Mark all as read" / "Delete all". Nothing in between. This adds a selection.

## What the reader gets

A checkbox per row, a header checkbox that takes the page, and — once the page is full and there is more behind it — a **Select all N** that reaches past it. With something ticked, the bar offers mark read, mark unread, archive (or move back to the inbox, following the tab) and delete.

The bar keeps its height whether or not anything is selected, so ticking a checkbox does not push the list down, and it wears no surface of its own: it reads as a header over the list rather than another row in it.

## API

Five collection endpoints per API — `read-bulk`, `unread-bulk`, `archive-bulk`, `unarchive-bulk`, `destroy-bulk` — taking either a list of `ids` or `all: true` plus the same `q` the index takes. That second form is what makes "select all 143" cheap: the client never holds ids it has not seen, and the selection survives paging.

Two decisions worth flagging:

- **`all` has to be spelled out.** A body naming neither `ids` nor `all` selects *nothing*, not everything — the other reading of it is `destroy_all` by accident. There is a test for it per API.
- **Each action narrows to the rows it has something to do to.** Marking an already read notification read again would move its `read_at` to now for nothing, and the count that comes back is then what actually changed.

All five are `PUT`, including the destructive one: the selection travels in the body, which a `DELETE` cannot carry everywhere. `vehicles#destroy_bulk` made the same call.

## Verification

- 43 new openapi integration tests (23 public, 20 admin), plus the existing 65 notification tests still green
- 8 unit tests for the selection composable, including that "all matching" survives turning the page but not a filter change
- 8 Playwright cases across both centers: ticking rows, taking the page, reaching past it, the confirm on delete, and an assertion that the bar's height does not change when a selection starts
- `oasdiff` reports no breaking changes against `main` for either schema

🤖
