### PR TITLE
fix(ui): quiet the table interior to match the panel frame

### DIFF
--- a/app/frontend/entrypoints/tailwind.css
+++ b/app/frontend/entrypoints/tailwind.css
@@ -116,6 +116,19 @@
     calc(var(--cap-r, 3px) * 0.75),
     calc(var(--cap-h-btn-lg, 3px) / 2)
   );
+
+  /*
+   * A table row is a smaller unit than a panel, so its rail steps down from the
+   * panel cap rather than matching it - at the full 4px the hover cue weighs as
+   * much as the frame around it. The radius is held to half the rail's own
+   * width for the same reason the button cap is: past that ceiling it stops
+   * reading as a seam and starts reading as a lozenge.
+   */
+  --cap-h-row: max(2px, calc(var(--cap-h, 4px) - 1px));
+  --cap-r-row: min(
+    calc(var(--cap-r, 3px) * 0.75),
+    calc(var(--cap-h-row, 3px) / 2)
+  );
 }
 
 /*

--- a/app/frontend/shared/components/base/Table/Col/index.scss
+++ b/app/frontend/shared/components/base/Table/Col/index.scss
@@ -1,7 +1,33 @@
+/*
+ * The hovered row is signed with the end-cap motif turned on its side:
+ * --cap-h-row wide, rounded on the inward edge only so the outward edge stays
+ * flush with the frame. It steps down from the panel's own --cap-h, because a
+ * row is a smaller unit than the frame and should not sign itself as heavily.
+ *
+ * It stays --color-primary rather than the neutral --color-endcap, because the
+ * rail only exists while the row is hovered. Btn draws the same distinction:
+ * its cap rests at --color-endcap and turns --color-primary on hover, active
+ * and focus-visible. A rail in the frame's own grey would state the row's
+ * structure, not that you are pointing at it.
+ *
+ * What goes is the bloom - three 10px shadows at 0.9 alpha, which was the
+ * loudest thing on a surface whose whole premise is restraint. Btn signals the
+ * same state with the flat colour alone.
+ *
+ * The var() fallbacks are load-bearing, not decorative - the embed bundle never
+ * registers :root. Same call Panel makes for its own caps.
+ */
 .base-table-col {
   padding: 10px;
   position: relative;
   transition: background-color 0.3s ease;
+
+  /*
+   * Both rails read as one cue on the same row, so the height is named once
+   * rather than written twice - the two had already drifted to 65% and 70%,
+   * which the bloom used to cover and a flat 3px rail does not.
+   */
+  --rail-h: 70%;
 
   &:first-child {
     padding-left: 20px;
@@ -9,20 +35,16 @@
     &::before {
       position: absolute;
       top: 50%;
-      width: 4px;
-      height: 65%;
+      width: var(--cap-h-row, 3px);
+      height: var(--rail-h, 70%);
       transform: translate(0, -50%);
       transition: opacity 0.3s ease;
-      background-color: $primary;
+      background-color: var(--color-primary, #428bca);
       opacity: 0;
       content: "";
       left: 0;
-      border-top-right-radius: 2px;
-      border-bottom-right-radius: 2px;
-      box-shadow:
-        3px 0 10px rgba(darken($primary, 20%), 0.9),
-        0 3px 10px rgba(darken($primary, 20%), 0.9),
-        0 -3px 10px rgba(darken($primary, 20%), 0.9);
+      border-top-right-radius: var(--cap-r-row, 1.5px);
+      border-bottom-right-radius: var(--cap-r-row, 1.5px);
     }
   }
 
@@ -32,20 +54,16 @@
     &::after {
       position: absolute;
       top: 50%;
-      width: 4px;
-      height: 70%;
+      width: var(--cap-h-row, 3px);
+      height: var(--rail-h, 70%);
       transition: opacity 0.3s ease;
       transform: translate(0, -50%);
-      background-color: $primary;
+      background-color: var(--color-primary, #428bca);
       opacity: 0;
       content: "";
       right: 0;
-      border-top-left-radius: 2px;
-      border-bottom-left-radius: 2px;
-      box-shadow:
-        -3px 0 10px rgba(darken($primary, 20%), 0.9),
-        0 3px 10px rgba(darken($primary, 20%), 0.9),
-        0 -3px 10px rgba(darken($primary, 20%), 0.9);
+      border-top-left-radius: var(--cap-r-row, 1.5px);
+      border-bottom-left-radius: var(--cap-r-row, 1.5px);
     }
   }
 
@@ -92,6 +110,6 @@
 
 th.base-table-col {
   color: darken($text-color, 20%);
-  border-bottom: 1px solid $gray;
+  border-bottom: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
   white-space: nowrap;
 }


### PR DESCRIPTION
Fixes #4369.

`BaseTable` composes `Panel`, so it picked up the new surface, 2px edge and 16px radius for free when the panel redesign landed. Its interior was deliberately left out of that PR's scope and has out-shouted the quieter frame around it since.

## The row hover rail

The bloom goes — three 10px shadows at 0.9 alpha, the loudest thing on a surface whose whole premise is restraint.

It **keeps `--color-primary`** rather than falling back to the neutral `--color-endcap`. The rail only exists while the row is hovered (`opacity: 0` → `1`), so it is an interaction cue, not a structural signature. `Btn` already draws that line — its cap rests at `--color-endcap` and turns `--color-primary` on hover, `.active` and `:focus-visible`. A rail in the frame's own grey would state the row's structure rather than that you are pointing at it.

The issue text suggested the neutral grey, reasoning from the *static* panel cap. That reading loses the hover signal, so this follows `Btn` instead: flat primary, no bloom.

## Why the token pair

The rail steps down from the panel's `--cap-h` to a new `--cap-h-row`, because a row is a smaller unit than the frame and should not sign itself as heavily.

Width and radius cannot move independently — past half the rail's width a cap rounds far enough to read as a lozenge rather than a seam, which is the ceiling `--cap-r-btn` already carries. `--cap-r-row` carries the same one, so retuning the rail is a single value rather than two that have to be kept in step by hand.

| Token | Formula | Resolves to |
| --- | --- | --- |
| `--cap-h` (panel) | — | 4px |
| `--cap-h-row` | `max(2px, --cap-h − 1px)` | 3px |
| `--cap-r-row` | `min(--cap-r × 0.75, --cap-h-row ÷ 2)` | 1.5px |

## Two rails, one height

They had drifted to 65% and 70% of the row height. The bloom covered that; a flat 3px rail does not. The height is now named once as `--rail-h`.

## Header rule

`1px solid $gray` → `--color-edge-soft`, the same call `Panel/Heading` makes for its own internal division.

## Verified

`bin/vite build` clean; the compiled `base-table-col` carries no `box-shadow`, both rails resolve identically but for the side, and both new tokens land in `:root`. Prettier clean.

## Out of scope

The same rail is copied byte-for-byte into four other places, none touched here:

- `FilterGroup/Option` — belongs to #4371
- `Table2/Row` — #4369 rules it out explicitly (4 call sites, all on the visual-tests page)
- `TabNavView/index.scss` and `stylesheets/frontend/partials/flex-list.scss` — **currently owned by no issue**; worth folding into #4371 or filing separately

🤖
