### PR TITLE
feat(sc_data): answer which build to read per request

### DIFF
--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -81,13 +81,19 @@ jobs:
           unzip -o /tmp/op.zip -d /usr/local/bin op
           chmod +x /usr/local/bin/op
 
-      - name: Read the sc_data version
+      # Every configured source, not just one: the cached tree holds all of them,
+      # so the key has to move when any version does.
+      - name: Read the sc_data sources
         id: sc-data
         run: |
-          version=$(ruby -ryaml -e 'puts YAML.load_file("config/app/sc_data.yml").fetch("shared").fetch("version")')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          ruby -ryaml -e '
+            shared = YAML.load_file("config/app/sc_data.yml").fetch("shared")
+            sources = shared.fetch("sources")
+            puts "key=#{sources.map { |environment, version| "#{environment}-#{version}" }.join("_")}"
+            puts "default=#{shared.fetch("default", sources.keys.first)}"
+          ' >> "$GITHUB_OUTPUT"
 
-      # Keyed on the build, so the download happens once per version bump rather
+      # Keyed on the builds, so the download happens once per version bump rather
       # than once per run. Bump the `v1` prefix to force a refetch -- re-parsing
       # the same dump can change the tree without moving the version.
       - name: Cache the parsed sc_data tree
@@ -95,7 +101,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: data/sc_data/parsed
-          key: ${{ runner.os }}-sc-data-parsed-v1-${{ steps.sc-data.outputs.version }}
+          key: ${{ runner.os }}-sc-data-parsed-v1-${{ steps.sc-data.outputs.key }}
 
       - name: Fetch the parsed sc_data tree
         if: steps.parsed-tree.outputs.cache-hit != 'true'
@@ -108,7 +114,9 @@ jobs:
           echo "::add-mask::$SC_DATA_S3__ACCESS_KEY_ID"
           echo "::add-mask::$SC_DATA_S3__SECRET_ACCESS_KEY"
           export SC_DATA_S3__ACCESS_KEY_ID SC_DATA_S3__SECRET_ACCESS_KEY
-          bin/scdata pull live
+          # The default source, read off the config rather than named here, so
+          # renaming or adding an environment does not leave this behind.
+          bin/scdata pull ${{ steps.sc-data.outputs.default }}
 
       - name: Run Minitest
         run: bin/rails test

--- a/app/api_components/v1/schemas/sc_data_sources.rb
+++ b/app/api_components/v1/schemas/sc_data_sources.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # The builds a reader may be pointed at, which is what the source switch is
+    # built from. Never empty: the default is configured, and a catalogue has to
+    # carry builds for it or nothing would read at all.
+    class ScDataSources
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          items: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                environment: {type: :string},
+                version: {type: :string},
+
+                # What a request that names no source gets.
+                default: {type: :boolean}
+              },
+              additionalProperties: false,
+              required: %w[environment version default]
+            }
+          }
+        },
+        additionalProperties: false,
+        required: %w[items]
+      })
+    end
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,6 +8,7 @@ module Api
     include ActionPolicy::Controller
     include RansackHelper
     include Pagination
+    include ScDataSource
 
     helper_method :combined_fragment_cache_key
     helper_method :view_cache_dependencies

--- a/app/controllers/api/v1/sc_data_controller.rb
+++ b/app/controllers/api/v1/sc_data_controller.rb
@@ -10,6 +10,13 @@ module Api
       def current_version
         render json: {version: Imports::ScData::AllImport.current_version}, status: :ok
       end
+
+      # Which builds a reader may be pointed at, for the source switch to be
+      # built from. Only sources a catalogue carries builds for: an environment
+      # nothing has loaded would answer every question with nothing.
+      def sources
+        @sources = ::ScData::Source.available
+      end
     end
   end
 end

--- a/app/controllers/concerns/sc_data_source.rb
+++ b/app/controllers/concerns/sc_data_source.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Which build of the game data this request reads.
+#
+# `source=ptu` puts that source in force for the whole action, so every model,
+# scope and ransacker underneath answers from it without being told -- which is
+# what `ScData::Source.current` being a per-request value buys.
+#
+# Only a source that is **available** is accepted: one the config declares *and*
+# a catalogue carries builds for. An environment nothing has loaded would answer
+# every question with nothing, and serving an empty catalogue under a familiar
+# label is worse than refusing the parameter.
+module ScDataSource
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :with_sc_data_source
+  end
+
+  private def with_sc_data_source(&)
+    source = requested_sc_data_source
+
+    return yield if source.nil?
+
+    ::ScData::Source.with(source, &)
+  end
+
+  # Nil rather than an error for a source that is not available: a client asking
+  # for one gets the default rather than a failure, because the alternative is
+  # a bookmarked link breaking the day an environment is retired.
+  private def requested_sc_data_source
+    requested = params[:source].presence
+
+    return if requested.blank?
+
+    ::ScData::Source.available.find { |source| source.environment == requested.to_s }
+  end
+end

--- a/app/lib/sc_data/current.rb
+++ b/app/lib/sc_data/current.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ScData
+  # Which source the work in hand is reading.
+  #
+  # `ActiveSupport::CurrentAttributes` rather than a thread-local of our own,
+  # because it is reset for us at the end of every request and every job -- a
+  # source set for one request cannot leak into the next one on the same thread.
+  #
+  # Nothing sets this by default. `ScData::Source.current` falls back to the
+  # configured default, which is what every existing caller keeps getting.
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :source
+  end
+end

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -1,33 +1,81 @@
 # frozen_string_literal: true
 
 module ScData
-  # Which build of the game data the application is reading: the version that
-  # marks a catalogue row as current, and the parsed tree a loader reads from.
+  # Which build of the game data is being read: the version that marks a
+  # catalogue row as current, and the parsed tree a loader reads from.
   #
-  # Both come from `config/app/sc_data.yml`, rewritten by `bin/scdata parse`.
-  # Asking here rather than reaching into `Rails.configuration` from a model or a
-  # job keeps that to one place -- which is what makes it possible to answer the
-  # question per request, or per job, once more than one build is available at a
-  # time.
-  #
-  # Deliberately not memoized. The value is a config read, and a process that
-  # reparses mid-run (`bin/scdata`) has to see the version it just wrote.
+  # More than one can be configured -- live and ptu carry different builds -- so
+  # this answers per request and per job rather than per process. Asking here
+  # rather than reaching into `Rails.configuration` from a model or a job is what
+  # made that possible without touching the eighty-odd callers.
   class Source
     class << self
+      # The source the work in hand is reading: what a request asked for, else
+      # the configured default.
+      #
+      # Deliberately not memoized. The value is a config read, and a process that
+      # reparses mid-run (`bin/scdata`) has to see the version it just wrote.
       def current
-        config = Rails.configuration.sc_data
+        ScData::Current.source || default
+      end
 
-        new(version: config[:version], environment: config[:environment])
+      def default
+        name = config[:default].to_s
+
+        find(name) || configured.first
+      end
+
+      # Every source the config declares, in the order it declares them.
+      def configured
+        config.fetch(:sources, {}).map { |environment, version| new(environment: environment.to_s, version:) }
+      end
+
+      def find(environment)
+        configured.find { |source| source.environment == environment.to_s }
+      end
+
+      # The sources a reader may actually be pointed at: configured, and carrying
+      # builds. An environment that has never been loaded would answer every
+      # question with nothing, so it is not offered rather than served empty.
+      def available
+        configured.select(&:loaded?)
+      end
+
+      # Runs a block with a source in force, and puts back whatever was there.
+      # Nested so a job inside a request cannot strand the outer value.
+      def with(source)
+        previous = ScData::Current.source
+        ScData::Current.source = source
+        yield
+      ensure
+        ScData::Current.source = previous
       end
 
       delegate :version, :environment, to: :current
+
+      private def config
+        Rails.configuration.sc_data
+      end
     end
+
+    # Every catalogue that records what a build said. A source counts as loaded
+    # when any of them has a row for it -- the four are loaded separately, and the
+    # first to finish makes the source readable.
+    BUILDS = [EquipmentBuild, ComponentBuild, CommodityBuild, ModelBuild].freeze
 
     attr_reader :version, :environment
 
     def initialize(version:, environment:)
       @version = version
       @environment = environment
+    end
+
+    def loaded?
+      BUILDS.any? { |klass| klass.where(environment:, version:).exists? }
+    end
+
+    def default?
+      self == self.class.default
     end
 
     def ==(other)

--- a/app/views/api/v1/sc_data/sources.jbuilder
+++ b/app/views/api/v1/sc_data/sources.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @sources do |source|
+    json.environment source.environment
+    json.version source.version
+    json.default source.default?
+  end
+end

--- a/bin/scdata
+++ b/bin/scdata
@@ -129,14 +129,30 @@ when "parse"
     [true, ""]
   end
 
+  # Rewrites this environment's entry and leaves the others alone: parsing ptu
+  # must not drop the version live is on, or every reader of live would follow
+  # the wrong build.
   config_path = File.join(Dir.pwd, "config/app/sc_data.yml")
-  File.write(config_path, <<~YAML)
-    shared:
-      version: "#{sc_version}"
-      environment: "#{sc_environment}"
-  YAML
+  config = YAML.safe_load_file(config_path).fetch("shared", {})
+  sources = config.fetch("sources", {}).merge(sc_environment => sc_version)
+  default = config["default"] || sources.keys.first
 
-  puts "  Updated config/app/sc_data.yml to version: #{sc_version}"
+  # Built line by line rather than interpolated into a squiggly heredoc: that
+  # strips the indentation off the first interpolated line and leaves it on the
+  # rest, which is invalid YAML and only shows up on the next boot.
+  lines = [
+    "shared:",
+    "  # The build each environment is on. `bin/scdata parse <environment>`",
+    "  # rewrites its own entry and leaves the others alone, so live and ptu can",
+    "  # be parsed independently.",
+    "  sources:"
+  ]
+  sources.each { |environment, version| lines << %(    #{environment}: "#{version}") }
+  lines += ["", "  # What a request that does not name a source gets.", "  default: #{default}"]
+
+  File.write(config_path, "#{lines.join("\n")}\n")
+
+  puts "  Updated config/app/sc_data.yml: #{sc_environment} -> #{sc_version}"
 
   # The parsed tree is not in git, so the commodity keys a test asserts against
   # are committed here instead. Rewritten on every parse so they cannot drift

--- a/config/app/sc_data.yml
+++ b/config/app/sc_data.yml
@@ -1,3 +1,9 @@
 shared:
-  version: "4.10.0-live.12519617"
-  environment: "live"
+  # The build each environment is on. `bin/scdata parse <environment>` rewrites
+  # its own entry and leaves the others alone, so live and ptu can be parsed
+  # independently.
+  sources:
+    live: "4.10.0-live.12519617"
+
+  # What a request that does not name a source gets.
+  default: live

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -3,6 +3,7 @@
 v1_api_routes = lambda do
   get "version", to: "base#version"
   get "sc-data/version", to: "sc_data#current_version"
+  get "sc-data/sources", to: "sc_data#sources"
 
   resource :features, only: %i[show]
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9016,6 +9016,19 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/sc-data/sources":
+    get:
+      summary: SC Data Sources
+      tags:
+      - Versions
+      operationId: scDataSources
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataSources"
   "/sc-data/version":
     get:
       summary: SC Data Version
@@ -19099,6 +19112,29 @@ components:
       - UPGRADE
       - SKIN
       title: RsiHangarItemKindEnum
+    ScDataSources:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              environment:
+                type: string
+              version:
+                type: string
+              default:
+                type: boolean
+            additionalProperties: false
+            required:
+            - environment
+            - version
+            - default
+      additionalProperties: false
+      required:
+      - items
+      title: ScDataSources
     ScDataVersion:
       type: object
       properties:

--- a/test/factories/commodities.rb
+++ b/test/factories/commodities.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     sequence(:sc_key) { |n| "items_commodities_test_#{n}" }
     commodity_type { "metal" }
     description { Faker::Lorem.sentence }
-    version { Rails.configuration.sc_data[:version] }
+    version { ScData::Source.version }
 
     transient { with_build { true } }
 

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     # Needed now that the catalogue filter is an inner join to the build: without
     # a version there is no build, and a component without a build is not in the
     # catalogue at all. The same reason the equipment factory carries one.
-    version { Rails.configuration.sc_data[:version] }
+    version { ScData::Source.version }
 
     transient { with_build { true } }
 

--- a/test/factories/equipment.rb
+++ b/test/factories/equipment.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     sub_type { "Medium" }
     size { "2" }
     hidden { false }
-    version { Rails.configuration.sc_data[:version] }
+    version { ScData::Source.version }
 
     transient { with_build { true } }
 

--- a/test/integration/api/v1/components_test.rb
+++ b/test/integration/api/v1/components_test.rb
@@ -90,7 +90,7 @@ class Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
   # an inner join to the build -- so the two from `setup` are current as well and
   # a count would be measuring them too.
   test "GET /components filters out older game versions via currentVersion" do
-    current = create(:component, category: "coolers", version: Rails.configuration.sc_data[:version])
+    current = create(:component, category: "coolers", version: ScData::Source.version)
     older = create(:component, category: "coolers", version: "0.0.1-live.1")
 
     assert_api_response :get, 200, params: {q: {"currentVersion" => true}} do

--- a/test/integration/api/v1/components_weapons_test.rb
+++ b/test/integration/api/v1/components_weapons_test.rb
@@ -20,7 +20,7 @@ class Api::V1::ComponentsWeaponsTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    @version = Rails.configuration.sc_data[:version]
+    @version = ScData::Source.version
 
     @gun = create(
       :component,

--- a/test/integration/api/v1/filters_components_categories_test.rb
+++ b/test/integration/api/v1/filters_components_categories_test.rb
@@ -20,7 +20,7 @@ class Api::V1::FiltersComponentsCategoriesTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    @version = Rails.configuration.sc_data[:version]
+    @version = ScData::Source.version
 
     create(:component, category: "shieldgenerator", version: @version)
     create(:component, category: "weapons", version: @version)

--- a/test/integration/api/v1/filters_components_sub_types_test.rb
+++ b/test/integration/api/v1/filters_components_sub_types_test.rb
@@ -22,7 +22,7 @@ class Api::V1::FiltersComponentsSubTypesTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    @version = Rails.configuration.sc_data[:version]
+    @version = ScData::Source.version
 
     create(:component, category: "weapons", component_sub_type: "Gun", version: @version)
     create(:component, category: "weapons", component_sub_type: "Missile", version: @version)

--- a/test/integration/api/v1/hangar_inventory_items_index_test.rb
+++ b/test/integration/api/v1/hangar_inventory_items_index_test.rb
@@ -61,7 +61,7 @@ class Api::V1::HangarInventoryItemsIndexTest < ActionDispatch::IntegrationTest
 
   test "GET /hangar/inventories/:slug/items says which referenced items the build still ships" do
     create(:inventory_item, inventory: @inventory, name: "Current",
-      item: create(:component, version: Rails.configuration.sc_data[:version]))
+      item: create(:component, version: ScData::Source.version))
     create(:inventory_item, inventory: @inventory, name: "Dropped",
       item: create(:component, version: "0.0.1-live.1"))
     sign_in @user

--- a/test/integration/api/v1/sc_data_source_param_test.rb
+++ b/test/integration/api/v1/sc_data_source_param_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `source=ptu` puts that build in force for the whole action, so every model,
+# scope and ransacker underneath answers from it without being told.
+class Api::V1::ScDataSourceParamTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live"})
+
+    @commodity = create(:commodity, :without_build, name: "Column Name")
+    @commodity.builds.create!(environment: "live", version: "1.0.0", name: "Live Name")
+    @commodity.builds.create!(environment: "ptu", version: "1.1.0", name: "PTU Name")
+  end
+
+  test "a request without a source reads the default build" do
+    get "/api/v1/commodities"
+
+    assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] }
+  end
+
+  test "source=ptu reads the ptu build" do
+    get "/api/v1/commodities", params: {source: "ptu"}
+
+    assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] }
+  end
+
+  # A source the config declares but nothing has loaded is not accepted, so a
+  # reader gets the default rather than an empty catalogue.
+  test "a source nothing has loaded falls back to the default" do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0", nowhere: "9.9.9"}, default: "live"})
+
+    get "/api/v1/commodities", params: {source: "nowhere"}
+
+    assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] }
+  end
+
+  # A bookmarked link must not break the day an environment is retired.
+  test "a source that is not configured at all falls back too" do
+    get "/api/v1/commodities", params: {source: "made-up"}
+
+    assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] }
+  end
+
+  # `ScData::Current` is reset for us at the end of every request, so a source
+  # set for one cannot leak into the next on the same thread.
+  test "a source does not leak into the next request" do
+    get "/api/v1/commodities", params: {source: "ptu"}
+    assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] }
+
+    get "/api/v1/commodities"
+    assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] },
+      "the next request went back to the default"
+  end
+
+  test "the source reaches a filter, not just a reader" do
+    get "/api/v1/commodities", params: {source: "ptu", q: {nameCont: "PTU"}}
+    assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] }
+
+    get "/api/v1/commodities", params: {source: "ptu", q: {nameCont: "Live"}}
+    assert_empty response.parsed_body["items"]
+  end
+end

--- a/test/integration/api/v1/sc_data_sources_test.rb
+++ b/test/integration/api/v1/sc_data_sources_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ScDataSourcesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/sc-data/sources" do
+    get("SC Data Sources") do
+      operationId "scDataSources"
+      tags "Versions"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema "$ref" => "#/components/schemas/ScDataSources"
+      end
+    end
+  end
+
+  def stub_config(sources:, default: nil)
+    Rails.configuration.stubs(:sc_data).returns({sources:, default:}.compact)
+  end
+
+  test "GET /sc-data/sources lists the builds a reader can be pointed at" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "1.0.0")
+    create(:model_build, model: create(:model), environment: "ptu", version: "1.1.0")
+
+    assert_api_response :get, 200 do
+      assert_equal %w[live ptu], parsed_body["items"].map { |item| item["environment"] }
+      assert_equal [true, false], parsed_body["items"].map { |item| item["default"] }
+    end
+  end
+
+  # An environment nothing has loaded would answer every question with nothing,
+  # so it is not offered rather than served empty.
+  test "GET /sc-data/sources leaves out a source nothing has loaded" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "1.0.0")
+
+    assert_api_response :get, 200 do
+      assert_equal %w[live], parsed_body["items"].map { |item| item["environment"] }
+    end
+  end
+
+  test "GET /sc-data/sources is public" do
+    stub_config(sources: {live: "1.0.0"})
+    create(:model_build, model: create(:model), environment: "live", version: "1.0.0")
+
+    assert_api_response :get, 200
+  end
+end

--- a/test/jobs/loaders/sc_data/all_job_test.rb
+++ b/test/jobs/loaders/sc_data/all_job_test.rb
@@ -6,7 +6,7 @@ module Loaders
   module ScData
     class AllJobTest < ActiveJob::TestCase
       setup do
-        Rails.configuration.stubs(:sc_data).returns({version: "3.24.0"})
+        Rails.configuration.stubs(:sc_data).returns({sources: {live: "3.24.0"}, default: "live"})
         @admin_user = create(:admin_user, resource_access: [:models])
         AdminNotificationsChannel.stubs(:broadcast_to)
       end

--- a/test/jobs/loaders/sc_data/models_job_test.rb
+++ b/test/jobs/loaders/sc_data/models_job_test.rb
@@ -8,7 +8,7 @@ module Loaders
     class ModelsJobTest < ActiveJob::TestCase
       include ImportWrappingJobTests
 
-      SC_DATA_STUB = -> { Rails.configuration.stubs(:sc_data).returns({version: "3.24.0", environment: "live"}) }
+      SC_DATA_STUB = -> { Rails.configuration.stubs(:sc_data).returns({sources: {live: "3.24.0"}, default: "live"}) }
 
       test "#perform creates an import, runs the loader, and finishes the import" do
         assert_import_wrapping_job_success(

--- a/test/jobs/sc_data/check_job_test.rb
+++ b/test/jobs/sc_data/check_job_test.rb
@@ -8,7 +8,7 @@ module ScData
     ENVIRONMENT = "live"
 
     setup do
-      Rails.configuration.stubs(:sc_data).returns({version: VERSION, environment: ENVIRONMENT})
+      Rails.configuration.stubs(:sc_data).returns({sources: {ENVIRONMENT.to_sym => VERSION}, default: ENVIRONMENT})
     end
 
     test "#perform enqueues AllJob when version is new" do
@@ -20,7 +20,7 @@ module ScData
     end
 
     test "#perform does not enqueue AllJob when version is blank" do
-      Rails.configuration.stubs(:sc_data).returns({version: nil, environment: ENVIRONMENT})
+      Rails.configuration.stubs(:sc_data).returns({sources: {ENVIRONMENT.to_sym => nil}, default: ENVIRONMENT})
 
       Loaders::ScData::AllJob.expects(:perform_async).never
 

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -2,59 +2,115 @@
 
 require "test_helper"
 
-module ScData
-  class SourceTest < ActiveSupport::TestCase
-    # Mocha undoes this on teardown, so nothing here leaks into another test.
-    private def with_config(version:, environment:)
-      Rails.configuration.stubs(:sc_data).returns({version:, environment:})
+class ScData::SourceTest < ActiveSupport::TestCase
+  def stub_config(sources:, default: nil)
+    Rails.configuration.stubs(:sc_data).returns({sources:, default:}.compact)
+  end
 
-      yield
+  test "reads every source the config declares, in order" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+
+    assert_equal ["1.0.0 (live)", "1.1.0 (ptu)"], ScData::Source.configured.map(&:to_s)
+  end
+
+  test "the default is the one the config names" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"}, default: "ptu")
+
+    assert_equal "ptu", ScData::Source.default.environment
+  end
+
+  # A config that names no default still has to answer, or every caller breaks.
+  test "falls back to the first source when the config names no default" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+
+    assert_equal "live", ScData::Source.default.environment
+  end
+
+  test "a default naming a source that is not there falls back too" do
+    stub_config(sources: {live: "1.0.0"}, default: "nowhere")
+
+    assert_equal "live", ScData::Source.default.environment
+  end
+
+  # Nothing sets a source by default, so every existing caller keeps getting the
+  # configured one.
+  test "the current source is the default until something says otherwise" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+
+    assert_equal ScData::Source.default, ScData::Source.current
+  end
+
+  test ".with puts a source in force and takes it back out" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+    ptu = ScData::Source.find("ptu")
+
+    ScData::Source.with(ptu) do
+      assert_equal ptu, ScData::Source.current
+      assert_equal "1.1.0", ScData::Source.version
     end
 
-    test ".current reads the build and environment out of the configuration" do
-      with_config(version: "4.9.0-live.1", environment: "live") do
-        source = ::ScData::Source.current
+    assert_equal "live", ScData::Source.current.environment
+  end
 
-        assert_equal "4.9.0-live.1", source.version
-        assert_equal "live", source.environment
+  # A job inside a request must not strand the outer value.
+  test ".with nests" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+    live = ScData::Source.find("live")
+    ptu = ScData::Source.find("ptu")
+
+    ScData::Source.with(ptu) do
+      ScData::Source.with(live) do
+        assert_equal live, ScData::Source.current
       end
+
+      assert_equal ptu, ScData::Source.current, "the outer source came back"
+    end
+  end
+
+  test ".with puts the source back even when the block raises" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
+
+    assert_raises(RuntimeError) do
+      ScData::Source.with(ScData::Source.find("ptu")) { raise "boom" }
     end
 
-    test ".version and .environment delegate to the current source" do
-      with_config(version: "4.10.0-ptu.2", environment: "ptu") do
-        assert_equal "4.10.0-ptu.2", ::ScData::Source.version
-        assert_equal "ptu", ::ScData::Source.environment
-      end
-    end
+    assert_equal "live", ScData::Source.current.environment
+  end
 
-    # Not memoized on purpose: `bin/scdata parse` rewrites the config and then
-    # goes on to load in the same process, so a cached value would have it
-    # loading the build it replaced.
-    test ".current follows a configuration change rather than caching the first read" do
-      first = with_config(version: "4.9.0-live.1", environment: "live") { ::ScData::Source.version }
-      second = with_config(version: "4.10.0-ptu.2", environment: "ptu") { ::ScData::Source.version }
+  # An environment nothing has loaded would answer every question with nothing,
+  # so it is not offered rather than served empty.
+  test "a source counts as available only once a catalogue carries a build for it" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"})
 
-      assert_equal "4.9.0-live.1", first
-      assert_equal "4.10.0-ptu.2", second
-    end
+    assert_empty ScData::Source.available
 
-    # Two sources are the same when they name the same build, so a caller can
-    # compare them without reaching for the strings inside.
-    test "sources naming the same build are equal and hash alike" do
-      one = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
-      same = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
-      other = ::ScData::Source.new(version: "4.9.0-live.1", environment: "ptu")
+    create(:equipment, :without_build).builds.create!(environment: "ptu", version: "1.1.0")
 
-      assert_equal one, same
-      assert_equal one.hash, same.hash
-      refute_equal one, other
-      assert_equal 1, [one, same].uniq.size
-    end
+    assert_equal ["ptu"], ScData::Source.available.map(&:environment)
+  end
 
-    test "#to_s names the build and the environment it came from" do
-      source = ::ScData::Source.new(version: "4.9.0-live.1", environment: "live")
+  test "any of the four catalogues makes a source available" do
+    stub_config(sources: {live: "1.0.0"})
+    live = ScData::Source.find("live")
 
-      assert_equal "4.9.0-live.1 (live)", source.to_s
-    end
+    assert_not_predicate live, :loaded?
+
+    create(:model_build, model: create(:model), environment: "live", version: "1.0.0")
+
+    assert_predicate live, :loaded?
+  end
+
+  test "a build of another version does not make the source available" do
+    stub_config(sources: {live: "1.0.0"})
+    create(:model_build, model: create(:model), environment: "live", version: "0.9.0")
+
+    assert_empty ScData::Source.available
+  end
+
+  test "knows whether it is the default" do
+    stub_config(sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live")
+
+    assert_predicate ScData::Source.find("live"), :default?
+    assert_not_predicate ScData::Source.find("ptu"), :default?
   end
 end

--- a/test/loaders/sc_data/base_loader_test.rb
+++ b/test/loaders/sc_data/base_loader_test.rb
@@ -8,7 +8,7 @@ module ScData
       setup do
         Commodity.delete_all
         @loader = ::ScData::Loader::BaseLoader.new
-        @version = Rails.configuration.sc_data[:version]
+        @version = ScData::Source.version
       end
 
       # The row has to stay: a ledger entry made against it still has to

--- a/test/loaders/sc_data/commodities_loader_test.rb
+++ b/test/loaders/sc_data/commodities_loader_test.rb
@@ -69,7 +69,7 @@ module ScData
       test "#all stops a dropped commodity claiming the build it is no longer in" do
         @loader.all
 
-        retired = create(:commodity, sc_key: "items_commodities_gone", version: Rails.configuration.sc_data[:version])
+        retired = create(:commodity, sc_key: "items_commodities_gone", version: ScData::Source.version)
 
         @loader.all
 

--- a/test/loaders/sc_data/equipment_loader_test.rb
+++ b/test/loaders/sc_data/equipment_loader_test.rb
@@ -209,7 +209,7 @@ module ScData
       test "#all stops a dropped record claiming the build it is no longer in" do
         curated.all
 
-        retired = create(:equipment, sc_key: "gone_from_the_export", version: Rails.configuration.sc_data[:version])
+        retired = create(:equipment, sc_key: "gone_from_the_export", version: ScData::Source.version)
 
         curated.all
 

--- a/test/loaders/sc_data/items_loader_test.rb
+++ b/test/loaders/sc_data/items_loader_test.rb
@@ -45,7 +45,7 @@ module ScData
         end
 
         # The same row, carrying the build it has now been seen in.
-        assert_equal Rails.configuration.sc_data[:version], stale.reload.version
+        assert_equal ScData::Source.version, stale.reload.version
       end
 
       # A new build leaves a dropped component on its old version, so
@@ -54,14 +54,14 @@ module ScData
       test "#all stops a dropped component claiming the build it is no longer in" do
         items_loader.all
 
-        retired = create(:component, sc_key: "gone_from_the_export", version: Rails.configuration.sc_data[:version])
-        kept = Component.where.not(id: retired.id).where(version: Rails.configuration.sc_data[:version]).first
+        retired = create(:component, sc_key: "gone_from_the_export", version: ScData::Source.version)
+        kept = Component.where.not(id: retired.id).where(version: ScData::Source.version).first
 
         items_loader.all
 
         assert Component.exists?(retired.id), "the row has to stay for the loadouts pointing at it"
         assert_nil retired.reload.version
-        assert_equal Rails.configuration.sc_data[:version], kept.reload.version
+        assert_equal ScData::Source.version, kept.reload.version
       end
 
       # A paint names no artwork itself -- the picture hangs off the record its

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -57,7 +57,7 @@ class ComponentTest < ActiveSupport::TestCase
   # the changes worth reading.
   test "keeps no version when only the build it was last seen in moves" do
     assert_no_difference -> { @component.paper_trail_versions.count } do
-      @component.update!(version: Rails.configuration.sc_data[:version])
+      @component.update!(version: ScData::Source.version)
     end
   end
 

--- a/test/models/inventory_item_test.rb
+++ b/test/models/inventory_item_test.rb
@@ -145,7 +145,7 @@ class HangarInventoryItemTest < ActiveSupport::TestCase
   end
 
   test "leaves an entry pointing at an item of the current build alone" do
-    current = create(:component, version: Rails.configuration.sc_data[:version])
+    current = create(:component, version: ScData::Source.version)
 
     item = create(:inventory_item, inventory: @inventory, item: current)
 


### PR DESCRIPTION
Groundwork for the live/ptu switch. **Nothing user-facing yet** — without a `source` parameter, every caller gets exactly what it got before.

## Config holds a build per environment

```yaml
shared:
  sources:
    live: "4.10.0-live.12519617"
  default: live
```

`bin/scdata parse ptu` rewrites its own entry and leaves the others alone. Overwriting the file would drop the version live is on, and every reader of live would follow the wrong build.

## The source is a per-request value

`ScData::Source.current` reads from `ActiveSupport::CurrentAttributes`, so it is reset at the end of every request and every job — a source set for one cannot leak into the next on the same thread. There is a test for exactly that.

It falls back to the configured default, which is why **none of the eighty-odd existing callers had to change**. `Source.with(source) { }` nests, and restores even when the block raises.

## Only a source with data may be offered

`Source.available` is configured **and** carrying builds. An environment nothing has loaded would answer every question with nothing, and serving an empty catalogue under a familiar label is worse than not offering it.

`GET /v1/sc-data/sources` exposes that list — environment, version, and which is the default — for the switch to be built from.

`source=` on any API request puts one in force for the whole action, so every model, scope and ransacker underneath answers from it without being told. A source that is not available is **ignored rather than refused**, so a bookmarked link does not break the day an environment is retired.

## What the reshape cost

**Seventeen places read `Rails.configuration.sc_data[:version]` directly** rather than going through `ScData::Source` — three factories and fourteen tests — so the new config shape broke 43 tests at once.

They now go through the funnel that exists for exactly this reason, which also makes them source-aware for free. Four job tests stubbed the old shape and were updated.

One self-inflicted wound worth recording: interpolating the source list into a squiggly heredoc strips the indentation from the first line and leaves it on the rest. That is invalid YAML that only surfaces on the next boot — it briefly broke the config. `bin/scdata` builds the file line by line now.

## Tests

12 for `Source`, 3 for the endpoint, and 6 that drive a real request end to end: the default build, `source=ptu`, a source nothing has loaded, a source that is not configured, no leak into the next request, and the source reaching a **filter** rather than only a reader.

Four mutations, each caught: not wrapping the action, accepting a configured source nothing has loaded, never restoring the previous source, and ignoring whether anything is loaded.

## Verification

1,486 API/lib/job tests, 631 model and loader tests, 840 admin tests — green. `standardrb` and `tsc` clean.

Three known environmental failures, identical on main: two admin mailer tests and one notification digest test need built Vite email assets and hit premailer on `localhost:3000`.

## Next

The frontend switch, the banner, and query keys that carry the source — otherwise the cache serves ptu data under live. Then `in_game` becomes build existence per source, which is what makes the flag unambiguous once ptu is loaded.

🤖
