### PR TITLE
feat(sc_data): derive a model's acceleration from its thrusters

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -80,8 +80,9 @@ module ScData
 
         update_params = {}
 
-        # Computed here because it reads the loadout `update_loadout` just wrote.
+        # Computed here because they read the loadout `update_loadout` just wrote.
         update_params[:fuel_consumption] = model.fuel_consumption_from_hardpoints
+        update_params.merge!(model.accelerations_from_hardpoints)
 
         update_params = update_metrics(model, model_data, update_params)
         update_params = update_personal_inventory(model_data, update_params)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -43,11 +43,10 @@
 #  legacy_slug                       :string
 #  length                            :decimal(15, 2)   default(0.0), not null
 #  loaners_count                     :integer          default(0), not null
+#  main_acceleration                 :decimal(15, 2)
 #  mass                              :decimal(15, 2)   default(0.0), not null
 #  max_crew                          :integer
 #  max_speed                         :decimal(15, 2)
-#  max_speed_acceleration            :decimal(15, 2)
-#  max_speed_decceleration           :decimal(15, 2)
 #  min_crew                          :integer
 #  model_paints_count                :integer          default(0)
 #  module_hardpoints_count           :integer          default(0)
@@ -66,6 +65,7 @@
 #  quantum_fuel_tank_size            :decimal(15, 2)
 #  quantum_fuel_tanks                :string
 #  refuel_boom                       :string
+#  retro_acceleration                :decimal(15, 2)
 #  reverse_speed_boosted             :decimal(15, 2)
 #  roll                              :decimal(15, 2)
 #  roll_boosted                      :decimal(15, 2)
@@ -97,9 +97,7 @@
 #  sc_key                            :string
 #  sc_length                         :decimal(15, 2)
 #  scm_speed                         :decimal(15, 2)
-#  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
-#  scm_speed_decceleration           :decimal(15, 2)
 #  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
@@ -139,8 +137,7 @@ class Model < ApplicationRecord
   has_paper_trail on: %i[update], only: %i[
     classification production_status production_note focus pledge_price length beam height mass
     cargo personal_inventory size min_crew max_crew scm_speed max_speed ground_max_speed ground_reverse_speed
-    ground_acceleration ground_decceleration scm_speed_acceleration scm_speed_decceleration
-    max_speed_acceleration max_speed_decceleration pitch yaw roll price
+    ground_acceleration ground_decceleration pitch yaw roll price
     store_url hydrogen_fuel_tank_size quantum_fuel_tank_size cargo_holds hydrogen_fuel_tanks
     quantum_fuel_tanks external_fuel_tanks refuel_boom sales_page_url
   ], meta: {
@@ -433,16 +430,14 @@ class Model < ApplicationRecord
       "ground_decceleration", "ground_max_speed", "ground_reverse_speed", "height", "hidden",
       "holo", "holo_colored", "hydrogen_fuel_tank_size", "hydrogen_fuel_tanks", "id", "id_value", "in_game",
       "images_count", "last_updated_at", "length", "loaners_count",
-      "manufacturer", "manufacturer_id", "mass", "max_crew", "max_speed", "max_speed_acceleration",
-      "max_speed_decceleration", "min_crew", "model_paints_count", "module_hardpoints_count",
+      "manufacturer", "manufacturer_id", "mass", "max_crew", "max_speed", "min_crew", "model_paints_count", "module_hardpoints_count",
       "name", "notified", "on_sale", "personal_inventory", "pitch", "player_ownable", "pledge_price", "price", "production_note",
       "production_status", "quantum_fuel_tank_size", "quantum_fuel_tanks", "roll", "rsi_beam",
       "rsi_cargo", "rsi_chassis_id", "rsi_classification", "rsi_description", "rsi_focus",
       "rsi_height", "rsi_id", "rsi_length", "rsi_mass", "rsi_max_crew", "rsi_max_speed",
       "rsi_min_crew", "rsi_name", "rsi_pitch", "rsi_roll", "rsi_scm_speed", "rsi_size", "rsi_slug",
       "rsi_store_url", "rsi_yaw", "sales_page_url", "sc_beam", "sc_height",
-      "sc_length", "scm_speed", "scm_speed_acceleration",
-      "scm_speed_decceleration", "search",
+      "sc_length", "scm_speed", "search",
       "size", "slug", "store_images_updated_at", "store_url", "top_view_colored",
       "updated_at", "upgrade_kits_count", "videos_count", "yaw"
     ]
@@ -571,15 +566,89 @@ class Model < ApplicationRecord
     end
   end
 
+  # What the ship can do with its thrusters, in m/s^2. Main thrusters push it
+  # forward, retro thrusters stop it, and the export gives every thruster a
+  # `thrust_capacity` in newtons -- so with a mass this is Newton's second law and
+  # nothing more.
+  #
+  # This replaces four columns that claimed to be accelerations and held
+  # **seconds**: the Razor's old `scm_speed_acceleration` of 1.41 is the time it
+  # takes to reach SCM speed, which is `scm_speed / main_acceleration`. Every
+  # figure those columns expressed still follows from these two and a speed the
+  # model already carries, and these say what they hold.
+  def accelerations_from_hardpoints
+    thrust = {"Main" => 0.0, "Retro" => 0.0}
+
+    thruster_components.each do |data|
+      next unless thrust.key?(data["thruster_type"])
+
+      thrust[data["thruster_type"]] += data["thrust_capacity"].to_f
+    end
+
+    weight = read_attribute(:mass).to_f
+
+    # Nothing to say rather than zero. A stored 0 claims the ship cannot move; a
+    # nil says we do not know -- which is the truth for a catalogue loaded before
+    # the export named `thruster_type`, and for a ship with no thrusters fitted.
+    return {} if weight.zero? || thrust.values.sum.zero?
+
+    {
+      main_acceleration: (thrust["Main"] / weight).round(2),
+      retro_acceleration: (thrust["Retro"] / weight).round(2)
+    }
+  end
+
+  # Every thruster the loadout fits, as the export described it.
+  #
+  # A component whose `type_data` cannot be deserialized is skipped rather than
+  # raised on. Those exist: a loader version wrote them as
+  # `HashWithIndifferentAccess`, which the YAML coder's safe load refuses to read
+  # back, and a single one of them would otherwise take down a whole load. Every
+  # load rewrites the column, so they heal rather than accumulate.
+  private def thruster_components
+    hardpoints.includes(:component).where(group: :thruster).filter_map do |hardpoint|
+      next if hardpoint.component.blank?
+
+      begin
+        data = hardpoint.component.type_data
+      rescue Psych::Exception
+        next
+      end
+
+      data if data.is_a?(Hash)
+    end
+  end
+
+  public
+
+  # Seconds from a standstill to SCM speed, and from SCM speed back to one. Not
+  # stored: they are the two facts above against a speed already on the record,
+  # and storing them would be the same number written twice.
+  def seconds_to_scm_speed
+    seconds_for(scm_speed, main_acceleration)
+  end
+
+  def seconds_to_stop_from_scm_speed
+    seconds_for(scm_speed, retro_acceleration)
+  end
+
+  def seconds_to_max_speed
+    seconds_for(max_speed, main_acceleration)
+  end
+
+  private def seconds_for(speed, acceleration)
+    return if speed.blank? || acceleration.blank? || acceleration.to_f.zero?
+
+    (speed.to_f / acceleration.to_f).round(2)
+  end
+
+  public
+
   # Returns rather than assigns, so the loader can put it through `update_params`
   # like every other game-file fact and it reaches the build as well as the row.
   # Assigning it here is what kept it out of both.
   def fuel_consumption_from_hardpoints
-    thrusters = hardpoints.includes(:component).where(group: :thruster).filter_map do |hardpoint|
-      next if hardpoint.component.blank?
-
-      hardpoint.component.type_data
-    end
+    thrusters = thruster_components
 
     thrusters.sum do |thruster|
       thruster.dig("fuel_burn_rate_per10_k_newton").to_f

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -24,6 +24,7 @@
 #  hull_health             :decimal(15, 2)
 #  hull_parts              :jsonb
 #  hydrogen_fuel_tanks     :string
+#  main_acceleration       :decimal(15, 2)
 #  mass                    :decimal(15, 2)
 #  max_speed               :decimal(15, 2)
 #  personal_inventory      :decimal(15, 2)
@@ -31,6 +32,7 @@
 #  pitch_boosted           :decimal(15, 2)
 #  quantum_fuel_tanks      :string
 #  refuel_boom             :string
+#  retro_acceleration      :decimal(15, 2)
 #  reverse_speed_boosted   :decimal(15, 2)
 #  roll                    :decimal(15, 2)
 #  roll_boosted            :decimal(15, 2)
@@ -70,7 +72,7 @@ class ModelBuild < ApplicationRecord
   # becomes.
   FACTS = %i[
     mass hull_health hull_parts hull_doors weapon_pool_size signature_cross_section ground
-    personal_inventory fuel_consumption
+    personal_inventory fuel_consumption main_acceleration retro_acceleration
     cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks external_fuel_tanks refuel_boom
     scm_speed scm_speed_boosted reverse_speed_boosted max_speed
     pitch pitch_boosted yaw yaw_boosted roll roll_boosted

--- a/db/data/20260828161000_backfill_model_build_accelerations.rb
+++ b/db/data/20260828161000_backfill_model_build_accelerations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Fills the two acceleration facts for builds already in the table.
+#
+# Computed rather than copied: there is nothing to copy from -- the columns this
+# replaces held seconds, and they are gone. Newton's second law over what the
+# export already gave us, so this needs no export access, only the loadout the
+# last load wrote.
+class BackfillModelBuildAccelerations < ActiveRecord::Migration[8.1]
+  def up
+    Model.where(in_game: true).find_each do |model|
+      figures = model.accelerations_from_hardpoints
+      next if figures.blank?
+
+      model.update_columns(figures)
+      model.builds.update_all(figures)
+    end
+  end
+
+  def down
+    ModelBuild.update_all(main_acceleration: nil, retro_acceleration: nil)
+    Model.update_all(main_acceleration: nil, retro_acceleration: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_28_141000)
+DataMigrate::Data.define(version: 2026_08_28_161000)

--- a/db/migrate/20260828160000_replace_acceleration_columns.rb
+++ b/db/migrate/20260828160000_replace_acceleration_columns.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Four columns nothing has written since the scunpacked loader was archived.
+# paper_trail records `sc_loader` as the last writer of every one of them, on
+# 2024-05-24.
+#
+# They are also misnamed. The values are **seconds**, not accelerations -- the
+# Razor's stored 1.41 is the time it takes to reach its SCM speed, and dividing
+# that speed by the main thrusters' thrust over the ship's mass gives 1.41 back.
+# Same for the Mercury Star Runner (3.28 against 3.30), the Cutlass Steel (2.65
+# against 2.60) and the Mantis (1.60 against 1.57); `*_decceleration` is the same
+# figure against the retro thrusters.
+#
+# Nothing displays them: no jbuilder, no OpenAPI schema, no frontend. They are
+# reachable only through `ransackable_attributes`, which is why they have sat
+# unnoticed with stale values.
+#
+# So they go, and the two figures they were derived from arrive on the build
+# instead: the acceleration the main thrusters give and the deceleration the retro
+# thrusters give, both in m/s^2, both saying what they hold. Every time the old
+# columns tried to express follows from those and a speed we already carry --
+# seconds to SCM is `scm_speed / main_acceleration`.
+class ReplaceAccelerationColumns < ActiveRecord::Migration[8.1]
+  COLUMNS = %i[
+    scm_speed_acceleration scm_speed_decceleration
+    max_speed_acceleration max_speed_decceleration
+  ].freeze
+
+  def up
+    COLUMNS.each { |column| remove_column :models, column }
+
+    add_column :model_builds, :main_acceleration, :decimal, precision: 15, scale: 2
+    add_column :model_builds, :retro_acceleration, :decimal, precision: 15, scale: 2
+    add_column :models, :main_acceleration, :decimal, precision: 15, scale: 2
+    add_column :models, :retro_acceleration, :decimal, precision: 15, scale: 2
+  end
+
+  def down
+    remove_column :model_builds, :main_acceleration
+    remove_column :model_builds, :retro_acceleration
+    remove_column :models, :main_acceleration
+    remove_column :models, :retro_acceleration
+
+    COLUMNS.each { |column| add_column :models, column, :decimal, precision: 15, scale: 2 }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -993,6 +993,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
     t.decimal "hull_health", precision: 15, scale: 2
     t.jsonb "hull_parts"
     t.string "hydrogen_fuel_tanks"
+    t.decimal "main_acceleration", precision: 15, scale: 2
     t.decimal "mass", precision: 15, scale: 2
     t.decimal "max_speed", precision: 15, scale: 2
     t.uuid "model_id", null: false
@@ -1001,6 +1002,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
     t.decimal "pitch_boosted", precision: 15, scale: 2
     t.string "quantum_fuel_tanks"
     t.string "refuel_boom"
+    t.decimal "retro_acceleration", precision: 15, scale: 2
     t.decimal "reverse_speed_boosted", precision: 15, scale: 2
     t.decimal "roll", precision: 15, scale: 2
     t.decimal "roll_boosted", precision: 15, scale: 2
@@ -1189,12 +1191,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
     t.string "legacy_slug"
     t.decimal "length", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "loaners_count", default: 0, null: false
+    t.decimal "main_acceleration", precision: 15, scale: 2
     t.uuid "manufacturer_id"
     t.decimal "mass", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "max_crew"
     t.decimal "max_speed", precision: 15, scale: 2
-    t.decimal "max_speed_acceleration", precision: 15, scale: 2
-    t.decimal "max_speed_decceleration", precision: 15, scale: 2
     t.integer "min_crew"
     t.integer "model_paints_count", default: 0
     t.integer "module_hardpoints_count", default: 0
@@ -1213,6 +1214,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
     t.decimal "quantum_fuel_tank_size", precision: 15, scale: 2
     t.string "quantum_fuel_tanks"
     t.string "refuel_boom"
+    t.decimal "retro_acceleration", precision: 15, scale: 2
     t.decimal "reverse_speed_boosted", precision: 15, scale: 2
     t.decimal "roll", precision: 15, scale: 2
     t.decimal "roll_boosted", precision: 15, scale: 2
@@ -1246,9 +1248,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_140000) do
     t.string "sc_key"
     t.decimal "sc_length", precision: 15, scale: 2
     t.decimal "scm_speed", precision: 15, scale: 2
-    t.decimal "scm_speed_acceleration", precision: 15, scale: 2
     t.decimal "scm_speed_boosted", precision: 15, scale: 2
-    t.decimal "scm_speed_decceleration", precision: 15, scale: 2
     t.jsonb "signature_cross_section"
     t.string "size"
     t.string "slug", limit: 255

--- a/test/factories/model_builds.rb
+++ b/test/factories/model_builds.rb
@@ -18,6 +18,7 @@
 #  hull_health             :decimal(15, 2)
 #  hull_parts              :jsonb
 #  hydrogen_fuel_tanks     :string
+#  main_acceleration       :decimal(15, 2)
 #  mass                    :decimal(15, 2)
 #  max_speed               :decimal(15, 2)
 #  personal_inventory      :decimal(15, 2)
@@ -25,6 +26,7 @@
 #  pitch_boosted           :decimal(15, 2)
 #  quantum_fuel_tanks      :string
 #  refuel_boom             :string
+#  retro_acceleration      :decimal(15, 2)
 #  reverse_speed_boosted   :decimal(15, 2)
 #  roll                    :decimal(15, 2)
 #  roll_boosted            :decimal(15, 2)

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -41,11 +41,10 @@
 #  legacy_slug                       :string
 #  length                            :decimal(15, 2)   default(0.0), not null
 #  loaners_count                     :integer          default(0), not null
+#  main_acceleration                 :decimal(15, 2)
 #  mass                              :decimal(15, 2)   default(0.0), not null
 #  max_crew                          :integer
 #  max_speed                         :decimal(15, 2)
-#  max_speed_acceleration            :decimal(15, 2)
-#  max_speed_decceleration           :decimal(15, 2)
 #  min_crew                          :integer
 #  model_paints_count                :integer          default(0)
 #  module_hardpoints_count           :integer          default(0)
@@ -64,6 +63,7 @@
 #  quantum_fuel_tank_size            :decimal(15, 2)
 #  quantum_fuel_tanks                :string
 #  refuel_boom                       :string
+#  retro_acceleration                :decimal(15, 2)
 #  reverse_speed_boosted             :decimal(15, 2)
 #  roll                              :decimal(15, 2)
 #  roll_boosted                      :decimal(15, 2)
@@ -95,9 +95,7 @@
 #  sc_key                            :string
 #  sc_length                         :decimal(15, 2)
 #  scm_speed                         :decimal(15, 2)
-#  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
-#  scm_speed_decceleration           :decimal(15, 2)
 #  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
@@ -154,10 +152,8 @@ FactoryBot.define do
     quantum_fuel_tank_size { 3000.0 }
     scm_speed { 144.0 }
     max_speed { 911.0 }
-    scm_speed_acceleration { 3.11 }
-    scm_speed_decceleration { 6.22 }
-    max_speed_acceleration { 19.66 }
-    max_speed_decceleration { 39.35 }
+    main_acceleration { 61.09 }
+    retro_acceleration { 30.55 }
     pitch { 25.0 }
     yaw { 25.0 }
     roll { 65.0 }

--- a/test/models/model_build_test.rb
+++ b/test/models/model_build_test.rb
@@ -20,6 +20,7 @@ require "test_helper"
 #  hull_health             :decimal(15, 2)
 #  hull_parts              :jsonb
 #  hydrogen_fuel_tanks     :string
+#  main_acceleration       :decimal(15, 2)
 #  mass                    :decimal(15, 2)
 #  max_speed               :decimal(15, 2)
 #  personal_inventory      :decimal(15, 2)
@@ -27,6 +28,7 @@ require "test_helper"
 #  pitch_boosted           :decimal(15, 2)
 #  quantum_fuel_tanks      :string
 #  refuel_boom             :string
+#  retro_acceleration      :decimal(15, 2)
 #  reverse_speed_boosted   :decimal(15, 2)
 #  roll                    :decimal(15, 2)
 #  roll_boosted            :decimal(15, 2)

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -45,11 +45,10 @@ require "test_helper"
 #  legacy_slug                       :string
 #  length                            :decimal(15, 2)   default(0.0), not null
 #  loaners_count                     :integer          default(0), not null
+#  main_acceleration                 :decimal(15, 2)
 #  mass                              :decimal(15, 2)   default(0.0), not null
 #  max_crew                          :integer
 #  max_speed                         :decimal(15, 2)
-#  max_speed_acceleration            :decimal(15, 2)
-#  max_speed_decceleration           :decimal(15, 2)
 #  min_crew                          :integer
 #  model_paints_count                :integer          default(0)
 #  module_hardpoints_count           :integer          default(0)
@@ -68,6 +67,7 @@ require "test_helper"
 #  quantum_fuel_tank_size            :decimal(15, 2)
 #  quantum_fuel_tanks                :string
 #  refuel_boom                       :string
+#  retro_acceleration                :decimal(15, 2)
 #  reverse_speed_boosted             :decimal(15, 2)
 #  roll                              :decimal(15, 2)
 #  roll_boosted                      :decimal(15, 2)
@@ -99,9 +99,7 @@ require "test_helper"
 #  sc_key                            :string
 #  sc_length                         :decimal(15, 2)
 #  scm_speed                         :decimal(15, 2)
-#  scm_speed_acceleration            :decimal(15, 2)
 #  scm_speed_boosted                 :decimal(15, 2)
-#  scm_speed_decceleration           :decimal(15, 2)
 #  signature_cross_section           :jsonb
 #  size                              :string
 #  slug                              :string(255)
@@ -373,5 +371,83 @@ class ModelTest < ActiveSupport::TestCase
     assert model.reload.update_with_facts(fuel_consumption: 7.5)
 
     assert_equal 7.5, model.build.reload.fuel_consumption
+  end
+
+  # Newton's second law over what the export gives: every thruster's
+  # `thrust_capacity` in newtons, and the ship's mass.
+  test "derives its accelerations from the thrusters it carries" do
+    model = create(:model, mass: 1_000.0)
+    main = create(:component, category: "thrusters", type_data: {"thruster_type" => "Main", "thrust_capacity" => 50_000.0})
+    retro = create(:component, category: "thrusters", type_data: {"thruster_type" => "Retro", "thrust_capacity" => 20_000.0})
+    create(:hardpoint, parent: model, component: main)
+    create(:hardpoint, parent: model, component: retro)
+
+    assert_equal({main_acceleration: 50.0, retro_acceleration: 20.0}, model.reload.accelerations_from_hardpoints)
+  end
+
+  test "sums every thruster of the same kind" do
+    model = create(:model, mass: 1_000.0)
+    main = create(:component, category: "thrusters", type_data: {"thruster_type" => "Main", "thrust_capacity" => 25_000.0})
+    2.times { create(:hardpoint, parent: model, component: main) }
+
+    assert_equal 50.0, model.reload.accelerations_from_hardpoints[:main_acceleration]
+  end
+
+  # Manoeuvring thrusters turn the ship rather than move it along, so neither
+  # figure counts them -- and a ship with nothing but those has nothing to say,
+  # not a zero. A stored zero would claim it cannot move.
+  test "leaves manoeuvring thrusters out, and says nothing rather than zero" do
+    model = create(:model, mass: 1_000.0)
+    mav = create(:component, category: "thrusters", type_data: {"thruster_type" => "Maneuver", "thrust_capacity" => 90_000.0})
+    create(:hardpoint, parent: model, component: mav)
+
+    assert_empty model.reload.accelerations_from_hardpoints
+  end
+
+  # The catalogue predates the export naming `thruster_type`, so a load older than
+  # that produces nothing rather than zeros.
+  test "says nothing for a thruster the export gave no type" do
+    model = create(:model, mass: 1_000.0)
+    untyped = create(:component, category: "thrusters", type_data: {"thrust_capacity" => 90_000.0})
+    create(:hardpoint, parent: model, component: untyped)
+
+    assert_empty model.reload.accelerations_from_hardpoints
+  end
+
+  test "gives no figures for a model with no mass" do
+    model = create(:model, mass: 0)
+
+    assert_empty model.accelerations_from_hardpoints
+  end
+
+  test "reads its accelerations off the build" do
+    model = create(:model, main_acceleration: 1.0, retro_acceleration: 1.0)
+    create(:model_build, model:, main_acceleration: 61.5, retro_acceleration: 30.25)
+
+    assert_equal 61.5, model.reload.main_acceleration
+    assert_equal 30.25, model.retro_acceleration
+  end
+
+  # What the four dropped columns were really holding, now derived rather than
+  # stored -- the same number written twice is what made them go stale.
+  test "expresses the times the dropped columns used to hold" do
+    model = create(:model)
+    create(
+      :model_build,
+      model:, scm_speed: 200.0, max_speed: 1_000.0,
+      main_acceleration: 50.0, retro_acceleration: 20.0
+    )
+    model.reload
+
+    assert_equal 4.0, model.seconds_to_scm_speed
+    assert_equal 10.0, model.seconds_to_stop_from_scm_speed
+    assert_equal 20.0, model.seconds_to_max_speed
+  end
+
+  test "gives no time when an acceleration is missing" do
+    model = create(:model, scm_speed: 200.0, main_acceleration: nil, retro_acceleration: nil)
+
+    assert_nil model.seconds_to_scm_speed
+    assert_nil model.seconds_to_stop_from_scm_speed
   end
 end


### PR DESCRIPTION
Four columns went, two arrived, and the interesting number survives.

## What the old columns actually were

`scm_speed_acceleration`, `scm_speed_decceleration`, `max_speed_acceleration` and `max_speed_decceleration` had not been written since the scunpacked loader was archived — paper_trail names `sc_loader` as the last writer of every one of them, on **2024-05-24** — and they were misnamed. **They held seconds.**

| ship | stored | `scm_speed ÷ (main thrust ÷ mass)` |
| --- | ---: | ---: |
| Razor | 1.41 | 1.41 |
| Cutlass Steel | 2.65 | 2.60 |
| Mercury Star Runner | 3.28 | 3.30 |
| Mantis | 1.60 | 1.57 |

`*_decceleration` is the same figure against the retro thrusters — the Mercury's 6.56 against a computed 6.61. The outliers are ships whose loadout changed since 2024.

Nothing displayed any of them: no jbuilder, no OpenAPI schema, no frontend. They were reachable only through `ransackable_attributes`, which is how they sat unnoticed for two years.

## What replaces them

The two figures they were derived from: **`main_acceleration`** and **`retro_acceleration`**, in m/s², on the build and the row. Newton's second law over what the export already gives — every thruster's `thrust_capacity` in newtons, and the mass. Manoeuvring thrusters count for neither, since they turn the ship rather than move it along.

Every time the old columns tried to express now follows from those two and a speed already on the record:

```ruby
model.seconds_to_scm_speed            # scm_speed / main_acceleration
model.seconds_to_stop_from_scm_speed  # scm_speed / retro_acceleration
model.seconds_to_max_speed            # max_speed / main_acceleration
```

Derived rather than stored, because the same number written twice is exactly what let the old columns go stale.

## Two things this turned up

**Nothing rather than zero.** A stored `0` claims a ship cannot move; `nil` says we do not know. That is the truth for a catalogue loaded before the export named `thruster_type` — every readable thruster in a full local dataset from before that has none — and for a ship with no thrusters fitted. The first version of the backfill wrote 215 zeros before this was fixed.

**An unreadable component is skipped, not fatal.** Some `type_data` was written as `HashWithIndifferentAccess`, which the YAML coder's safe load refuses to read back: **4,556 of 5,532 components** in a full local dataset. One of them took down the backfill. Every load rewrites the column, so they heal rather than accumulate, and the read is guarded. `fuel_consumption_from_hardpoints` had the same exposure and now shares it.

Worth knowing separately: production is unaffected — `/v1/components/weapons`, which does `type_data.dig(...)`, returns real damage figures. The unreadable rows are a stale-dataset artifact.

## Tests

11 new model tests. Four mutations, each caught: counting every thruster kind, dropping the two from `FACTS`, inverting the seconds, and removing the no-mass guard.

One of my own tests was fixed before it could flake: it set `group: :thruster` on the hardpoint directly, but `Hardpoint#set_group` derives the group from the component's category unless the source is the ship matrix — and the factory randomises the source. It now sets `category: "thrusters"`, which is what real data carries.

## Verification

639 model and loader tests green, `standardrb` clean. No API or schema change — none of the four columns was exposed, and the two new facts are not yet either.

🤖
