### PR TITLE
fix(sc_data): name the commodity that borrows the ammo crate's keys

### DIFF
--- a/app/lib/sc_data/parser/commodities_parser.rb
+++ b/app/lib/sc_data/parser/commodities_parser.rb
@@ -10,10 +10,10 @@ module ScData
       CANONICAL_PATH = "entities/commodities"
       SOURCE_PATHS = [CANONICAL_PATH, "entities/scitem/carryables"]
 
-      # Refuel and rearm goods — ship ammunition, the two countermeasure
-      # supplies, EVA fuel — are bought by volume and hauled in generic
-      # containers, so they have no crate entity and appear in neither tree.
-      # This database is the only place they are named.
+      # Refuel and rearm goods — the nine sized ship ammunition supplies, the
+      # two countermeasures, EVA fuel — are bought by volume and hauled in
+      # generic containers, so they have no crate entity and appear in neither
+      # tree. This database is the only place they are named.
       RESOURCE_TYPES_PATH = "resourcetypedatabase/resourcetypedatabase.records.xml"
 
       # It also holds the label for each group of resources, under the same
@@ -35,6 +35,20 @@ module ScData
         "items_commodities_consumergoods",
         "items_commodities_atlasium_8scu"
       ].freeze
+
+      # Ship Ammunition — the bulk rearm supply, hauled in its own crates and
+      # priced at every trade terminal — names itself with the ammo crate
+      # item's keys rather than a commodity one, so nothing here can see it.
+      # Aliasing the pair into the commodity namespace is enough to give it a
+      # key of its own.
+      #
+      # Spelled out rather than inferred: of the five resources that name
+      # themselves from outside the namespace this is the only good, the rest
+      # being a helmet and two unnamed mission props.
+      KEY_ALIASES = {
+        "item_nameammocrate" => "#{NAME_PREFIX}shipammunition",
+        "item_descammocrate" => "#{NAME_PREFIX}shipammunition_desc"
+      }.freeze
 
       TYPE_SLUGS = {
         "agriculturalSupply" => "agricultural_supply",
@@ -270,6 +284,7 @@ module ScData
       # commodity doesn't end up named after a paragraph of flavour text.
       private def commodity_key(display_name)
         key = display_name.to_s.delete("@").sub(/,P\z/, "").downcase
+        key = KEY_ALIASES.fetch(key, key)
 
         return unless key.start_with?(NAME_PREFIX)
 
@@ -283,6 +298,8 @@ module ScData
       private def commodity_translations
         @commodity_translations ||= translations.each_with_object({}) do |(key, value), index|
           index[key.sub(/,P\z/, "").downcase] = value
+        end.tap do |index|
+          KEY_ALIASES.each { |from, to| index[to] = index[from] if index.key?(from) }
         end
       end
 

--- a/test/fixtures/sc_data/live/commodity_keys.json
+++ b/test/fixtures/sc_data/live/commodity_keys.json
@@ -169,6 +169,7 @@
   "items_commodities_shipammo_size_7",
   "items_commodities_shipammo_size_8",
   "items_commodities_shipammo_size_9",
+  "items_commodities_shipammunition",
   "items_commodities_silicon",
   "items_commodities_silnex",
   "items_commodities_slam",

--- a/test/parsers/sc_data/commodities_parser_test.rb
+++ b/test/parsers/sc_data/commodities_parser_test.rb
@@ -122,6 +122,41 @@ module ScData
         assert_equal ["Ship Ammunition - Size 1"], @parser.commodities.pluck(:name)
       end
 
+      # Ship Ammunition is the one good the game names from outside the
+      # commodity namespace: its record borrows the ammo crate item's keys, so
+      # it went missing altogether and its prices had nothing to attach to.
+      test "#commodities names the good that borrows the ammo crate's keys" do
+        translate(
+          "item_NameAmmoCrate" => "Ship Ammunition",
+          "item_DescAmmoCrate" => "Refill your ship's ballistic ammunition.",
+          "items_commodities_type_processedGoods" => "Processed Goods"
+        )
+        commodity_record(
+          "processedgoods/shipammunition",
+          display_name: "@item_NameAmmoCrate",
+          display_type: "@items_commodities_type_processedGoods"
+        )
+
+        commodity = @parser.commodities.first
+
+        assert_equal "items_commodities_shipammunition", commodity[:sc_key]
+        assert_equal "Ship Ammunition", commodity[:name]
+        assert_equal "Refill your ship's ballistic ammunition.", commodity[:description]
+        assert_equal "processed_goods", commodity[:commodity_type]
+      end
+
+      # Only that one is aliased. The rest of what the database names from
+      # outside the namespace is a helmet and two unnamed mission props, and
+      # a rule reading any key at all would carry them in.
+      test "#commodities keeps a resource named from outside the namespace out of the catalogue" do
+        translate("item_Name_basl_combat_light_helmet_02_01_01" => "Ace Interceptor Helmet")
+        resource_types(
+          resource_type("AceInterceptorHelmet", display_name: "@item_Name_basl_combat_light_helmet_02_01_01")
+        )
+
+        assert_empty @parser.commodities
+      end
+
       # The database names each group of resources under the same form of key
       # the crates use for their own type labels.
       test "#commodities keeps the name of a group of resources out of the catalogue" do


### PR DESCRIPTION
Fixes #4580.

UEX prices **Ship Ammunition** (id `128`) at every trade terminal, but it resolved to no `Commodity`, so the prices were dropped. It turned out to be neither of the two causes the issue body offers — the game declares it, and no `MAPPINGS` entry is needed.

## What was wrong

The game names this one from outside the commodity namespace. Its canonical record is `entities/commodities/processedgoods/shipammunition.xml`, sitting next to RMC, HPMC and the two fuels, with a full set of 1–32 SCU crates and a `ResourceType.ShipAmmunition` entry. Every one of them carries `displayName="@item_NameAmmoCrate"` instead of an `items_commodities_*` key, and that prefix is what `CommoditiesParser#commodity_key` reads a commodity out of — so the record produced no key and the commodity never entered the catalogue.

`item_NameAmmoCrate` localises to exactly "Ship Ammunition", which is UEX's own spelling.

## The fix

A `KEY_ALIASES` pair aliasing `item_nameammocrate` / `item_descammocrate` into the commodity namespace as `items_commodities_shipammunition`, applied in `commodity_key` and mirrored into the translation index so the name and description both resolve. The commodity then matches UEX by name, with no `Uex::CommodityMatcher::MAPPINGS` entry.

Deliberately a list of one rather than a rule: of the five resources that name themselves from outside the namespace, this is the only good — the rest are a helmet and two unnamed mission props, which a general "read any key" rule would drag in. There is a test for that.

## Not the same as either near neighbour

- **Ammo Crate** (`items_commodities_ammocrate`), which we already carry, is a mission-delivery prop under `missiondata/pu_items`.
- **Ship Ammunition - Size 1…9** are the volumetric rearm supplies the resource database names.

Mapping id `128` onto either would have attached the price to the wrong item.

## Verification

- Full `bin/scdata parse` over `4.10.0-live.12519617`: 231 → 232 commodities, the key list diff is exactly the one added line — nothing else gained or lost. Parses as `processed_goods` with description and icon. (The icon is HPMC's; RMC already shares it, so that is existing upstream behaviour, not new drift.)
- Feeding the live UEX feed to `CommodityMatcher` with the commodity present: `128 -> "Ship Ammunition"`, matched by name.
- Parser and UEX suites green; standardrb clean.

## Before this closes the loop

The loaders read the pushed parsed tree, so the commodity only reaches the database — and the prices only get something to attach to — once `bin/scdata push` has run. That push is not part of this PR, and it would also carry whatever else the re-parse changed relative to what is in the bucket today. 🤖
