### PR TITLE
feat(sc_data): answer "is it in the game" per source

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
@@ -14,7 +14,6 @@ module Admin
               description: {type: [:string, :null]},
               hidden: {type: :boolean},
               active: {type: :boolean},
-              inGame: {type: :boolean},
               adiMap: {type: :boolean},
               ground: {type: :boolean},
               mass: {type: [:number, :null]},

--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -171,7 +171,7 @@ module Admin
 
         private def model_params
           @model_params ||= params.permit(
-            :name, :description, :hidden, :active, :in_game, :adi_map, :ground, :mass, :min_crew, :max_crew,
+            :name, :description, :hidden, :active, :adi_map, :ground, :mass, :min_crew, :max_crew,
             :scm_speed, :scm_speed_boosted, :max_speed, :reverse_speed_boosted, :yaw, :yaw_boosted,
             :pitch, :pitch_boosted, :roll, :roll_boosted, :erkul_identifier, :sc_key,
             :manufacturer_id, :rsi_id, :base_model_id, :production_status, :production_note,

--- a/app/frontend/admin/pages/models/[id]/edit/index.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/index.vue
@@ -37,7 +37,6 @@ const initialValues = ref<ModelUpdateInput>({
   description: props.model.description,
   hidden: props.model.hidden,
   active: props.model.active,
-  inGame: props.model.inGame,
   adiMap: props.model.adiMap,
   playerOwnable: props.model.playerOwnable,
   ground: props.model.metrics.isGroundVehicle,
@@ -68,7 +67,6 @@ const [name, nameProps] = defineField("name");
 const [description, descriptionProps] = defineField("description");
 const [hidden, hiddenProps] = defineField("hidden");
 const [active, activeProps] = defineField("active");
-const [inGame, inGameProps] = defineField("inGame");
 const [adiMap, adiMapProps] = defineField("adiMap");
 const [playerOwnable, playerOwnableProps] = defineField("playerOwnable");
 const [ground, groundProps] = defineField("ground");
@@ -161,14 +159,6 @@ const [brochure, brochureProps] = defineField("brochure");
               translation-key="model.playerOwnable"
               v-bind="playerOwnableProps"
               name="playerOwnable"
-            />
-          </div>
-          <div class="col-12 col-md-4">
-            <FormToggle
-              v-model="inGame"
-              translation-key="model.inGame"
-              v-bind="inGameProps"
-              name="inGame"
             />
           </div>
           <div class="col-12 col-md-4">

--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -10,6 +10,7 @@ import AppNavigationHeader from "@/shared/components/AppNavigation/Header/index.
 import FrontendNavigationMobile from "@/frontend/components/Navigation/Mobile/index.vue";
 import AppFooter from "@/shared/components/AppFooter/index.vue";
 import SupportBtn from "@/frontend/components/SupportBtn/index.vue";
+import ScDataSourceBar from "@/frontend/components/ScDataSource/index.vue";
 import AppEnvironment from "@/shared/components/AppEnvironment/index.vue";
 import AppModal from "@/shared/components/AppModal/index.vue";
 import OffCanvas from "@/shared/components/OffCanvas/index.vue";

--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -249,6 +249,8 @@ const setLocale = (locale: string) => {
         <div class="main-inner">
           <AppNavigationHeader />
 
+          <ScDataSourceBar />
+
           <router-view v-slot="{ Component, route: viewRoute }">
             <transition name="fade" mode="out-in">
               <SecurePage

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -3,6 +3,9 @@ import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { ref, nextTick } from "vue";
 
+const SWITCH = '[data-test="sc-data-source-switch"]';
+const WARNING_THUMB = ".btn-group__thumb--tone-warning";
+
 const live = { environment: "live", version: "1.0.0", default: true };
 const ptu = { environment: "ptu", version: "1.1.0", default: false };
 
@@ -28,12 +31,14 @@ import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 const mountBar = async () => {
   const wrapper = mount(ScDataSourceBar, {
     global: {
+      directives: {
+        // The app registers this globally; without it every mount warns.
+        tooltip: {},
+      },
       stubs: {
         // Rendered in place: the bar teleports into the header, which does not
         // exist in a mounted component's own tree.
         Teleport: true,
-        Btn: { template: "<button><slot /></button>" },
-        BtnGroup: { template: "<div><slot /></div>" },
       },
     },
   });
@@ -55,16 +60,17 @@ describe("ScDataSourceBar", () => {
     sources.value = { items: [live] };
     const wrapper = await mountBar();
 
-    expect(wrapper.find(".sc-data-source").exists()).toBe(false);
+    expect(wrapper.find(SWITCH).exists()).toBe(false);
   });
 
   it("offers every build the server named", async () => {
     sources.value = { items: [live, ptu] };
     const wrapper = await mountBar();
 
-    expect(wrapper.find(".sc-data-source").exists()).toBe(true);
-    expect(wrapper.text()).toContain("live");
-    expect(wrapper.text()).toContain("ptu");
+    expect(wrapper.findAll("button").map((btn) => btn.text())).toEqual([
+      "live",
+      "ptu",
+    ]);
   });
 
   // Everything cached was fetched against another build, so it all goes --
@@ -90,14 +96,18 @@ describe("ScDataSourceBar", () => {
     expect(clear).not.toHaveBeenCalled();
   });
 
-  it("says so when the build is not the default one", async () => {
+  // A grouped button drops its cap, so a member's own tone would show nothing at
+  // rest. The group's thumb is what marks the choice, so it carries the warning.
+  it("warns through the group when the build is not the default one", async () => {
     sources.value = { items: [live, ptu] };
     const wrapper = await mountBar();
 
-    expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(false);
+    expect(wrapper.find(WARNING_THUMB).exists()).toBe(false);
 
     await wrapper.findAll("button")[1].trigger("click");
+    // The handler awaits the query client before the group re-renders.
+    await nextTick();
 
-    expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(true);
+    expect(wrapper.find(WARNING_THUMB).exists()).toBe(true);
   });
 });

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
-import { ref } from "vue";
+import { ref, nextTick } from "vue";
 
 const live = { environment: "live", version: "1.0.0", default: true };
 const ptu = { environment: "ptu", version: "1.1.0", default: false };
@@ -24,15 +24,24 @@ vi.mock("@/shared/composables/useI18n", () => ({
 import ScDataSourceBar from "./index.vue";
 import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 
-const mountBar = () =>
-  mount(ScDataSourceBar, {
+// The teleport waits for `onMounted`, so the first render carries nothing.
+const mountBar = async () => {
+  const wrapper = mount(ScDataSourceBar, {
     global: {
       stubs: {
+        // Rendered in place: the bar teleports into the header, which does not
+        // exist in a mounted component's own tree.
+        Teleport: true,
         Btn: { template: "<button><slot /></button>" },
         BtnGroup: { template: "<div><slot /></div>" },
       },
     },
   });
+
+  await nextTick();
+
+  return wrapper;
+};
 
 describe("ScDataSourceBar", () => {
   beforeEach(() => {
@@ -42,16 +51,16 @@ describe("ScDataSourceBar", () => {
     refetchQueries.mockClear();
   });
 
-  it("stays out of the way when there is only one build", () => {
+  it("stays out of the way when there is only one build", async () => {
     sources.value = { items: [live] };
-    const wrapper = mountBar();
+    const wrapper = await mountBar();
 
     expect(wrapper.find(".sc-data-source").exists()).toBe(false);
   });
 
-  it("offers every build the server named", () => {
+  it("offers every build the server named", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = mountBar();
+    const wrapper = await mountBar();
 
     expect(wrapper.find(".sc-data-source").exists()).toBe(true);
     expect(wrapper.text()).toContain("live");
@@ -63,7 +72,7 @@ describe("ScDataSourceBar", () => {
   // happens to refetch.
   it("throws the cache away when the build changes", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = mountBar();
+    const wrapper = await mountBar();
 
     await wrapper.findAll("button")[1].trigger("click");
 
@@ -74,7 +83,7 @@ describe("ScDataSourceBar", () => {
 
   it("does nothing when the build already selected is picked again", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = mountBar();
+    const wrapper = await mountBar();
 
     await wrapper.findAll("button")[0].trigger("click");
 
@@ -83,13 +92,12 @@ describe("ScDataSourceBar", () => {
 
   it("says so when the build is not the default one", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = mountBar();
+    const wrapper = await mountBar();
 
     expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(false);
 
     await wrapper.findAll("button")[1].trigger("click");
 
     expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(true);
-    expect(wrapper.text()).toContain("labels.scDataSource.notLive");
   });
 });

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -14,10 +14,9 @@ vi.mock("@/services/fyApi", () => ({
   useScDataSources: () => ({ data: sources }),
 }));
 
-const clear = vi.fn();
-const refetchQueries = vi.fn();
+const invalidateQueries = vi.fn();
 vi.mock("@tanstack/vue-query", () => ({
-  useQueryClient: () => ({ clear, refetchQueries }),
+  useQueryClient: () => ({ invalidateQueries }),
 }));
 
 vi.mock("@/shared/composables/useI18n", () => ({
@@ -52,8 +51,7 @@ describe("ScDataSourceBar", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     sources.value = undefined;
-    clear.mockClear();
-    refetchQueries.mockClear();
+    invalidateQueries.mockClear();
   });
 
   it("stays out of the way when there is only one build", async () => {
@@ -76,15 +74,17 @@ describe("ScDataSourceBar", () => {
   // Everything cached was fetched against another build, so it all goes --
   // otherwise the old build's data shows under the new label until each query
   // happens to refetch.
-  it("throws the cache away when the build changes", async () => {
+  // `clear()` was the first attempt and it made the switch do nothing: it
+  // removes the queries, so the mounted observers have none left to refetch and
+  // no request goes out. Invalidating is what reloads the page.
+  it("invalidates every query when the build changes", async () => {
     sources.value = { items: [live, ptu] };
     const wrapper = await mountBar();
 
     await wrapper.findAll("button")[1].trigger("click");
 
     expect(useScDataSourceStore().requestParam).toBe("ptu");
-    expect(clear).toHaveBeenCalledOnce();
-    expect(refetchQueries).toHaveBeenCalledOnce();
+    expect(invalidateQueries).toHaveBeenCalledOnce();
   });
 
   it("does nothing when the build already selected is picked again", async () => {
@@ -93,7 +93,7 @@ describe("ScDataSourceBar", () => {
 
     await wrapper.findAll("button")[0].trigger("click");
 
-    expect(clear).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 
   // A grouped button drops its cap, so a member's own tone would show nothing at

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { ref } from "vue";
+
+const live = { environment: "live", version: "1.0.0", default: true };
+const ptu = { environment: "ptu", version: "1.1.0", default: false };
+
+const sources = ref<{ items: (typeof live)[] } | undefined>(undefined);
+vi.mock("@/services/fyApi", () => ({
+  useScDataSources: () => ({ data: sources }),
+}));
+
+const clear = vi.fn();
+const refetchQueries = vi.fn();
+vi.mock("@tanstack/vue-query", () => ({
+  useQueryClient: () => ({ clear, refetchQueries }),
+}));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+import ScDataSourceBar from "./index.vue";
+import { useScDataSourceStore } from "@/shared/stores/scDataSource";
+
+const mountBar = () =>
+  mount(ScDataSourceBar, {
+    global: {
+      stubs: {
+        Btn: { template: "<button><slot /></button>" },
+        BtnGroup: { template: "<div><slot /></div>" },
+      },
+    },
+  });
+
+describe("ScDataSourceBar", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    sources.value = undefined;
+    clear.mockClear();
+    refetchQueries.mockClear();
+  });
+
+  it("stays out of the way when there is only one build", () => {
+    sources.value = { items: [live] };
+    const wrapper = mountBar();
+
+    expect(wrapper.find(".sc-data-source").exists()).toBe(false);
+  });
+
+  it("offers every build the server named", () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = mountBar();
+
+    expect(wrapper.find(".sc-data-source").exists()).toBe(true);
+    expect(wrapper.text()).toContain("live");
+    expect(wrapper.text()).toContain("ptu");
+  });
+
+  // Everything cached was fetched against another build, so it all goes --
+  // otherwise the old build's data shows under the new label until each query
+  // happens to refetch.
+  it("throws the cache away when the build changes", async () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = mountBar();
+
+    await wrapper.findAll("button")[1].trigger("click");
+
+    expect(useScDataSourceStore().requestParam).toBe("ptu");
+    expect(clear).toHaveBeenCalledOnce();
+    expect(refetchQueries).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when the build already selected is picked again", async () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = mountBar();
+
+    await wrapper.findAll("button")[0].trigger("click");
+
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("says so when the build is not the default one", async () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = mountBar();
+
+    expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(false);
+
+    await wrapper.findAll("button")[1].trigger("click");
+
+    expect(wrapper.find(".sc-data-source-off-default").exists()).toBe(true);
+    expect(wrapper.text()).toContain("labels.scDataSource.notLive");
+  });
+});

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -31,6 +31,20 @@ watch(
 
 const selected = computed(() => store.selected);
 
+// The header is a sibling in this same tree, so its target is not in the
+// document while this mounts -- Vue would fail to locate it and render nothing.
+// Route components teleport into it fine because they mount after the layout.
+const mounted = ref(false);
+onMounted(() => {
+  mounted.value = true;
+});
+
+const hint = computed(() =>
+  selected.value && !selected.value.default
+    ? t("labels.scDataSource.notLive")
+    : t("labels.scDataSource.reading"),
+);
+
 // Everything cached was fetched against another build, so it all goes. Sending
 // the new source without this would show the old build's data under the new
 // label until each query happened to refetch.
@@ -49,58 +63,50 @@ const select = async (environment: string) => {
 </script>
 
 <template>
-  <div
-    v-if="hasChoice"
-    class="sc-data-source"
-    :class="{ 'sc-data-source-off-default': selected && !selected.default }"
-  >
-    <span class="sc-data-source-label">
-      <i class="fa-duotone fa-database" />
-      {{ t("labels.scDataSource.reading") }}
-    </span>
+  <!-- Into the header rather than a row of its own: this is a global control
+       like Compare and Fleetchart beside it, and a full-width bar of its own
+       pushed every page's toolbar down and lined up with nothing. -->
+  <Teleport v-if="mounted" to="#header-right">
+    <div
+      v-if="hasChoice"
+      class="sc-data-source"
+      :class="{ 'sc-data-source-off-default': selected && !selected.default }"
+    >
+      <span v-tooltip="hint" class="sc-data-source-label">
+        <i class="fa-duotone fa-database" />
+      </span>
 
-    <BtnGroup>
-      <Btn
-        v-for="source in available"
-        :key="source.environment"
-        v-tooltip="source.version"
-        :size="BtnSizesEnum.SM"
-        :active="source.environment === selected?.environment"
-        @click="select(source.environment)"
-      >
-        {{ source.environment }}
-      </Btn>
-    </BtnGroup>
-
-    <span v-if="selected && !selected.default" class="sc-data-source-warning">
-      {{ t("labels.scDataSource.notLive") }}
-    </span>
-  </div>
+      <BtnGroup>
+        <Btn
+          v-for="source in available"
+          :key="source.environment"
+          v-tooltip="source.version"
+          :size="BtnSizesEnum.SM"
+          :active="source.environment === selected?.environment"
+          @click="select(source.environment)"
+        >
+          {{ source.environment }}
+        </Btn>
+      </BtnGroup>
+    </div>
+  </Teleport>
 </template>
 
 <style lang="scss" scoped>
 .sc-data-source {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  padding: 0.4rem 0.75rem;
-  font-size: 0.85rem;
+  gap: 0.5rem;
 }
 
 .sc-data-source-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  opacity: 0.7;
+  opacity: 0.6;
 }
 
-.sc-data-source-off-default {
-  border-left: 3px solid $warning;
-  background: rgba($warning, 0.08);
-}
-
-.sc-data-source-warning {
+// Off the default build, the icon says so rather than a bar of its own -- the
+// active button already names which build is being read.
+.sc-data-source-off-default .sc-data-source-label {
   color: $warning;
+  opacity: 1;
 }
 </style>

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -79,8 +79,6 @@ const select = async (environment: string) => {
 </template>
 
 <style lang="scss" scoped>
-@use "@/stylesheets/variables" as *;
-
 .sc-data-source {
   display: flex;
   align-items: center;

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -76,13 +76,13 @@ const select = async (environment: string) => {
       v-if="hasChoice"
       v-tooltip="hint"
       segmented
+      :size="BtnSizesEnum.MD"
       :tone="offDefault ? BtnTonesEnum.WARNING : undefined"
       data-test="sc-data-source-switch"
     >
       <Btn
         v-for="source in available"
         :key="source.environment"
-        :size="BtnSizesEnum.SM"
         :active="source.environment === selected?.environment"
         @click="select(source.environment)"
       >

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -39,8 +39,6 @@ onMounted(() => {
   mounted.value = true;
 });
 
-const offDefault = computed(() => !!selected.value && !selected.value.default);
-
 const hint = computed(() =>
   selected.value && !selected.value.default
     ? t("labels.scDataSource.notLive")
@@ -77,12 +75,15 @@ const select = async (environment: string) => {
       v-tooltip="hint"
       segmented
       :size="BtnSizesEnum.MD"
-      :tone="offDefault ? BtnTonesEnum.WARNING : undefined"
       data-test="sc-data-source-switch"
     >
+      <!-- The tone sits on the source rather than on the group: it is this
+           particular choice that is worth flagging, so the thumb only colours
+           once it is parked on one. -->
       <Btn
         v-for="source in available"
         :key="source.environment"
+        :tone="source.default ? undefined : BtnTonesEnum.WARNING"
         :active="source.environment === selected?.environment"
         @click="select(source.environment)"
       >

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -1,0 +1,108 @@
+<script lang="ts">
+export default {
+  name: "ScDataSourceBar",
+};
+</script>
+
+<script lang="ts" setup>
+import { storeToRefs } from "pinia";
+import { useQueryClient } from "@tanstack/vue-query";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useScDataSourceStore } from "@/shared/stores/scDataSource";
+import { useScDataSources } from "@/services/fyApi";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+
+const { t } = useI18n();
+const queryClient = useQueryClient();
+const store = useScDataSourceStore();
+const { available, hasChoice } = storeToRefs(store);
+
+// The switch is also what tells the store which builds exist, so the two cannot
+// disagree: a source the server stopped offering is dropped from the choice.
+const { data } = useScDataSources();
+
+watch(
+  () => data.value,
+  (result) => {
+    if (result?.items) store.setAvailable(result.items);
+  },
+  { immediate: true },
+);
+
+const selected = computed(() => store.selected);
+
+// Everything cached was fetched against another build, so it all goes. Sending
+// the new source without this would show the old build's data under the new
+// label until each query happened to refetch.
+const select = async (environment: string) => {
+  if (selected.value?.environment === environment) return;
+
+  const option = available.value.find(
+    (source) => source.environment === environment,
+  );
+
+  store.select(option?.default ? undefined : environment);
+
+  queryClient.clear();
+  await queryClient.refetchQueries({ type: "active" });
+};
+</script>
+
+<template>
+  <div
+    v-if="hasChoice"
+    class="sc-data-source"
+    :class="{ 'sc-data-source-off-default': selected && !selected.default }"
+  >
+    <span class="sc-data-source-label">
+      <i class="fa-duotone fa-database" />
+      {{ t("labels.scDataSource.reading") }}
+    </span>
+
+    <BtnGroup>
+      <Btn
+        v-for="source in available"
+        :key="source.environment"
+        v-tooltip="source.version"
+        :size="BtnSizesEnum.SM"
+        :active="source.environment === selected?.environment"
+        @click="select(source.environment)"
+      >
+        {{ source.environment }}
+      </Btn>
+    </BtnGroup>
+
+    <span v-if="selected && !selected.default" class="sc-data-source-warning">
+      {{ t("labels.scDataSource.notLive") }}
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "@/stylesheets/variables" as *;
+
+.sc-data-source {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.sc-data-source-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  opacity: 0.7;
+}
+
+.sc-data-source-off-default {
+  border-left: 3px solid $warning;
+  background: rgba($warning, 0.08);
+}
+
+.sc-data-source-warning {
+  color: $warning;
+}
+</style>

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -76,7 +76,7 @@ const select = async (environment: string) => {
         <i class="fa-duotone fa-database" />
       </span>
 
-      <BtnGroup>
+      <BtnGroup segmented data-test="sc-data-source-switch">
         <Btn
           v-for="source in available"
           :key="source.environment"

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -10,7 +10,7 @@ import { useQueryClient } from "@tanstack/vue-query";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 import { useScDataSources } from "@/services/fyApi";
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
@@ -39,10 +39,12 @@ onMounted(() => {
   mounted.value = true;
 });
 
+const offDefault = computed(() => !!selected.value && !selected.value.default);
+
 const hint = computed(() =>
   selected.value && !selected.value.default
     ? t("labels.scDataSource.notLive")
-    : t("labels.scDataSource.reading"),
+    : t("labels.scDataSource.dataSource"),
 );
 
 // Everything cached was fetched against another build, so it all goes. Sending
@@ -67,46 +69,22 @@ const select = async (environment: string) => {
        like Compare and Fleetchart beside it, and a full-width bar of its own
        pushed every page's toolbar down and lined up with nothing. -->
   <Teleport v-if="mounted" to="#header-right">
-    <div
+    <BtnGroup
       v-if="hasChoice"
-      class="sc-data-source"
-      :class="{ 'sc-data-source-off-default': selected && !selected.default }"
+      v-tooltip="hint"
+      segmented
+      :tone="offDefault ? BtnTonesEnum.WARNING : undefined"
+      data-test="sc-data-source-switch"
     >
-      <span v-tooltip="hint" class="sc-data-source-label">
-        <i class="fa-duotone fa-database" />
-      </span>
-
-      <BtnGroup segmented data-test="sc-data-source-switch">
-        <Btn
-          v-for="source in available"
-          :key="source.environment"
-          v-tooltip="source.version"
-          :size="BtnSizesEnum.SM"
-          :active="source.environment === selected?.environment"
-          @click="select(source.environment)"
-        >
-          {{ source.environment }}
-        </Btn>
-      </BtnGroup>
-    </div>
+      <Btn
+        v-for="source in available"
+        :key="source.environment"
+        :size="BtnSizesEnum.SM"
+        :active="source.environment === selected?.environment"
+        @click="select(source.environment)"
+      >
+        {{ source.environment }}
+      </Btn>
+    </BtnGroup>
   </Teleport>
 </template>
-
-<style lang="scss" scoped>
-.sc-data-source {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.sc-data-source-label {
-  opacity: 0.6;
-}
-
-// Off the default build, the icon says so rather than a bar of its own -- the
-// active button already names which build is being read.
-.sc-data-source-off-default .sc-data-source-label {
-  color: $warning;
-  opacity: 1;
-}
-</style>

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -59,8 +59,11 @@ const select = async (environment: string) => {
 
   store.select(option?.default ? undefined : environment);
 
-  queryClient.clear();
-  await queryClient.refetchQueries({ type: "active" });
+  // Invalidated rather than cleared. `clear()` removes every query, so the
+  // mounted observers have nothing left to refetch and the page keeps showing
+  // what it already had -- no request goes out at all. Invalidating marks them
+  // stale and refetches the active ones, which is what makes the switch visible.
+  await queryClient.invalidateQueries();
 };
 </script>
 

--- a/app/frontend/frontend/pages/visual-tests/buttons.vue
+++ b/app/frontend/frontend/pages/visual-tests/buttons.vue
@@ -70,6 +70,7 @@ const segmentedByTone = ref<Record<string, string>>({
   warning: "ptu",
   danger: "live",
 });
+const build = ref("live");
 const density = ref("comfortable");
 const scope = ref("all");
 const autoRotate = ref(true);
@@ -215,14 +216,6 @@ const toggleLoading = () => {
         <Btn :active="active === 'list'" @click="active = 'list'">List</Btn>
         <Btn :active="active === 'table'" @click="active = 'table'">Table</Btn>
       </BtnGroup>
-      <BtnGroup :size="BtnSizesEnum.LG">
-        <Btn>Large</Btn>
-        <Btn>Group</Btn>
-      </BtnGroup>
-      <BtnGroup>
-        <Btn aria-label="Grid"><i class="fa-solid fa-table-cells" /></Btn>
-        <Btn aria-label="List"><i class="fa-solid fa-list" /></Btn>
-      </BtnGroup>
     </div>
   </div>
   <Heading :level="HeadingLevelEnum.H2"
@@ -258,8 +251,10 @@ const toggleLoading = () => {
   <Heading :level="HeadingLevelEnum.H2">Segmented — tone</Heading>
   <p>
     The thumb wears the tone, because a member drops its own cap inside a group.
-    Warning is the source switch's case: off the default build is a state worth
-    noticing, not an error.
+    A tone on the group colours the thumb wherever it stands; a tone on a member
+    colours it only once it is parked there, which is the usual case — it is one
+    particular choice that is worth flagging, not the act of choosing. Warning
+    is the source switch's: a pre-release build is worth noticing, not an error.
   </p>
   <div class="row">
     <div class="col-12 vt-row">
@@ -282,6 +277,30 @@ const toggleLoading = () => {
           </Btn>
         </BtnGroup>
       </template>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 vt-row">
+      <!-- Per member, the source switch's own shape: neutral is Btn's default
+           and reads as no opinion, so only the flagged segments colour. -->
+      <BtnGroup segmented>
+        <Btn :active="build === 'live'" @click="build = 'live'">live</Btn>
+        <Btn
+          :tone="BtnTonesEnum.WARNING"
+          :active="build === 'ptu'"
+          @click="build = 'ptu'"
+        >
+          ptu
+        </Btn>
+        <Btn
+          :tone="BtnTonesEnum.DANGER"
+          :active="build === 'evocati'"
+          @click="build = 'evocati'"
+        >
+          evocati
+        </Btn>
+      </BtnGroup>
     </div>
   </div>
 
@@ -337,6 +356,18 @@ const toggleLoading = () => {
   <Heading :level="HeadingLevelEnum.H2"
     >Group — container owns the chrome</Heading
   >
+  <div class="row">
+    <div class="col-12 vt-row">
+      <BtnGroup :size="BtnSizesEnum.LG">
+        <Btn>Large</Btn>
+        <Btn>Group</Btn>
+      </BtnGroup>
+      <BtnGroup>
+        <Btn aria-label="Grid"><i class="fa-solid fa-table-cells" /></Btn>
+        <Btn aria-label="List"><i class="fa-solid fa-list" /></Btn>
+      </BtnGroup>
+    </div>
+  </div>
   <div class="row">
     <div class="col-12 vt-row" data-test="group-with-label">
       <!-- A group holding a plain label segment as well as buttons, the shape

--- a/app/frontend/frontend/pages/visual-tests/buttons.vue
+++ b/app/frontend/frontend/pages/visual-tests/buttons.vue
@@ -51,12 +51,27 @@ const variants = [
   BtnVariantsEnum.GHOST,
   BtnVariantsEnum.BARE,
 ];
-const tones = [BtnTonesEnum.NEUTRAL, BtnTonesEnum.DANGER];
+const tones = [BtnTonesEnum.NEUTRAL, BtnTonesEnum.DANGER, BtnTonesEnum.WARNING];
 
 const loading = ref(false);
 const active = ref<string | null>("grid");
 const source = ref("game");
 const view = ref("exterior");
+// One switch per size and per tone, so each row is live rather than a set of
+// frozen screenshots - a thumb that cannot move hides half of what it does.
+const segmentedBySize = ref<Record<string, string>>({
+  xs: "on",
+  sm: "on",
+  md: "on",
+  lg: "on",
+});
+const segmentedByTone = ref<Record<string, string>>({
+  neutral: "live",
+  warning: "ptu",
+  danger: "live",
+});
+const density = ref("comfortable");
+const scope = ref("all");
 const autoRotate = ref(true);
 const zoom = ref(false);
 const colour = ref(true);
@@ -210,6 +225,115 @@ const toggleLoading = () => {
       </BtnGroup>
     </div>
   </div>
+  <Heading :level="HeadingLevelEnum.H2"
+    >Segmented — every size, beside a button of the same size</Heading
+  >
+  <p>
+    A switch is normally placed in a toolbar next to ordinary buttons, so the
+    pairing is the test: the group and the button next to it must share a top
+    and a bottom edge. The recess is inset from the group, not added to it.
+  </p>
+  <div class="row">
+    <div class="col-12 vt-row">
+      <template v-for="size in sizes" :key="`segmented-${size}`">
+        <BtnGroup segmented :size="size">
+          <Btn
+            :active="segmentedBySize[size] === 'on'"
+            @click="segmentedBySize[size] = 'on'"
+          >
+            On
+          </Btn>
+          <Btn
+            :active="segmentedBySize[size] === 'off'"
+            @click="segmentedBySize[size] = 'off'"
+          >
+            Off
+          </Btn>
+        </BtnGroup>
+        <Btn :size="size">{{ size }}</Btn>
+      </template>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Segmented — tone</Heading>
+  <p>
+    The thumb wears the tone, because a member drops its own cap inside a group.
+    Warning is the source switch's case: off the default build is a state worth
+    noticing, not an error.
+  </p>
+  <div class="row">
+    <div class="col-12 vt-row">
+      <template v-for="tone in tones" :key="`segmented-tone-${tone}`">
+        <BtnGroup
+          segmented
+          :tone="tone === BtnTonesEnum.NEUTRAL ? undefined : tone"
+        >
+          <Btn
+            :active="segmentedByTone[tone] === 'live'"
+            @click="segmentedByTone[tone] = 'live'"
+          >
+            live
+          </Btn>
+          <Btn
+            :active="segmentedByTone[tone] === 'ptu'"
+            @click="segmentedByTone[tone] = 'ptu'"
+          >
+            ptu
+          </Btn>
+        </BtnGroup>
+      </template>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2"
+    >Segmented — content that fights the columns</Heading
+  >
+  <p>
+    Segments are equal columns that may not size below their widest label, which
+    only shows up when the labels are uneven or when there is no label at all.
+  </p>
+  <div class="row">
+    <div class="col-12 vt-row">
+      <BtnGroup segmented>
+        <Btn :active="scope === 'all'" @click="scope = 'all'">All</Btn>
+        <Btn :active="scope === 'mine'" @click="scope = 'mine'">
+          Only the ones I own and have flown
+        </Btn>
+      </BtnGroup>
+      <BtnGroup segmented>
+        <Btn
+          aria-label="Grid"
+          :active="active === 'grid'"
+          @click="active = 'grid'"
+        >
+          <i class="fa-solid fa-table-cells" />
+        </Btn>
+        <Btn
+          aria-label="List"
+          :active="active === 'list'"
+          @click="active = 'list'"
+        >
+          <i class="fa-solid fa-list" />
+        </Btn>
+      </BtnGroup>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <BtnGroup segmented block>
+        <Btn
+          :active="density === 'comfortable'"
+          @click="density = 'comfortable'"
+        >
+          Comfortable
+        </Btn>
+        <Btn :active="density === 'compact'" @click="density = 'compact'">
+          Compact
+        </Btn>
+      </BtnGroup>
+    </div>
+  </div>
+
   <Heading :level="HeadingLevelEnum.H2"
     >Group — container owns the chrome</Heading
   >

--- a/app/frontend/services/axiosClient.ts
+++ b/app/frontend/services/axiosClient.ts
@@ -1,5 +1,6 @@
 import Axios, { type AxiosRequestConfig, type AxiosError } from "axios";
 import Qs from "qs";
+import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: `${window.API_ENDPOINT}`,
@@ -14,6 +15,11 @@ export const AXIOS_INSTANCE = Axios.create({
 export const axiosClient = <T>(config: AxiosRequestConfig): Promise<T> => {
   const source = Axios.CancelToken.source();
 
+  // One choke point for which build of the game data a request reads, mirroring
+  // `ScData::Source` on the other side. Nothing is sent for the default, so a
+  // reader who has never touched the switch sends what it always sent.
+  const scDataSource = useScDataSourceStore().requestParam;
+
   const headers = {
     ...config.headers,
     Accept: "application/json",
@@ -23,6 +29,9 @@ export const axiosClient = <T>(config: AxiosRequestConfig): Promise<T> => {
   const promise = AXIOS_INSTANCE({
     ...config,
     headers,
+    params: scDataSource
+      ? { ...(config.params as object), source: scDataSource }
+      : config.params,
     cancelToken: source.token,
   }).then(({ data }) => data);
 

--- a/app/frontend/shared/components/base/Btn/context.ts
+++ b/app/frontend/shared/components/base/Btn/context.ts
@@ -1,5 +1,8 @@
 import type { ComputedRef, InjectionKey } from "vue";
-import type { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import type {
+  BtnSizesEnum,
+  BtnTonesEnum,
+} from "@/shared/components/base/Btn/types";
 
 /**
  * Provided by containers that change how a Btn should look inside them, and
@@ -34,8 +37,16 @@ export type BtnContainerContext = {
    * rather than measured: the group would otherwise have to reach into the DOM
    * for a member's index and active state, which is the coupling this context
    * exists to avoid. Registration order is mount order, which is DOM order.
+   *
+   * The tone comes along because a member has no cap of its own to show it in,
+   * so the thumb shows it instead - which means the container has to know the
+   * tone of the member it is currently parked on. `neutral` reads as no
+   * opinion, leaving whatever the container itself was given.
    */
-  register?: (active: () => boolean) => {
+  register?: (
+    active: () => boolean,
+    tone: () => `${BtnTonesEnum}`,
+  ) => {
     unregister: () => void;
   };
 };

--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -74,7 +74,10 @@ const isSegment = computed(
 // every group member, not just segmented ones, because `segmented` can flip at
 // runtime and a member that never registered would leave a gap in the order.
 if (container?.register) {
-  const entry = container.register(() => props.active);
+  const entry = container.register(
+    () => props.active,
+    () => props.tone,
+  );
   onUnmounted(entry.unregister);
 }
 

--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -441,6 +441,29 @@ const handleClick = (event: MouseEvent) => {
   background-color: rgb(220 53 69 / 0.18);
 }
 
+/*
+ * Warning says "this is not the usual choice" rather than "this destroys
+ * something", so it follows danger's shape exactly and only changes the colour.
+ * Same consequence as danger: grouped and bare members drop their cap, so a
+ * warning member of a BtnGroup is marked by the group's thumb rather than here.
+ */
+.btn--tone-warning {
+  --btn-cap: var(--color-warning, #fa6800);
+}
+.btn--tone-warning.btn--solid:hover:not([disabled]),
+.btn--tone-warning.btn--ghost:hover:not([disabled]) {
+  @apply bg-warning border-warning text-white;
+  --btn-cap: rgb(255 255 255 / 0.65);
+}
+.btn--tone-warning.btn--solid:focus-visible,
+.btn--tone-warning.btn--ghost:focus-visible {
+  --btn-cap: rgb(255 255 255 / 0.65);
+}
+.btn--tone-warning.btn--bare:hover:not([disabled]) {
+  @apply text-white;
+  background-color: rgb(250 104 0 / 0.18);
+}
+
 /* ---------- states ---------- */
 .btn[disabled] {
   @apply cursor-default;

--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -448,7 +448,9 @@ const handleClick = (event: MouseEvent) => {
  * Warning says "this is not the usual choice" rather than "this destroys
  * something", so it follows danger's shape exactly and only changes the colour.
  * Same consequence as danger: grouped and bare members drop their cap, so a
- * warning member of a BtnGroup is marked by the group's thumb rather than here.
+ * warning member of a BtnGroup is marked by the group's thumb rather than here,
+ * and both tones need the grouped and menu hover tints further down - without
+ * them the flood below applies inside a container that cannot take it.
  */
 .btn--tone-warning {
   --btn-cap: var(--color-warning, #fa6800);
@@ -538,6 +540,13 @@ const handleClick = (event: MouseEvent) => {
   @apply text-white;
   background-color: rgb(220 53 69 / 0.35);
 }
+/* Warning needs its own, or the standalone rule above floods the segment solid
+   orange to its square edges - which is the exact failure the danger rule
+   exists to avoid. */
+.btn--grouped.btn--tone-warning:hover:not([disabled]) {
+  @apply text-white;
+  background-color: rgb(250 104 0 / 0.35);
+}
 /*
  * Engaged, not hovered. A grouped member has no end-caps to carry state, and a
  * 0.22 tint sat too close to the neutral hover fill to be told apart - so this
@@ -595,6 +604,17 @@ const handleClick = (event: MouseEvent) => {
   @apply text-lifted;
 }
 
+/* A tone must not bring a fill back. The grouped tints below are written for a
+   plain group, where a member is its own surface; in a switch the thumb is the
+   only fill there is, and a toned segment that floods on hover reads as a
+   second, differently shaped thumb. Four selectors deep to match those rules,
+   and after them so it wins on order. The tone still shows: it colours the
+   thumb once the segment is chosen. */
+.btn--segment.btn--tone-danger:hover:not([disabled]),
+.btn--segment.btn--tone-warning:hover:not([disabled]) {
+  @apply bg-transparent;
+}
+
 /* ---------- inside a BtnDropdown list ---------- */
 .btn--menu-item {
   @apply w-full justify-start rounded-none border-0 bg-transparent;
@@ -619,6 +639,10 @@ const handleClick = (event: MouseEvent) => {
 .btn--menu-item.btn--tone-danger:hover:not([disabled]) {
   @apply text-white;
   background-color: rgb(220 53 69 / 0.18);
+}
+.btn--menu-item.btn--tone-warning:hover:not([disabled]) {
+  @apply text-white;
+  background-color: rgb(250 104 0 / 0.18);
 }
 
 /* ---------- loading ---------- */

--- a/app/frontend/shared/components/base/Btn/types.ts
+++ b/app/frontend/shared/components/base/Btn/types.ts
@@ -23,4 +23,5 @@ export enum BtnVariantsEnum {
 export enum BtnTonesEnum {
   NEUTRAL = "neutral",
   DANGER = "danger",
+  WARNING = "warning",
 }

--- a/app/frontend/shared/components/base/BtnGroup/index.vue
+++ b/app/frontend/shared/components/base/BtnGroup/index.vue
@@ -6,10 +6,9 @@ export default {
 
 <script lang="ts" setup>
 import { BTN_CONTAINER } from "@/shared/components/base/Btn/context";
-import type {
-  BtnSizesEnum,
-  BtnTonesEnum,
-} from "@/shared/components/base/Btn/types";
+// A value, not just a type: the segmented size class falls back to it.
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import type { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 
 type Props = {
   /** Set once here instead of on every member. */
@@ -38,6 +37,11 @@ const props = withDefaults(defineProps<Props>(), {
   segmented: false,
   tone: undefined,
 });
+
+// A segmented group claims the height its members would have had on their own,
+// so the track's inset comes out of them rather than adding to the control. Btn
+// falls back to `sm` when nothing sets a size, so this does too.
+const sizeClass = computed(() => `btn-group--${props.size ?? BtnSizesEnum.SM}`);
 
 // Members report themselves in mount order, which is DOM order, so the thumb can
 // be placed without this component reading a member's index or state out of the
@@ -104,6 +108,7 @@ provide(BTN_CONTAINER, {
     :class="{
       'btn-group--block': block,
       'btn-group--segmented': segmented,
+      [sizeClass]: segmented,
     }"
     :role="segmented ? 'radiogroup' : 'group'"
     :style="
@@ -216,6 +221,53 @@ provide(BTN_CONTAINER, {
   gap: 0;
 }
 
+/* ---------- segmented sizing ----------
+ * A segmented group is a recessed track: 3px of inset and a 1px border around
+ * its members. Left to grow, that made the control eight pixels taller than a
+ * bare button of the same size, so a switch standing next to one sat visibly
+ * proud of it.
+ *
+ * So the group claims the height its members would have had on their own, and
+ * the inset comes out of them instead of adding to it - `box-sizing: border-box`
+ * is what folds the padding and border into the declared height.
+ *
+ * The heights mirror Btn's own size rules and have to be restated rather than
+ * inherited, because size is a per-member prop the group cannot read - the same
+ * reason the label segment below restates .btn--sm. If Btn's scale moves, this
+ * moves with it. The sm fallback is Btn's default too, so a group that names no
+ * size matches a button that names none.
+ *
+ * Only segmented: a plain group is a row of ordinary buttons, which already
+ * carry their own heights.
+ */
+.btn-group--segmented.btn-group--xs {
+  height: 29px;
+}
+.btn-group--segmented.btn-group--sm {
+  height: 43px;
+}
+.btn-group--segmented.btn-group--md {
+  height: 48px;
+}
+.btn-group--segmented.btn-group--lg {
+  height: 55px;
+}
+
+/* The members fill what the inset leaves rather than carrying their own height,
+ * which needs the track to have a height for them to be a percentage of.
+ *
+ * :deep, because a member is a slotted component's root and so wears the calling
+ * component's scope id, not this one's - without it the rule silently matches
+ * nothing and the member keeps its own size. */
+.btn-group--segmented .btn-group__track {
+  height: 100%;
+}
+
+.btn-group--segmented :deep(.btn--segment) {
+  height: 100%;
+  min-height: 0;
+}
+
 .btn-group__thumb {
   @apply bg-control border-edge absolute border;
   top: 0;
@@ -260,8 +312,13 @@ provide(BTN_CONTAINER, {
  * otherwise the track's fill shows straight through and the label reads as a
  * highlighted panel. Direct children only, so .btn__content inside a member is
  * untouched.
+ *
+ * The thumb is excluded by name because it is a span in the track too: it was
+ * picking up the min-height, which held it at 43px inside a shorter track and
+ * pushed it out of the recess, and the divider shadow, which drew a seam down
+ * its leading edge.
  */
-.btn-group__track > :deep(span) {
+.btn-group__track > :deep(span:not(.btn-group__thumb)) {
   @apply bg-control text-text flex items-center justify-center px-3.5;
   /* And the divider a member would draw, for the same reason. */
   box-shadow: -1px 0 0 var(--color-seam, #3a3f44);

--- a/app/frontend/shared/components/base/BtnGroup/index.vue
+++ b/app/frontend/shared/components/base/BtnGroup/index.vue
@@ -7,20 +7,20 @@ export default {
 <script lang="ts" setup>
 import { BTN_CONTAINER } from "@/shared/components/base/Btn/context";
 // A value, not just a type: the segmented size class falls back to it.
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
-import type { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 
 type Props = {
   /** Set once here instead of on every member. */
   size?: `${BtnSizesEnum}`;
   block?: boolean;
   /**
-   * Colours the thumb, for a segmented group whose current choice is worth
-   * flagging -- reading a pre-release build rather than the live one.
+   * Colours the thumb, for a segmented group where being on any segment at all
+   * is worth flagging.
    *
-   * On the group rather than on the member because a grouped button drops its
-   * cap, so a member's own tone shows nothing at rest. The thumb is what marks
-   * the choice, so it is what says the choice is unusual.
+   * A member may carry its own tone instead, and usually should: it is normally
+   * one particular choice that is unusual -- reading a pre-release build rather
+   * than the live one -- and then only that segment should colour the thumb.
+   * The member's tone wins where it has one; this is the fallback for the rest.
    */
   tone?: `${BtnTonesEnum}`;
   /**
@@ -45,16 +45,23 @@ const sizeClass = computed(() => `btn-group--${props.size ?? BtnSizesEnum.SM}`);
 
 // Members report themselves in mount order, which is DOM order, so the thumb can
 // be placed without this component reading a member's index or state out of the
-// DOM. Shallow refs of getters rather than values: a member's `active` changes
-// after registration and the thumb has to follow.
-const members = ref<Array<() => boolean>>([]);
+// DOM. Getters rather than values: a member's `active` changes after
+// registration and the thumb has to follow.
+type Member = {
+  active: () => boolean;
+  tone: () => `${BtnTonesEnum}`;
+};
 
-const register = (active: () => boolean) => {
-  members.value = [...members.value, active];
+const members = ref<Member[]>([]);
+
+const register = (active: Member["active"], tone: Member["tone"]) => {
+  const member: Member = { active, tone };
+
+  members.value = [...members.value, member];
 
   return {
     unregister: () => {
-      members.value = members.value.filter((entry) => entry !== active);
+      members.value = members.value.filter((entry) => entry !== member);
     },
   };
 };
@@ -73,7 +80,7 @@ if (import.meta.env.DEV) {
       return;
     }
 
-    const active = members.value.filter((isActive) => isActive()).length;
+    const active = members.value.filter((member) => member.active()).length;
 
     if (active > 1) {
       console.warn(
@@ -87,8 +94,17 @@ if (import.meta.env.DEV) {
 // -1 while nothing is chosen, which parks the thumb off the first segment rather
 // than under it - a switch with no selection should not claim one.
 const activeIndex = computed(() =>
-  members.value.findIndex((isActive) => isActive()),
+  members.value.findIndex((member) => member.active()),
 );
+
+// The chosen member's tone, since the thumb is the only chrome left to show it
+// in. `neutral` is Btn's default and so cannot mean anything but "unset" here,
+// which is what lets the group's own tone stand as the fallback.
+const thumbTone = computed(() => {
+  const chosen = members.value[activeIndex.value]?.tone();
+
+  return chosen && chosen !== BtnTonesEnum.NEUTRAL ? chosen : props.tone;
+});
 
 // Members read this and drop their own border, radius and end-caps, so this
 // component never needs descendant selectors into Btn's internals. The previous
@@ -123,7 +139,7 @@ provide(BTN_CONTAINER, {
       <span
         v-if="segmented && activeIndex >= 0"
         class="btn-group__thumb"
-        :class="tone ? `btn-group__thumb--tone-${tone}` : undefined"
+        :class="thumbTone ? `btn-group__thumb--tone-${thumbTone}` : undefined"
         aria-hidden="true"
       />
       <slot />

--- a/app/frontend/shared/components/base/BtnGroup/index.vue
+++ b/app/frontend/shared/components/base/BtnGroup/index.vue
@@ -6,12 +6,24 @@ export default {
 
 <script lang="ts" setup>
 import { BTN_CONTAINER } from "@/shared/components/base/Btn/context";
-import type { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import type {
+  BtnSizesEnum,
+  BtnTonesEnum,
+} from "@/shared/components/base/Btn/types";
 
 type Props = {
   /** Set once here instead of on every member. */
   size?: `${BtnSizesEnum}`;
   block?: boolean;
+  /**
+   * Colours the thumb, for a segmented group whose current choice is worth
+   * flagging -- reading a pre-release build rather than the live one.
+   *
+   * On the group rather than on the member because a grouped button drops its
+   * cap, so a member's own tone shows nothing at rest. The thumb is what marks
+   * the choice, so it is what says the choice is unusual.
+   */
+  tone?: `${BtnTonesEnum}`;
   /**
    * A switch rather than a row of actions: the track recesses, one thumb slides
    * to the chosen segment, and members take radio semantics. Use it wherever a
@@ -24,6 +36,7 @@ const props = withDefaults(defineProps<Props>(), {
   size: undefined,
   block: false,
   segmented: false,
+  tone: undefined,
 });
 
 // Members report themselves in mount order, which is DOM order, so the thumb can
@@ -105,6 +118,7 @@ provide(BTN_CONTAINER, {
       <span
         v-if="segmented && activeIndex >= 0"
         class="btn-group__thumb"
+        :class="tone ? `btn-group__thumb--tone-${tone}` : undefined"
         aria-hidden="true"
       />
       <slot />
@@ -211,6 +225,17 @@ provide(BTN_CONTAINER, {
   border-radius: var(--radius-control-inner, 7px);
   transform: translateX(calc(var(--seg-index, 0) * 100%));
   transition: transform 150ms ease;
+}
+
+/* The thumb carries the group's tone, since a member's own cap is dropped in a
+   group. Border and a wash rather than a flood: the label still has to read. */
+.btn-group__thumb--tone-danger {
+  border-color: var(--color-danger, #dc3545);
+  background-color: rgb(220 53 69 / 0.18);
+}
+.btn-group__thumb--tone-warning {
+  border-color: var(--color-warning, #fa6800);
+  background-color: rgb(250 104 0 / 0.18);
 }
 
 /* The grid sizes the segments; the member only drops its fill, since the thumb is

--- a/app/frontend/shared/stores/scDataSource.spec.ts
+++ b/app/frontend/shared/stores/scDataSource.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useScDataSourceStore } from "./scDataSource";
+
+const live = { environment: "live", version: "1.0.0", default: true };
+const ptu = { environment: "ptu", version: "1.1.0", default: false };
+
+describe("scDataSource store", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("selects the server's default until somebody chooses", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live, ptu]);
+
+    expect(store.selected).toEqual(live);
+    expect(store.requestParam).toBeUndefined();
+  });
+
+  // Nothing is sent for the default, so a reader who has not chosen sends
+  // exactly what it always sent.
+  it("sends no parameter for the default and the environment otherwise", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live, ptu]);
+
+    store.select("ptu");
+    expect(store.requestParam).toBe("ptu");
+
+    store.select(undefined);
+    expect(store.requestParam).toBeUndefined();
+  });
+
+  it("offers no switch when there is nothing to switch to", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live]);
+
+    expect(store.hasChoice).toBe(false);
+
+    store.setAvailable([live, ptu]);
+    expect(store.hasChoice).toBe(true);
+  });
+
+  // A source that has gone away must not stay selected, or every request would
+  // carry a parameter the server ignores while the switch claims otherwise.
+  it("drops a selection the server stopped offering", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live, ptu]);
+    store.select("ptu");
+
+    store.setAvailable([live]);
+
+    expect(store.environment).toBeUndefined();
+    expect(store.requestParam).toBeUndefined();
+    expect(store.selected).toEqual(live);
+  });
+
+  it("keeps a selection the server still offers", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live, ptu]);
+    store.select("ptu");
+
+    store.setAvailable([live, ptu]);
+
+    expect(store.requestParam).toBe("ptu");
+  });
+
+  it("has nothing selected before the server has answered", () => {
+    const store = useScDataSourceStore();
+
+    expect(store.selected).toBeUndefined();
+    expect(store.requestParam).toBeUndefined();
+    expect(store.hasChoice).toBe(false);
+  });
+});

--- a/app/frontend/shared/stores/scDataSource.ts
+++ b/app/frontend/shared/stores/scDataSource.ts
@@ -1,0 +1,78 @@
+import { defineStore } from "pinia";
+
+// Declared here rather than imported from the generated client on purpose: the
+// axios client asks this store which source a request carries, and importing the
+// client's types back into the store would close that circle.
+export type ScDataSourceOption = {
+  environment: string;
+  version: string;
+  default: boolean;
+};
+
+interface ScDataSourceState {
+  // Undefined means "whatever the server calls default", which is what a reader
+  // who has never touched the switch gets.
+  environment?: string;
+  available: ScDataSourceOption[];
+}
+
+export const useScDataSourceStore = defineStore("scDataSource", {
+  state: (): ScDataSourceState => ({
+    environment: undefined,
+    available: [],
+  }),
+  getters: {
+    // The one the server would pick on its own, which is what the switch shows
+    // as selected until somebody chooses otherwise.
+    defaultSource(state): ScDataSourceOption | undefined {
+      return state.available.find((source) => source.default);
+    },
+
+    selected(state): ScDataSourceOption | undefined {
+      if (!state.environment) return this.defaultSource;
+
+      return state.available.find(
+        (source) => source.environment === state.environment,
+      );
+    },
+
+    // Only worth a switch when there is something to switch to.
+    hasChoice(state): boolean {
+      return state.available.length > 1;
+    },
+
+    // What the axios client puts on a request. Nothing for the default, so a
+    // reader who has not chosen sends exactly what it always sent.
+    requestParam(): string | undefined {
+      const selected = this.selected as ScDataSourceOption | undefined;
+
+      if (!selected || selected.default) return undefined;
+
+      return selected.environment;
+    },
+  },
+  actions: {
+    setAvailable(available: ScDataSourceOption[]) {
+      this.available = available;
+
+      // A source that has gone away -- an environment retired, or one that has
+      // not been loaded since -- must not stay selected, or every request would
+      // carry a parameter the server ignores while the switch claims otherwise.
+      if (
+        this.environment &&
+        !available.some((source) => source.environment === this.environment)
+      ) {
+        this.environment = undefined;
+      }
+    },
+
+    select(environment?: string) {
+      this.environment = environment;
+    },
+  },
+  persist: {
+    // The available list comes from the server on every boot; only the choice is
+    // worth keeping.
+    pick: ["environment"],
+  },
+});

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1434,7 +1434,7 @@
         "linkHint": "Welches Schiff im Katalog ist %{identifier}? Der Vorschlag stammt aus dem Export und kann falsch sein."
       },
       "scDataSource": {
-        "reading": "Datenstand",
+        "dataSource": "Datenquelle",
         "notLive": "Nicht der Live-Build"
       }
     }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1432,6 +1432,10 @@
       },
       "unlistedModel": {
         "linkHint": "Welches Schiff im Katalog ist %{identifier}? Der Vorschlag stammt aus dem Export und kann falsch sein."
+      },
+      "scDataSource": {
+        "reading": "Datenstand",
+        "notLive": "Nicht der Live-Build"
       }
     }
   }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2209,7 +2209,7 @@
         "linkHint": "Which ship in the catalogue is %{identifier}? The suggestion comes from the export and may be wrong."
       },
       "scDataSource": {
-        "reading": "Reading",
+        "dataSource": "Data source",
         "notLive": "Not the live build"
       }
     }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2207,6 +2207,10 @@
       },
       "unlistedModel": {
         "linkHint": "Which ship in the catalogue is %{identifier}? The suggestion comes from the export and may be wrong."
+      },
+      "scDataSource": {
+        "reading": "Reading",
+        "notLive": "Not the live build"
       }
     }
   }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1317,6 +1317,10 @@
       },
       "unlistedModel": {
         "linkHint": "¿Qué nave del catálogo es %{identifier}? La sugerencia viene del export y puede estar equivocada."
+      },
+      "scDataSource": {
+        "reading": "Datos de",
+        "notLive": "No es la compilación live"
       }
     }
   }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1319,7 +1319,7 @@
         "linkHint": "¿Qué nave del catálogo es %{identifier}? La sugerencia viene del export y puede estar equivocada."
       },
       "scDataSource": {
-        "reading": "Datos de",
+        "dataSource": "Fuente de datos",
         "notLive": "No es la compilación live"
       }
     }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1322,6 +1322,10 @@
       },
       "unlistedModel": {
         "linkHint": "Quel vaisseau du catalogue est %{identifier} ? La suggestion vient de l'export et peut être fausse."
+      },
+      "scDataSource": {
+        "reading": "Données de",
+        "notLive": "Pas la version live"
       }
     }
   }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1324,7 +1324,7 @@
         "linkHint": "Quel vaisseau du catalogue est %{identifier} ? La suggestion vient de l'export et peut être fausse."
       },
       "scDataSource": {
-        "reading": "Données de",
+        "dataSource": "Source des données",
         "notLive": "Pas la version live"
       }
     }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1318,6 +1318,10 @@
       },
       "unlistedModel": {
         "linkHint": "Quale nave del catalogo è %{identifier}? Il suggerimento viene dall'export e può essere sbagliato."
+      },
+      "scDataSource": {
+        "reading": "Dati di",
+        "notLive": "Non è la build live"
       }
     }
   }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1320,7 +1320,7 @@
         "linkHint": "Quale nave del catalogo è %{identifier}? Il suggerimento viene dall'export e può essere sbagliato."
       },
       "scDataSource": {
-        "reading": "Dati di",
+        "dataSource": "Fonte dati",
         "notLive": "Non è la build live"
       }
     }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1315,7 +1315,7 @@
         "linkHint": "%{identifier} 对应目录中的哪艘飞船？建议来自导出数据，可能有误。"
       },
       "scDataSource": {
-        "reading": "数据来源",
+        "dataSource": "数据来源",
         "notLive": "不是 live 版本"
       }
     }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1313,6 +1313,10 @@
       },
       "unlistedModel": {
         "linkHint": "%{identifier} 对应目录中的哪艘飞船？建议来自导出数据，可能有误。"
+      },
+      "scDataSource": {
+        "reading": "数据来源",
+        "notLive": "不是 live 版本"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1313,6 +1313,10 @@
       },
       "unlistedModel": {
         "linkHint": "%{identifier} 對應目錄中的哪艘飛船？建議來自匯出資料，可能有誤。"
+      },
+      "scDataSource": {
+        "reading": "資料來源",
+        "notLive": "不是 live 版本"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1315,7 +1315,7 @@
         "linkHint": "%{identifier} 對應目錄中的哪艘飛船？建議來自匯出資料，可能有誤。"
       },
       "scDataSource": {
-        "reading": "資料來源",
+        "dataSource": "資料來源",
         "notLive": "不是 live 版本"
       }
     }

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -40,18 +40,20 @@ module ScData
       DEFAULT_AXIS_ORDER = %i[y x z].freeze
 
       def all
-        update_in_game_flags
-
         loaded = []
 
-        Model.where(in_game: true).find_each do |model|
+        # Every model whose file this build ships, asked of the tree rather than
+        # of a stored flag: writing that flag is what made "is it in the game"
+        # answerable only for whichever environment loaded last.
+        Model.find_each do |model|
+          next unless parsed?(model)
+
           loaded << model.id if load_model(model)
         end
 
-        # A model the export dropped loses its current build and keeps the row.
-        # `in_game` already went false above, but a build row is the thing that
-        # says which patch last described the ship, and a hangar entry pointing
-        # at a retired ship still has to resolve.
+        # A model the export dropped loses its current build and keeps the row --
+        # which is now also what makes `in_game?` false for it. A hangar entry
+        # pointing at a retired ship still has to resolve, so the row stays.
         retire_absent_builds(ModelBuild, :model_id, loaded)
 
         prune_builds(ModelBuild)
@@ -60,8 +62,6 @@ module ScData
       end
 
       def one(model)
-        update_in_game_flag(model)
-
         load_model(model.reload)
 
         model.hardpoints.find_each(&:save) # hack to generate correct group_keys
@@ -95,6 +95,12 @@ module ScData
         update_params = update_speeds(hardpoints, update_params)
         update_params = update_ground_speeds(model_data, update_params)
 
+        # A ship the build ships is flying, and this is where that used to be
+        # recorded -- alongside the flag, on the transition into the game. The
+        # transition is now "it had no build for this source before this load",
+        # which is the same moment said in terms of what is actually true.
+        update_params[:production_status] = "flight-ready" if model.build.blank?
+
         apply(model, update_params.merge(update_reason: :sc_data_loader))
 
         # Dual-write. Built from `update_params` before the reason is merged in:
@@ -103,23 +109,13 @@ module ScData
         apply_build(model, update_params.slice(*ModelBuild::FACTS))
       end
 
-      private def update_in_game_flags
-        Model.find_each { |model| update_in_game_flag(model) }
-      end
-
-      private def update_in_game_flag(model)
+      # Whether this build ships a file for the model, which is what a build row
+      # comes to express once one is written.
+      private def parsed?(model)
         identifier = model.sc_data_identifier
-        return if identifier.blank?
+        return false if identifier.blank?
 
-        file_exists = File.exist?(
-          Rails.root.join("data/sc_data/parsed/#{sc_environment}/models/#{identifier}.json")
-        )
-
-        if file_exists && !model.in_game?
-          apply_columns(model, {in_game: true, production_status: "flight-ready"})
-        elsif !file_exists && model.in_game?
-          apply_columns(model, {in_game: false})
-        end
+        export_path.join("models", "#{identifier}.json").exist?
       end
 
       private def load_model_data(sc_data_identifier)

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -34,11 +34,23 @@ module ScData
         configured.find { |source| source.environment == environment.to_s }
       end
 
-      # The sources a reader may actually be pointed at: configured, and carrying
-      # builds. An environment that has never been loaded would answer every
-      # question with nothing, so it is not offered rather than served empty.
+      # The sources a reader may actually be pointed at: configured, carrying
+      # builds, and not behind the default. An environment that has never been
+      # loaded would answer every question with nothing, so it is not offered
+      # rather than served empty.
+      #
+      # Behind the default means stale rather than alternative. A ptu cycle ends
+      # with live catching up and passing it, and from that moment the ptu tree
+      # still sitting there describes an *older* build -- offering it would put
+      # last month's data behind a label that promises next month's. So a source
+      # is offered while it is ahead, and stops being offered the moment live
+      # overtakes it, without anyone having to edit the config.
       def available
-        configured.select(&:loaded?)
+        chosen = default
+
+        configured.select do |source|
+          source.loaded? && (source == chosen || source.ahead_of?(chosen))
+        end
       end
 
       # Runs a block with a source in force, and puts back whatever was there.
@@ -76,6 +88,27 @@ module ScData
 
     def default?
       self == self.class.default
+    end
+
+    # Ordered the way the game names a build: `4.10.0-live.12519617` is the
+    # version, then the id of the build that carries it.
+    #
+    # The id is the tiebreak rather than the key, because the case this exists
+    # to catch is a live build that has caught up with a finished ptu cycle: same
+    # version on both sides, and live's id the higher one. Comparing versions
+    # alone would call that a draw and keep offering the ptu tree.
+    #
+    # A version with no build id -- which is every version a test writes -- sorts
+    # as id zero, so the two forms still compare.
+    def ahead_of?(other)
+      (precedence <=> other.precedence) == 1
+    end
+
+    protected def precedence
+      release, build = version.to_s.split("-", 2)
+      id = build.to_s[/\d+\z/].to_i
+
+      [Gem::Version.correct?(release) ? Gem::Version.new(release) : Gem::Version.new(0), id]
     end
 
     def ==(other)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -186,6 +186,44 @@ class Model < ApplicationRecord
   # carries and no build ever will, and filtering on a build row would hide every
   # one of them. `in_game` stays the flag.
 
+  # Whether the build we are on describes this ship.
+  #
+  # Derived rather than stored. The column it replaces was a single boolean set
+  # from whichever environment loaded last, so a ptu load overwrote what live had
+  # said and a ship added in ptu appeared in the live view. A build row carries
+  # its environment, so the same question has a different answer per source --
+  # which is the whole point.
+  #
+  # This is not the catalogue filter: 31 of 246 models are concept ships no build
+  # will ever describe, and hiding them would empty the catalogue of everything
+  # not yet flying. `visible` and `active` stay what decides that.
+  #
+  # `build` is preloaded by `rendered_associations`, so a list costs no queries
+  # for this.
+  def in_game?
+    build.present?
+  end
+  alias_method :in_game, :in_game?
+
+  # The filter keeps its name -- a ransacker wins over a same-named column -- so
+  # `inGameEq` needs no API change. An `EXISTS` rather than the correlated
+  # subquery the fact filters use, because this asks whether a row is there
+  # rather than what it says, and the unique index answers it directly.
+  ransacker(:in_game) do
+    source = ::ScData::Source.current
+
+    Arel.sql(
+      sanitize_sql_array([<<~SQL.squish, source.environment, source.version])
+        EXISTS (
+          SELECT 1 FROM model_builds
+          WHERE model_builds.model_id = models.id
+            AND model_builds.environment = ?
+            AND model_builds.version = ?
+        )
+      SQL
+    )
+  end
+
   # The build we are on, or the last one that described the model. A hangar entry
   # pointing at a ship the export dropped still has to resolve to something.
   def facts

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -13746,8 +13746,6 @@ components:
           type: boolean
         active:
           type: boolean
-        inGame:
-          type: boolean
         adiMap:
           type: boolean
         ground:

--- a/test/factories/fleet_events.rb
+++ b/test/factories/fleet_events.rb
@@ -97,7 +97,7 @@ FactoryBot.define do
 
     trait :strict do
       classification { nil }
-      association :model, in_game: true
+      association :model, factory: %i[model in_game]
     end
   end
 

--- a/test/factories/missions.rb
+++ b/test/factories/missions.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
 
     trait :strict do
       classification { nil }
-      association :model, in_game: true
+      association :model, factory: %i[model in_game]
     end
 
     trait :ranged do

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -148,6 +148,21 @@ FactoryBot.define do
     upgrade_kits_count { 0 }
     videos_count { 0 }
     ground { false }
+
+    # `in_game?` reads a build row rather than a column, so this is what puts a
+    # ship in the game. No hook by default: 31 of 246 models in a real catalogue
+    # are concept ships with no build, and that is the more common case.
+    trait :in_game do
+      after(:create) do |model|
+        model.builds.create!(
+          environment: ScData::Source.environment,
+          version: ScData::Source.version
+        )
+
+        model.association(:build).reset
+        model.association(:last_build).reset
+      end
+    end
     hydrogen_fuel_tank_size { 660000.0 }
     quantum_fuel_tank_size { 3000.0 }
     scm_speed { 144.0 }

--- a/test/integration/api/v1/fleets_mission_teams_ships_create_test.rb
+++ b/test/integration/api/v1/fleets_mission_teams_ships_create_test.rb
@@ -60,7 +60,7 @@ class Api::V1::FleetsMissionTeamsShipsCreateTest < ActionDispatch::IntegrationTe
   end
 
   test "POST /fleets/:slug/missions/:slug/teams/:id/ships creates a specific model with materialized seats" do
-    model = create(:model, in_game: true)
+    model = create(:model, :in_game)
     positions = [
       create(:model_position, model: model, name: "Pilot", position_type: :pilot, position: 0),
       create(:model_position, model: model, name: "Co-Pilot", position_type: :copilot, position: 1)
@@ -79,7 +79,7 @@ class Api::V1::FleetsMissionTeamsShipsCreateTest < ActionDispatch::IntegrationTe
   end
 
   test "POST /fleets/:slug/missions/:slug/teams/:id/ships returns 400 for non-in-game model" do
-    model = create(:model, in_game: false)
+    model = create(:model)
     sign_in @admin
 
     assert_api_response :post, 400,

--- a/test/integration/fleet_event_ship_allowed_models_test.rb
+++ b/test/integration/fleet_event_ship_allowed_models_test.rb
@@ -11,8 +11,8 @@ class FleetEventShipAllowedModelsTest < ActionDispatch::IntegrationTest
     Flipper.enable_actor("fleet_mission_builder", @fleet)
     @event = create(:fleet_event, :open, fleet: @fleet, created_by: @admin)
     @team = create(:fleet_event_team, fleet_event: @event)
-    @connie = create(:model, name: "Constellation Andromeda", in_game: true)
-    @freelancer = create(:model, name: "Freelancer MAX", in_game: true)
+    @connie = create(:model, :in_game, name: "Constellation Andromeda")
+    @freelancer = create(:model, :in_game, name: "Freelancer MAX")
     sign_in @admin
   end
 
@@ -32,7 +32,7 @@ class FleetEventShipAllowedModelsTest < ActionDispatch::IntegrationTest
   end
 
   test "a list cannot name a ship that is not in the game" do
-    concept = create(:model, in_game: false)
+    concept = create(:model)
 
     post ships_path,
       params: {title: "Escort", allowedModelIds: [concept.id]},

--- a/test/integration/fleet_mission_ship_allowed_models_test.rb
+++ b/test/integration/fleet_mission_ship_allowed_models_test.rb
@@ -12,8 +12,8 @@ class FleetMissionShipAllowedModelsTest < ActionDispatch::IntegrationTest
     Flipper.enable_actor("fleet_mission_builder", @fleet)
     @mission = create(:mission, fleet: @fleet, created_by: @admin)
     @team = create(:mission_team, mission: @mission)
-    @connie = create(:model, name: "Constellation Andromeda", in_game: true)
-    @freelancer = create(:model, name: "Freelancer MAX", in_game: true)
+    @connie = create(:model, :in_game, name: "Constellation Andromeda")
+    @freelancer = create(:model, :in_game, name: "Freelancer MAX")
     sign_in @admin
   end
 
@@ -51,7 +51,7 @@ class FleetMissionShipAllowedModelsTest < ActionDispatch::IntegrationTest
   end
 
   test "a list cannot name a ship that is not in the game" do
-    concept = create(:model, in_game: false)
+    concept = create(:model)
 
     post ships_path,
       params: {title: "Escort", allowedModelIds: [concept.id]},

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -107,6 +107,44 @@ class ScData::SourceTest < ActiveSupport::TestCase
     assert_empty ScData::Source.available
   end
 
+  # A finished ptu cycle leaves its tree in place while live moves past it, so
+  # the config still names a ptu build long after it stopped being the newer one.
+  test "a source behind the default is not offered" do
+    stub_config(sources: {live: "4.10.0-live.12519617", ptu: "4.10.0-ptu.12490000"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "4.10.0-live.12519617")
+    create(:model_build, model: create(:model), environment: "ptu", version: "4.10.0-ptu.12490000")
+
+    assert_equal ["live"], ScData::Source.available.map(&:environment)
+  end
+
+  test "a source ahead of the default is offered" do
+    stub_config(sources: {live: "4.9.0-live.12344265", ptu: "4.10.0-ptu.12600000"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "4.9.0-live.12344265")
+    create(:model_build, model: create(:model), environment: "ptu", version: "4.10.0-ptu.12600000")
+
+    assert_equal ["live", "ptu"], ScData::Source.available.map(&:environment)
+  end
+
+  # Same version on both sides is the moment live catches up: only the build id
+  # separates them, and it has to be what decides.
+  test "the build id decides when the versions match" do
+    stub_config(sources: {live: "4.10.0-live.12519617", ptu: "4.10.0-ptu.12600000"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "4.10.0-live.12519617")
+    create(:model_build, model: create(:model), environment: "ptu", version: "4.10.0-ptu.12600000")
+
+    assert_equal ["live", "ptu"], ScData::Source.available.map(&:environment)
+  end
+
+  # The default is what everything else is measured against, so it is offered on
+  # its own terms -- otherwise a config whose default is the older build would
+  # offer nothing at all.
+  test "the default is offered even when another source is ahead of it" do
+    stub_config(sources: {live: "4.9.0-live.12344265", ptu: "4.10.0-ptu.12600000"}, default: "live")
+    create(:model_build, model: create(:model), environment: "live", version: "4.9.0-live.12344265")
+
+    assert_equal ["live"], ScData::Source.available.map(&:environment)
+  end
+
   test "knows whether it is the default" do
     stub_config(sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live")
 

--- a/test/loaders/sc_data/base_loader_apply_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_test.rb
@@ -57,19 +57,22 @@ module ScData
 
       # Counted separately from `apply` because it deliberately skips
       # validations and callbacks, so `changed?` is never consulted.
+      # `hidden` rather than `in_game`: what is under test is the counting, and
+      # `in_game?` reads a build row now rather than a column, so writing it
+      # through `apply_columns` would prove nothing.
       test "#apply_columns writes the columns and counts an update" do
-        model = create(:model, in_game: false)
+        model = create(:model, hidden: false)
 
-        @loader.apply_columns(model, {in_game: true})
+        @loader.apply_columns(model, {hidden: true})
 
-        assert_predicate model.reload, :in_game?
+        assert_predicate model.reload, :hidden?
         assert_equal({created: 0, updated: 1, unchanged: 0}, @loader.stats["Model"])
       end
 
       test "counts are kept per model class" do
         @loader.apply(Commodity.new, {name: "Agricium", sc_key: "agricium"})
         @loader.apply(Commodity.new, {name: "Aluminium", sc_key: "aluminium"})
-        @loader.apply_columns(create(:model), {in_game: true})
+        @loader.apply_columns(create(:model), {hidden: true})
 
         assert_equal 2, @loader.stats["Commodity"][:created]
         assert_equal 1, @loader.stats["Model"][:updated]

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -15,7 +15,7 @@ module ScData
       test "#one loads data from game files" do
         loader = ::ScData::Loader::ModelsLoader.new
         manufacturer = create(:manufacturer, name: "Roberts Space Industries", slug: "rsi", code: "RSI")
-        model = create(:model, name: "Constellation Andromeda", manufacturer: manufacturer, in_game: true)
+        model = create(:model, :in_game, name: "Constellation Andromeda", manufacturer: manufacturer)
 
         assert_difference -> { Hardpoint.where(parent: model).count }, 95 do
           loader.one(model)
@@ -24,7 +24,7 @@ module ScData
 
       test "#load_model persists the parsed cross section signature" do
         loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Cross Section Test", in_game: true)
+        model = create(:model, :in_game, name: "Cross Section Test")
         cross_section = {"x" => 12.5, "y" => 34.0, "z" => 56.25}
 
         loader.stubs(:load_model_data).returns(
@@ -109,7 +109,7 @@ module ScData
 
       test "#load_model persists the parsed ground speeds" do
         loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Ground Speed Test", in_game: true)
+        model = create(:model, :in_game, name: "Ground Speed Test")
 
         loader.stubs(:load_model_data).returns(
           {
@@ -135,7 +135,7 @@ module ScData
 
       test "#load_model keeps the ground speeds a vehicle does not declare" do
         loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Wheel Cap Test", in_game: true, ground_reverse_speed: 9.0)
+        model = create(:model, :in_game, name: "Wheel Cap Test", ground_reverse_speed: 9.0)
 
         loader.stubs(:load_model_data).returns(
           {"mass" => 1000.0, "loadout" => [], "speeds" => {"max" => 36.0}}
@@ -150,7 +150,7 @@ module ScData
 
       test "#load_model persists the personal inventory the container declares" do
         loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Personal Inventory Test", in_game: true)
+        model = create(:model, :in_game, name: "Personal Inventory Test")
 
         loader.stubs(:load_model_data).returns(
           {
@@ -170,7 +170,7 @@ module ScData
 
       test "#load_model keeps the personal inventory when the container is unknown" do
         loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Unknown Container Test", in_game: true, personal_inventory: 1.72)
+        model = create(:model, :in_game, name: "Unknown Container Test", personal_inventory: 1.72)
 
         loader.stubs(:load_model_data).returns(
           {"mass" => 1000.0, "loadout" => [], "inventory_container_ref" => "missing-ref"}

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -450,4 +450,84 @@ class ModelTest < ActiveSupport::TestCase
     assert_nil model.seconds_to_scm_speed
     assert_nil model.seconds_to_stop_from_scm_speed
   end
+
+  # `in_game` used to be one boolean set from whichever environment loaded last,
+  # so a ptu load overwrote what live had said. A build row carries its
+  # environment, so the same question now has a different answer per source.
+  test "is in game when the build we are on describes it" do
+    model = create(:model)
+
+    assert_not_predicate model, :in_game?
+
+    create(:model_build, model:)
+
+    assert_predicate model.reload, :in_game?
+  end
+
+  test "is not in game when only an older build describes it" do
+    model = create(:model)
+    create(:model_build, model:, version: "0.0.1-live.1")
+
+    assert_not_predicate model.reload, :in_game?
+  end
+
+  test "answers differently per source" do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live"})
+    model = create(:model)
+    create(:model_build, model:, environment: "ptu", version: "1.1.0")
+
+    assert_not_predicate model.reload, :in_game?, "live does not ship it"
+
+    ScData::Source.with(ScData::Source.find("ptu")) do
+      assert_predicate model.reload, :in_game?, "ptu does"
+    end
+  end
+
+  test "the filter keeps its name and follows the source" do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0", ptu: "1.1.0"}, default: "live"})
+    shipped = create(:model)
+    create(:model_build, model: shipped, environment: "ptu", version: "1.1.0")
+    concept = create(:model)
+
+    assert_empty Model.ransack(in_game_eq: true).result
+
+    ScData::Source.with(ScData::Source.find("ptu")) do
+      assert_equal [shipped], Model.ransack(in_game_eq: true).result.to_a
+      assert_equal [concept], Model.ransack(in_game_eq: false).result.to_a
+    end
+  end
+
+  # A build of the same environment at another version must not answer, or every
+  # ship that ever shipped would read as current.
+  test "the filter ignores a build of another version" do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0"}, default: "live"})
+    model = create(:model)
+    create(:model_build, model:, environment: "live", version: "0.9.0")
+
+    assert_empty Model.ransack(in_game_eq: true).result
+    assert_equal [model], Model.ransack(in_game_eq: false).result.to_a
+  end
+
+  # Same version, other environment: ptu and live carry the same version string
+  # while shipping different data, so the environment has to be part of it.
+  test "the filter ignores a build of another environment at the same version" do
+    Rails.configuration.stubs(:sc_data).returns({sources: {live: "1.0.0", ptu: "1.0.0"}, default: "live"})
+    model = create(:model)
+    create(:model_build, model:, environment: "ptu", version: "1.0.0")
+
+    assert_empty Model.ransack(in_game_eq: true).result
+
+    ScData::Source.with(ScData::Source.find("ptu")) do
+      assert_equal [model], Model.ransack(in_game_eq: true).result.to_a
+    end
+  end
+
+  # 31 of 246 models are concept ships no build will ever describe. `in_game` is
+  # not what decides whether they are in the catalogue.
+  test "a concept ship stays in the catalogue while not being in game" do
+    concept = create(:model, hidden: false, active: true)
+
+    assert_not_predicate concept, :in_game?
+    assert_includes Model.visible.active, concept
+  end
 end


### PR DESCRIPTION
> **Stacked on #4591** → #4590. This is the piece that makes the switch mean something for models.

`in_game` was a single boolean, set from whichever environment loaded last. A ptu load overwrote what live had said, and a ship added in ptu appeared in the live view. A build row carries its environment, so the same question now has a different answer per source.

## What changed

`Model#in_game?` is `build.present?` — the build for the source the request is reading. `build` is already preloaded by `rendered_associations`, so a list costs no queries for it.

The filter keeps its name: a ransacker wins over a same-named column, so **`inGameEq` needs no API change**. It is an `EXISTS` rather than the correlated subquery the fact filters use — this asks whether a row is there rather than what it says, and the unique index answers that directly.

## It is not the catalogue filter

31 of 246 models are concept ships no build will ever describe. Hiding them would empty the catalogue of everything not yet flying, so `visible` and `active` stay what decides membership. There is a test for exactly that, because it is the mistake this invites.

## The loader stops maintaining it

It asks the parsed tree which models this build ships, rather than reading a column it wrote itself a moment earlier.

The `production_status: "flight-ready"` write moves with it, to the same moment said in terms of what is true: **the model had no build for this source before this load**. Previously that was "the flag was false and a file appeared".

## The admin stops offering a toggle

A switch that silently did nothing would be worse than what was there, so the field goes from the form, the permitted params and the input schema. The payload still reports it, read only.

That removes `inGame` from `ModelUpdateInput` — a request property that was already being ignored.

## What this cost in tests

**Sixteen places set `in_game: true`** on a model to satisfy the mission and fleet-event validations, and setting a column no longer does that. They take an `:in_game` trait that writes a build row.

Deliberately a trait rather than a default hook: a real catalogue is mostly concept ships without one, so a hook would make every test unrepresentative.

One loader test used `in_game` as a convenient column to exercise `apply_columns`. It uses `hidden` now — what is under test there is the counting, not the flag.

## Tests

Seven new model tests. Three mutations, each caught:

| mutation | failures |
| --- | --- |
| any build counts, not the one we are on | 2 |
| the filter ignores the version | 1 |
| the filter ignores the environment | 1 |

The last two only failed once **neighbouring build rows** existed — with a single row, a filter that ignores both still finds it. Worth recording: the first version of those tests passed under both mutations.

## Verification

654 model and loader tests, 1,319 public API tests, 840 admin tests — green. `standardrb` and `tsc` clean.

Three known environmental failures, identical on main: two admin mailer tests and one notification digest test need built Vite email assets.

## What is left

The cleanup: dropping the fact columns, which had to wait for this — the column was what covered a source with no build, and now a source with no builds is not offered at all.

🤖
