### PR TITLE
fix(navigation): four mobile fixes - tab bar, header actions, submenus, toast insets

### DIFF
--- a/app/frontend/admin/components/Navigation/Mobile/index.vue
+++ b/app/frontend/admin/components/Navigation/Mobile/index.vue
@@ -32,10 +32,13 @@ const { isAuthenticated } = storeToRefs(sessionStore);
 
 <template>
   <AppNavigationMobile>
+    <!-- A tab bar has no room to expand a submenu into: it would push the
+         children out over the page. Each tab links to its first child. -->
     <AppNavigationItems
       :routes="mobileRoutes"
       :current-route="route"
       :authenticated="isAuthenticated"
+      hide-submenus
     />
   </AppNavigationMobile>
 </template>

--- a/app/frontend/docs/components/Navigation/Mobile/index.vue
+++ b/app/frontend/docs/components/Navigation/Mobile/index.vue
@@ -32,10 +32,13 @@ const { isAuthenticated } = storeToRefs(sessionStore);
 
 <template>
   <AppNavigationMobile>
+    <!-- A tab bar has no room to expand a submenu into: it would push the
+         children out over the page. Each tab links to its first child. -->
     <AppNavigationItems
       :routes="mobileRoutes"
       :current-route="route"
       :authenticated="isAuthenticated"
+      hide-submenus
     />
   </AppNavigationMobile>
 </template>

--- a/app/frontend/shared/components/AppNavigation/Header/index.scss
+++ b/app/frontend/shared/components/AppNavigation/Header/index.scss
@@ -38,19 +38,27 @@
     transition: right ease $transition-base-speed;
 
     &__left {
-      flex: 1 1 auto;
+      // Outbids the actions for the free space on a shared row, so they stay at
+      // their natural size there and only grow once they have wrapped.
+      flex: 1000 1 auto;
       min-width: 0;
       max-width: 100%;
     }
 
     &__right {
-      flex: 0 0 auto;
+      flex: 1 1 auto;
       justify-content: flex-end;
 
       // an empty teleport target would still claim the flex gap and pull the
       // quicksearch away from the right edge the rows below align to
       &:not(:has(*)) {
         display: none;
+      }
+
+      // Once wrapped, the actions have a whole row to themselves - they share
+      // it rather than huddling against one edge of it.
+      > :deep(*) {
+        flex: 1 1 auto;
       }
     }
   }

--- a/app/frontend/shared/components/AppNavigation/Items/index.test.ts
+++ b/app/frontend/shared/components/AppNavigation/Items/index.test.ts
@@ -1,0 +1,60 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { createRouter, createWebHashHistory } from "vue-router";
+import type { RouteLocationNormalizedLoaded, RouteRecordRaw } from "vue-router";
+import Component from "./index.vue";
+
+const Blank = { template: "<div />" };
+
+const routes = [
+  {
+    path: "/models/",
+    component: Blank,
+    meta: { title: "models", icon: "fa-duotone fa-starship" },
+    children: [
+      { path: "", name: "models", component: Blank, meta: { title: "index" } },
+      {
+        path: "unlisted",
+        name: "models-unlisted",
+        component: Blank,
+        meta: { title: "unlisted" },
+      },
+    ],
+  },
+] as RouteRecordRaw[];
+
+const currentRoute = {
+  name: "models",
+  meta: {},
+} as RouteLocationNormalizedLoaded;
+
+const mountItems = async (props: Record<string, unknown>) => {
+  const router = createRouter({ history: createWebHashHistory(), routes });
+  await router.push("/models/");
+  await router.isReady();
+
+  return mountWithDefaults<typeof Component>(Component, {
+    props: { routes, currentRoute, ...props },
+    plugins: [router],
+  });
+};
+
+describe("AppNavigationItems", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("expands a route with several children into a submenu", async () => {
+    const wrapper = await mountItems({});
+
+    expect(wrapper.find(".nav-item__sub-menu").exists()).toBe(true);
+  });
+
+  it("links straight to the first child when submenus are hidden", async () => {
+    const wrapper = await mountItems({ hideSubmenus: true });
+
+    expect(wrapper.find(".nav-item__sub-menu").exists()).toBe(false);
+    expect(wrapper.find("a").attributes("href")).toBe("#/models/");
+  });
+});

--- a/app/frontend/shared/components/AppNavigation/Items/index.vue
+++ b/app/frontend/shared/components/AppNavigation/Items/index.vue
@@ -19,12 +19,14 @@ type Props = {
   authenticated?: boolean;
   hasAccessTo?: (access?: string[]) => boolean;
   isFeatureEnabled?: (feature: string) => boolean;
+  hideSubmenus?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   authenticated: false,
   hasAccessTo: undefined,
   isFeatureEnabled: undefined,
+  hideSubmenus: false,
 });
 
 const { t } = useI18n();
@@ -117,6 +119,10 @@ const isSubmenuActive = (route: RouteRecordRaw): boolean => {
 };
 
 const hasSubmenu = (route: RouteRecordRaw) => {
+  if (props.hideSubmenus) {
+    return false;
+  }
+
   const childRoutes = filteredChildRoutes(route.children || []);
 
   return childRoutes.length > 1;

--- a/app/frontend/shared/components/AppNavigation/Mobile/index.scss
+++ b/app/frontend/shared/components/AppNavigation/Mobile/index.scss
@@ -71,8 +71,24 @@
         padding: 0;
       }
 
+      // The inner wrap grows to fill the item so the badge can sit at its far
+      // end. Here there is no label to sit beside, so growing would leave the
+      // icon at the item's leading edge instead of on the tab's centre line.
+      .nav-item-inner {
+        flex-grow: 0;
+      }
+
       .nav-item-icon {
         margin-right: 0;
+      }
+
+      // Same reason: with no label to sit beside, an inline count would drag
+      // the icon off centre, so it rides the icon's corner instead.
+      .nav-item-badge {
+        position: absolute;
+        top: -6px;
+        inset-inline-start: 18px;
+        margin-inline-start: 0;
       }
     }
 

--- a/app/frontend/shared/components/AppNotifications/index.scss
+++ b/app/frontend/shared/components/AppNotifications/index.scss
@@ -1,7 +1,7 @@
 .app-notifications {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  top: calc(20px + env(safe-area-inset-top));
+  right: calc(20px + env(safe-area-inset-right));
   z-index: 1100;
 }
 


### PR DESCRIPTION
Four mobile fixes, reported from a phone, one commit each.

### The tab bar icons were off centre

`#4554` gave `.nav-item-inner` `flex-grow: 1` so the badge's auto margin had free space to push into. On the tab bar the anchor is already full width, so the grown wrap fills the whole tab and drops the icon at its leading edge. Measured in a harness built from the real compiled+scoped CSS: **every icon sat exactly 24px left of its tab's centre line**, while the hamburger — a plain button, not a `nav-item` — stayed centred.

The wrap no longer grows there, and the unread count now rides the icon's corner: with no label beside it, an inline count dragged the notifications icon 14px off centre in turn. All five tabs measure 0px offset after.

### Toasts landed under the notch

`.app-notifications` was pinned at a flat `top: 20px`. The layout is served `viewport-fit=cover`, so on a notched phone that is inside the status bar. Now offset by the safe-area insets, which compute to the same `20px` everywhere else.

### The header actions ignored the empty half of their row

The teleported page actions wrap below the quicksearch on a phone, where `flex: 0 0 auto` left them at their natural 42px against one edge of an otherwise empty row.

They should grow *only* once they have wrapped, which flexbox cannot ask directly — so the quicksearch outbids them for the free space on a shared row instead. Measured in Chromium and WebKit, identical in both:

| width | actions | before | after |
| --- | --- | --- | --- |
| 390 | 4 | wrapped, 42px each, left-huddled | wrapped, **83px each, full row** |
| 390 | 1–2 | one row, 42px | unchanged |
| 600 / 768 / 900 | 4 | one row, 42px | unchanged |
| 1200 | any | desktop | unchanged |

### Submenu items spilled out of the tab bar

The admin and docs tab bars render through `AppNavigationItems`, which expands any route with more than one child into a submenu. A 60px bar has nowhere to put one, so the children rendered out over the page — the chevron beside the ship icon in the report is the giveaway.

The invisible half: a `NavItem` with a submenu slot renders a `<button>` that toggles the menu rather than an `<a>`, so those tabs never navigated at all. `routeTo` already resolves a parent to its first child, so suppressing the submenu is enough to make them links again. Two tests cover both paths.

### Verification

The layout claims above are measurements, not eyeballing — a static harness of the real SCSS, scoped through Vue's own `compileStyle`, driven at several widths in both engines. Nav unit tests pass (8), Prettier and ESLint clean on the touched files. Not verified in the running app.

Still open, and **not** addressed here: a `[Vue warn] Set operation on key "name" failed: target is readonly` reported alongside these. There is no assignment to `.name` in `app/frontend` outside a DOM input, no `readonly()` of our own, and no dynamic key write that could land on `name` — so it is a library writing to something we hand it, and worth noting this repo is on vue-router 5, where the route object is readonly in a way it was not in 4. It needs the component trace from the console to pin down rather than a guess.

🤖
