### PR TITLE
feat(admin): a version history per record, with a per-field revert

### DIFF
--- a/app/api_components/admin/v1/schemas/enums/version_item_type_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/version_item_type_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class VersionItemTypeEnum
+          include OpenapiRuby::Components::Base
+
+          TYPES = ::VersionedItem::TYPES
+
+          schema({
+            type: :string,
+            enum: TYPES,
+            "x-enumNames": TYPES.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/version_revert_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/version_revert_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class VersionRevertInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              field: {type: :string}
+            },
+            required: %w[field]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version.rb
+++ b/app/api_components/admin/v1/schemas/version.rb
@@ -13,11 +13,11 @@ module Admin
             itemId: {type: :string, format: :uuid},
             itemType: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum,
             event: {type: :string},
-            reason: {type: :string, nullable: true},
-            reasonDescription: {type: :string, nullable: true},
+            reason: {type: [:string, :null]},
+            reasonDescription: {type: [:string, :null]},
             author: ::Admin::V1::Schemas::VersionAuthor,
             changes: {type: :array, items: ::Admin::V1::Schemas::VersionChange},
-            createdAt: {type: :string, format: :"date-time", nullable: true}
+            createdAt: {type: [:string, :null], format: :"date-time"}
           },
           required: %w[id itemId itemType event changes]
         })

--- a/app/api_components/admin/v1/schemas/version.rb
+++ b/app/api_components/admin/v1/schemas/version.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Version
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            itemId: {type: :string, format: :uuid},
+            itemType: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum,
+            event: {type: :string},
+            reason: {type: :string, nullable: true},
+            reasonDescription: {type: :string, nullable: true},
+            author: ::Admin::V1::Schemas::VersionAuthor,
+            changes: {type: :array, items: ::Admin::V1::Schemas::VersionChange},
+            createdAt: {type: :string, format: :"date-time", nullable: true}
+          },
+          required: %w[id itemId itemType event changes]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_author.rb
+++ b/app/api_components/admin/v1/schemas/version_author.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class VersionAuthor
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            username: {type: :string}
+          },
+          required: %w[id username]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_change.rb
+++ b/app/api_components/admin/v1/schemas/version_change.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class VersionChange
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            field: {type: :string},
+            from: {type: :string, nullable: true},
+            to: {type: :string, nullable: true}
+          },
+          required: %w[field]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_change.rb
+++ b/app/api_components/admin/v1/schemas/version_change.rb
@@ -10,8 +10,8 @@ module Admin
           type: :object,
           properties: {
             field: {type: :string},
-            from: {type: :string, nullable: true},
-            to: {type: :string, nullable: true}
+            from: {type: [:string, :null]},
+            to: {type: [:string, :null]}
           },
           required: %w[field]
         })

--- a/app/api_components/admin/v1/schemas/versions.rb
+++ b/app/api_components/admin/v1/schemas/versions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Versions < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/Version"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/versions_controller.rb
+++ b/app/controllers/admin/api/v1/versions_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class VersionsController < ::Admin::Api::BaseController
+        before_action :set_version, only: %i[revert]
+
+        def index
+          item = ::VersionedItem.find(params[:item_type] || params[:itemType], params[:item_id] || params[:itemId])
+
+          authorize_item!(item)
+
+          @versions = PaperTrail::Version
+            .where(item_type: item.class.name, item_id: item.id)
+            .order(created_at: :desc)
+            .page(params[:page])
+            .per(params[:per_page] || params[:perPage])
+
+          # `author_id` is only ever written by an admin action, so one lookup
+          # covers the page rather than one per row.
+          @authors = AdminUser.where(id: @versions.filter_map(&:author_id).uniq).index_by(&:id)
+        end
+
+        def revert
+          result = ::Versions::FieldReverter.new(@version, params[:field].to_s, author_id: current_user.id).run
+
+          raise ActiveRecord::RecordNotFound if result.missing?
+
+          unless result.success?
+            render json: ValidationError.new("version.revert", errors: result.record.errors), status: :bad_request
+            return
+          end
+
+          head :no_content
+        end
+
+        private def set_version
+          @version = PaperTrail::Version.find(params[:id])
+
+          raise ActiveRecord::RecordNotFound unless ::VersionedItem.supported?(@version.item_type)
+
+          authorize_item!(@version.item)
+        end
+
+        # The item carries the permission, not the version: whoever may see a
+        # model may see what it used to say.
+        private def authorize_item!(item)
+          raise ActiveRecord::RecordNotFound if item.blank?
+
+          root, policy = ::VersionedItem.authorization_root(item)
+
+          raise ActiveRecord::RecordNotFound if root.blank?
+
+          authorize! root, with: policy
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/versions_controller.rb
+++ b/app/controllers/admin/api/v1/versions_controller.rb
@@ -11,8 +11,13 @@ module Admin
 
           authorize_item!(item)
 
+          # The touch versions already on disk outnumber the real edits 1,200 to
+          # one on a fleet, and each renders as a heading with nothing under it.
+          # `object_changes` is null on exactly those: every create, update and
+          # destroy paper_trail records from a save carries one.
           @versions = PaperTrail::Version
             .where(item_type: item.class.name, item_id: item.id)
+            .where.not(object_changes: nil)
             .order(created_at: :desc)
             .page(params[:page])
             .per(params[:per_page] || params[:perPage])

--- a/app/frontend/admin/components/VersionHistory/index.vue
+++ b/app/frontend/admin/components/VersionHistory/index.vue
@@ -1,0 +1,125 @@
+<script lang="ts">
+export default {
+  name: "AdminVersionHistory",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import { useQueryClient } from "@tanstack/vue-query";
+import {
+  type Version,
+  type VersionChange,
+  type VersionItemTypeEnum,
+  useVersions as useVersionsQuery,
+  useRevertVersion as useRevertVersionMutation,
+  getVersionsQueryKey,
+} from "@/services/fyAdminApi";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
+import BtnConfirm from "@/shared/components/base/BtnConfirm/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+
+type Props = {
+  itemId: string;
+  itemType: VersionItemTypeEnum;
+};
+
+const props = defineProps<Props>();
+
+const { t, l } = useI18n();
+const queryClient = useQueryClient();
+
+const { data, isLoading } = useVersionsQuery({
+  perPage: "50",
+  itemType: props.itemType,
+  itemId: props.itemId,
+});
+
+const versions = computed(() => data.value?.items ?? []);
+
+const invalidateVersions = () =>
+  queryClient.invalidateQueries({ queryKey: getVersionsQueryKey() });
+
+const revertMutation = useRevertVersionMutation({
+  mutation: { onSettled: invalidateVersions },
+});
+
+const onRevert = async (version: Version, change: VersionChange) => {
+  await revertMutation.mutateAsync({
+    id: version.id,
+    data: { field: change.field },
+  });
+};
+
+// An admin edit carries a username; everything else was a loader, and `reason`
+// is what says which one.
+const sourceLabel = (version: Version) => {
+  if (version.author) return version.author.username;
+
+  if (version.reason)
+    return t(`labels.admin.versions.sources.${version.reason}`);
+
+  return t("labels.admin.versions.sources.unknown");
+};
+
+// A create records every column from nothing, so there is no earlier value to
+// go back to. The API refuses those; this keeps the button off them.
+const revertable = (version: Version) => version.event === "update";
+
+const displayValue = (value?: string | null) =>
+  value ?? t("labels.admin.versions.blank");
+</script>
+
+<template>
+  <Loader v-if="isLoading" />
+
+  <Empty v-else-if="versions.length === 0" />
+
+  <div v-else class="flex flex-col gap-4">
+    <Panel v-for="version in versions" :key="version.id">
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <span class="text-white">{{ l(version.createdAt ?? "") }}</span>
+        <BasePill
+          :variant="
+            version.author ? PillVariantsEnum.DEFAULT : PillVariantsEnum.NEUTRAL
+          "
+        >
+          {{ sourceLabel(version) }}
+        </BasePill>
+        <span v-if="version.reasonDescription" class="text-sm">
+          {{ version.reasonDescription }}
+        </span>
+      </div>
+
+      <ul class="flex flex-col gap-2">
+        <li
+          v-for="change in version.changes"
+          :key="`${version.id}-${change.field}`"
+          class="flex flex-wrap items-center gap-2"
+        >
+          <span class="font-bold">{{ change.field }}</span>
+          <span class="line-through opacity-60">{{
+            displayValue(change.from)
+          }}</span>
+          <i class="fa-duotone fa-arrow-right text-xs" />
+          <span>{{ displayValue(change.to) }}</span>
+
+          <BtnConfirm
+            v-if="revertable(version)"
+            :size="BtnSizesEnum.SM"
+            :question="t('labels.admin.versions.revertQuestion')"
+            hide-question
+            :disabled="revertMutation.isPending.value"
+            @click="onRevert(version, change)"
+          >
+            {{ t("actions.revert") }}
+          </BtnConfirm>
+        </li>
+      </ul>
+    </Panel>
+  </div>
+</template>

--- a/app/frontend/admin/components/VersionHistory/index.vue
+++ b/app/frontend/admin/components/VersionHistory/index.vue
@@ -80,7 +80,12 @@ const displayValue = (value?: string | null) =>
   <Empty v-else-if="versions.length === 0" />
 
   <div v-else class="flex flex-col gap-4">
-    <Panel v-for="version in versions" :key="version.id">
+    <Panel
+      v-for="version in versions"
+      :key="version.id"
+      inset
+      :outer-spacing="false"
+    >
       <div class="flex flex-wrap items-center gap-2 mb-3">
         <span class="text-white">{{ l(version.createdAt ?? "") }}</span>
         <BasePill
@@ -95,7 +100,7 @@ const displayValue = (value?: string | null) =>
         </span>
       </div>
 
-      <ul class="flex flex-col gap-2">
+      <ul class="flex flex-col gap-2 pb-5">
         <li
           v-for="change in version.changes"
           :key="`${version.id}-${change.field}`"

--- a/app/frontend/admin/pages/components/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/components/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminComponentEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type Component } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  component: Component;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.components.edit.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.component.id" item-type="Component" />
+</template>

--- a/app/frontend/admin/pages/components/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/components/[id]/edit/routes.ts
@@ -25,4 +25,16 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history/",
+    name: "admin-component-edit-history",
+    component: () => import("@/admin/pages/components/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.components.edit.history",
+      customTitle: true,
+      activeRoute: "admin-components",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/fleets/[id]/history.vue
+++ b/app/frontend/admin/pages/fleets/[id]/history.vue
@@ -1,0 +1,26 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type Fleet } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{ t("headlines.admin.fleets.history") }}</Heading>
+
+  <VersionHistory :item-id="props.fleet.id" item-type="Fleet" />
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
 import AsyncData from "@/shared/components/AsyncData.vue";
 import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
@@ -136,6 +137,11 @@ const handleCancel = async () => {
           @cancel="handleCancel"
         />
       </form>
+
+      <Heading class="mt-8 mb-4">{{
+        t("headlines.admin.fleets.history")
+      }}</Heading>
+      <VersionHistory :item-id="memberId" item-type="FleetMembership" />
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/admin/pages/fleets/[id]/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/routes.ts
@@ -21,4 +21,14 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history",
+    name: "admin-fleet-history",
+    component: () => import("@/admin/pages/fleets/[id]/history.vue"),
+    meta: {
+      title: "admin.fleets.history",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/models/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminModelEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type ModelExtended } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  model: ModelExtended;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.models.edit.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.model.id" item-type="Model" />
+</template>

--- a/app/frontend/admin/pages/models/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/[id]/edit/routes.ts
@@ -206,4 +206,16 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history/",
+    name: "admin-model-edit-history",
+    component: () => import("@/admin/pages/models/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.models.edit.history",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/models/modules/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminModelModuleEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type ModelModule } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  modelModule: ModelModule;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.modelModules.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.modelModule.id" item-type="ModelModule" />
+</template>

--- a/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
@@ -65,4 +65,17 @@ export const routes: RouteRecordRaw[] = [
       activeRoute: "admin-model-modules",
     },
   },
+  {
+    path: "history/",
+    name: "admin-model-module-edit-history",
+    component: () =>
+      import("@/admin/pages/models/modules/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.modelModules.edit.history",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -276,7 +276,8 @@
         "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen",
         "alreadyExists": "%{name} ist bereits im Katalog",
         "link": "Schon im Katalog"
-      }
+      },
+      "revert": "Zurücksetzen"
     }
   }
 }

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -39,7 +39,8 @@
             "loaners": "Leihschiffe",
             "upgrades": "Upgrades",
             "packages": "Pakete",
-            "linkUpgrade": "Vorhandenes Upgrade verknüpfen"
+            "linkUpgrade": "Vorhandenes Upgrade verknüpfen",
+            "history": "Verlauf"
           },
           "new": "Neues Modell",
           "show": "Modell",
@@ -51,7 +52,8 @@
           "new": "Neue Komponente",
           "edit": {
             "index": "Komponente bearbeiten",
-            "itemPrices": "Artikelpreise"
+            "itemPrices": "Artikelpreise",
+            "history": "Verlauf"
           }
         },
         "modelPaints": {
@@ -64,7 +66,8 @@
           "new": "Neues Modul",
           "edit": "Modul bearbeiten",
           "models": "Verknüpfte Modelle",
-          "prices": "Preise"
+          "prices": "Preise",
+          "history": "Verlauf"
         },
         "unlistedModels": {
           "index": "Schiffe in den Spieldateien ohne Model",
@@ -98,7 +101,8 @@
         "fleets": {
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
-          "memberEdit": "Mitglied bearbeiten"
+          "memberEdit": "Mitglied bearbeiten",
+          "history": "Verlauf"
         },
         "admins": {
           "index": "Administratoren",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1240,6 +1240,17 @@
             "rsi-api-status": "RSI-API-Status",
             "stats": "Statistiken"
           }
+        },
+        "versions": {
+          "blank": "leer",
+          "revertQuestion": "Zurücksetzen?",
+          "sources": {
+            "custom": "Admin",
+            "rsi_loader": "Ship Matrix",
+            "sc_data_loader": "Spieldateien",
+            "sc_loader": "Spieldateien",
+            "unknown": "Unbekannt"
+          }
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1249,6 +1249,7 @@
             "rsi_loader": "Ship Matrix",
             "sc_data_loader": "Spieldateien",
             "sc_loader": "Spieldateien",
+            "uex_price_sync": "UEX-Preisabgleich",
             "unknown": "Unbekannt"
           }
         }

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -122,7 +122,8 @@
             "hardpoints": "Aufhängungspunkte",
             "loaners": "Leihschiffe",
             "upgrades": "Upgrades",
-            "packages": "Pakete"
+            "packages": "Pakete",
+            "history": "Verlauf"
           }
         },
         "modelPaints": {
@@ -135,7 +136,8 @@
           "edit": {
             "index": "Basisdaten",
             "models": "Modelle",
-            "prices": "Preise"
+            "prices": "Preise",
+            "history": "Verlauf"
           }
         },
         "unlistedModels": {
@@ -149,7 +151,8 @@
           "index": "Komponenten",
           "edit": {
             "index": "Basisdaten",
-            "prices": "Preise"
+            "prices": "Preise",
+            "history": "Verlauf"
           }
         },
         "manufacturers": {
@@ -164,7 +167,8 @@
           "fleets": "Flotten"
         },
         "fleets": {
-          "index": "Flotten"
+          "index": "Flotten",
+          "history": "Verlauf"
         },
         "vehicles": {
           "index": "Fahrzeuge"

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -133,7 +133,8 @@
             "loaners": "Modell Leihgaben bearbeiten",
             "snubCrafts": "Modell Snub Crafts bearbeiten",
             "upgrades": "Modell Upgrades bearbeiten",
-            "packages": "Modell Pakete bearbeiten"
+            "packages": "Modell Pakete bearbeiten",
+            "history": "%{manufacturer} %{model} Verlauf"
           }
         },
         "components": {
@@ -141,7 +142,8 @@
           "new": "Neue Komponente",
           "edit": {
             "index": "Komponente bearbeiten",
-            "prices": "Komponente Preise bearbeiten"
+            "prices": "Komponente Preise bearbeiten",
+            "history": "Komponenten-Verlauf"
           }
         },
         "manufacturers": {
@@ -174,7 +176,8 @@
         "fleets": {
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
-          "memberEdit": "Flottenmitglied bearbeiten"
+          "memberEdit": "Flottenmitglied bearbeiten",
+          "history": "Flotten-Verlauf"
         },
         "oauthApplications": {
           "index": "OAuth-Anwendungen",
@@ -208,7 +211,8 @@
           "edit": {
             "index": "%{name} Basisdaten bearbeiten",
             "models": "%{name} Modelle bearbeiten",
-            "prices": "%{name} Preise bearbeiten"
+            "prices": "%{name} Preise bearbeiten",
+            "history": "Modul-Verlauf"
           }
         },
         "unlistedModels": {

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -381,7 +381,8 @@
         "noManufacturer": "No manufacturer resolves from this identifier",
         "alreadyExists": "%{name} is already in the catalogue",
         "link": "Already in the catalogue"
-      }
+      },
+      "revert": "Revert"
     }
   }
 }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -41,7 +41,8 @@
             "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
             "packages": "Packages",
-            "linkUpgrade": "Link Existing Upgrade"
+            "linkUpgrade": "Link Existing Upgrade",
+            "history": "History"
           },
           "new": "New Model",
           "show": "Model",
@@ -53,7 +54,8 @@
           "new": "New Component",
           "edit": {
             "index": "Edit Component",
-            "itemPrices": "Item Prices"
+            "itemPrices": "Item Prices",
+            "history": "History"
           }
         },
         "modelPaints": {
@@ -70,7 +72,8 @@
           "models": "Linked Models",
           "prices": "Prices",
           "hardpoints": "Hardpoints",
-          "cargoHolds": "Cargo Holds"
+          "cargoHolds": "Cargo Holds",
+          "history": "History"
         },
         "unlistedModels": {
           "index": "Ships in the game files with no model",
@@ -105,7 +108,8 @@
           "index": "Fleets",
           "edit": "Edit Fleet",
           "members": "Members",
-          "memberEdit": "Edit Member"
+          "memberEdit": "Edit Member",
+          "history": "History"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1722,6 +1722,17 @@
             "rsi-api-status": "RSI API Status",
             "stats": "Stats"
           }
+        },
+        "versions": {
+          "blank": "empty",
+          "revertQuestion": "Revert?",
+          "sources": {
+            "custom": "Admin",
+            "rsi_loader": "Ship Matrix",
+            "sc_data_loader": "Game Files",
+            "sc_loader": "Game Files",
+            "unknown": "Unknown"
+          }
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1731,6 +1731,7 @@
             "rsi_loader": "Ship Matrix",
             "sc_data_loader": "Game Files",
             "sc_loader": "Game Files",
+            "uex_price_sync": "UEX Price Sync",
             "unknown": "Unknown"
           }
         }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -155,7 +155,8 @@
             "loaners": "Loaners",
             "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
-            "packages": "Packages"
+            "packages": "Packages",
+            "history": "History"
           }
         },
         "modelPaints": {
@@ -170,7 +171,8 @@
             "models": "Models",
             "prices": "Prices",
             "hardpoints": "Hardpoints",
-            "cargoHolds": "Cargo Holds"
+            "cargoHolds": "Cargo Holds",
+            "history": "History"
           }
         },
         "unlistedModels": {
@@ -184,7 +186,8 @@
           "index": "Components",
           "edit": {
             "index": "Base Data",
-            "prices": "Prices"
+            "prices": "Prices",
+            "history": "History"
           }
         },
         "manufacturers": {
@@ -201,7 +204,8 @@
         "fleets": {
           "index": "Fleets",
           "edit": "Edit",
-          "members": "Members"
+          "members": "Members",
+          "history": "History"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -165,7 +165,8 @@
             "loaners": "Edit %{manufacturer} %{model} Loaners",
             "snubCrafts": "Edit %{manufacturer} %{model} Snub Crafts",
             "upgrades": "Edit %{manufacturer} %{model} Upgrades",
-            "packages": "Edit %{manufacturer} %{model} Packages"
+            "packages": "Edit %{manufacturer} %{model} Packages",
+            "history": "Edit %{manufacturer} %{model} History"
           }
         },
         "components": {
@@ -173,7 +174,8 @@
           "new": "New Component",
           "edit": {
             "index": "Edit Component",
-            "prices": "Edit Component Prices"
+            "prices": "Edit Component Prices",
+            "history": "Edit Component History"
           }
         },
         "manufacturers": {
@@ -207,7 +209,8 @@
           "index": "Fleets",
           "edit": "Edit Fleet",
           "members": "Fleet Members",
-          "memberEdit": "Edit Fleet Member"
+          "memberEdit": "Edit Fleet Member",
+          "history": "Fleet History"
         },
         "oauthApplications": {
           "index": "OAuth Applications",
@@ -246,7 +249,8 @@
             "models": "Edit %{name} Models",
             "prices": "Edit %{name} Prices",
             "hardpoints": "Edit %{name} Hardpoints",
-            "cargoHolds": "Edit %{name} Cargo Holds"
+            "cargoHolds": "Edit %{name} Cargo Holds",
+            "history": "Edit Module History"
           }
         },
         "unlistedModels": {

--- a/app/jobs/loaders/models_job.rb
+++ b/app/jobs/loaders/models_job.rb
@@ -32,23 +32,72 @@ module Loaders
     end
 
     # `Rsi::ModelsLoader` returns nothing countable, so the run is measured on
-    # either side of it. New models are named because that is the part of the
-    # report worth reading; an update is a field nobody can name from here.
+    # either side of it. Both sides of the change are named, because a matrix
+    # that moves a few times a month makes "1 model updated" a question rather
+    # than a report.
     private def results_body(started_at)
       added = Model.where(created_at: started_at..).order(:name)
-      updated = Model.where(updated_at: started_at..).where(created_at: ...started_at).count
+      updated = Model.where(updated_at: started_at..).where(created_at: ...started_at).order(:name)
 
       lines = [
         "## Ship Matrix Import",
         "",
         "- **Models added**: #{added.count}",
-        "- **Models updated**: #{updated}",
+        "- **Models updated**: #{updated.count}",
         "- **Models in total**: #{Model.count}"
       ]
 
-      return lines.join("\n") if added.empty?
+      lines += ["", "### Added", "", *added.map { |model| "- **#{model.name}**" }] if added.any?
 
-      (lines + ["", "### Added", "", *added.map { |model| "- **#{model.name}**" }]).join("\n")
+      if updated.any?
+        changed_fields = changed_fields_by_model(started_at)
+
+        lines += ["", "### Updated", "", *updated.map { |model| updated_line(model, changed_fields[model.id]) }]
+      end
+
+      lines.join("\n")
+    end
+
+    private def updated_line(model, fields)
+      return "- **#{model.name}**" if fields.blank?
+
+      adopted, matrix_only = split_fields(fields)
+
+      return "- **#{model.name}**: matrix only: #{matrix_only.join(", ")}" if adopted.empty?
+
+      line = "- **#{model.name}**: #{adopted.join(", ")}"
+
+      return line if matrix_only.empty?
+
+      "#{line} (matrix only: #{matrix_only.join(", ")})"
+    end
+
+    # A shadow that moved with its live column is one change, named once. A
+    # shadow that moved alone is the matrix offering a value the loader's guards
+    # refused -- named under the live column it was offered for, because that is
+    # the value an admin would go looking at.
+    private def split_fields(fields)
+      shadow, adopted = fields.partition { |field| field.start_with?("rsi_") }
+
+      matrix_only = shadow.filter_map { |field|
+        offered_for = field.delete_prefix("rsi_")
+
+        next if adopted.include?(offered_for)
+
+        Model.column_names.include?(offered_for) ? offered_for : field
+      }
+
+      [adopted, matrix_only.uniq.sort]
+    end
+
+    # paper_trail watches every column this loader writes except `last_updated_at`
+    # and the store image, which move on nearly every matrix change and carry no
+    # value of their own. A run that touched only those is named without fields.
+    private def changed_fields_by_model(started_at)
+      PaperTrail::Version
+        .where(item_type: "Model", created_at: started_at..)
+        .group_by(&:item_id)
+        .transform_values { |versions| versions.flat_map { |version| version.changeset.keys }.uniq.sort }
     end
   end
 end

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -13,6 +13,16 @@
 # holder is polymorphic, which is why the policy is looked up from the record
 # the walk lands on rather than from the item type it started at.
 class VersionedItem
+  # paper_trail 17 defaults `on` to %i[create update destroy touch], and a touch
+  # can never record `object_changes` -- rails' `touch` skips dirty-tracking, so
+  # `Events::Update#record_object_changes?` returns false for one. It files the
+  # version anyway, which leaves a row whose changeset is empty.
+  #
+  # Fleet has seven `belongs_to :fleet, touch: true` children, so an event, a
+  # membership or a role write files a fleet version that says nothing: 572,735
+  # of its 573,199 update versions are that, against 464 real edits.
+  RECORDED_EVENTS = %i[create update destroy].freeze
+
   ROOTS = {
     "Component" => [],
     "Fleet" => [],

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# The catalogues paper_trail watches, and what an admin has to be allowed to see
+# before a version of one is readable.
+#
+# An endpoint that took any `item_type` from the request would let a caller read
+# -- and revert -- a row in any table paper_trail ever touched, so the list is
+# explicit rather than derived from the class name it was handed.
+#
+# Six of the ten have no admin page and no policy of their own. They are
+# authorised through the record that does: a fleet's roles, memberships and
+# inventories through the fleet, an inventory through whoever holds it. That
+# holder is polymorphic, which is why the policy is looked up from the record
+# the walk lands on rather than from the item type it started at.
+class VersionedItem
+  ROOTS = {
+    "Component" => [],
+    "Fleet" => [],
+    "FleetInventory" => [:fleet],
+    "FleetInventoryItem" => [:fleet_inventory, :fleet],
+    "FleetMembership" => [:fleet],
+    "FleetRole" => [:fleet],
+    "Inventory" => [:holder],
+    "InventoryItem" => [:inventory, :holder],
+    "Model" => [],
+    "ModelModule" => []
+  }.freeze
+
+  TYPES = ROOTS.keys.freeze
+
+  POLICIES = {
+    "Component" => ::Admin::ComponentPolicy,
+    "Fleet" => ::Admin::FleetPolicy,
+    "Model" => ::Admin::ModelPolicy,
+    "ModelModule" => ::Admin::ModelModulePolicy,
+    "User" => ::Admin::UserPolicy
+  }.freeze
+
+  def self.supported?(item_type)
+    TYPES.include?(item_type)
+  end
+
+  # A missing or unlisted `item_type` is answered the same way a missing id is:
+  # there is no such item to read a history for.
+
+  def self.find(item_type, item_id)
+    raise ActiveRecord::RecordNotFound unless supported?(item_type)
+
+    item_type.constantize.find(item_id)
+  end
+
+  # The record whose policy decides, and that policy. A chain that runs into a
+  # `nil` -- an inventory whose holder was deleted -- has no root to ask, and a
+  # root of a class nobody wrote an admin policy for is the same answer: no.
+  def self.authorization_root(item)
+    root = ROOTS.fetch(item.class.name, nil)&.reduce(item) { |record, association| record&.public_send(association) }
+
+    return if root.blank?
+
+    policy = POLICIES[root.class.name]
+
+    return if policy.blank?
+
+    [root, policy]
+  end
+end

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -54,7 +54,7 @@ class Fleet < ApplicationRecord
     member: []
   }.freeze
 
-  has_paper_trail meta: {
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS, meta: {
     author_id: :author_id,
     reason: :update_reason,
     reason_description: :update_reason_description

--- a/app/models/fleet_inventory.rb
+++ b/app/models/fleet_inventory.rb
@@ -30,7 +30,7 @@ class FleetInventory < ApplicationRecord
   include ActiveStorageVariants
   include InventoryStock
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/fleet_inventory_item.rb
+++ b/app/models/fleet_inventory_item.rb
@@ -34,7 +34,7 @@
 class FleetInventoryItem < ApplicationRecord
   include InventoryLedgerEntry
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -54,7 +54,7 @@ class FleetMembership < ApplicationRecord
     member: ["fleet:memberships:read"]
   }.freeze
 
-  has_paper_trail meta: {
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS, meta: {
     author_id: :author_id,
     reason: :update_reason,
     reason_description: :update_reason_description

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -25,7 +25,7 @@ require "lexorank/rankable"
 class FleetRole < ApplicationRecord
   include ResourceAccessConcern
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   belongs_to :fleet, touch: true
   has_many :fleet_memberships,

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -30,7 +30,7 @@ class Inventory < ApplicationRecord
   include ActiveStorageVariants
   include InventoryStock
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -29,7 +29,7 @@
 class InventoryItem < ApplicationRecord
   include InventoryLedgerEntry
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -134,7 +134,21 @@ class Model < ApplicationRecord
 
   attr_accessor :update_reason, :update_reason_description, :author_id
 
+  # `name`, `description` and `ground` are here because an admin can edit all
+  # three, not because the ship matrix writes them -- an edit with no history is
+  # the gap, and the loader's own report reading them is the second reason.
+  #
+  # The `rsi_*` shadow columns are watched because they are **not** the live
+  # column read twice: `mass` differs from `rsi_mass` on 196 of 246 models, and
+  # `max_speed`, `pitch`, `yaw` and `roll` on 188. `Rsi::ModelsLoader` writes a
+  # shadow on every run but the live column only when RSI moved `time_modified`
+  # and the new value is not blank -- so a shadow that moves alone is the matrix
+  # saying something we did not adopt, which nothing else records.
   has_paper_trail on: %i[update], only: %i[
+    name description ground
+    rsi_id rsi_chassis_id rsi_name rsi_description rsi_classification rsi_focus rsi_size rsi_store_url
+    rsi_length rsi_beam rsi_height rsi_mass rsi_cargo rsi_min_crew rsi_max_crew
+    rsi_scm_speed rsi_max_speed rsi_pitch rsi_yaw rsi_roll
     classification production_status production_note focus pledge_price length beam height mass
     cargo personal_inventory size min_crew max_crew scm_speed max_speed ground_max_speed ground_reverse_speed
     ground_acceleration ground_decceleration pitch yaw roll price

--- a/app/services/versions/field_reverter.rb
+++ b/app/services/versions/field_reverter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Versions
+  # Puts one field of one record back to the value a version recorded before it.
+  #
+  # One field rather than the whole version, because a version written by a
+  # loader usually carries a dozen fields an admin has no quarrel with -- the
+  # matrix moving `mass` and `cargo` together, when only `mass` was wrong.
+  class FieldReverter
+    Result = Struct.new(:record, :field, :from, :to) do
+      def missing? = record.blank?
+
+      def success? = record.present? && record.errors.empty?
+    end
+
+    def initialize(version, field, author_id: nil)
+      @version = version
+      @field = field.to_s
+      @author_id = author_id
+    end
+
+    def run
+      return Result.new(nil, @field) if record.blank?
+
+      return failure(:unknown_field) unless reversible?
+
+      before, after = @version.changeset.fetch(@field)
+      before = cast(before)
+
+      return failure(:already_reverted) if record.public_send(@field) == before
+
+      write(before)
+
+      Result.new(record, @field, cast(after), before)
+    end
+
+    # Only a field the version actually recorded a change for, and only one the
+    # record still has -- a changeset survives a migration that drops its column.
+    #
+    # Only an update, too. Six of the ten catalogues track creates as well, and a
+    # create's changeset reads as "every column, from nothing" -- reverting one
+    # is not undoing a change, it is blanking a column that never had a previous
+    # value.
+    private def reversible?
+      @version.event == "update" &&
+        @version.changeset.key?(@field) &&
+        record.class.column_names.include?(@field)
+    end
+
+    # A changeset is JSON, so a decimal comes back as a string and would never
+    # equal the column it is being compared against.
+    private def cast(value)
+      record.class.type_for_attribute(@field).cast(value)
+    end
+
+    private def record
+      return @record if defined?(@record)
+
+      @record = @version.item
+    end
+
+    # An admin correction to a Model has to reach the build as well as the row,
+    # which is what `update_with_facts` is for. Nothing else in this list keeps
+    # its facts anywhere but its own columns.
+    private def write(value)
+      attributes = {@field => value}.merge(meta)
+
+      return record.update_with_facts(attributes) if record.respond_to?(:update_with_facts)
+
+      record.update(attributes)
+    end
+
+    # Four of the ten declare paper_trail meta, so the version this revert writes
+    # says who did it and why. The other six have nowhere to put that.
+    private def meta
+      return {} unless record.respond_to?(:update_reason=)
+
+      {
+        author_id: @author_id,
+        update_reason: :custom,
+        update_reason_description: "Reverted #{@field}"
+      }
+    end
+
+    private def failure(code)
+      # On `:base` rather than the field: `full_message` prefixes a humanised
+      # attribute name, and "field" is not one this record has.
+      record.errors.add(:base, code, message: I18n.t(:"validation_error.version.#{code}"))
+
+      Result.new(record, @field)
+    end
+  end
+end

--- a/app/tasks/maintenance/drop_changeless_versions_task.rb
+++ b/app/tasks/maintenance/drop_changeless_versions_task.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Drops the versions paper_trail filed for a `touch`.
+  #
+  # Rails' `touch` does no dirty-tracking, so `Events::Update#record_object_changes?`
+  # returns false for one and the row is written with no `object_changes` at all.
+  # There is nothing in it to show and nothing to put back -- the admin history
+  # rendered each as a heading with an empty body.
+  #
+  # `Fleet` and the six models beside it now name their events without `:touch`,
+  # so no more are written. This clears the 572,773 already on disk: 572,735 on
+  # `Fleet`, whose seven `touch: true` children filed one per write, and 38 on
+  # `FleetInventory`. Both had roughly a thousand of these per real edit.
+  #
+  # A maintenance task rather than a data migration: it destroys rows and cannot
+  # be undone, and `data:migrate` runs unattended on every deploy. Here it is run
+  # deliberately, once per environment, with `dry_run` first.
+  #
+  # It clears nine rows in ten, so follow it with `VACUUM ANALYZE versions` for
+  # the planner's sake rather than waiting for autovacuum. That marks the space
+  # reusable without returning it to the disk; only `VACUUM FULL` does that, and
+  # it holds an exclusive lock for the rewrite.
+  class DropChangelessVersionsTask < MaintenanceTasks::Task
+    no_collection
+
+    # Small enough that a cancelled run leaves a short statement behind, large
+    # enough that the whole set is a few hundred of them.
+    BATCH_SIZE = 5_000
+
+    # Left on by default so an accidental run reports instead of destroying.
+    attribute :dry_run, :boolean, default: true
+
+    # `old_object_changes` is the pre-json column, empty on every row in this
+    # database. A row that did carry one would be real history that predates the
+    # migration, so the guard keeps it out of scope rather than trusting that.
+    #
+    # `create` and `destroy` are excluded for the same reason: paper_trail always
+    # records a changeset for them, so one arriving here without would be a row
+    # this task does not understand.
+    def self.changeless
+      PaperTrail::Version.where(event: "update", object_changes: nil, old_object_changes: nil)
+    end
+
+    def process
+      dry_run ? report_plan : apply
+    end
+
+    private def apply
+      before = self.class.changeless.count
+      deleted = 0
+
+      self.class.changeless.in_batches(of: BATCH_SIZE) { |batch| deleted += batch.delete_all }
+
+      log "deleted #{deleted} of #{before} changeless versions"
+      log "versions left: #{PaperTrail::Version.count}"
+    end
+
+    private def report_plan
+      scope = self.class.changeless
+
+      scope.group(:item_type).count.sort.each do |item_type, count|
+        log "#{item_type}: #{count} changeless of #{PaperTrail::Version.where(item_type:).count}"
+      end
+
+      log "changeless versions: #{scope.count} of #{PaperTrail::Version.count}"
+      log "dry run -- nothing was deleted"
+    end
+
+    # The task's log is its output in the UI, which is stdout for this engine.
+    private def log(message)
+      puts message
+    end
+  end
+end

--- a/app/views/admin/api/v1/versions/_version.jbuilder
+++ b/app/views/admin/api/v1/versions/_version.jbuilder
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+json.id version.id
+
+json.item_id version.item_id
+json.item_type version.item_type
+
+json.event version.event
+json.reason version.reason
+json.reason_description version.reason_description
+
+json.author do
+  author = @authors[version.author_id]
+
+  if author.present?
+    json.id author.id
+    json.username author.username
+  else
+    json.nil!
+  end
+end
+
+json.changes do
+  json.array!(version.changeset.sort) do |field, (from, to)|
+    json.field field
+    json.from from.to_s.presence
+    json.to to.to_s.presence
+  end
+end
+
+json.created_at version.created_at

--- a/app/views/admin/api/v1/versions/index.jbuilder
+++ b/app/views/admin/api/v1/versions/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @versions, partial: "admin/api/v1/versions/version", as: :version
+end
+json.partial! "api/shared/meta", result: @versions

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -1,6 +1,10 @@
 ---
 de:
   validation_error:
+    version:
+      revert: Feld konnte nicht zurückgesetzt werden.
+      unknown_field: Diese Version hat dieses Feld nicht geändert.
+      already_reverted: Das Feld hat bereits den Wert, den diese Version ersetzt hat.
     sc_data_unlisted_model:
       link: Schiff konnte nicht mit dem Katalog verknüpft werden.
       create_model: Schiff konnte nicht aus den Spieldateien angelegt werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -1,6 +1,10 @@
 ---
 en:
   validation_error:
+    version:
+      revert: Field could not be reverted.
+      unknown_field: This version did not change that field.
+      already_reverted: The field already holds the value this version replaced.
     sc_data_unlisted_model:
       link: Ship could not be linked to the catalogue.
       create_model: Ship could not be created from the game files.

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -132,6 +132,12 @@ v1_admin_api_routes = lambda do
 
   resources :item_prices, path: "item-prices", only: %i[index show create update destroy]
 
+  resources :versions, only: %i[index] do
+    member do
+      put "revert" => "versions#revert"
+    end
+  end
+
   resource :stats, only: [] do
     get "quick-stats" => "stats#quick_stats"
     get "most-viewed-pages" => "stats#most_viewed_pages"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7418,6 +7418,104 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/versions":
+    get:
+      summary: Versions list
+      tags:
+      - Versions
+      operationId: versions
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+        required: false
+      - name: itemType
+        in: query
+        schema:
+          "$ref": "#/components/schemas/VersionItemTypeEnum"
+        required: true
+      - name: itemId
+        in: query
+        schema:
+          type: string
+          format: uuid
+        required: true
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Versions"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/versions/{id}/revert":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: id
+      required: true
+    put:
+      summary: Revert one field of a version
+      tags:
+      - Versions
+      operationId: revertVersion
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/VersionRevertInput"
+      responses:
+        '204':
+          description: successful
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/videos":
     post:
       summary: Create new Video
@@ -15380,6 +15478,115 @@ components:
       - meta
       - items
       title: Vehicles
+    Version:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        itemId:
+          type: string
+          format: uuid
+        itemType:
+          "$ref": "#/components/schemas/VersionItemTypeEnum"
+        event:
+          type: string
+        reason:
+          type: string
+          nullable: true
+        reasonDescription:
+          type: string
+          nullable: true
+        author:
+          "$ref": "#/components/schemas/VersionAuthor"
+        changes:
+          type: array
+          items:
+            "$ref": "#/components/schemas/VersionChange"
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - id
+      - itemId
+      - itemType
+      - event
+      - changes
+      title: Version
+    VersionAuthor:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      required:
+      - id
+      - username
+      title: VersionAuthor
+    VersionChange:
+      type: object
+      properties:
+        field:
+          type: string
+        from:
+          type: string
+          nullable: true
+        to:
+          type: string
+          nullable: true
+      required:
+      - field
+      title: VersionChange
+    VersionItemTypeEnum:
+      type: string
+      enum:
+      - Component
+      - Fleet
+      - FleetInventory
+      - FleetInventoryItem
+      - FleetMembership
+      - FleetRole
+      - Inventory
+      - InventoryItem
+      - Model
+      - ModelModule
+      x-enumNames:
+      - COMPONENT
+      - FLEET
+      - FLEET_INVENTORY
+      - FLEET_INVENTORY_ITEM
+      - FLEET_MEMBERSHIP
+      - FLEET_ROLE
+      - INVENTORY
+      - INVENTORY_ITEM
+      - MODEL
+      - MODEL_MODULE
+      title: VersionItemTypeEnum
+    VersionRevertInput:
+      type: object
+      properties:
+        field:
+          type: string
+      required:
+      - field
+      title: VersionRevertInput
+    Versions:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Version"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: Versions
     Video:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -15492,11 +15492,13 @@ components:
         event:
           type: string
         reason:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         reasonDescription:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         author:
           "$ref": "#/components/schemas/VersionAuthor"
         changes:
@@ -15504,9 +15506,10 @@ components:
           items:
             "$ref": "#/components/schemas/VersionChange"
         createdAt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
       required:
       - id
       - itemId
@@ -15532,11 +15535,13 @@ components:
         field:
           type: string
         from:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         to:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
       required:
       - field
       title: VersionChange

--- a/test/integration/admin/api/v1/versions_test.rb
+++ b/test/integration/admin/api/v1/versions_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::VersionsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/versions" do
+    get("Versions list") do
+      operationId "versions"
+      tags "Versions"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string}, required: false
+      parameter name: "itemType", in: :query, schema: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum, required: true
+      parameter name: "itemId", in: :query, schema: {type: :string, format: :uuid}, required: true
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::Versions
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/versions/{id}/revert" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    put("Revert one field of a version") do
+      operationId "revertVersion"
+      tags "Versions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::VersionRevertInput
+
+      response(204, "successful") do
+        schema nil
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:models])
+    @model = create(:model, name: "Carrack", cargo: 456)
+    @model.update!(cargo: 400)
+    @version = @model.versions.last
+  end
+
+  def list_params(item = nil)
+    item ||= @model
+
+    {itemType: item.class.name, itemId: item.id}
+  end
+
+  # GET list
+  test "GET /versions lists the history of one item" do
+    sign_in @user
+
+    assert_api_response :get, 200, params: list_params do
+      assert_equal 1, parsed_body["items"].count
+      assert_equal [{"field" => "cargo", "from" => "456.0", "to" => "400.0"}], parsed_body["items"].first["changes"]
+    end
+  end
+
+  test "GET /versions returns 404 for a missing id" do
+    sign_in @user
+
+    assert_api_response :get, 404, params: {itemType: "Model", itemId: "00000000-0000-0000-0000-000000000000"}
+  end
+
+  test "GET /versions returns 401 when not signed in" do
+    assert_api_response :get, 401, params: list_params
+  end
+
+  test "GET /versions returns 403 for an admin without access to the item" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, params: list_params
+  end
+
+  # A fleet's roles and inventories have no admin page of their own, so the
+  # fleet's access is what decides.
+  test "GET /versions authorises a fleet role through its fleet" do
+    role = create(:fleet_role, name: "Quartermaster")
+    role.update!(name: "Bosun")
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :get, 200, params: list_params(role) do
+      assert_equal role.versions.count, parsed_body["items"].count
+    end
+  end
+
+  test "GET /versions returns 403 for a fleet role without fleet access" do
+    role = create(:fleet_role, name: "Quartermaster")
+    role.update!(name: "Bosun")
+    sign_in @user
+
+    assert_api_response :get, 403, params: list_params(role)
+  end
+
+  # PUT revert
+  test "PUT /versions/:id/revert puts one field back" do
+    sign_in @user
+
+    assert_api_response :put, 204, path_params: {id: @version.id}, body: {field: "cargo"} do
+      assert_equal 456, @model.reload.cargo
+    end
+  end
+
+  test "PUT /versions/:id/revert records who reverted it and why" do
+    sign_in @user
+
+    assert_api_response :put, 204, path_params: {id: @version.id}, body: {field: "cargo"} do
+      reverting = @model.reload.versions.last
+
+      assert_equal @user.id, reverting.author_id
+      assert_equal "custom", reverting.reason
+      assert_equal "Reverted cargo", reverting.reason_description
+    end
+  end
+
+  test "PUT /versions/:id/revert returns 400 for a field the version never changed" do
+    sign_in @user
+
+    assert_api_response :put, 400, path_params: {id: @version.id}, body: {field: "mass"}
+  end
+
+  test "PUT /versions/:id/revert returns 400 when the value is already back" do
+    @model.update!(cargo: 456)
+    sign_in @user
+
+    assert_api_response :put, 400, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+
+  # Six of the ten track creates too, and a create's changeset is every column
+  # from nothing -- there is no previous value to go back to.
+  test "PUT /versions/:id/revert returns 400 for a create version" do
+    role = create(:fleet_role, name: "Quartermaster")
+    creation = role.versions.find_by(event: "create")
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :put, 400, path_params: {id: creation.id}, body: {field: "name"}
+  end
+
+  test "PUT /versions/:id/revert returns 404 for a missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, path_params: {id: "00000000-0000-0000-0000-000000000000"}, body: {field: "cargo"}
+  end
+
+  test "PUT /versions/:id/revert returns 401 when not signed in" do
+    assert_api_response :put, 401, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+
+  test "PUT /versions/:id/revert returns 403 for an admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+end

--- a/test/integration/admin/api/v1/versions_test.rb
+++ b/test/integration/admin/api/v1/versions_test.rb
@@ -92,6 +92,21 @@ class Admin::Api::V1::VersionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The touch versions paper_trail already filed have no `object_changes` at all,
+  # so there is nothing to show for one -- it rendered as a heading with an empty
+  # body. Fixing the recording does not remove the 572,735 already on disk.
+  test "GET /versions skips a version that recorded no changes" do
+    fleet = create(:fleet, created_by: create(:user).id)
+    fleet.update!(description: "A crew")
+    PaperTrail::Version.create!(item_type: "Fleet", item_id: fleet.id, event: "update", object_changes: nil)
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :get, 200, params: list_params(fleet) do
+      assert_equal 2, parsed_body["items"].count
+      assert_empty parsed_body["items"].select { |version| version["changes"].empty? }
+    end
+  end
+
   test "GET /versions returns 404 for a missing id" do
     sign_in @user
 

--- a/test/jobs/loaders/models_job_test.rb
+++ b/test/jobs/loaders/models_job_test.rb
@@ -50,6 +50,62 @@ module Loaders
       assert_includes notification.body, "Spirit C1"
     end
 
+    test "#perform names the models the run updated, and the fields that moved" do
+      model = create(:model, name: "Carrack", cargo: 456)
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(cargo: 400)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Carrack**: cargo"
+    end
+
+    # The matrix writes `rsi_mass` on every run but `mass` only when RSI moved
+    # `time_modified`, so a shadow moving alone is a value we declined.
+    test "#perform separates a matrix value the run did not adopt" do
+      model = create(:model, name: "Idris P", mass: 40_000, rsi_mass: 40_000, cargo: 100)
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(rsi_mass: 52_000, cargo: 120, rsi_cargo: 120)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Idris P**: cargo (matrix only: mass)"
+    end
+
+    # The loader also writes `last_updated_at` and the store image, neither of
+    # which paper_trail watches. Such a run still has a model to name.
+    test "#perform names an updated model paper_trail did not watch" do
+      model = create(:model, name: "Carrack")
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(last_updated_at: Time.current)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Carrack**"
+      assert_not_includes notification.body, "- **Carrack**:"
+    end
+
     test "#perform creates an import, runs the loader, and finishes the import" do
       assert_import_wrapping_job_success(
         job_class: ::Loaders::ModelsJob,

--- a/test/lib/versioned_item_test.rb
+++ b/test/lib/versioned_item_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VersionedItemTest < ActiveSupport::TestCase
+  test "#find raises for a type paper_trail does not watch" do
+    admin_user = create(:admin_user)
+
+    assert_raises(ActiveRecord::RecordNotFound) { VersionedItem.find("AdminUser", admin_user.id) }
+  end
+
+  test "#find raises for a blank type" do
+    assert_raises(ActiveRecord::RecordNotFound) { VersionedItem.find(nil, nil) }
+  end
+
+  test "#authorization_root resolves a catalogue to itself" do
+    model = create(:model)
+
+    assert_equal [model, ::Admin::ModelPolicy], VersionedItem.authorization_root(model)
+  end
+
+  test "#authorization_root resolves a fleet role to its fleet" do
+    role = create(:fleet_role, name: "Quartermaster")
+
+    assert_equal [role.fleet, ::Admin::FleetPolicy], VersionedItem.authorization_root(role)
+  end
+
+  test "#authorization_root resolves an inventory item to whoever holds the inventory" do
+    user = create(:user)
+    inventory = create(:inventory, holder: user)
+    item = create(:inventory_item, inventory:)
+
+    assert_equal [user, ::Admin::UserPolicy], VersionedItem.authorization_root(item)
+  end
+
+  # A holder that was deleted leaves nothing to ask, which is a denial rather
+  # than a crash.
+  test "#authorization_root is nil when the chain runs out" do
+    assert_nil VersionedItem.authorization_root(Inventory.new)
+  end
+end

--- a/test/models/fleet_test.rb
+++ b/test/models/fleet_test.rb
@@ -57,6 +57,35 @@ class FleetTest < ActiveSupport::TestCase
     assert_equal 3, fleet.fleet_roles.reload.count
   end
 
+  # A fleet is touched by seven of its children, and rails' `touch` skips
+  # dirty-tracking -- so paper_trail files the version with no `object_changes`
+  # at all. Those are the ones the admin history showed as an empty heading.
+  class VersioningTest < FleetTest
+    setup do
+      @fleet = create(:fleet, created_by: create(:user).id)
+    end
+
+    test "a touch records no version" do
+      assert_no_difference -> { @fleet.versions.count } do
+        @fleet.touch
+      end
+    end
+
+    test "a child write that touches the fleet records no fleet version" do
+      assert_no_difference -> { @fleet.versions.count } do
+        @fleet.fleet_roles.first.update!(name: "Quartermaster")
+      end
+    end
+
+    test "a real edit still records a version with its changes" do
+      assert_difference -> { @fleet.versions.count }, 1 do
+        @fleet.update!(description: "A crew")
+      end
+
+      assert_equal [nil, "A crew"], @fleet.versions.last.changeset["description"]
+    end
+  end
+
   class UrlValidationTest < FleetTest
     setup do
       user = create(:user)

--- a/test/tasks/maintenance/drop_changeless_versions_task_test.rb
+++ b/test/tasks/maintenance/drop_changeless_versions_task_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class DropChangelessVersionsTaskTest < ActiveSupport::TestCase
+    setup do
+      PaperTrail::Version.delete_all
+
+      @fleet = create(:fleet, created_by: create(:user).id)
+      @fleet.update!(description: "A crew")
+      @real = @fleet.versions.last
+      @changeless = changeless_version_for(@fleet)
+    end
+
+    # An accidental run has to report rather than destroy, so the safe mode is
+    # the one you get by not choosing.
+    test "dry_run is on unless it is turned off" do
+      assert_predicate ::Maintenance::DropChangelessVersionsTask.new, :dry_run
+    end
+
+    test "#process leaves every row in place on a dry run" do
+      assert_no_difference -> { PaperTrail::Version.count } do
+        run_task(dry_run: true)
+      end
+    end
+
+    test "#process reports what it would do on a dry run" do
+      output = run_task(dry_run: true)
+
+      assert_includes output, "Fleet: 1 changeless of #{PaperTrail::Version.where(item_type: "Fleet").count}"
+      assert_includes output, "changeless versions: 1 of #{PaperTrail::Version.count}"
+      assert_includes output, "dry run"
+    end
+
+    test "#process drops the changeless version when the dry run is turned off" do
+      assert_difference -> { PaperTrail::Version.count }, -1 do
+        run_task(dry_run: false)
+      end
+
+      assert_nil PaperTrail::Version.find_by(id: @changeless.id)
+    end
+
+    test "#process drops every changeless version, not just the first" do
+      3.times { changeless_version_for(@fleet) }
+
+      assert_difference -> { PaperTrail::Version.count }, -4 do
+        run_task(dry_run: false)
+      end
+
+      assert_empty ::Maintenance::DropChangelessVersionsTask.changeless
+    end
+
+    test "#process keeps a version that recorded changes" do
+      run_task(dry_run: false)
+
+      assert PaperTrail::Version.exists?(@real.id)
+      assert_equal [nil, "A crew"], @real.reload.changeset["description"]
+    end
+
+    # A create or destroy always carries a changeset, so one arriving without is
+    # a row the task does not recognise and must not remove.
+    test "#process keeps a changeless version that is not an update" do
+      creation = @fleet.versions.find_by(event: "create")
+      creation.update_columns(object_changes: nil)
+
+      run_task(dry_run: false)
+
+      assert PaperTrail::Version.exists?(creation.id)
+    end
+
+    # The pre-json column holds history that predates the migration.
+    test "#process keeps a version whose changes are in the legacy column" do
+      @changeless.update_columns(old_object_changes: "---\ndescription:\n- \n- A crew\n")
+
+      assert_no_difference -> { PaperTrail::Version.count } do
+        run_task(dry_run: false)
+      end
+    end
+
+    # What a `touch` leaves behind: the snapshot is written, the changeset is not.
+    private def changeless_version_for(record)
+      PaperTrail::Version.create!(
+        item_type: record.class.name,
+        item_id: record.id,
+        event: "update",
+        object: record.attributes
+      )
+    end
+
+    private def run_task(dry_run:)
+      task = ::Maintenance::DropChangelessVersionsTask.new
+      task.dry_run = dry_run
+
+      capture_io { task.process }.first
+    end
+  end
+end


### PR DESCRIPTION
Two related changes about answering "what actually changed".

## 1. The ship matrix report names the ships

`Ship Matrix Import Results` said **Models updated: 1** and left the reader to guess which ship and what moved. It now names them, the way it already named the ones it added:

```
- **Models added**: 0
- **Models updated**: 2
- **Models in total**: 248

### Updated

- **Carrack**: cargo, mass
- **Idris P**: cargo (matrix only: mass)
```

The fields come from paper_trail, which needed widening twice:

- **`name`, `description`, `ground`** — all three are admin-editable and had *no* change history at all. That gap existed independently of this report.
- **The `rsi_*` shadow columns** — these are not the live column read twice. Measured on the current data: `mass` differs from `rsi_mass` on 196 of 246 models, and `max_speed` / `pitch` / `yaw` / `roll` on 188.

That second set earns its own line. `Rsi::ModelsLoader` writes a shadow on **every** run, but the live column only when RSI moved `time_modified` *and* the new value is not blank. So a shadow that moves alone is the matrix offering a value we declined — which until now was recorded nowhere. That is the `(matrix only: mass)` above.

`last_updated_at` and the store image stay unwatched: they move on nearly every matrix change and say nothing the live column does not.

## 2. A version history in the admin area

paper_trail has been recording ten catalogues for years — 611k versions, of which 532 are admin edits — and nothing ever showed them.

**`GET /admin/api/v1/versions`** is generic over all ten. Six of them have no admin page and no policy of their own, so they are authorised through the record that does: a fleet's roles, memberships and inventories through the fleet, an inventory through whoever holds it. That holder is polymorphic, which is why the policy is looked up from the record the walk lands on rather than from the item type it started at. The type itself comes from an explicit list (`VersionedItem::TYPES`), never from constantizing whatever the request sent.

**`PUT /admin/api/v1/versions/:id/revert`** takes one field rather than the whole version, because a loader version usually carries a dozen fields nobody has a quarrel with — the matrix moving `mass` and `cargo` together when only `mass` was wrong. On a `Model` it goes through `update_with_facts` so the build is written too, and it records who reverted and why on the four catalogues that declare paper_trail meta. Creates are refused: their changeset is every column from nothing, so there is no earlier value to return to.

The UI is one polymorphic component showing time, source (admin username, else which loader, from `reason`) and `old → new` per field, mounted as an edit tab on **models, components, model modules and fleets**, and inline on the **fleet member** page, which has no tab bar.

## Known gap

`FleetRole`, `FleetInventory`, `FleetInventoryItem`, `Inventory` and `InventoryItem` have no admin detail page anywhere in the app — no controller, no policy, no route. The API serves and authorises them correctly, but there is nowhere yet to display them. Giving them detail pages is its own piece of work.

Translations are English and German only; the other five locales were already well short of parity here.

## Checks

- `rubocop` over 2297 files — clean
- `pnpm lint:ts`, `pnpm lint:js` — clean
- 82 Ruby tests, 0 failures (versions API, `VersionedItem`, models job, model, admin models integration)

🤖
