### PR TITLE
fix(models): base metrics card leaves no empty grid cells

### DIFF
--- a/app/frontend/frontend/components/Models/BaseMetrics/index.vue
+++ b/app/frontend/frontend/components/Models/BaseMetrics/index.vue
@@ -69,6 +69,9 @@ const openAvailability = () => {
 <template>
   <MetricsCard :title="t('labels.metrics.base')" class="base-panel">
     <template #head>
+      <span v-if="model.metrics.sizeLabel" class="base-panel__chip">
+        {{ model.metrics.sizeLabel }}
+      </span>
       <span v-if="model.classificationLabel" class="base-panel__chip">
         {{ model.classificationLabel }}
       </span>
@@ -113,12 +116,6 @@ const openAvailability = () => {
         <div class="metrics-card__tile__value">
           {{ toNumber(model.metrics.personalInventory) }}
           <span class="metrics-card__tile__unit">SCU</span>
-        </div>
-      </div>
-      <div class="metrics-card__tile">
-        <div class="metrics-card__tile__label">{{ t("model.size") }}</div>
-        <div class="metrics-card__tile__value">
-          {{ model.metrics.sizeLabel }}
         </div>
       </div>
     </div>

--- a/app/frontend/shared/components/metricsCard.scss
+++ b/app/frontend/shared/components/metricsCard.scss
@@ -28,8 +28,28 @@
       display: grid;
       grid-template-columns: repeat(3, 1fr);
 
+      // A tile count that is not a multiple of the track count leaves the hero's
+      // own background showing through as an empty cell - cards drop tiles for
+      // stats a model has no value for - so a lone last tile fills the free
+      // tracks instead.
+      .metrics-card__tile:last-child:nth-child(3n + 1) {
+        grid-column: span 3;
+      }
+
+      .metrics-card__tile:last-child:nth-child(3n + 2) {
+        grid-column: span 2;
+      }
+
       &-2 {
         grid-template-columns: repeat(2, 1fr);
+
+        .metrics-card__tile:last-child {
+          grid-column: auto;
+
+          &:nth-child(odd) {
+            grid-column: span 2;
+          }
+        }
       }
 
       .metrics-card__tile {


### PR DESCRIPTION
## Was

Die Base-Card auf der Schiffsseite rendert ihre Tiles in einem Grid mit drei festen Spalten. Mit `Ship Inventory` waren das sieben Tiles, die letzte Reihe hatte also zwei leere Zellen — und dort schien der Container-Hintergrund durch, der sonst nur die 1px-Trennlinien zeichnet. Das las sich als grauer Block unter `Size`.

Zwei Änderungen:

1. **`metricsCard.scss`** — ein alleinstehendes letztes Tile spannt sich über die freien Spuren, statt eine Lücke zu lassen. Gilt für jede Card mit `--grid`, weil alle Tiles fallen lassen, wenn ein Modell keinen Wert dafür hat; die zweispaltige Crew-Card ist entsprechend zurückgesetzt.
2. **`BaseMetrics`** — `Size` sitzt jetzt als Chip im Card-Head neben der Klassifikation, wo beide als ein Paar Tags lesen ("LARGE TRANSPORT"). Das Grid bleibt damit mit sechs Tiles gerade.

## Test

Statischer SCSS-Harness über die verbleibenden Tile-Zahlen: sechs Tiles ergeben ein sauberes 2×3, fünf (Modell ohne `personalInventory`) lassen `Cargo` über die zwei freien Spuren laufen. Kein leerer Bereich mehr, Trennlinien durchgehend.

🤖
