### PR TITLE
feat(admin): reach the versioned collections in the admin UI

### DIFF
--- a/app/api_components/admin/v1/schemas/enums/fleet_inventory_visibility_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/fleet_inventory_visibility_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class FleetInventoryVisibilityEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = ::FleetInventory.visibilities.keys.map(&:to_s).freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/enums/inventory_category_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/inventory_category_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class InventoryCategoryEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = ::InventoryLedgerEntry::CATEGORIES.keys.map(&:to_s).freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/enums/inventory_entry_type_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/inventory_entry_type_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class InventoryEntryTypeEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = ::InventoryLedgerEntry::ENTRY_TYPES.keys.map(&:to_s).freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/enums/inventory_unit_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/inventory_unit_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class InventoryUnitEnum
+          include OpenapiRuby::Components::Base
+
+          VALUES = ::InventoryLedgerEntry::UNITS.keys.map(&:to_s).freeze
+
+          schema({
+            type: :string,
+            enum: VALUES,
+            "x-enumNames": VALUES.map { |value| transform_enum_key(value) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/enums/version_item_type_enum.rb
+++ b/app/api_components/admin/v1/schemas/enums/version_item_type_enum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Enums
+        class VersionItemTypeEnum
+          include OpenapiRuby::Components::Base
+
+          TYPES = ::VersionedItem::TYPES
+
+          schema({
+            type: :string,
+            enum: TYPES,
+            "x-enumNames": TYPES.map { |v| transform_enum_key(v) }
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/fleet_inventories.rb
+++ b/app/api_components/admin/v1/schemas/fleet_inventories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FleetInventories < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: ::Admin::V1::Schemas::FleetInventory}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/fleet_inventory.rb
+++ b/app/api_components/admin/v1/schemas/fleet_inventory.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FleetInventory
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            fleetId: {type: :string, format: :uuid},
+            name: {type: :string},
+            slug: {type: :string},
+            description: {type: [:string, :null]},
+            location: {type: [:string, :null]},
+            visibility: ::Admin::V1::Schemas::Enums::FleetInventoryVisibilityEnum,
+            managerId: {type: [:string, :null], format: :uuid},
+            managerUsername: {type: [:string, :null]},
+            itemsCount: {type: :integer},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id fleetId name slug visibility itemsCount createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/fleet_inventory_item.rb
+++ b/app/api_components/admin/v1/schemas/fleet_inventory_item.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FleetInventoryItem
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            fleetInventoryId: {type: :string, format: :uuid},
+            name: {type: :string},
+            category: ::Admin::V1::Schemas::Enums::InventoryCategoryEnum,
+            entryType: ::Admin::V1::Schemas::Enums::InventoryEntryTypeEnum,
+            unit: ::Admin::V1::Schemas::Enums::InventoryUnitEnum,
+            quantity: {type: :string},
+            quality: {type: [:integer, :null]},
+            notes: {type: [:string, :null]},
+            # The catalogue row this entry was filled from, when it was named
+            # from one rather than typed in free-hand.
+            itemId: {type: [:string, :null], format: :uuid},
+            itemType: {type: [:string, :null]},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id fleetInventoryId name category entryType unit quantity createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/fleet_inventory_items.rb
+++ b/app/api_components/admin/v1/schemas/fleet_inventory_items.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class FleetInventoryItems < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: ::Admin::V1::Schemas::FleetInventoryItem}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/version_revert_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/version_revert_input.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class VersionRevertInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              field: {type: :string}
+            },
+            required: %w[field]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inventories.rb
+++ b/app/api_components/admin/v1/schemas/inventories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Inventories < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: ::Admin::V1::Schemas::Inventory}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inventory.rb
+++ b/app/api_components/admin/v1/schemas/inventory.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Inventory
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            holderId: {type: :string, format: :uuid},
+            holderType: {type: :string},
+            name: {type: :string},
+            slug: {type: :string},
+            description: {type: [:string, :null]},
+            location: {type: [:string, :null]},
+            # A ship provisions its own; the rest were made by hand.
+            vehicleId: {type: [:string, :null], format: :uuid},
+            itemsCount: {type: :integer},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id holderId holderType name slug itemsCount createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inventory_item.rb
+++ b/app/api_components/admin/v1/schemas/inventory_item.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class InventoryItem
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            inventoryId: {type: :string, format: :uuid},
+            name: {type: :string},
+            category: ::Admin::V1::Schemas::Enums::InventoryCategoryEnum,
+            entryType: ::Admin::V1::Schemas::Enums::InventoryEntryTypeEnum,
+            unit: ::Admin::V1::Schemas::Enums::InventoryUnitEnum,
+            quantity: {type: :string},
+            quality: {type: [:integer, :null]},
+            notes: {type: [:string, :null]},
+            # The catalogue row this entry was filled from, when it was named
+            # from one rather than typed in free-hand.
+            itemId: {type: [:string, :null], format: :uuid},
+            itemType: {type: [:string, :null]},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id inventoryId name category entryType unit quantity createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inventory_items.rb
+++ b/app/api_components/admin/v1/schemas/inventory_items.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class InventoryItems < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: ::Admin::V1::Schemas::InventoryItem}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version.rb
+++ b/app/api_components/admin/v1/schemas/version.rb
@@ -13,11 +13,11 @@ module Admin
             itemId: {type: :string, format: :uuid},
             itemType: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum,
             event: {type: :string},
-            reason: {type: :string, nullable: true},
-            reasonDescription: {type: :string, nullable: true},
+            reason: {type: [:string, :null]},
+            reasonDescription: {type: [:string, :null]},
             author: ::Admin::V1::Schemas::VersionAuthor,
             changes: {type: :array, items: ::Admin::V1::Schemas::VersionChange},
-            createdAt: {type: :string, format: :"date-time", nullable: true}
+            createdAt: {type: [:string, :null], format: :"date-time"}
           },
           required: %w[id itemId itemType event changes]
         })

--- a/app/api_components/admin/v1/schemas/version.rb
+++ b/app/api_components/admin/v1/schemas/version.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Version
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            itemId: {type: :string, format: :uuid},
+            itemType: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum,
+            event: {type: :string},
+            reason: {type: :string, nullable: true},
+            reasonDescription: {type: :string, nullable: true},
+            author: ::Admin::V1::Schemas::VersionAuthor,
+            changes: {type: :array, items: ::Admin::V1::Schemas::VersionChange},
+            createdAt: {type: :string, format: :"date-time", nullable: true}
+          },
+          required: %w[id itemId itemType event changes]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_author.rb
+++ b/app/api_components/admin/v1/schemas/version_author.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class VersionAuthor
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            username: {type: :string}
+          },
+          required: %w[id username]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_change.rb
+++ b/app/api_components/admin/v1/schemas/version_change.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class VersionChange
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            field: {type: :string},
+            from: {type: :string, nullable: true},
+            to: {type: :string, nullable: true}
+          },
+          required: %w[field]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/version_change.rb
+++ b/app/api_components/admin/v1/schemas/version_change.rb
@@ -10,8 +10,8 @@ module Admin
           type: :object,
           properties: {
             field: {type: :string},
-            from: {type: :string, nullable: true},
-            to: {type: :string, nullable: true}
+            from: {type: [:string, :null]},
+            to: {type: [:string, :null]}
           },
           required: %w[field]
         })

--- a/app/api_components/admin/v1/schemas/versions.rb
+++ b/app/api_components/admin/v1/schemas/versions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class Versions < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/Version"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/fleet_inventories_controller.rb
+++ b/app/controllers/admin/api/v1/fleet_inventories_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class FleetInventoriesController < ::Admin::Api::BaseController
+        before_action :set_fleet
+        before_action :set_inventory, only: %i[show]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.base"))
+        end
+
+        def index
+          @inventories = @fleet.fleet_inventories
+            .includes(:manager)
+            .order(name: :asc)
+            .page(params[:page])
+            .per(per_page(FleetInventory))
+        end
+
+        def show
+        end
+
+        private def set_fleet
+          @fleet = Fleet.find(params[:fleet_id])
+
+          authorize! @fleet, with: ::Admin::FleetPolicy
+        end
+
+        private def set_inventory
+          @inventory = @fleet.fleet_inventories.includes(:manager).find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/fleet_inventory_items_controller.rb
+++ b/app/controllers/admin/api/v1/fleet_inventory_items_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class FleetInventoryItemsController < ::Admin::Api::BaseController
+        before_action :set_inventory
+        before_action :set_item, only: %i[show]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.base"))
+        end
+
+        def index
+          @items = @inventory.fleet_inventory_items
+            .order(created_at: :desc)
+            .page(params[:page])
+            .per(per_page(FleetInventoryItem))
+        end
+
+        def show
+        end
+
+        # The fleet carries the permission, the same walk `VersionedItem` makes
+        # to decide who may read one of these entries' versions.
+        private def set_inventory
+          fleet = Fleet.find(params[:fleet_id])
+
+          authorize! fleet, with: ::Admin::FleetPolicy
+
+          @inventory = fleet.fleet_inventories.find(params[:fleet_inventory_id])
+        end
+
+        private def set_item
+          @item = @inventory.fleet_inventory_items.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/inventories_controller.rb
+++ b/app/controllers/admin/api/v1/inventories_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class InventoriesController < ::Admin::Api::BaseController
+        before_action :set_user
+        before_action :set_inventory, only: %i[show]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.base"))
+        end
+
+        def index
+          @inventories = @user.inventories
+            .order(name: :asc)
+            .page(params[:page])
+            .per(per_page(Inventory))
+        end
+
+        def show
+        end
+
+        # `holder` is polymorphic, but a user is the only thing that holds one
+        # today, and the user's policy is what `VersionedItem` walks to as well.
+        private def set_user
+          @user = User.find(params[:user_id])
+
+          authorize! @user, with: ::Admin::UserPolicy
+        end
+
+        private def set_inventory
+          @inventory = @user.inventories.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/inventory_items_controller.rb
+++ b/app/controllers/admin/api/v1/inventory_items_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class InventoryItemsController < ::Admin::Api::BaseController
+        before_action :set_inventory
+        before_action :set_item, only: %i[show]
+
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.base"))
+        end
+
+        def index
+          @items = @inventory.inventory_items
+            .order(created_at: :desc)
+            .page(params[:page])
+            .per(per_page(InventoryItem))
+        end
+
+        def show
+        end
+
+        private def set_inventory
+          user = User.find(params[:user_id])
+
+          authorize! user, with: ::Admin::UserPolicy
+
+          @inventory = user.inventories.find(params[:inventory_id])
+        end
+
+        private def set_item
+          @item = @inventory.inventory_items.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/versions_controller.rb
+++ b/app/controllers/admin/api/v1/versions_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      class VersionsController < ::Admin::Api::BaseController
+        before_action :set_version, only: %i[revert]
+
+        def index
+          item = ::VersionedItem.find(params[:item_type] || params[:itemType], params[:item_id] || params[:itemId])
+
+          authorize_item!(item)
+
+          @versions = PaperTrail::Version
+            .where(item_type: item.class.name, item_id: item.id)
+            .order(created_at: :desc)
+            .page(params[:page])
+            .per(params[:per_page] || params[:perPage])
+
+          # `author_id` is only ever written by an admin action, so one lookup
+          # covers the page rather than one per row.
+          @authors = AdminUser.where(id: @versions.filter_map(&:author_id).uniq).index_by(&:id)
+        end
+
+        def revert
+          result = ::Versions::FieldReverter.new(@version, params[:field].to_s, author_id: current_user.id).run
+
+          raise ActiveRecord::RecordNotFound if result.missing?
+
+          unless result.success?
+            render json: ValidationError.new("version.revert", errors: result.record.errors), status: :bad_request
+            return
+          end
+
+          head :no_content
+        end
+
+        private def set_version
+          @version = PaperTrail::Version.find(params[:id])
+
+          raise ActiveRecord::RecordNotFound unless ::VersionedItem.supported?(@version.item_type)
+
+          authorize_item!(@version.item)
+        end
+
+        # The item carries the permission, not the version: whoever may see a
+        # model may see what it used to say.
+        private def authorize_item!(item)
+          raise ActiveRecord::RecordNotFound if item.blank?
+
+          root, policy = ::VersionedItem.authorization_root(item)
+
+          raise ActiveRecord::RecordNotFound if root.blank?
+
+          authorize! root, with: policy
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/versions_controller.rb
+++ b/app/controllers/admin/api/v1/versions_controller.rb
@@ -11,8 +11,13 @@ module Admin
 
           authorize_item!(item)
 
+          # The touch versions already on disk outnumber the real edits 1,200 to
+          # one on a fleet, and each renders as a heading with nothing under it.
+          # `object_changes` is null on exactly those: every create, update and
+          # destroy paper_trail records from a save carries one.
           @versions = PaperTrail::Version
             .where(item_type: item.class.name, item_id: item.id)
+            .where.not(object_changes: nil)
             .order(created_at: :desc)
             .page(params[:page])
             .per(params[:per_page] || params[:perPage])

--- a/app/frontend/admin/components/DetailList/index.vue
+++ b/app/frontend/admin/components/DetailList/index.vue
@@ -1,0 +1,57 @@
+<script lang="ts">
+export default {
+  name: "AdminDetailList",
+};
+</script>
+
+<script lang="ts" setup>
+import Panel from "@/shared/components/base/Panel/index.vue";
+import { type Detail } from "@/admin/components/DetailList/types";
+
+type Props = {
+  details: Detail[];
+};
+
+const props = defineProps<Props>();
+
+const display = (value: Detail["value"]) =>
+  value === null || value === undefined || value === "" ? "—" : String(value);
+</script>
+
+<template>
+  <Panel inset :outer-spacing="false">
+    <dl class="detail-list">
+      <template v-for="detail in props.details" :key="detail.label">
+        <dt>{{ detail.label }}</dt>
+        <dd>{{ display(detail.value) }}</dd>
+      </template>
+    </dl>
+  </Panel>
+</template>
+
+<style scoped>
+@reference "../../../entrypoints/tailwind.css";
+
+/*
+ * Two columns on anything but a phone, where a label above its value reads
+ * better than a label squeezed into a third of the width.
+ */
+.detail-list {
+  @apply grid gap-x-6 gap-y-2 pb-5;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .detail-list {
+    grid-template-columns: max-content 1fr;
+  }
+}
+
+.detail-list dt {
+  @apply text-sm text-muted;
+}
+
+.detail-list dd {
+  @apply m-0 text-white;
+}
+</style>

--- a/app/frontend/admin/components/DetailList/types.ts
+++ b/app/frontend/admin/components/DetailList/types.ts
@@ -1,0 +1,5 @@
+export type Detail = {
+  label: string;
+  /** A row with no value renders as a dash rather than an empty cell. */
+  value?: string | number | null;
+};

--- a/app/frontend/admin/components/Fleets/Members/Actions/Items.vue
+++ b/app/frontend/admin/components/Fleets/Members/Actions/Items.vue
@@ -1,0 +1,102 @@
+<script lang="ts">
+export default {
+  name: "FleetMemberActionItems",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  type Fleet,
+  type AdminFleetMember,
+  getFleetMembersQueryKey,
+  loginAsFleetMember,
+  removeFleetMember,
+} from "@/services/fyAdminApi";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  fleet: Fleet;
+  member: AdminFleetMember;
+  withLabels?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  withLabels: false,
+});
+
+const { t } = useI18n();
+const { displayConfirm, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
+const router = useRouter();
+
+// The permanent role cannot be left without a holder, so its member keeps the
+// remove action off rather than being told no after asking.
+const isPermanent = computed(() => {
+  if (!props.member.roleId) return false;
+
+  return (props.fleet.fleetRoles || []).some(
+    (role) => role.permanent && role.id === props.member.roleId,
+  );
+});
+
+const invalidateMembers = () =>
+  queryClient.invalidateQueries({
+    queryKey: getFleetMembersQueryKey(props.fleet.id),
+  });
+
+const editRole = () => {
+  void router.push({
+    name: "admin-fleet-member-edit",
+    params: { id: props.fleet.id, memberId: props.member.id },
+  });
+};
+
+const loginAs = () => {
+  displayConfirm({
+    text: t("messages.confirm.user.loginAs"),
+    onConfirm: async () => {
+      await loginAsFleetMember(props.fleet.id, props.member.id);
+      window.open(window.FRONTEND_ENDPOINT, "_blank");
+    },
+  });
+};
+
+const remove = () => {
+  displayConfirm({
+    text: t("messages.confirm.fleet.members.remove"),
+    onConfirm: async () => {
+      await removeFleetMember(props.fleet.id, props.member.id)
+        .then(invalidateMembers)
+        .catch((error) => {
+          displayAlert({ text: error.response?.data?.message });
+        });
+    },
+  });
+};
+</script>
+
+<template>
+  <Btn v-tooltip="!withLabels && t('actions.users.loginAs')" @click="loginAs">
+    <i class="fa-duotone fa-right-to-bracket" />
+    <span v-if="withLabels">{{ t("actions.users.loginAs") }}</span>
+  </Btn>
+  <Btn
+    v-tooltip="!withLabels && t('actions.fleet.members.editRole')"
+    @click="editRole"
+  >
+    <i class="fa-duotone fa-user-pen" />
+    <span v-if="withLabels">{{ t("actions.fleet.members.editRole") }}</span>
+  </Btn>
+  <Btn
+    v-if="!isPermanent"
+    v-tooltip="!withLabels && t('actions.fleet.members.remove')"
+    @click="remove"
+    :tone="BtnTonesEnum.DANGER"
+  >
+    <i class="fa-duotone fa-trash" />
+    <span v-if="withLabels">{{ t("actions.fleet.members.remove") }}</span>
+  </Btn>
+</template>

--- a/app/frontend/admin/components/Fleets/Members/Actions/index.vue
+++ b/app/frontend/admin/components/Fleets/Members/Actions/index.vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+export default {
+  name: "FleetMemberActions",
+};
+</script>
+
+<script lang="ts" setup>
+import Items from "@/admin/components/Fleets/Members/Actions/Items.vue";
+import { useMobile } from "@/shared/composables/useMobile";
+import { type Fleet, type AdminFleetMember } from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+  member: AdminFleetMember;
+};
+
+const props = defineProps<Props>();
+
+const mobile = useMobile();
+</script>
+
+<template>
+  <BtnDropdown v-if="mobile">
+    <Items :fleet="props.fleet" :member="props.member" with-labels />
+  </BtnDropdown>
+  <BtnGroup v-else>
+    <Items :fleet="props.fleet" :member="props.member" />
+  </BtnGroup>
+</template>

--- a/app/frontend/admin/components/InventoryItemDetail/index.vue
+++ b/app/frontend/admin/components/InventoryItemDetail/index.vue
@@ -1,0 +1,66 @@
+<script lang="ts">
+export default {
+  name: "AdminInventoryItemDetail",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import DetailList from "@/admin/components/DetailList/index.vue";
+import { type Detail } from "@/admin/components/DetailList/types";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+import {
+  type FleetInventoryItem,
+  type InventoryItem,
+  type VersionItemTypeEnum,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  /*
+   * A fleet's entry and a user's carry the same ledger columns and differ only
+   * in which inventory they name, so one detail serves both.
+   */
+  item: FleetInventoryItem | InventoryItem;
+  itemType: VersionItemTypeEnum;
+};
+
+const props = defineProps<Props>();
+
+const { t, lUtc: l } = useI18n();
+
+const details = computed<Detail[]>(() => [
+  { label: t("labels.inventoryItems.name"), value: props.item.name },
+  {
+    label: t("labels.inventoryItems.category"),
+    value: t(`labels.inventoryItems.categories.${props.item.category}`),
+  },
+  {
+    label: t("labels.inventoryItems.entryType"),
+    value: t(`labels.inventoryItems.entryTypes.${props.item.entryType}`),
+  },
+  {
+    label: t("labels.inventoryItems.quantity"),
+    value: `${props.item.quantity} ${t(`labels.inventoryItems.units.${props.item.unit}`)}`,
+  },
+  { label: t("labels.inventoryItems.quality"), value: props.item.quality },
+  { label: t("labels.inventoryItems.notes"), value: props.item.notes },
+  { label: t("labels.inventoryItems.itemType"), value: props.item.itemType },
+  {
+    label: t("labels.createdAt"),
+    value: l(props.item.createdAt, "datetime.formats.short"),
+  },
+]);
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{ props.item.name }}</Heading>
+
+  <DetailList :details="details" />
+
+  <Heading class="mt-8 mb-4">
+    {{ t("headlines.admin.fleets.history") }}
+  </Heading>
+
+  <VersionHistory :item-id="props.item.id" :item-type="props.itemType" />
+</template>

--- a/app/frontend/admin/components/InventoryItemDetail/index.vue
+++ b/app/frontend/admin/components/InventoryItemDetail/index.vue
@@ -58,9 +58,11 @@ const details = computed<Detail[]>(() => [
 
   <DetailList :details="details" />
 
-  <Heading class="mt-8 mb-4">
-    {{ t("headlines.admin.fleets.history") }}
-  </Heading>
+  <section class="mt-10">
+    <Heading class="mb-4">
+      {{ t("headlines.admin.fleets.history") }}
+    </Heading>
 
-  <VersionHistory :item-id="props.item.id" :item-type="props.itemType" />
+    <VersionHistory :item-id="props.item.id" :item-type="props.itemType" />
+  </section>
 </template>

--- a/app/frontend/admin/components/VersionHistory/index.vue
+++ b/app/frontend/admin/components/VersionHistory/index.vue
@@ -1,0 +1,125 @@
+<script lang="ts">
+export default {
+  name: "AdminVersionHistory",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import { useQueryClient } from "@tanstack/vue-query";
+import {
+  type Version,
+  type VersionChange,
+  type VersionItemTypeEnum,
+  useVersions as useVersionsQuery,
+  useRevertVersion as useRevertVersionMutation,
+  getVersionsQueryKey,
+} from "@/services/fyAdminApi";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
+import BtnConfirm from "@/shared/components/base/BtnConfirm/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+
+type Props = {
+  itemId: string;
+  itemType: VersionItemTypeEnum;
+};
+
+const props = defineProps<Props>();
+
+const { t, l } = useI18n();
+const queryClient = useQueryClient();
+
+const { data, isLoading } = useVersionsQuery({
+  perPage: "50",
+  itemType: props.itemType,
+  itemId: props.itemId,
+});
+
+const versions = computed(() => data.value?.items ?? []);
+
+const invalidateVersions = () =>
+  queryClient.invalidateQueries({ queryKey: getVersionsQueryKey() });
+
+const revertMutation = useRevertVersionMutation({
+  mutation: { onSettled: invalidateVersions },
+});
+
+const onRevert = async (version: Version, change: VersionChange) => {
+  await revertMutation.mutateAsync({
+    id: version.id,
+    data: { field: change.field },
+  });
+};
+
+// An admin edit carries a username; everything else was a loader, and `reason`
+// is what says which one.
+const sourceLabel = (version: Version) => {
+  if (version.author) return version.author.username;
+
+  if (version.reason)
+    return t(`labels.admin.versions.sources.${version.reason}`);
+
+  return t("labels.admin.versions.sources.unknown");
+};
+
+// A create records every column from nothing, so there is no earlier value to
+// go back to. The API refuses those; this keeps the button off them.
+const revertable = (version: Version) => version.event === "update";
+
+const displayValue = (value?: string | null) =>
+  value ?? t("labels.admin.versions.blank");
+</script>
+
+<template>
+  <Loader v-if="isLoading" />
+
+  <Empty v-else-if="versions.length === 0" />
+
+  <div v-else class="flex flex-col gap-4">
+    <Panel v-for="version in versions" :key="version.id">
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <span class="text-white">{{ l(version.createdAt ?? "") }}</span>
+        <BasePill
+          :variant="
+            version.author ? PillVariantsEnum.DEFAULT : PillVariantsEnum.NEUTRAL
+          "
+        >
+          {{ sourceLabel(version) }}
+        </BasePill>
+        <span v-if="version.reasonDescription" class="text-sm">
+          {{ version.reasonDescription }}
+        </span>
+      </div>
+
+      <ul class="flex flex-col gap-2">
+        <li
+          v-for="change in version.changes"
+          :key="`${version.id}-${change.field}`"
+          class="flex flex-wrap items-center gap-2"
+        >
+          <span class="font-bold">{{ change.field }}</span>
+          <span class="line-through opacity-60">{{
+            displayValue(change.from)
+          }}</span>
+          <i class="fa-duotone fa-arrow-right text-xs" />
+          <span>{{ displayValue(change.to) }}</span>
+
+          <BtnConfirm
+            v-if="revertable(version)"
+            :size="BtnSizesEnum.SM"
+            :question="t('labels.admin.versions.revertQuestion')"
+            hide-question
+            :disabled="revertMutation.isPending.value"
+            @click="onRevert(version, change)"
+          >
+            {{ t("actions.revert") }}
+          </BtnConfirm>
+        </li>
+      </ul>
+    </Panel>
+  </div>
+</template>

--- a/app/frontend/admin/components/VersionHistory/index.vue
+++ b/app/frontend/admin/components/VersionHistory/index.vue
@@ -80,7 +80,12 @@ const displayValue = (value?: string | null) =>
   <Empty v-else-if="versions.length === 0" />
 
   <div v-else class="flex flex-col gap-4">
-    <Panel v-for="version in versions" :key="version.id">
+    <Panel
+      v-for="version in versions"
+      :key="version.id"
+      inset
+      :outer-spacing="false"
+    >
       <div class="flex flex-wrap items-center gap-2 mb-3">
         <span class="text-white">{{ l(version.createdAt ?? "") }}</span>
         <BasePill
@@ -95,7 +100,7 @@ const displayValue = (value?: string | null) =>
         </span>
       </div>
 
-      <ul class="flex flex-col gap-2">
+      <ul class="flex flex-col gap-2 pb-5">
         <li
           v-for="change in version.changes"
           :key="`${version.id}-${change.field}`"

--- a/app/frontend/admin/pages/components/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/components/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminComponentEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type Component } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  component: Component;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.components.edit.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.component.id" item-type="Component" />
+</template>

--- a/app/frontend/admin/pages/components/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/components/[id]/edit/routes.ts
@@ -25,4 +25,16 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history/",
+    name: "admin-component-edit-history",
+    component: () => import("@/admin/pages/components/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.components.edit.history",
+      customTitle: true,
+      activeRoute: "admin-components",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/fleets/[id]/history.vue
+++ b/app/frontend/admin/pages/fleets/[id]/history.vue
@@ -1,0 +1,26 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type Fleet } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{ t("headlines.admin.fleets.history") }}</Heading>
+
+  <VersionHistory :item-id="props.fleet.id" item-type="Fleet" />
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/inventories.vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories.vue
@@ -1,0 +1,138 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetInventoriesPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { BaseTableCol } from "@/shared/components/base/Table/types";
+import { usePagination } from "@/shared/composables/usePagination";
+import {
+  type Fleet,
+  type FleetInventory,
+  useFleetInventories as useFleetInventoriesQuery,
+  getFleetInventoriesQueryKey,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t, lUtc: l } = useI18n();
+
+const queryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+}));
+
+const queryKey = computed(() =>
+  getFleetInventoriesQueryKey(props.fleet.id, queryParams.value),
+);
+
+const { perPage, page, updatePerPage } = usePagination(queryKey);
+
+const { data: inventories, ...asyncStatus } = useFleetInventoriesQuery(
+  props.fleet.id,
+  queryParams,
+);
+
+const columns: BaseTableCol<FleetInventory>[] = [
+  {
+    name: "name",
+    label: t("labels.fleet.inventories.name"),
+  },
+  {
+    name: "location",
+    label: t("labels.fleet.inventories.location"),
+  },
+  {
+    name: "visibility",
+    label: t("labels.fleet.inventories.visibility"),
+  },
+  {
+    name: "managerUsername",
+    label: t("labels.fleet.inventories.manager"),
+  },
+  {
+    name: "itemsCount",
+    label: t("labels.fleet.inventories.itemsCount"),
+  },
+  {
+    name: "createdAt",
+    label: t("labels.createdAt"),
+  },
+];
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.fleets.inventories") }}
+    <HeadingSmall v-if="inventories">
+      {{
+        t("headlines.pagination.count", {
+          current: inventories?.items.length,
+          total: inventories?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <FilteredList
+    v-if="inventories"
+    name="admin-fleet-inventories"
+    :records="inventories.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+  >
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="inventories.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+      >
+        <template #col-name="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-fleet-inventory',
+              params: { id: props.fleet.id, inventoryId: record.id },
+            }"
+          >
+            {{ record.name }}
+          </router-link>
+        </template>
+        <template #col-visibility="{ record }">
+          {{ t(`labels.fleet.inventories.visibilities.${record.visibility}`) }}
+        </template>
+        <template #col-createdAt="{ record }">
+          {{ l(record.createdAt, "datetime.formats.short") }}
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-top>
+      <Paginator
+        v-if="inventories"
+        :query-result-ref="inventories"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="inventories"
+        :query-result-ref="inventories"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
@@ -110,58 +110,62 @@ const columns: BaseTableCol<FleetInventoryItem>[] = [
 
       <DetailList :details="details" />
 
-      <Heading class="mt-8 mb-4">
-        {{ t("headlines.admin.fleets.inventoryItems") }}
-      </Heading>
+      <section class="mt-10">
+        <Heading class="mb-4">
+          {{ t("headlines.admin.fleets.inventoryItems") }}
+        </Heading>
 
-      <BaseTable
-        v-if="items"
-        :records="items.items || []"
-        primary-key="id"
-        :columns="columns"
-        :empty-visible="(items.items || []).length === 0"
-      >
-        <template #col-name="{ record }">
-          <router-link
-            :to="{
-              name: 'admin-fleet-inventory-item',
-              params: {
-                id: props.fleet.id,
-                inventoryId,
-                itemId: record.id,
-              },
-            }"
-          >
-            {{ record.name }}
-          </router-link>
-        </template>
-        <template #col-category="{ record }">
-          {{ t(`labels.inventoryItems.categories.${record.category}`) }}
-        </template>
-        <template #col-entryType="{ record }">
-          {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
-        </template>
-        <template #col-quantity="{ record }">
-          {{ record.quantity }}
-          {{ t(`labels.inventoryItems.units.${record.unit}`) }}
-        </template>
-        <template #col-createdAt="{ record }">
-          {{ l(record.createdAt, "datetime.formats.short") }}
-        </template>
-      </BaseTable>
+        <BaseTable
+          v-if="items"
+          :records="items.items || []"
+          primary-key="id"
+          :columns="columns"
+          :empty-visible="(items.items || []).length === 0"
+        >
+          <template #col-name="{ record }">
+            <router-link
+              :to="{
+                name: 'admin-fleet-inventory-item',
+                params: {
+                  id: props.fleet.id,
+                  inventoryId,
+                  itemId: record.id,
+                },
+              }"
+            >
+              {{ record.name }}
+            </router-link>
+          </template>
+          <template #col-category="{ record }">
+            {{ t(`labels.inventoryItems.categories.${record.category}`) }}
+          </template>
+          <template #col-entryType="{ record }">
+            {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
+          </template>
+          <template #col-quantity="{ record }">
+            {{ record.quantity }}
+            {{ t(`labels.inventoryItems.units.${record.unit}`) }}
+          </template>
+          <template #col-createdAt="{ record }">
+            {{ l(record.createdAt, "datetime.formats.short") }}
+          </template>
+        </BaseTable>
 
-      <Paginator
-        v-if="items"
-        :query-result-ref="items"
-        :per-page="perPage"
-        :update-per-page="updatePerPage"
-      />
+        <Paginator
+          v-if="items"
+          :query-result-ref="items"
+          :per-page="perPage"
+          :update-per-page="updatePerPage"
+        />
+      </section>
 
-      <Heading class="mt-8 mb-4">
-        {{ t("headlines.admin.fleets.history") }}
-      </Heading>
+      <section class="mt-10">
+        <Heading class="mb-4">
+          {{ t("headlines.admin.fleets.history") }}
+        </Heading>
 
-      <VersionHistory :item-id="inventoryId" item-type="FleetInventory" />
+        <VersionHistory :item-id="inventoryId" item-type="FleetInventory" />
+      </section>
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
@@ -1,0 +1,167 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetInventoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import AsyncData from "@/shared/components/AsyncData.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { BaseTableCol } from "@/shared/components/base/Table/types";
+import { usePagination } from "@/shared/composables/usePagination";
+import DetailList from "@/admin/components/DetailList/index.vue";
+import { type Detail } from "@/admin/components/DetailList/types";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+import {
+  type Fleet,
+  type FleetInventoryItem,
+  useFleetInventory as useFleetInventoryQuery,
+  useFleetInventoryItems as useFleetInventoryItemsQuery,
+  getFleetInventoryItemsQueryKey,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t, lUtc: l } = useI18n();
+const route = useRoute();
+
+const inventoryId = computed(() => route.params.inventoryId as string);
+
+const { data: inventory, ...asyncStatus } = useFleetInventoryQuery(
+  props.fleet.id,
+  inventoryId,
+);
+
+const itemsQueryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+}));
+
+const itemsQueryKey = computed(() =>
+  getFleetInventoryItemsQueryKey(
+    props.fleet.id,
+    inventoryId.value,
+    itemsQueryParams.value,
+  ),
+);
+
+const { perPage, page, updatePerPage } = usePagination(itemsQueryKey);
+
+const { data: items } = useFleetInventoryItemsQuery(
+  props.fleet.id,
+  inventoryId,
+  itemsQueryParams,
+);
+
+const details = computed<Detail[]>(() =>
+  inventory.value
+    ? [
+        {
+          label: t("labels.fleet.inventories.name"),
+          value: inventory.value.name,
+        },
+        { label: t("labels.slug"), value: inventory.value.slug },
+        {
+          label: t("labels.fleet.inventories.description"),
+          value: inventory.value.description,
+        },
+        {
+          label: t("labels.fleet.inventories.location"),
+          value: inventory.value.location,
+        },
+        {
+          label: t("labels.fleet.inventories.visibility"),
+          value: t(
+            `labels.fleet.inventories.visibilities.${inventory.value.visibility}`,
+          ),
+        },
+        {
+          label: t("labels.fleet.inventories.manager"),
+          value: inventory.value.managerUsername,
+        },
+        {
+          label: t("labels.createdAt"),
+          value: l(inventory.value.createdAt, "datetime.formats.short"),
+        },
+      ]
+    : [],
+);
+
+const columns: BaseTableCol<FleetInventoryItem>[] = [
+  { name: "name", label: t("labels.inventoryItems.name") },
+  { name: "category", label: t("labels.inventoryItems.category") },
+  { name: "entryType", label: t("labels.inventoryItems.entryType") },
+  { name: "quantity", label: t("labels.inventoryItems.quantity") },
+  { name: "createdAt", label: t("labels.createdAt") },
+];
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <Heading hero class="mb-4">{{ inventory?.name }}</Heading>
+
+      <DetailList :details="details" />
+
+      <Heading class="mt-8 mb-4">
+        {{ t("headlines.admin.fleets.inventoryItems") }}
+      </Heading>
+
+      <BaseTable
+        v-if="items"
+        :records="items.items || []"
+        primary-key="id"
+        :columns="columns"
+        :empty-visible="(items.items || []).length === 0"
+      >
+        <template #col-name="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-fleet-inventory-item',
+              params: {
+                id: props.fleet.id,
+                inventoryId,
+                itemId: record.id,
+              },
+            }"
+          >
+            {{ record.name }}
+          </router-link>
+        </template>
+        <template #col-category="{ record }">
+          {{ t(`labels.inventoryItems.categories.${record.category}`) }}
+        </template>
+        <template #col-entryType="{ record }">
+          {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
+        </template>
+        <template #col-quantity="{ record }">
+          {{ record.quantity }}
+          {{ t(`labels.inventoryItems.units.${record.unit}`) }}
+        </template>
+        <template #col-createdAt="{ record }">
+          {{ l(record.createdAt, "datetime.formats.short") }}
+        </template>
+      </BaseTable>
+
+      <Paginator
+        v-if="items"
+        :query-result-ref="items"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+
+      <Heading class="mt-8 mb-4">
+        {{ t("headlines.admin.fleets.history") }}
+      </Heading>
+
+      <VersionHistory :item-id="inventoryId" item-type="FleetInventory" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId]/items/[itemId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId]/items/[itemId].vue
@@ -1,0 +1,43 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetInventoryItemPage",
+};
+</script>
+
+<script lang="ts" setup>
+import AsyncData from "@/shared/components/AsyncData.vue";
+import InventoryItemDetail from "@/admin/components/InventoryItemDetail/index.vue";
+import {
+  type Fleet,
+  useFleetInventoryItem as useFleetInventoryItemQuery,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const route = useRoute();
+
+const inventoryId = computed(() => route.params.inventoryId as string);
+const itemId = computed(() => route.params.itemId as string);
+
+const { data: item, ...asyncStatus } = useFleetInventoryItemQuery(
+  props.fleet.id,
+  inventoryId,
+  itemId,
+);
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <InventoryItemDetail
+        v-if="item"
+        :item="item"
+        item-type="FleetInventoryItem"
+      />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/inventories/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/routes.ts
@@ -1,0 +1,26 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "inventories/:inventoryId",
+    name: "admin-fleet-inventory",
+    component: () =>
+      import("@/admin/pages/fleets/[id]/inventories/[inventoryId].vue"),
+    meta: {
+      title: "admin.fleets.inventory",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
+  {
+    path: "inventories/:inventoryId/items/:itemId",
+    name: "admin-fleet-inventory-item",
+    component: () =>
+      import("@/admin/pages/fleets/[id]/inventories/[inventoryId]/items/[itemId].vue"),
+    meta: {
+      title: "admin.fleets.inventoryItem",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
+];

--- a/app/frontend/admin/pages/fleets/[id]/inventories/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/routes.ts
@@ -9,6 +9,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.fleets.inventory",
       activeRoute: "admin-fleets",
+      activeTab: "admin-fleet-inventories",
       needsAuthentication: true,
     },
   },
@@ -20,6 +21,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.fleets.inventoryItem",
       activeRoute: "admin-fleets",
+      activeTab: "admin-fleet-inventories",
       needsAuthentication: true,
     },
   },

--- a/app/frontend/admin/pages/fleets/[id]/members.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members.vue
@@ -14,16 +14,13 @@ import Paginator from "@/shared/components/Paginator/index.vue";
 import { BaseTableCol } from "@/shared/components/base/Table/types";
 import { usePagination } from "@/shared/composables/usePagination";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
-import { useAppNotifications } from "@/shared/composables/useAppNotifications";
-import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import FleetMemberActions from "@/admin/components/Fleets/Members/Actions/index.vue";
 import {
   type Fleet,
   type AdminFleetMember,
   type FleetMembershipSortEnum,
   useFleetMembers as useFleetMembersQuery,
   getFleetMembersQueryKey,
-  loginAsFleetMember,
-  removeFleetMember,
 } from "@/services/fyAdminApi";
 
 type Props = {
@@ -33,22 +30,8 @@ type Props = {
 const props = defineProps<Props>();
 
 const { t, lUtc: l, timeDistance } = useI18n();
-const { displayConfirm, displayAlert } = useAppNotifications();
 
 const route = useRoute();
-const router = useRouter();
-
-const permanentRoleIds = computed(
-  () =>
-    new Set(
-      (props.fleet.fleetRoles || [])
-        .filter((role) => role.permanent)
-        .map((role) => role.id),
-    ),
-);
-
-const isPermanentMember = (member: AdminFleetMember) =>
-  member.roleId ? permanentRoleIds.value.has(member.roleId) : false;
 
 const sorts = computed((): FleetMembershipSortEnum[] => {
   return route.query.s ? [route.query.s as FleetMembershipSortEnum] : [];
@@ -124,36 +107,6 @@ const columns: BaseTableCol<AdminFleetMember>[] = [
     sortable: true,
   },
 ];
-
-const loginAs = (member: AdminFleetMember) => {
-  displayConfirm({
-    text: t("messages.confirm.user.loginAs"),
-    onConfirm: async () => {
-      await loginAsFleetMember(props.fleet.id, member.id);
-      window.open(window.FRONTEND_ENDPOINT, "_blank");
-    },
-  });
-};
-
-const editRole = (member: AdminFleetMember) => {
-  void router.push({
-    name: "admin-fleet-member-edit",
-    params: { id: props.fleet.id, memberId: member.id },
-  });
-};
-
-const removeMember = (member: AdminFleetMember) => {
-  displayConfirm({
-    text: t("messages.confirm.fleet.members.remove"),
-    onConfirm: async () => {
-      await removeFleetMember(props.fleet.id, member.id)
-        .then(() => refetch())
-        .catch((error) => {
-          displayAlert({ text: error.response?.data?.message });
-        });
-    },
-  });
-};
 </script>
 
 <template>
@@ -204,23 +157,7 @@ const removeMember = (member: AdminFleetMember) => {
           {{ l(record.createdAt, "datetime.formats.short") }}
         </template>
         <template #actions="{ record }">
-          <Btn v-tooltip="t('actions.users.loginAs')" @click="loginAs(record)">
-            <i class="fa-duotone fa-right-to-bracket" />
-          </Btn>
-          <Btn
-            v-tooltip="t('actions.fleet.members.editRole')"
-            @click="editRole(record)"
-          >
-            <i class="fa-duotone fa-user-pen" />
-          </Btn>
-          <Btn
-            v-if="!isPermanentMember(record)"
-            v-tooltip="t('actions.fleet.members.remove')"
-            @click="removeMember(record)"
-            :tone="BtnTonesEnum.DANGER"
-          >
-            <i class="fa-duotone fa-trash" />
-          </Btn>
+          <FleetMemberActions :fleet="props.fleet" :member="record" />
         </template>
       </BaseTable>
     </template>

--- a/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
 import AsyncData from "@/shared/components/AsyncData.vue";
 import FilterGroup from "@/shared/components/base/FilterGroup/index.vue";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
@@ -136,6 +137,11 @@ const handleCancel = async () => {
           @cancel="handleCancel"
         />
       </form>
+
+      <Heading class="mt-8 mb-4">{{
+        t("headlines.admin.fleets.history")
+      }}</Heading>
+      <VersionHistory :item-id="memberId" item-type="FleetMembership" />
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members/[memberId]/edit.vue
@@ -138,10 +138,12 @@ const handleCancel = async () => {
         />
       </form>
 
-      <Heading class="mt-8 mb-4">{{
-        t("headlines.admin.fleets.history")
-      }}</Heading>
-      <VersionHistory :item-id="memberId" item-type="FleetMembership" />
+      <section class="mt-10">
+        <Heading class="mb-4">{{
+          t("headlines.admin.fleets.history")
+        }}</Heading>
+        <VersionHistory :item-id="memberId" item-type="FleetMembership" />
+      </section>
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/admin/pages/fleets/[id]/members/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/members/routes.ts
@@ -9,6 +9,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.fleets.memberEdit",
       activeRoute: "admin-fleets",
+      activeTab: "admin-fleet-members",
       needsAuthentication: true,
     },
   },

--- a/app/frontend/admin/pages/fleets/[id]/roles.vue
+++ b/app/frontend/admin/pages/fleets/[id]/roles.vue
@@ -1,0 +1,72 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetRolesPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import { BaseTableCol } from "@/shared/components/base/Table/types";
+import { type Fleet, type AdminFleetRole } from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+
+// The fleet payload already carries its roles, so there is no query here and
+// nothing to paginate: a fleet has a handful of them.
+const roles = computed(() => props.fleet.fleetRoles || []);
+
+const columns: BaseTableCol<AdminFleetRole>[] = [
+  {
+    name: "name",
+    label: t("labels.fleet.roles.name"),
+  },
+  {
+    name: "rank",
+    label: t("labels.fleet.roles.rank"),
+  },
+  {
+    name: "permanent",
+    label: t("labels.fleet.roles.permanent"),
+  },
+];
+</script>
+
+<template>
+  <Heading hero class="mb-4">
+    {{ t("headlines.admin.fleets.roles") }}
+    <HeadingSmall>{{ roles.length }}</HeadingSmall>
+  </Heading>
+
+  <BaseTable
+    :records="roles"
+    primary-key="id"
+    :columns="columns"
+    :empty-visible="roles.length === 0"
+  >
+    <template #col-name="{ record }">
+      <router-link
+        :to="{
+          name: 'admin-fleet-role',
+          params: { id: props.fleet.id, roleId: record.id },
+        }"
+      >
+        {{ record.name }}
+      </router-link>
+    </template>
+    <template #col-permanent="{ record }">
+      <i
+        v-if="record.permanent"
+        v-tooltip="t('labels.fleet.roles.permanent')"
+        class="fa-duotone fa-check"
+      />
+    </template>
+  </BaseTable>
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/roles/[roleId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/roles/[roleId].vue
@@ -49,10 +49,12 @@ const details = computed(() =>
 
     <DetailList :details="details" />
 
-    <Heading class="mt-8 mb-4">
-      {{ t("headlines.admin.fleets.history") }}
-    </Heading>
+    <section class="mt-10">
+      <Heading class="mb-4">
+        {{ t("headlines.admin.fleets.history") }}
+      </Heading>
 
-    <VersionHistory :item-id="roleId" item-type="FleetRole" />
+      <VersionHistory :item-id="roleId" item-type="FleetRole" />
+    </section>
   </template>
 </template>

--- a/app/frontend/admin/pages/fleets/[id]/roles/[roleId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/roles/[roleId].vue
@@ -1,0 +1,58 @@
+<script lang="ts">
+export default {
+  name: "AdminFleetRolePage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import DetailList from "@/admin/components/DetailList/index.vue";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+import { type Fleet } from "@/services/fyAdminApi";
+
+type Props = {
+  fleet: Fleet;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const route = useRoute();
+
+const roleId = computed(() => route.params.roleId as string);
+
+const role = computed(() =>
+  (props.fleet.fleetRoles || []).find((entry) => entry.id === roleId.value),
+);
+
+const details = computed(() =>
+  role.value
+    ? [
+        { label: t("labels.fleet.roles.name"), value: role.value.name },
+        { label: t("labels.fleet.roles.rank"), value: role.value.rank },
+        {
+          label: t("labels.fleet.roles.permanent"),
+          value: role.value.permanent ? t("labels.true") : t("labels.false"),
+        },
+      ]
+    : [],
+);
+</script>
+
+<template>
+  <Empty v-if="!role" />
+
+  <template v-else>
+    <Heading hero class="mb-4">{{ role.name }}</Heading>
+
+    <DetailList :details="details" />
+
+    <Heading class="mt-8 mb-4">
+      {{ t("headlines.admin.fleets.history") }}
+    </Heading>
+
+    <VersionHistory :item-id="roleId" item-type="FleetRole" />
+  </template>
+</template>

--- a/app/frontend/admin/pages/fleets/[id]/roles/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/roles/routes.ts
@@ -1,0 +1,14 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "roles/:roleId",
+    name: "admin-fleet-role",
+    component: () => import("@/admin/pages/fleets/[id]/roles/[roleId].vue"),
+    meta: {
+      title: "admin.fleets.role",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
+];

--- a/app/frontend/admin/pages/fleets/[id]/roles/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/roles/routes.ts
@@ -8,6 +8,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.fleets.role",
       activeRoute: "admin-fleets",
+      activeTab: "admin-fleet-roles",
       needsAuthentication: true,
     },
   },

--- a/app/frontend/admin/pages/fleets/[id]/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/routes.ts
@@ -22,6 +22,26 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "roles",
+    name: "admin-fleet-roles",
+    component: () => import("@/admin/pages/fleets/[id]/roles.vue"),
+    meta: {
+      title: "admin.fleets.roles",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
+  {
+    path: "inventories",
+    name: "admin-fleet-inventories",
+    component: () => import("@/admin/pages/fleets/[id]/inventories.vue"),
+    meta: {
+      title: "admin.fleets.inventories",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
+  {
     path: "history",
     name: "admin-fleet-history",
     component: () => import("@/admin/pages/fleets/[id]/history.vue"),

--- a/app/frontend/admin/pages/fleets/[id]/routes.ts
+++ b/app/frontend/admin/pages/fleets/[id]/routes.ts
@@ -21,4 +21,14 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history",
+    name: "admin-fleet-history",
+    component: () => import("@/admin/pages/fleets/[id]/history.vue"),
+    meta: {
+      title: "admin.fleets.history",
+      activeRoute: "admin-fleets",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/fleets/routes.ts
+++ b/app/frontend/admin/pages/fleets/routes.ts
@@ -1,6 +1,8 @@
 import type { RouteRecordRaw } from "vue-router";
 import { routes as fleetRoutes } from "@/admin/pages/fleets/[id]/routes";
 import { routes as fleetMemberRoutes } from "@/admin/pages/fleets/[id]/members/routes";
+import { routes as fleetRoleRoutes } from "@/admin/pages/fleets/[id]/roles/routes";
+import { routes as fleetInventoryRoutes } from "@/admin/pages/fleets/[id]/inventories/routes";
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -28,7 +30,12 @@ export const routes: RouteRecordRaw[] = [
   {
     path: ":id/",
     component: () => import("@/admin/pages/fleets/[id].vue"),
-    children: [...fleetRoutes, ...fleetMemberRoutes],
+    children: [
+      ...fleetRoutes,
+      ...fleetMemberRoutes,
+      ...fleetRoleRoutes,
+      ...fleetInventoryRoutes,
+    ],
     redirect: { name: fleetRoutes[0].name },
     meta: {
       needsAuthentication: true,

--- a/app/frontend/admin/pages/models/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminModelEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type ModelExtended } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  model: ModelExtended;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.models.edit.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.model.id" item-type="Model" />
+</template>

--- a/app/frontend/admin/pages/models/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/[id]/edit/routes.ts
@@ -206,4 +206,16 @@ export const routes: RouteRecordRaw[] = [
       needsAuthentication: true,
     },
   },
+  {
+    path: "history/",
+    name: "admin-model-edit-history",
+    component: () => import("@/admin/pages/models/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.models.edit.history",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/models/modules/[id]/edit/history.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/history.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+  name: "AdminModelModuleEditHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import { type ModelModule } from "@/services/fyAdminApi";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+
+type Props = {
+  modelModule: ModelModule;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Heading hero class="mb-4">{{
+    t("headlines.admin.modelModules.history")
+  }}</Heading>
+
+  <VersionHistory :item-id="props.modelModule.id" item-type="ModelModule" />
+</template>

--- a/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
@@ -65,4 +65,17 @@ export const routes: RouteRecordRaw[] = [
       activeRoute: "admin-model-modules",
     },
   },
+  {
+    path: "history/",
+    name: "admin-model-module-edit-history",
+    component: () =>
+      import("@/admin/pages/models/modules/[id]/edit/history.vue"),
+    meta: {
+      title: "admin.modelModules.edit.history",
+      customTitle: true,
+      activeRoute: "admin-models",
+      nav: "editTabs",
+      needsAuthentication: true,
+    },
+  },
 ];

--- a/app/frontend/admin/pages/users/[id]/inventories.vue
+++ b/app/frontend/admin/pages/users/[id]/inventories.vue
@@ -1,0 +1,125 @@
+<script lang="ts">
+export default {
+  name: "AdminUserInventoriesPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import FilteredList from "@/shared/components/FilteredList/index.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { BaseTableCol } from "@/shared/components/base/Table/types";
+import { usePagination } from "@/shared/composables/usePagination";
+import {
+  type User,
+  type Inventory,
+  useUserInventories as useUserInventoriesQuery,
+  getUserInventoriesQueryKey,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  user: User;
+};
+
+const props = defineProps<Props>();
+
+const { t, lUtc: l } = useI18n();
+
+const queryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+}));
+
+const queryKey = computed(() =>
+  getUserInventoriesQueryKey(props.user.id!, queryParams.value),
+);
+
+const { perPage, page, updatePerPage } = usePagination(queryKey);
+
+const { data: inventories, ...asyncStatus } = useUserInventoriesQuery(
+  props.user.id!,
+  queryParams,
+);
+
+const columns: BaseTableCol<Inventory>[] = [
+  { name: "name", label: t("labels.fleet.inventories.name") },
+  { name: "location", label: t("labels.fleet.inventories.location") },
+  { name: "source", label: t("labels.inventories.source") },
+  { name: "itemsCount", label: t("labels.fleet.inventories.itemsCount") },
+  { name: "createdAt", label: t("labels.createdAt") },
+];
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.users.inventories") }}
+    <HeadingSmall v-if="inventories">
+      {{
+        t("headlines.pagination.count", {
+          current: inventories?.items.length,
+          total: inventories?.meta.pagination?.totalCount,
+        })
+      }}
+    </HeadingSmall>
+  </Heading>
+
+  <FilteredList
+    v-if="inventories"
+    name="admin-user-inventories"
+    :records="inventories.items || []"
+    :async-status="asyncStatus"
+    hide-loading
+    hide-empty
+  >
+    <template #default="{ loading, refetching, emptyVisible }">
+      <BaseTable
+        :records="inventories.items || []"
+        primary-key="id"
+        :columns="columns"
+        :loading="loading || refetching"
+        :empty-visible="emptyVisible"
+      >
+        <template #col-name="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-user-inventory',
+              params: { id: props.user.id, inventoryId: record.id },
+            }"
+          >
+            {{ record.name }}
+          </router-link>
+        </template>
+        <!-- A ship provisions its own inventory; everything else was made by
+             hand, and only the vehicle link tells them apart. -->
+        <template #col-source="{ record }">
+          {{
+            record.vehicleId
+              ? t("labels.inventories.sources.vehicle")
+              : t("labels.inventories.sources.handMade")
+          }}
+        </template>
+        <template #col-createdAt="{ record }">
+          {{ l(record.createdAt, "datetime.formats.short") }}
+        </template>
+      </BaseTable>
+    </template>
+    <template #pagination-top>
+      <Paginator
+        v-if="inventories"
+        :query-result-ref="inventories"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+    <template #pagination-bottom>
+      <Paginator
+        v-if="inventories"
+        :query-result-ref="inventories"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+    </template>
+  </FilteredList>
+</template>

--- a/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
@@ -1,0 +1,163 @@
+<script lang="ts">
+export default {
+  name: "AdminUserInventoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import AsyncData from "@/shared/components/AsyncData.vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import { BaseTableCol } from "@/shared/components/base/Table/types";
+import { usePagination } from "@/shared/composables/usePagination";
+import DetailList from "@/admin/components/DetailList/index.vue";
+import { type Detail } from "@/admin/components/DetailList/types";
+import VersionHistory from "@/admin/components/VersionHistory/index.vue";
+import {
+  type User,
+  type InventoryItem,
+  useUserInventory as useUserInventoryQuery,
+  useUserInventoryItems as useUserInventoryItemsQuery,
+  getUserInventoryItemsQueryKey,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  user: User;
+};
+
+const props = defineProps<Props>();
+
+const { t, lUtc: l } = useI18n();
+const route = useRoute();
+
+const inventoryId = computed(() => route.params.inventoryId as string);
+
+const { data: inventory, ...asyncStatus } = useUserInventoryQuery(
+  props.user.id!,
+  inventoryId,
+);
+
+const itemsQueryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+}));
+
+const itemsQueryKey = computed(() =>
+  getUserInventoryItemsQueryKey(
+    props.user.id!,
+    inventoryId.value,
+    itemsQueryParams.value,
+  ),
+);
+
+const { perPage, page, updatePerPage } = usePagination(itemsQueryKey);
+
+const { data: items } = useUserInventoryItemsQuery(
+  props.user.id!,
+  inventoryId,
+  itemsQueryParams,
+);
+
+const details = computed<Detail[]>(() =>
+  inventory.value
+    ? [
+        {
+          label: t("labels.fleet.inventories.name"),
+          value: inventory.value.name,
+        },
+        { label: t("labels.slug"), value: inventory.value.slug },
+        {
+          label: t("labels.fleet.inventories.description"),
+          value: inventory.value.description,
+        },
+        {
+          label: t("labels.fleet.inventories.location"),
+          value: inventory.value.location,
+        },
+        {
+          label: t("labels.inventories.source"),
+          value: inventory.value.vehicleId
+            ? t("labels.inventories.sources.vehicle")
+            : t("labels.inventories.sources.handMade"),
+        },
+        {
+          label: t("labels.createdAt"),
+          value: l(inventory.value.createdAt, "datetime.formats.short"),
+        },
+      ]
+    : [],
+);
+
+const columns: BaseTableCol<InventoryItem>[] = [
+  { name: "name", label: t("labels.inventoryItems.name") },
+  { name: "category", label: t("labels.inventoryItems.category") },
+  { name: "entryType", label: t("labels.inventoryItems.entryType") },
+  { name: "quantity", label: t("labels.inventoryItems.quantity") },
+  { name: "createdAt", label: t("labels.createdAt") },
+];
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <Heading hero class="mb-4">{{ inventory?.name }}</Heading>
+
+      <DetailList :details="details" />
+
+      <Heading class="mt-8 mb-4">
+        {{ t("headlines.admin.fleets.inventoryItems") }}
+      </Heading>
+
+      <BaseTable
+        v-if="items"
+        :records="items.items || []"
+        primary-key="id"
+        :columns="columns"
+        :empty-visible="(items.items || []).length === 0"
+      >
+        <template #col-name="{ record }">
+          <router-link
+            :to="{
+              name: 'admin-user-inventory-item',
+              params: {
+                id: props.user.id,
+                inventoryId,
+                itemId: record.id,
+              },
+            }"
+          >
+            {{ record.name }}
+          </router-link>
+        </template>
+        <template #col-category="{ record }">
+          {{ t(`labels.inventoryItems.categories.${record.category}`) }}
+        </template>
+        <template #col-entryType="{ record }">
+          {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
+        </template>
+        <template #col-quantity="{ record }">
+          {{ record.quantity }}
+          {{ t(`labels.inventoryItems.units.${record.unit}`) }}
+        </template>
+        <template #col-createdAt="{ record }">
+          {{ l(record.createdAt, "datetime.formats.short") }}
+        </template>
+      </BaseTable>
+
+      <Paginator
+        v-if="items"
+        :query-result-ref="items"
+        :per-page="perPage"
+        :update-per-page="updatePerPage"
+      />
+
+      <Heading class="mt-8 mb-4">
+        {{ t("headlines.admin.fleets.history") }}
+      </Heading>
+
+      <VersionHistory :item-id="inventoryId" item-type="Inventory" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
@@ -106,58 +106,62 @@ const columns: BaseTableCol<InventoryItem>[] = [
 
       <DetailList :details="details" />
 
-      <Heading class="mt-8 mb-4">
-        {{ t("headlines.admin.fleets.inventoryItems") }}
-      </Heading>
+      <section class="mt-10">
+        <Heading class="mb-4">
+          {{ t("headlines.admin.fleets.inventoryItems") }}
+        </Heading>
 
-      <BaseTable
-        v-if="items"
-        :records="items.items || []"
-        primary-key="id"
-        :columns="columns"
-        :empty-visible="(items.items || []).length === 0"
-      >
-        <template #col-name="{ record }">
-          <router-link
-            :to="{
-              name: 'admin-user-inventory-item',
-              params: {
-                id: props.user.id,
-                inventoryId,
-                itemId: record.id,
-              },
-            }"
-          >
-            {{ record.name }}
-          </router-link>
-        </template>
-        <template #col-category="{ record }">
-          {{ t(`labels.inventoryItems.categories.${record.category}`) }}
-        </template>
-        <template #col-entryType="{ record }">
-          {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
-        </template>
-        <template #col-quantity="{ record }">
-          {{ record.quantity }}
-          {{ t(`labels.inventoryItems.units.${record.unit}`) }}
-        </template>
-        <template #col-createdAt="{ record }">
-          {{ l(record.createdAt, "datetime.formats.short") }}
-        </template>
-      </BaseTable>
+        <BaseTable
+          v-if="items"
+          :records="items.items || []"
+          primary-key="id"
+          :columns="columns"
+          :empty-visible="(items.items || []).length === 0"
+        >
+          <template #col-name="{ record }">
+            <router-link
+              :to="{
+                name: 'admin-user-inventory-item',
+                params: {
+                  id: props.user.id,
+                  inventoryId,
+                  itemId: record.id,
+                },
+              }"
+            >
+              {{ record.name }}
+            </router-link>
+          </template>
+          <template #col-category="{ record }">
+            {{ t(`labels.inventoryItems.categories.${record.category}`) }}
+          </template>
+          <template #col-entryType="{ record }">
+            {{ t(`labels.inventoryItems.entryTypes.${record.entryType}`) }}
+          </template>
+          <template #col-quantity="{ record }">
+            {{ record.quantity }}
+            {{ t(`labels.inventoryItems.units.${record.unit}`) }}
+          </template>
+          <template #col-createdAt="{ record }">
+            {{ l(record.createdAt, "datetime.formats.short") }}
+          </template>
+        </BaseTable>
 
-      <Paginator
-        v-if="items"
-        :query-result-ref="items"
-        :per-page="perPage"
-        :update-per-page="updatePerPage"
-      />
+        <Paginator
+          v-if="items"
+          :query-result-ref="items"
+          :per-page="perPage"
+          :update-per-page="updatePerPage"
+        />
+      </section>
 
-      <Heading class="mt-8 mb-4">
-        {{ t("headlines.admin.fleets.history") }}
-      </Heading>
+      <section class="mt-10">
+        <Heading class="mb-4">
+          {{ t("headlines.admin.fleets.history") }}
+        </Heading>
 
-      <VersionHistory :item-id="inventoryId" item-type="Inventory" />
+        <VersionHistory :item-id="inventoryId" item-type="Inventory" />
+      </section>
     </template>
   </AsyncData>
 </template>

--- a/app/frontend/admin/pages/users/[id]/inventories/[inventoryId]/items/[itemId].vue
+++ b/app/frontend/admin/pages/users/[id]/inventories/[inventoryId]/items/[itemId].vue
@@ -1,0 +1,39 @@
+<script lang="ts">
+export default {
+  name: "AdminUserInventoryItemPage",
+};
+</script>
+
+<script lang="ts" setup>
+import AsyncData from "@/shared/components/AsyncData.vue";
+import InventoryItemDetail from "@/admin/components/InventoryItemDetail/index.vue";
+import {
+  type User,
+  useUserInventoryItem as useUserInventoryItemQuery,
+} from "@/services/fyAdminApi";
+
+type Props = {
+  user: User;
+};
+
+const props = defineProps<Props>();
+
+const route = useRoute();
+
+const inventoryId = computed(() => route.params.inventoryId as string);
+const itemId = computed(() => route.params.itemId as string);
+
+const { data: item, ...asyncStatus } = useUserInventoryItemQuery(
+  props.user.id!,
+  inventoryId,
+  itemId,
+);
+</script>
+
+<template>
+  <AsyncData :async-status="asyncStatus">
+    <template #resolved>
+      <InventoryItemDetail v-if="item" :item="item" item-type="InventoryItem" />
+    </template>
+  </AsyncData>
+</template>

--- a/app/frontend/admin/pages/users/[id]/inventories/routes.ts
+++ b/app/frontend/admin/pages/users/[id]/inventories/routes.ts
@@ -9,6 +9,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.users.inventory",
       activeRoute: "users",
+      activeTab: "admin-user-inventories",
       needsAuthentication: true,
     },
   },
@@ -20,6 +21,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: "admin.users.inventoryItem",
       activeRoute: "users",
+      activeTab: "admin-user-inventories",
       needsAuthentication: true,
     },
   },

--- a/app/frontend/admin/pages/users/[id]/inventories/routes.ts
+++ b/app/frontend/admin/pages/users/[id]/inventories/routes.ts
@@ -1,0 +1,26 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "inventories/:inventoryId",
+    name: "admin-user-inventory",
+    component: () =>
+      import("@/admin/pages/users/[id]/inventories/[inventoryId].vue"),
+    meta: {
+      title: "admin.users.inventory",
+      activeRoute: "users",
+      needsAuthentication: true,
+    },
+  },
+  {
+    path: "inventories/:inventoryId/items/:itemId",
+    name: "admin-user-inventory-item",
+    component: () =>
+      import("@/admin/pages/users/[id]/inventories/[inventoryId]/items/[itemId].vue"),
+    meta: {
+      title: "admin.users.inventoryItem",
+      activeRoute: "users",
+      needsAuthentication: true,
+    },
+  },
+];

--- a/app/frontend/admin/pages/users/[id]/routes.ts
+++ b/app/frontend/admin/pages/users/[id]/routes.ts
@@ -12,6 +12,16 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "inventories",
+    name: "admin-user-inventories",
+    component: () => import("@/admin/pages/users/[id]/inventories.vue"),
+    meta: {
+      title: "admin.users.inventories",
+      activeRoute: "users",
+      needsAuthentication: true,
+    },
+  },
+  {
     path: "fleets",
     name: "admin-user-fleets",
     component: () => import("@/admin/pages/users/[id]/fleets.vue"),

--- a/app/frontend/admin/pages/users/routes.ts
+++ b/app/frontend/admin/pages/users/routes.ts
@@ -1,5 +1,6 @@
 import type { RouteRecordRaw } from "vue-router";
 import { routes as userRoutes } from "@/admin/pages/users/[id]/routes";
+import { routes as userInventoryRoutes } from "@/admin/pages/users/[id]/inventories/routes";
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -15,7 +16,7 @@ export const routes: RouteRecordRaw[] = [
   {
     path: ":id/",
     component: () => import("@/admin/pages/users/[id].vue"),
-    children: userRoutes,
+    children: [...userRoutes, ...userInventoryRoutes],
     redirect: { name: userRoutes[0].name },
     meta: {
       needsAuthentication: true,

--- a/app/frontend/shared/components/TabNavView/Items/index.vue
+++ b/app/frontend/shared/components/TabNavView/Items/index.vue
@@ -6,8 +6,12 @@ export default {
 
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
-import { type RouteRecordName, type RouteRecordRaw } from "vue-router";
+import { type RouteRecordRaw } from "vue-router";
 import { checkAccess } from "@/shared/utils/Access";
+import {
+  routeName,
+  useActiveTab,
+} from "@/shared/components/TabNavView/useActiveTab";
 
 type Props = {
   routes: RouteRecordRaw[];
@@ -33,24 +37,7 @@ const filteredRoutes = computed(() => {
 
 const { t } = useI18n();
 
-const route = useRoute();
-
-const activeRoute = (tabRouteName?: RouteRecordName) => {
-  if (tabRouteName === route.name) return true;
-
-  const tabRoute = filteredRoutes.value.find(
-    (r) => routeName(r) === tabRouteName,
-  );
-  if (!tabRoute?.children?.length) return false;
-
-  return route.matched.some(
-    (matched) => (matched.redirect as RouteRecordRaw)?.name === tabRouteName,
-  );
-};
-
-const routeName = (route: RouteRecordRaw) => {
-  return route.name || (route.redirect as RouteRecordRaw)?.name;
-};
+const { isActive } = useActiveTab(filteredRoutes);
 </script>
 
 <template>
@@ -63,7 +50,7 @@ const routeName = (route: RouteRecordRaw) => {
   >
     <li
       role="link"
-      :class="{ active: activeRoute(routeName(item)) }"
+      :class="{ active: isActive(routeName(item)) }"
       @click="navigate"
       @keypress.enter="() => navigate"
     >

--- a/app/frontend/shared/components/TabNavView/MobileDropdown/index.vue
+++ b/app/frontend/shared/components/TabNavView/MobileDropdown/index.vue
@@ -6,8 +6,12 @@ export default {
 
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
-import { type RouteRecordName, type RouteRecordRaw } from "vue-router";
+import { type RouteRecordRaw } from "vue-router";
 import { checkAccess } from "@/shared/utils/Access";
+import {
+  routeName,
+  useActiveTab,
+} from "@/shared/components/TabNavView/useActiveTab";
 
 type Props = {
   routes: RouteRecordRaw[];
@@ -36,26 +40,7 @@ const filteredRoutes = computed(() => {
     .filter((r) => checkAccess(props.resourceAccess, r.meta?.access));
 });
 
-const routeName = (r: RouteRecordRaw) => {
-  return r.name || (r.redirect as RouteRecordRaw)?.name;
-};
-
-const isActive = (tabRouteName?: RouteRecordName) => {
-  if (tabRouteName === route.name) return true;
-
-  const tabRoute = filteredRoutes.value.find(
-    (r) => routeName(r) === tabRouteName,
-  );
-  if (!tabRoute?.children?.length) return false;
-
-  return route.matched.some(
-    (matched) => (matched.redirect as RouteRecordRaw)?.name === tabRouteName,
-  );
-};
-
-const activeRoute = computed(() =>
-  filteredRoutes.value.find((r) => isActive(routeName(r))),
-);
+const { isActive, activeRoute } = useActiveTab(filteredRoutes);
 
 const activeLabel = computed(() => {
   if (!activeRoute.value) return "";

--- a/app/frontend/shared/components/TabNavView/useActiveTab.spec.ts
+++ b/app/frontend/shared/components/TabNavView/useActiveTab.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import type { RouteRecordRaw } from "vue-router";
+
+const currentRoute = {
+  name: "" as string,
+  meta: {} as Record<string, unknown>,
+  matched: [] as unknown[],
+};
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRoute: () => currentRoute,
+}));
+
+const { useActiveTab, routeName } = await import("./useActiveTab");
+
+const tab = (name: string): RouteRecordRaw =>
+  ({ path: name, name, component: {} }) as RouteRecordRaw;
+
+const tabs = ref<RouteRecordRaw[]>([
+  tab("admin-fleet-edit"),
+  tab("admin-fleet-members"),
+  tab("admin-fleet-inventories"),
+]);
+
+const at = (name: string, meta: Record<string, unknown> = {}) => {
+  currentRoute.name = name;
+  currentRoute.meta = meta;
+  currentRoute.matched = [];
+
+  return useActiveTab(tabs);
+};
+
+describe("useActiveTab", () => {
+  it("lights the tab you are standing on", () => {
+    const { isActive } = at("admin-fleet-members");
+
+    expect(isActive("admin-fleet-members")).toBe(true);
+    expect(isActive("admin-fleet-inventories")).toBe(false);
+  });
+
+  // Without this the strip goes blank the moment you open a record.
+  it("lights the tab a detail page names", () => {
+    const { isActive, activeRoute } = at("admin-fleet-inventory", {
+      activeTab: "admin-fleet-inventories",
+    });
+
+    expect(isActive("admin-fleet-inventories")).toBe(true);
+    expect(isActive("admin-fleet-members")).toBe(false);
+    expect(routeName(activeRoute.value!)).toBe("admin-fleet-inventories");
+  });
+
+  it("lights it from a detail page nested deeper still", () => {
+    const { isActive } = at("admin-fleet-inventory-item", {
+      activeTab: "admin-fleet-inventories",
+    });
+
+    expect(isActive("admin-fleet-inventories")).toBe(true);
+  });
+
+  it("lights nothing when the page claims no tab", () => {
+    const { isActive, activeRoute } = at("admin-fleet-inventory");
+
+    expect(tabs.value.every((t) => !isActive(routeName(t)))).toBe(true);
+    expect(activeRoute.value).toBeUndefined();
+  });
+
+  /*
+   * A grouped tab carries no name of its own: it redirects to its first child,
+   * and `routeName` reports that. Standing on any child has to keep the group
+   * lit, which is the case the `activeTab` shortcut must not have broken.
+   */
+  it("still lights a grouped tab from one of its children", () => {
+    const group = {
+      path: ":id/",
+      component: {},
+      children: [
+        { path: "", name: "admin-commodity-edit", component: {} },
+        { path: "prices", name: "admin-commodity-edit-prices", component: {} },
+      ],
+      redirect: { name: "admin-commodity-edit" },
+    } as unknown as RouteRecordRaw;
+
+    const grouped = ref<RouteRecordRaw[]>([group]);
+
+    expect(routeName(group)).toBe("admin-commodity-edit");
+
+    currentRoute.name = "admin-commodity-edit-prices";
+    currentRoute.meta = {};
+    currentRoute.matched = [{ redirect: { name: "admin-commodity-edit" } }];
+
+    const { isActive } = useActiveTab(grouped);
+
+    expect(isActive("admin-commodity-edit")).toBe(true);
+  });
+});

--- a/app/frontend/shared/components/TabNavView/useActiveTab.ts
+++ b/app/frontend/shared/components/TabNavView/useActiveTab.ts
@@ -1,0 +1,33 @@
+import { type RouteRecordName, type RouteRecordRaw } from "vue-router";
+
+export const routeName = (route: RouteRecordRaw) =>
+  route.name || (route.redirect as RouteRecordRaw)?.name;
+
+/*
+ * Which tab the strip should light up. Shared by the desktop strip and the
+ * mobile dropdown, which have to agree -- and did so by holding two copies of
+ * this.
+ */
+export const useActiveTab = (routes: Ref<RouteRecordRaw[]>) => {
+  const route = useRoute();
+
+  const isActive = (tabRouteName?: RouteRecordName) => {
+    if (tabRouteName === route.name) return true;
+
+    // A detail page is not a tab, so it names the one it sits under.
+    if (route.meta?.activeTab === tabRouteName) return true;
+
+    const tabRoute = routes.value.find((r) => routeName(r) === tabRouteName);
+    if (!tabRoute?.children?.length) return false;
+
+    return route.matched.some(
+      (matched) => (matched.redirect as RouteRecordRaw)?.name === tabRouteName,
+    );
+  };
+
+  const activeRoute = computed(() =>
+    routes.value.find((r) => isActive(routeName(r))),
+  );
+
+  return { isActive, activeRoute };
+};

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -276,7 +276,8 @@
         "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen",
         "alreadyExists": "%{name} ist bereits im Katalog",
         "link": "Schon im Katalog"
-      }
+      },
+      "revert": "Zurücksetzen"
     }
   }
 }

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -92,7 +92,8 @@
         "users": {
           "index": "Benutzer",
           "edit": "Benutzer bearbeiten",
-          "fleets": "Flotten"
+          "fleets": "Flotten",
+          "inventories": "Inventare"
         },
         "vehicles": {
           "index": "Fahrzeuge",
@@ -102,7 +103,10 @@
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
           "memberEdit": "Mitglied bearbeiten",
-          "history": "Verlauf"
+          "history": "Verlauf",
+          "roles": "Rollen",
+          "inventories": "Inventare",
+          "inventoryItems": "Einträge"
         },
         "admins": {
           "index": "Administratoren",

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -39,7 +39,8 @@
             "loaners": "Leihschiffe",
             "upgrades": "Upgrades",
             "packages": "Pakete",
-            "linkUpgrade": "Vorhandenes Upgrade verknüpfen"
+            "linkUpgrade": "Vorhandenes Upgrade verknüpfen",
+            "history": "Verlauf"
           },
           "new": "Neues Modell",
           "show": "Modell",
@@ -51,7 +52,8 @@
           "new": "Neue Komponente",
           "edit": {
             "index": "Komponente bearbeiten",
-            "itemPrices": "Artikelpreise"
+            "itemPrices": "Artikelpreise",
+            "history": "Verlauf"
           }
         },
         "modelPaints": {
@@ -64,7 +66,8 @@
           "new": "Neues Modul",
           "edit": "Modul bearbeiten",
           "models": "Verknüpfte Modelle",
-          "prices": "Preise"
+          "prices": "Preise",
+          "history": "Verlauf"
         },
         "unlistedModels": {
           "index": "Schiffe in den Spieldateien ohne Model",
@@ -98,7 +101,8 @@
         "fleets": {
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
-          "memberEdit": "Mitglied bearbeiten"
+          "memberEdit": "Mitglied bearbeiten",
+          "history": "Verlauf"
         },
         "admins": {
           "index": "Administratoren",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1240,6 +1240,17 @@
             "rsi-api-status": "RSI-API-Status",
             "stats": "Statistiken"
           }
+        },
+        "versions": {
+          "blank": "leer",
+          "revertQuestion": "Zurücksetzen?",
+          "sources": {
+            "custom": "Admin",
+            "rsi_loader": "Ship Matrix",
+            "sc_data_loader": "Spieldateien",
+            "sc_loader": "Spieldateien",
+            "unknown": "Unbekannt"
+          }
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -398,7 +398,9 @@
             "fleet:roles:update": "Rollen bearbeiten",
             "fleet:roles:delete": "Rollen löschen",
             "fleet:roles:manage": "Rollen verwalten"
-          }
+          },
+          "name": "Name",
+          "rank": "Rang"
         },
         "inviteUrls": {
           "noLimit": "Kein Limit",
@@ -425,6 +427,18 @@
             "25": "25 uses",
             "50": "50 uses",
             "100": "100 uses"
+          }
+        },
+        "inventories": {
+          "name": "Name",
+          "description": "Beschreibung",
+          "location": "Ort",
+          "visibility": "Sichtbarkeit",
+          "manager": "Verwalter",
+          "itemsCount": "Einträge",
+          "visibilities": {
+            "members_only": "Nur Mitglieder",
+            "officers_only": "Nur Offiziere"
           }
         }
       },
@@ -1444,6 +1458,40 @@
       },
       "unlistedModel": {
         "linkHint": "Welches Schiff im Katalog ist %{identifier}? Der Vorschlag stammt aus dem Export und kann falsch sein."
+      },
+      "slug": "Slug",
+      "inventories": {
+        "source": "Herkunft",
+        "sources": {
+          "vehicle": "Schiff",
+          "handMade": "Selbst angelegt"
+        }
+      },
+      "inventoryItems": {
+        "name": "Name",
+        "category": "Kategorie",
+        "entryType": "Buchung",
+        "quantity": "Menge",
+        "quality": "Qualität",
+        "notes": "Notizen",
+        "itemType": "Katalog",
+        "categories": {
+          "commodity": "Ware",
+          "component": "Komponente",
+          "weapon": "Waffe",
+          "equipment": "Ausrüstung",
+          "ammunition": "Munition",
+          "consumable": "Verbrauchsgut",
+          "other": "Sonstiges"
+        },
+        "entryTypes": {
+          "deposit": "Einlagerung",
+          "withdrawal": "Entnahme"
+        },
+        "units": {
+          "scu": "SCU",
+          "units": "Stück"
+        }
       }
     }
   }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1249,6 +1249,7 @@
             "rsi_loader": "Ship Matrix",
             "sc_data_loader": "Spieldateien",
             "sc_loader": "Spieldateien",
+            "uex_price_sync": "UEX-Preisabgleich",
             "unknown": "Unbekannt"
           }
         }

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -122,7 +122,8 @@
             "hardpoints": "Aufhängungspunkte",
             "loaners": "Leihschiffe",
             "upgrades": "Upgrades",
-            "packages": "Pakete"
+            "packages": "Pakete",
+            "history": "Verlauf"
           }
         },
         "modelPaints": {
@@ -135,7 +136,8 @@
           "edit": {
             "index": "Basisdaten",
             "models": "Modelle",
-            "prices": "Preise"
+            "prices": "Preise",
+            "history": "Verlauf"
           }
         },
         "unlistedModels": {
@@ -149,7 +151,8 @@
           "index": "Komponenten",
           "edit": {
             "index": "Basisdaten",
-            "prices": "Preise"
+            "prices": "Preise",
+            "history": "Verlauf"
           }
         },
         "manufacturers": {
@@ -164,7 +167,8 @@
           "fleets": "Flotten"
         },
         "fleets": {
-          "index": "Flotten"
+          "index": "Flotten",
+          "history": "Verlauf"
         },
         "vehicles": {
           "index": "Fahrzeuge"

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -164,11 +164,14 @@
         "users": {
           "index": "Benutzer",
           "edit": "Bearbeiten",
-          "fleets": "Flotten"
+          "fleets": "Flotten",
+          "inventories": "Inventare"
         },
         "fleets": {
           "index": "Flotten",
-          "history": "Verlauf"
+          "history": "Verlauf",
+          "roles": "Rollen",
+          "inventories": "Inventare"
         },
         "vehicles": {
           "index": "Fahrzeuge"

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -166,7 +166,8 @@
           "edit": "Benutzer bearbeiten",
           "inventories": "Nutzer-Inventare",
           "inventory": "Nutzer-Inventar",
-          "inventoryItem": "Inventar-Eintrag"
+          "inventoryItem": "Inventar-Eintrag",
+          "fleets": "Nutzer-Flotten"
         },
         "vehicles": {
           "index": "Fahrzeuge",

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -133,7 +133,8 @@
             "loaners": "Modell Leihgaben bearbeiten",
             "snubCrafts": "Modell Snub Crafts bearbeiten",
             "upgrades": "Modell Upgrades bearbeiten",
-            "packages": "Modell Pakete bearbeiten"
+            "packages": "Modell Pakete bearbeiten",
+            "history": "%{manufacturer} %{model} Verlauf"
           }
         },
         "components": {
@@ -141,7 +142,8 @@
           "new": "Neue Komponente",
           "edit": {
             "index": "Komponente bearbeiten",
-            "prices": "Komponente Preise bearbeiten"
+            "prices": "Komponente Preise bearbeiten",
+            "history": "Komponenten-Verlauf"
           }
         },
         "manufacturers": {
@@ -174,7 +176,8 @@
         "fleets": {
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
-          "memberEdit": "Flottenmitglied bearbeiten"
+          "memberEdit": "Flottenmitglied bearbeiten",
+          "history": "Flotten-Verlauf"
         },
         "oauthApplications": {
           "index": "OAuth-Anwendungen",
@@ -208,7 +211,8 @@
           "edit": {
             "index": "%{name} Basisdaten bearbeiten",
             "models": "%{name} Modelle bearbeiten",
-            "prices": "%{name} Preise bearbeiten"
+            "prices": "%{name} Preise bearbeiten",
+            "history": "Modul-Verlauf"
           }
         },
         "unlistedModels": {

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -163,7 +163,10 @@
         },
         "users": {
           "index": "Benutzer",
-          "edit": "Benutzer bearbeiten"
+          "edit": "Benutzer bearbeiten",
+          "inventories": "Nutzer-Inventare",
+          "inventory": "Nutzer-Inventar",
+          "inventoryItem": "Inventar-Eintrag"
         },
         "vehicles": {
           "index": "Fahrzeuge",
@@ -177,7 +180,12 @@
           "index": "Flotten",
           "edit": "Flotte bearbeiten",
           "memberEdit": "Flottenmitglied bearbeiten",
-          "history": "Flotten-Verlauf"
+          "history": "Flotten-Verlauf",
+          "roles": "Flotten-Rollen",
+          "role": "Flotten-Rolle",
+          "inventories": "Flotten-Inventare",
+          "inventory": "Flotten-Inventar",
+          "inventoryItem": "Inventar-Eintrag"
         },
         "oauthApplications": {
           "index": "OAuth-Anwendungen",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -381,7 +381,8 @@
         "noManufacturer": "No manufacturer resolves from this identifier",
         "alreadyExists": "%{name} is already in the catalogue",
         "link": "Already in the catalogue"
-      }
+      },
+      "revert": "Revert"
     }
   }
 }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -41,7 +41,8 @@
             "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
             "packages": "Packages",
-            "linkUpgrade": "Link Existing Upgrade"
+            "linkUpgrade": "Link Existing Upgrade",
+            "history": "History"
           },
           "new": "New Model",
           "show": "Model",
@@ -53,7 +54,8 @@
           "new": "New Component",
           "edit": {
             "index": "Edit Component",
-            "itemPrices": "Item Prices"
+            "itemPrices": "Item Prices",
+            "history": "History"
           }
         },
         "modelPaints": {
@@ -70,7 +72,8 @@
           "models": "Linked Models",
           "prices": "Prices",
           "hardpoints": "Hardpoints",
-          "cargoHolds": "Cargo Holds"
+          "cargoHolds": "Cargo Holds",
+          "history": "History"
         },
         "unlistedModels": {
           "index": "Ships in the game files with no model",
@@ -105,7 +108,8 @@
           "index": "Fleets",
           "edit": "Edit Fleet",
           "members": "Members",
-          "memberEdit": "Edit Member"
+          "memberEdit": "Edit Member",
+          "history": "History"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -98,7 +98,8 @@
         "users": {
           "index": "Users",
           "edit": "Edit User",
-          "fleets": "Fleets"
+          "fleets": "Fleets",
+          "inventories": "Inventories"
         },
         "vehicles": {
           "index": "Vehicles",
@@ -109,7 +110,10 @@
           "edit": "Edit Fleet",
           "members": "Members",
           "memberEdit": "Edit Member",
-          "history": "History"
+          "history": "History",
+          "roles": "Roles",
+          "inventories": "Inventories",
+          "inventoryItems": "Entries"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1722,6 +1722,17 @@
             "rsi-api-status": "RSI API Status",
             "stats": "Stats"
           }
+        },
+        "versions": {
+          "blank": "empty",
+          "revertQuestion": "Revert?",
+          "sources": {
+            "custom": "Admin",
+            "rsi_loader": "Ship Matrix",
+            "sc_data_loader": "Game Files",
+            "sc_loader": "Game Files",
+            "unknown": "Unknown"
+          }
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1731,6 +1731,7 @@
             "rsi_loader": "Ship Matrix",
             "sc_data_loader": "Game Files",
             "sc_loader": "Game Files",
+            "uex_price_sync": "UEX Price Sync",
             "unknown": "Unknown"
           }
         }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -476,7 +476,9 @@
             "fleet:events:delete": "Delete Events",
             "fleet:events:manage": "Manage Events",
             "fleet:notifications:manage": "Manage Notification Settings"
-          }
+          },
+          "name": "Name",
+          "rank": "Rank"
         },
         "inviteUrls": {
           "noLimit": "No limit",
@@ -528,6 +530,18 @@
               "created": "Signup added",
               "withdrawn": "Signup withdrawn"
             }
+          }
+        },
+        "inventories": {
+          "name": "Name",
+          "description": "Description",
+          "location": "Location",
+          "visibility": "Visibility",
+          "manager": "Manager",
+          "itemsCount": "Entries",
+          "visibilities": {
+            "members_only": "Members only",
+            "officers_only": "Officers only"
           }
         }
       },
@@ -2219,6 +2233,40 @@
       },
       "unlistedModel": {
         "linkHint": "Which ship in the catalogue is %{identifier}? The suggestion comes from the export and may be wrong."
+      },
+      "slug": "Slug",
+      "inventories": {
+        "source": "Source",
+        "sources": {
+          "vehicle": "Ship",
+          "handMade": "Made by hand"
+        }
+      },
+      "inventoryItems": {
+        "name": "Name",
+        "category": "Category",
+        "entryType": "Entry",
+        "quantity": "Quantity",
+        "quality": "Quality",
+        "notes": "Notes",
+        "itemType": "Catalogue",
+        "categories": {
+          "commodity": "Commodity",
+          "component": "Component",
+          "weapon": "Weapon",
+          "equipment": "Equipment",
+          "ammunition": "Ammunition",
+          "consumable": "Consumable",
+          "other": "Other"
+        },
+        "entryTypes": {
+          "deposit": "Deposit",
+          "withdrawal": "Withdrawal"
+        },
+        "units": {
+          "scu": "SCU",
+          "units": "units"
+        }
       }
     }
   }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -199,13 +199,16 @@
         "users": {
           "index": "Users",
           "edit": "Edit",
-          "fleets": "Fleets"
+          "fleets": "Fleets",
+          "inventories": "Inventories"
         },
         "fleets": {
           "index": "Fleets",
           "edit": "Edit",
           "members": "Members",
-          "history": "History"
+          "history": "History",
+          "roles": "Roles",
+          "inventories": "Inventories"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -155,7 +155,8 @@
             "loaners": "Loaners",
             "snubCrafts": "Snub Crafts",
             "upgrades": "Upgrades",
-            "packages": "Packages"
+            "packages": "Packages",
+            "history": "History"
           }
         },
         "modelPaints": {
@@ -170,7 +171,8 @@
             "models": "Models",
             "prices": "Prices",
             "hardpoints": "Hardpoints",
-            "cargoHolds": "Cargo Holds"
+            "cargoHolds": "Cargo Holds",
+            "history": "History"
           }
         },
         "unlistedModels": {
@@ -184,7 +186,8 @@
           "index": "Components",
           "edit": {
             "index": "Base Data",
-            "prices": "Prices"
+            "prices": "Prices",
+            "history": "History"
           }
         },
         "manufacturers": {
@@ -201,7 +204,8 @@
         "fleets": {
           "index": "Fleets",
           "edit": "Edit",
-          "members": "Members"
+          "members": "Members",
+          "history": "History"
         },
         "destroyedFleets": {
           "index": "Destroyed Fleets"

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -198,7 +198,8 @@
           "edit": "Edit User",
           "inventories": "User Inventories",
           "inventory": "User Inventory",
-          "inventoryItem": "Inventory Entry"
+          "inventoryItem": "Inventory Entry",
+          "fleets": "User Fleets"
         },
         "vehicles": {
           "index": "Vehicles",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -165,7 +165,8 @@
             "loaners": "Edit %{manufacturer} %{model} Loaners",
             "snubCrafts": "Edit %{manufacturer} %{model} Snub Crafts",
             "upgrades": "Edit %{manufacturer} %{model} Upgrades",
-            "packages": "Edit %{manufacturer} %{model} Packages"
+            "packages": "Edit %{manufacturer} %{model} Packages",
+            "history": "Edit %{manufacturer} %{model} History"
           }
         },
         "components": {
@@ -173,7 +174,8 @@
           "new": "New Component",
           "edit": {
             "index": "Edit Component",
-            "prices": "Edit Component Prices"
+            "prices": "Edit Component Prices",
+            "history": "Edit Component History"
           }
         },
         "manufacturers": {
@@ -207,7 +209,8 @@
           "index": "Fleets",
           "edit": "Edit Fleet",
           "members": "Fleet Members",
-          "memberEdit": "Edit Fleet Member"
+          "memberEdit": "Edit Fleet Member",
+          "history": "Fleet History"
         },
         "oauthApplications": {
           "index": "OAuth Applications",
@@ -246,7 +249,8 @@
             "models": "Edit %{name} Models",
             "prices": "Edit %{name} Prices",
             "hardpoints": "Edit %{name} Hardpoints",
-            "cargoHolds": "Edit %{name} Cargo Holds"
+            "cargoHolds": "Edit %{name} Cargo Holds",
+            "history": "Edit Module History"
           }
         },
         "unlistedModels": {

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -195,7 +195,10 @@
         },
         "users": {
           "index": "Users",
-          "edit": "Edit User"
+          "edit": "Edit User",
+          "inventories": "User Inventories",
+          "inventory": "User Inventory",
+          "inventoryItem": "Inventory Entry"
         },
         "vehicles": {
           "index": "Vehicles",
@@ -210,7 +213,12 @@
           "edit": "Edit Fleet",
           "members": "Fleet Members",
           "memberEdit": "Edit Fleet Member",
-          "history": "Fleet History"
+          "history": "Fleet History",
+          "roles": "Fleet Roles",
+          "role": "Fleet Role",
+          "inventories": "Fleet Inventories",
+          "inventory": "Fleet Inventory",
+          "inventoryItem": "Inventory Entry"
         },
         "oauthApplications": {
           "index": "OAuth Applications",

--- a/app/frontend/typings.d.ts
+++ b/app/frontend/typings.d.ts
@@ -11,6 +11,12 @@ declare module "vue-router" {
     icon?: string;
     exact?: boolean;
     activeRoute?: string;
+    /*
+     * The tab this route belongs under, for a page that is reached from a tab
+     * but is not one itself -- a record's detail. Without it the tab strip goes
+     * blank as soon as you open one.
+     */
+    activeTab?: string;
     access?: string[];
     nav?: "main" | "sub" | "footer" | "editTabs" | "hidden";
     mobileNav?: number;

--- a/app/jobs/loaders/models_job.rb
+++ b/app/jobs/loaders/models_job.rb
@@ -32,23 +32,72 @@ module Loaders
     end
 
     # `Rsi::ModelsLoader` returns nothing countable, so the run is measured on
-    # either side of it. New models are named because that is the part of the
-    # report worth reading; an update is a field nobody can name from here.
+    # either side of it. Both sides of the change are named, because a matrix
+    # that moves a few times a month makes "1 model updated" a question rather
+    # than a report.
     private def results_body(started_at)
       added = Model.where(created_at: started_at..).order(:name)
-      updated = Model.where(updated_at: started_at..).where(created_at: ...started_at).count
+      updated = Model.where(updated_at: started_at..).where(created_at: ...started_at).order(:name)
 
       lines = [
         "## Ship Matrix Import",
         "",
         "- **Models added**: #{added.count}",
-        "- **Models updated**: #{updated}",
+        "- **Models updated**: #{updated.count}",
         "- **Models in total**: #{Model.count}"
       ]
 
-      return lines.join("\n") if added.empty?
+      lines += ["", "### Added", "", *added.map { |model| "- **#{model.name}**" }] if added.any?
 
-      (lines + ["", "### Added", "", *added.map { |model| "- **#{model.name}**" }]).join("\n")
+      if updated.any?
+        changed_fields = changed_fields_by_model(started_at)
+
+        lines += ["", "### Updated", "", *updated.map { |model| updated_line(model, changed_fields[model.id]) }]
+      end
+
+      lines.join("\n")
+    end
+
+    private def updated_line(model, fields)
+      return "- **#{model.name}**" if fields.blank?
+
+      adopted, matrix_only = split_fields(fields)
+
+      return "- **#{model.name}**: matrix only: #{matrix_only.join(", ")}" if adopted.empty?
+
+      line = "- **#{model.name}**: #{adopted.join(", ")}"
+
+      return line if matrix_only.empty?
+
+      "#{line} (matrix only: #{matrix_only.join(", ")})"
+    end
+
+    # A shadow that moved with its live column is one change, named once. A
+    # shadow that moved alone is the matrix offering a value the loader's guards
+    # refused -- named under the live column it was offered for, because that is
+    # the value an admin would go looking at.
+    private def split_fields(fields)
+      shadow, adopted = fields.partition { |field| field.start_with?("rsi_") }
+
+      matrix_only = shadow.filter_map { |field|
+        offered_for = field.delete_prefix("rsi_")
+
+        next if adopted.include?(offered_for)
+
+        Model.column_names.include?(offered_for) ? offered_for : field
+      }
+
+      [adopted, matrix_only.uniq.sort]
+    end
+
+    # paper_trail watches every column this loader writes except `last_updated_at`
+    # and the store image, which move on nearly every matrix change and carry no
+    # value of their own. A run that touched only those is named without fields.
+    private def changed_fields_by_model(started_at)
+      PaperTrail::Version
+        .where(item_type: "Model", created_at: started_at..)
+        .group_by(&:item_id)
+        .transform_values { |versions| versions.flat_map { |version| version.changeset.keys }.uniq.sort }
     end
   end
 end

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -13,6 +13,16 @@
 # holder is polymorphic, which is why the policy is looked up from the record
 # the walk lands on rather than from the item type it started at.
 class VersionedItem
+  # paper_trail 17 defaults `on` to %i[create update destroy touch], and a touch
+  # can never record `object_changes` -- rails' `touch` skips dirty-tracking, so
+  # `Events::Update#record_object_changes?` returns false for one. It files the
+  # version anyway, which leaves a row whose changeset is empty.
+  #
+  # Fleet has seven `belongs_to :fleet, touch: true` children, so an event, a
+  # membership or a role write files a fleet version that says nothing: 572,735
+  # of its 573,199 update versions are that, against 464 real edits.
+  RECORDED_EVENTS = %i[create update destroy].freeze
+
   ROOTS = {
     "Component" => [],
     "Fleet" => [],

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# The catalogues paper_trail watches, and what an admin has to be allowed to see
+# before a version of one is readable.
+#
+# An endpoint that took any `item_type` from the request would let a caller read
+# -- and revert -- a row in any table paper_trail ever touched, so the list is
+# explicit rather than derived from the class name it was handed.
+#
+# Six of the ten have no admin page and no policy of their own. They are
+# authorised through the record that does: a fleet's roles, memberships and
+# inventories through the fleet, an inventory through whoever holds it. That
+# holder is polymorphic, which is why the policy is looked up from the record
+# the walk lands on rather than from the item type it started at.
+class VersionedItem
+  ROOTS = {
+    "Component" => [],
+    "Fleet" => [],
+    "FleetInventory" => [:fleet],
+    "FleetInventoryItem" => [:fleet_inventory, :fleet],
+    "FleetMembership" => [:fleet],
+    "FleetRole" => [:fleet],
+    "Inventory" => [:holder],
+    "InventoryItem" => [:inventory, :holder],
+    "Model" => [],
+    "ModelModule" => []
+  }.freeze
+
+  TYPES = ROOTS.keys.freeze
+
+  POLICIES = {
+    "Component" => ::Admin::ComponentPolicy,
+    "Fleet" => ::Admin::FleetPolicy,
+    "Model" => ::Admin::ModelPolicy,
+    "ModelModule" => ::Admin::ModelModulePolicy,
+    "User" => ::Admin::UserPolicy
+  }.freeze
+
+  def self.supported?(item_type)
+    TYPES.include?(item_type)
+  end
+
+  # A missing or unlisted `item_type` is answered the same way a missing id is:
+  # there is no such item to read a history for.
+
+  def self.find(item_type, item_id)
+    raise ActiveRecord::RecordNotFound unless supported?(item_type)
+
+    item_type.constantize.find(item_id)
+  end
+
+  # The record whose policy decides, and that policy. A chain that runs into a
+  # `nil` -- an inventory whose holder was deleted -- has no root to ask, and a
+  # root of a class nobody wrote an admin policy for is the same answer: no.
+  def self.authorization_root(item)
+    root = ROOTS.fetch(item.class.name, nil)&.reduce(item) { |record, association| record&.public_send(association) }
+
+    return if root.blank?
+
+    policy = POLICIES[root.class.name]
+
+    return if policy.blank?
+
+    [root, policy]
+  end
+end

--- a/app/models/fleet.rb
+++ b/app/models/fleet.rb
@@ -54,7 +54,7 @@ class Fleet < ApplicationRecord
     member: []
   }.freeze
 
-  has_paper_trail meta: {
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS, meta: {
     author_id: :author_id,
     reason: :update_reason,
     reason_description: :update_reason_description

--- a/app/models/fleet_inventory.rb
+++ b/app/models/fleet_inventory.rb
@@ -30,7 +30,7 @@ class FleetInventory < ApplicationRecord
   include ActiveStorageVariants
   include InventoryStock
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/fleet_inventory_item.rb
+++ b/app/models/fleet_inventory_item.rb
@@ -34,7 +34,7 @@
 class FleetInventoryItem < ApplicationRecord
   include InventoryLedgerEntry
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -54,7 +54,7 @@ class FleetMembership < ApplicationRecord
     member: ["fleet:memberships:read"]
   }.freeze
 
-  has_paper_trail meta: {
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS, meta: {
     author_id: :author_id,
     reason: :update_reason,
     reason_description: :update_reason_description

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -25,7 +25,7 @@ require "lexorank/rankable"
 class FleetRole < ApplicationRecord
   include ResourceAccessConcern
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   belongs_to :fleet, touch: true
   has_many :fleet_memberships,

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -30,7 +30,7 @@ class Inventory < ApplicationRecord
   include ActiveStorageVariants
   include InventoryStock
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -29,7 +29,7 @@
 class InventoryItem < ApplicationRecord
   include InventoryLedgerEntry
 
-  has_paper_trail
+  has_paper_trail on: ::VersionedItem::RECORDED_EVENTS
 
   paginates_per 30
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -134,7 +134,21 @@ class Model < ApplicationRecord
 
   attr_accessor :update_reason, :update_reason_description, :author_id
 
+  # `name`, `description` and `ground` are here because an admin can edit all
+  # three, not because the ship matrix writes them -- an edit with no history is
+  # the gap, and the loader's own report reading them is the second reason.
+  #
+  # The `rsi_*` shadow columns are watched because they are **not** the live
+  # column read twice: `mass` differs from `rsi_mass` on 196 of 246 models, and
+  # `max_speed`, `pitch`, `yaw` and `roll` on 188. `Rsi::ModelsLoader` writes a
+  # shadow on every run but the live column only when RSI moved `time_modified`
+  # and the new value is not blank -- so a shadow that moves alone is the matrix
+  # saying something we did not adopt, which nothing else records.
   has_paper_trail on: %i[update], only: %i[
+    name description ground
+    rsi_id rsi_chassis_id rsi_name rsi_description rsi_classification rsi_focus rsi_size rsi_store_url
+    rsi_length rsi_beam rsi_height rsi_mass rsi_cargo rsi_min_crew rsi_max_crew
+    rsi_scm_speed rsi_max_speed rsi_pitch rsi_yaw rsi_roll
     classification production_status production_note focus pledge_price length beam height mass
     cargo personal_inventory size min_crew max_crew scm_speed max_speed ground_max_speed ground_reverse_speed
     ground_acceleration ground_decceleration pitch yaw roll price

--- a/app/services/versions/field_reverter.rb
+++ b/app/services/versions/field_reverter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Versions
+  # Puts one field of one record back to the value a version recorded before it.
+  #
+  # One field rather than the whole version, because a version written by a
+  # loader usually carries a dozen fields an admin has no quarrel with -- the
+  # matrix moving `mass` and `cargo` together, when only `mass` was wrong.
+  class FieldReverter
+    Result = Struct.new(:record, :field, :from, :to) do
+      def missing? = record.blank?
+
+      def success? = record.present? && record.errors.empty?
+    end
+
+    def initialize(version, field, author_id: nil)
+      @version = version
+      @field = field.to_s
+      @author_id = author_id
+    end
+
+    def run
+      return Result.new(nil, @field) if record.blank?
+
+      return failure(:unknown_field) unless reversible?
+
+      before, after = @version.changeset.fetch(@field)
+      before = cast(before)
+
+      return failure(:already_reverted) if record.public_send(@field) == before
+
+      write(before)
+
+      Result.new(record, @field, cast(after), before)
+    end
+
+    # Only a field the version actually recorded a change for, and only one the
+    # record still has -- a changeset survives a migration that drops its column.
+    #
+    # Only an update, too. Six of the ten catalogues track creates as well, and a
+    # create's changeset reads as "every column, from nothing" -- reverting one
+    # is not undoing a change, it is blanking a column that never had a previous
+    # value.
+    private def reversible?
+      @version.event == "update" &&
+        @version.changeset.key?(@field) &&
+        record.class.column_names.include?(@field)
+    end
+
+    # A changeset is JSON, so a decimal comes back as a string and would never
+    # equal the column it is being compared against.
+    private def cast(value)
+      record.class.type_for_attribute(@field).cast(value)
+    end
+
+    private def record
+      return @record if defined?(@record)
+
+      @record = @version.item
+    end
+
+    # An admin correction to a Model has to reach the build as well as the row,
+    # which is what `update_with_facts` is for. Nothing else in this list keeps
+    # its facts anywhere but its own columns.
+    private def write(value)
+      attributes = {@field => value}.merge(meta)
+
+      return record.update_with_facts(attributes) if record.respond_to?(:update_with_facts)
+
+      record.update(attributes)
+    end
+
+    # Four of the ten declare paper_trail meta, so the version this revert writes
+    # says who did it and why. The other six have nowhere to put that.
+    private def meta
+      return {} unless record.respond_to?(:update_reason=)
+
+      {
+        author_id: @author_id,
+        update_reason: :custom,
+        update_reason_description: "Reverted #{@field}"
+      }
+    end
+
+    private def failure(code)
+      # On `:base` rather than the field: `full_message` prefixes a humanised
+      # attribute name, and "field" is not one this record has.
+      record.errors.add(:base, code, message: I18n.t(:"validation_error.version.#{code}"))
+
+      Result.new(record, @field)
+    end
+  end
+end

--- a/app/tasks/maintenance/drop_changeless_versions_task.rb
+++ b/app/tasks/maintenance/drop_changeless_versions_task.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Drops the versions paper_trail filed for a `touch`.
+  #
+  # Rails' `touch` does no dirty-tracking, so `Events::Update#record_object_changes?`
+  # returns false for one and the row is written with no `object_changes` at all.
+  # There is nothing in it to show and nothing to put back -- the admin history
+  # rendered each as a heading with an empty body.
+  #
+  # `Fleet` and the six models beside it now name their events without `:touch`,
+  # so no more are written. This clears the 572,773 already on disk: 572,735 on
+  # `Fleet`, whose seven `touch: true` children filed one per write, and 38 on
+  # `FleetInventory`. Both had roughly a thousand of these per real edit.
+  #
+  # A maintenance task rather than a data migration: it destroys rows and cannot
+  # be undone, and `data:migrate` runs unattended on every deploy. Here it is run
+  # deliberately, once per environment, with `dry_run` first.
+  #
+  # It clears nine rows in ten, so follow it with `VACUUM ANALYZE versions` for
+  # the planner's sake rather than waiting for autovacuum. That marks the space
+  # reusable without returning it to the disk; only `VACUUM FULL` does that, and
+  # it holds an exclusive lock for the rewrite.
+  class DropChangelessVersionsTask < MaintenanceTasks::Task
+    no_collection
+
+    # Small enough that a cancelled run leaves a short statement behind, large
+    # enough that the whole set is a few hundred of them.
+    BATCH_SIZE = 5_000
+
+    # Left on by default so an accidental run reports instead of destroying.
+    attribute :dry_run, :boolean, default: true
+
+    # `old_object_changes` is the pre-json column, empty on every row in this
+    # database. A row that did carry one would be real history that predates the
+    # migration, so the guard keeps it out of scope rather than trusting that.
+    #
+    # `create` and `destroy` are excluded for the same reason: paper_trail always
+    # records a changeset for them, so one arriving here without would be a row
+    # this task does not understand.
+    def self.changeless
+      PaperTrail::Version.where(event: "update", object_changes: nil, old_object_changes: nil)
+    end
+
+    def process
+      dry_run ? report_plan : apply
+    end
+
+    private def apply
+      before = self.class.changeless.count
+      deleted = 0
+
+      self.class.changeless.in_batches(of: BATCH_SIZE) { |batch| deleted += batch.delete_all }
+
+      log "deleted #{deleted} of #{before} changeless versions"
+      log "versions left: #{PaperTrail::Version.count}"
+    end
+
+    private def report_plan
+      scope = self.class.changeless
+
+      scope.group(:item_type).count.sort.each do |item_type, count|
+        log "#{item_type}: #{count} changeless of #{PaperTrail::Version.where(item_type:).count}"
+      end
+
+      log "changeless versions: #{scope.count} of #{PaperTrail::Version.count}"
+      log "dry run -- nothing was deleted"
+    end
+
+    # The task's log is its output in the UI, which is stdout for this engine.
+    private def log(message)
+      puts message
+    end
+  end
+end

--- a/app/views/admin/api/v1/fleet_inventories/_base.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventories/_base.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+json.id inventory.id
+json.fleet_id inventory.fleet_id
+json.name inventory.name
+json.slug inventory.slug
+json.description inventory.description
+json.location inventory.location
+json.visibility inventory.visibility
+json.manager_id inventory.managed_by
+json.manager_username inventory.manager&.username
+json.items_count inventory.fleet_inventory_items.size
+
+json.partial! "api/shared/dates", record: inventory

--- a/app/views/admin/api/v1/fleet_inventories/_fleet_inventory.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventories/_fleet_inventory.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", "admin_fleet_inventory", inventory] do
+  json.partial!("admin/api/v1/fleet_inventories/base", inventory:)
+end

--- a/app/views/admin/api/v1/fleet_inventories/index.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventories/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @inventories, partial: "admin/api/v1/fleet_inventories/fleet_inventory", as: :inventory
+end
+json.partial! "api/shared/meta", result: @inventories

--- a/app/views/admin/api/v1/fleet_inventories/show.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventories/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/fleet_inventories/fleet_inventory", inventory: @inventory

--- a/app/views/admin/api/v1/fleet_inventory_items/_base.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventory_items/_base.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.id item.id
+json.fleet_inventory_id item.fleet_inventory_id
+json.name item.name
+json.category item.category
+json.entry_type item.entry_type
+json.unit item.unit
+json.quantity item.quantity.to_s
+json.quality item.quality
+json.notes item.notes
+json.item_id item.item_id
+json.item_type item.item_type
+
+json.partial! "api/shared/dates", record: item

--- a/app/views/admin/api/v1/fleet_inventory_items/_fleet_inventory_item.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventory_items/_fleet_inventory_item.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", "admin_fleet_inventory_item", item] do
+  json.partial!("admin/api/v1/fleet_inventory_items/base", item:)
+end

--- a/app/views/admin/api/v1/fleet_inventory_items/index.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventory_items/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @items, partial: "admin/api/v1/fleet_inventory_items/fleet_inventory_item", as: :item
+end
+json.partial! "api/shared/meta", result: @items

--- a/app/views/admin/api/v1/fleet_inventory_items/show.jbuilder
+++ b/app/views/admin/api/v1/fleet_inventory_items/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/fleet_inventory_items/fleet_inventory_item", item: @item

--- a/app/views/admin/api/v1/inventories/_base.jbuilder
+++ b/app/views/admin/api/v1/inventories/_base.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+json.id inventory.id
+json.holder_id inventory.holder_id
+json.holder_type inventory.holder_type
+json.name inventory.name
+json.slug inventory.slug
+json.description inventory.description
+json.location inventory.location
+json.vehicle_id inventory.vehicle_id
+json.items_count inventory.inventory_items.size
+
+json.partial! "api/shared/dates", record: inventory

--- a/app/views/admin/api/v1/inventories/_inventory.jbuilder
+++ b/app/views/admin/api/v1/inventories/_inventory.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", "admin_inventory", inventory] do
+  json.partial!("admin/api/v1/inventories/base", inventory:)
+end

--- a/app/views/admin/api/v1/inventories/index.jbuilder
+++ b/app/views/admin/api/v1/inventories/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @inventories, partial: "admin/api/v1/inventories/inventory", as: :inventory
+end
+json.partial! "api/shared/meta", result: @inventories

--- a/app/views/admin/api/v1/inventories/show.jbuilder
+++ b/app/views/admin/api/v1/inventories/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/inventories/inventory", inventory: @inventory

--- a/app/views/admin/api/v1/inventory_items/_base.jbuilder
+++ b/app/views/admin/api/v1/inventory_items/_base.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.id item.id
+json.inventory_id item.inventory_id
+json.name item.name
+json.category item.category
+json.entry_type item.entry_type
+json.unit item.unit
+json.quantity item.quantity.to_s
+json.quality item.quality
+json.notes item.notes
+json.item_id item.item_id
+json.item_type item.item_type
+
+json.partial! "api/shared/dates", record: item

--- a/app/views/admin/api/v1/inventory_items/_inventory_item.jbuilder
+++ b/app/views/admin/api/v1/inventory_items/_inventory_item.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.cache! ["v1", "admin_inventory_item", item] do
+  json.partial!("admin/api/v1/inventory_items/base", item:)
+end

--- a/app/views/admin/api/v1/inventory_items/index.jbuilder
+++ b/app/views/admin/api/v1/inventory_items/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @items, partial: "admin/api/v1/inventory_items/inventory_item", as: :item
+end
+json.partial! "api/shared/meta", result: @items

--- a/app/views/admin/api/v1/inventory_items/show.jbuilder
+++ b/app/views/admin/api/v1/inventory_items/show.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "admin/api/v1/inventory_items/inventory_item", item: @item

--- a/app/views/admin/api/v1/versions/_version.jbuilder
+++ b/app/views/admin/api/v1/versions/_version.jbuilder
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+json.id version.id
+
+json.item_id version.item_id
+json.item_type version.item_type
+
+json.event version.event
+json.reason version.reason
+json.reason_description version.reason_description
+
+json.author do
+  author = @authors[version.author_id]
+
+  if author.present?
+    json.id author.id
+    json.username author.username
+  else
+    json.nil!
+  end
+end
+
+json.changes do
+  json.array!(version.changeset.sort) do |field, (from, to)|
+    json.field field
+    json.from from.to_s.presence
+    json.to to.to_s.presence
+  end
+end
+
+json.created_at version.created_at

--- a/app/views/admin/api/v1/versions/index.jbuilder
+++ b/app/views/admin/api/v1/versions/index.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @versions, partial: "admin/api/v1/versions/version", as: :version
+end
+json.partial! "api/shared/meta", result: @versions

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -1,6 +1,10 @@
 ---
 de:
   validation_error:
+    version:
+      revert: Feld konnte nicht zurückgesetzt werden.
+      unknown_field: Diese Version hat dieses Feld nicht geändert.
+      already_reverted: Das Feld hat bereits den Wert, den diese Version ersetzt hat.
     sc_data_unlisted_model:
       link: Schiff konnte nicht mit dem Katalog verknüpft werden.
       create_model: Schiff konnte nicht aus den Spieldateien angelegt werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -1,6 +1,10 @@
 ---
 en:
   validation_error:
+    version:
+      revert: Field could not be reverted.
+      unknown_field: This version did not change that field.
+      already_reverted: The field already holds the value this version replaced.
     sc_data_unlisted_model:
       link: Ship could not be linked to the catalogue.
       create_model: Ship could not be created from the game files.

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -23,6 +23,10 @@ v1_admin_api_routes = lambda do
     end
 
     resources :fleets, only: %i[index], controller: "user_fleets"
+
+    resources :inventories, only: %i[index show] do
+      resources :inventory_items, path: "items", only: %i[index show]
+    end
   end
 
   resources :models, only: %i[index show create update destroy] do
@@ -119,6 +123,10 @@ v1_admin_api_routes = lambda do
       member do
         get "login-as", to: "fleet_members#login_as"
       end
+    end
+
+    resources :fleet_inventories, path: "inventories", only: %i[index show] do
+      resources :fleet_inventory_items, path: "items", only: %i[index show]
     end
   end
 

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -132,6 +132,12 @@ v1_admin_api_routes = lambda do
 
   resources :item_prices, path: "item-prices", only: %i[index show create update destroy]
 
+  resources :versions, only: %i[index] do
+    member do
+      put "revert" => "versions#revert"
+    end
+  end
+
   resource :stats, only: [] do
     get "quick-stats" => "stats#quick_stats"
     get "most-viewed-pages" => "stats#most_viewed_pages"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -7418,6 +7418,104 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/versions":
+    get:
+      summary: Versions list
+      tags:
+      - Versions
+      operationId: versions
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - name: perPage
+        in: query
+        schema:
+          type: string
+        required: false
+      - name: itemType
+        in: query
+        schema:
+          "$ref": "#/components/schemas/VersionItemTypeEnum"
+        required: true
+      - name: itemId
+        in: query
+        schema:
+          type: string
+          format: uuid
+        required: true
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Versions"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/versions/{id}/revert":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: id
+      required: true
+    put:
+      summary: Revert one field of a version
+      tags:
+      - Versions
+      operationId: revertVersion
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/VersionRevertInput"
+      responses:
+        '204':
+          description: successful
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/videos":
     post:
       summary: Create new Video
@@ -15380,6 +15478,115 @@ components:
       - meta
       - items
       title: Vehicles
+    Version:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        itemId:
+          type: string
+          format: uuid
+        itemType:
+          "$ref": "#/components/schemas/VersionItemTypeEnum"
+        event:
+          type: string
+        reason:
+          type: string
+          nullable: true
+        reasonDescription:
+          type: string
+          nullable: true
+        author:
+          "$ref": "#/components/schemas/VersionAuthor"
+        changes:
+          type: array
+          items:
+            "$ref": "#/components/schemas/VersionChange"
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - id
+      - itemId
+      - itemType
+      - event
+      - changes
+      title: Version
+    VersionAuthor:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+      required:
+      - id
+      - username
+      title: VersionAuthor
+    VersionChange:
+      type: object
+      properties:
+        field:
+          type: string
+        from:
+          type: string
+          nullable: true
+        to:
+          type: string
+          nullable: true
+      required:
+      - field
+      title: VersionChange
+    VersionItemTypeEnum:
+      type: string
+      enum:
+      - Component
+      - Fleet
+      - FleetInventory
+      - FleetInventoryItem
+      - FleetMembership
+      - FleetRole
+      - Inventory
+      - InventoryItem
+      - Model
+      - ModelModule
+      x-enumNames:
+      - COMPONENT
+      - FLEET
+      - FLEET_INVENTORY
+      - FLEET_INVENTORY_ITEM
+      - FLEET_MEMBERSHIP
+      - FLEET_ROLE
+      - INVENTORY
+      - INVENTORY_ITEM
+      - MODEL
+      - MODEL_MODULE
+      title: VersionItemTypeEnum
+    VersionRevertInput:
+      type: object
+      properties:
+        field:
+          type: string
+      required:
+      - field
+      title: VersionRevertInput
+    Versions:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Version"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: Versions
     Video:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -1913,6 +1913,202 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleet_id}/inventories":
+    parameters:
+    - name: fleet_id
+      in: path
+      description: Fleet id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: Fleet Inventories list
+      tags:
+      - FleetInventories
+      operationId: fleetInventories
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetInventories"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items":
+    parameters:
+    - name: fleet_id
+      in: path
+      description: Fleet id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: fleet_inventory_id
+      in: path
+      description: Fleet inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: Fleet Inventory Items list
+      tags:
+      - FleetInventories
+      operationId: fleetInventoryItems
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetInventoryItems"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items/{id}":
+    parameters:
+    - name: fleet_id
+      in: path
+      description: Fleet id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: fleet_inventory_id
+      in: path
+      description: Fleet inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Fleet inventory item id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: One fleet inventory item
+      tags:
+      - FleetInventories
+      operationId: fleetInventoryItem
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetInventoryItem"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/fleets/{fleet_id}/inventories/{id}":
+    parameters:
+    - name: fleet_id
+      in: path
+      description: Fleet id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Fleet inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: One fleet inventory
+      tags:
+      - FleetInventories
+      operationId: fleetInventory
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetInventory"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/fleets/{fleet_id}/members":
     parameters:
     - name: fleet_id
@@ -7264,6 +7460,202 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/users/{user_id}/inventories":
+    parameters:
+    - name: user_id
+      in: path
+      description: User id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: User Inventories list
+      tags:
+      - Inventories
+      operationId: userInventories
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Inventories"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/users/{user_id}/inventories/{id}":
+    parameters:
+    - name: user_id
+      in: path
+      description: User id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: One user inventory
+      tags:
+      - Inventories
+      operationId: userInventory
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Inventory"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/users/{user_id}/inventories/{inventory_id}/items":
+    parameters:
+    - name: user_id
+      in: path
+      description: User id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: inventory_id
+      in: path
+      description: Inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: Inventory Items list
+      tags:
+      - Inventories
+      operationId: userInventoryItems
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InventoryItems"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/users/{user_id}/inventories/{inventory_id}/items/{id}":
+    parameters:
+    - name: user_id
+      in: path
+      description: User id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: inventory_id
+      in: path
+      description: Inventory id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    - name: id
+      in: path
+      description: Inventory item id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: One inventory item
+      tags:
+      - Inventories
+      operationId: userInventoryItem
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InventoryItem"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/vehicles":
     get:
       summary: Vehicles list
@@ -10556,6 +10948,148 @@ components:
           - 'null'
       additionalProperties: false
       title: FleetInput
+    FleetInventories:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetInventory"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: FleetInventories
+    FleetInventory:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        location:
+          type:
+          - string
+          - 'null'
+        visibility:
+          "$ref": "#/components/schemas/FleetInventoryVisibilityEnum"
+        managerId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        managerUsername:
+          type:
+          - string
+          - 'null'
+        itemsCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - fleetId
+      - name
+      - slug
+      - visibility
+      - itemsCount
+      - createdAt
+      - updatedAt
+      title: FleetInventory
+    FleetInventoryItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        fleetInventoryId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        category:
+          "$ref": "#/components/schemas/InventoryCategoryEnum"
+        entryType:
+          "$ref": "#/components/schemas/InventoryEntryTypeEnum"
+        unit:
+          "$ref": "#/components/schemas/InventoryUnitEnum"
+        quantity:
+          type: string
+        quality:
+          type:
+          - integer
+          - 'null'
+        notes:
+          type:
+          - string
+          - 'null'
+        itemId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        itemType:
+          type:
+          - string
+          - 'null'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - fleetInventoryId
+      - name
+      - category
+      - entryType
+      - unit
+      - quantity
+      - createdAt
+      - updatedAt
+      title: FleetInventoryItem
+    FleetInventoryItems:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FleetInventoryItem"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: FleetInventoryItems
+    FleetInventoryVisibilityEnum:
+      type: string
+      enum:
+      - members_only
+      - officers_only
+      x-enumNames:
+      - MEMBERS_ONLY
+      - OFFICERS_ONLY
+      title: FleetInventoryVisibilityEnum
     FleetMembershipSortEnum:
       type: string
       enum:
@@ -11324,6 +11858,172 @@ components:
       - meta
       - items
       title: Imports
+    Inventories:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Inventory"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: Inventories
+    Inventory:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        holderId:
+          type: string
+          format: uuid
+        holderType:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        location:
+          type:
+          - string
+          - 'null'
+        vehicleId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        itemsCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - holderId
+      - holderType
+      - name
+      - slug
+      - itemsCount
+      - createdAt
+      - updatedAt
+      title: Inventory
+    InventoryCategoryEnum:
+      type: string
+      enum:
+      - commodity
+      - component
+      - weapon
+      - equipment
+      - ammunition
+      - consumable
+      - other
+      x-enumNames:
+      - COMMODITY
+      - COMPONENT
+      - WEAPON
+      - EQUIPMENT
+      - AMMUNITION
+      - CONSUMABLE
+      - OTHER
+      title: InventoryCategoryEnum
+    InventoryEntryTypeEnum:
+      type: string
+      enum:
+      - deposit
+      - withdrawal
+      x-enumNames:
+      - DEPOSIT
+      - WITHDRAWAL
+      title: InventoryEntryTypeEnum
+    InventoryItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        inventoryId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        category:
+          "$ref": "#/components/schemas/InventoryCategoryEnum"
+        entryType:
+          "$ref": "#/components/schemas/InventoryEntryTypeEnum"
+        unit:
+          "$ref": "#/components/schemas/InventoryUnitEnum"
+        quantity:
+          type: string
+        quality:
+          type:
+          - integer
+          - 'null'
+        notes:
+          type:
+          - string
+          - 'null'
+        itemId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        itemType:
+          type:
+          - string
+          - 'null'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - inventoryId
+      - name
+      - category
+      - entryType
+      - unit
+      - quantity
+      - createdAt
+      - updatedAt
+      title: InventoryItem
+    InventoryItems:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/InventoryItem"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: InventoryItems
+    InventoryUnitEnum:
+      type: string
+      enum:
+      - scu
+      - units
+      x-enumNames:
+      - SCU
+      - UNITS
+      title: InventoryUnitEnum
     ItemAvailability:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -15492,11 +15492,13 @@ components:
         event:
           type: string
         reason:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         reasonDescription:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         author:
           "$ref": "#/components/schemas/VersionAuthor"
         changes:
@@ -15504,9 +15506,10 @@ components:
           items:
             "$ref": "#/components/schemas/VersionChange"
         createdAt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
       required:
       - id
       - itemId
@@ -15532,11 +15535,13 @@ components:
         field:
           type: string
         from:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         to:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
       required:
       - field
       title: VersionChange

--- a/test/integration/admin/api/v1/fleet_inventories_test.rb
+++ b/test/integration/admin/api/v1/fleet_inventories_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::FleetInventoriesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/fleets/{fleet_id}/inventories" do
+    parameter name: "fleet_id", in: :path, description: "Fleet id", schema: {type: :string, format: :uuid}
+
+    get("Fleet Inventories list") do
+      operationId "fleetInventories"
+      tags "FleetInventories"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::FleetInventories
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/fleets/{fleet_id}/inventories/{id}" do
+    parameter name: "fleet_id", in: :path, description: "Fleet id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Fleet inventory id", schema: {type: :string, format: :uuid}
+
+    get("One fleet inventory") do
+      operationId "fleetInventory"
+      tags "FleetInventories"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::FleetInventory
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:admin_user, resource_access: [:fleets])
+    @fleet = create(:fleet, created_by: create(:user).id)
+    @inventory = create(:fleet_inventory, fleet: @fleet, name: "Quartermaster's Hold")
+  end
+
+  def index_path = "/fleets/{fleet_id}/inventories"
+
+  def show_path = "/fleets/{fleet_id}/inventories/{id}"
+
+  test "GET /fleets/:fleet_id/inventories lists the fleet's inventories" do
+    create(:fleet_inventory, fleet: create(:fleet, created_by: create(:user).id), name: "Another Fleet's")
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: {fleet_id: @fleet.id} do
+      assert_equal ["Quartermaster's Hold"], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  test "GET /fleets/:fleet_id/inventories counts the entries in one" do
+    create_list(:fleet_inventory_item, 2, fleet_inventory: @inventory)
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: {fleet_id: @fleet.id} do
+      assert_equal 2, parsed_body["items"].first["itemsCount"]
+    end
+  end
+
+  test "GET /fleets/:fleet_id/inventories returns 404 for a missing fleet" do
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: index_path, path_params: {fleet_id: SecureRandom.uuid}
+  end
+
+  test "GET /fleets/:fleet_id/inventories returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: index_path, path_params: {fleet_id: @fleet.id}
+  end
+
+  test "GET /fleets/:fleet_id/inventories returns 403 for an admin without fleet access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: index_path, path_params: {fleet_id: @fleet.id}
+  end
+
+  test "GET /fleets/:fleet_id/inventories/:id returns the inventory" do
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: show_path, path_params: {fleet_id: @fleet.id, id: @inventory.id} do
+      assert_equal "Quartermaster's Hold", parsed_body["name"]
+      assert_equal "members_only", parsed_body["visibility"]
+    end
+  end
+
+  test "GET /fleets/:fleet_id/inventories/:id names the manager when one is set" do
+    manager = create(:user)
+    @inventory.update!(manager:)
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: show_path, path_params: {fleet_id: @fleet.id, id: @inventory.id} do
+      assert_equal manager.username, parsed_body["managerUsername"]
+    end
+  end
+
+  # The fleet in the path is what scopes the lookup, so another fleet's
+  # inventory is not readable through a fleet the admin may see.
+  test "GET /fleets/:fleet_id/inventories/:id returns 404 for another fleet's inventory" do
+    other = create(:fleet_inventory, fleet: create(:fleet, created_by: create(:user).id))
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: show_path, path_params: {fleet_id: @fleet.id, id: other.id}
+  end
+
+  test "GET /fleets/:fleet_id/inventories/:id returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: show_path, path_params: {fleet_id: @fleet.id, id: @inventory.id}
+  end
+
+  test "GET /fleets/:fleet_id/inventories/:id returns 403 for an admin without fleet access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: show_path, path_params: {fleet_id: @fleet.id, id: @inventory.id}
+  end
+end

--- a/test/integration/admin/api/v1/fleet_inventory_items_test.rb
+++ b/test/integration/admin/api/v1/fleet_inventory_items_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::FleetInventoryItemsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items" do
+    parameter name: "fleet_id", in: :path, description: "Fleet id", schema: {type: :string, format: :uuid}
+    parameter name: "fleet_inventory_id", in: :path, description: "Fleet inventory id", schema: {type: :string, format: :uuid}
+
+    get("Fleet Inventory Items list") do
+      operationId "fleetInventoryItems"
+      tags "FleetInventories"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::FleetInventoryItems
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items/{id}" do
+    parameter name: "fleet_id", in: :path, description: "Fleet id", schema: {type: :string, format: :uuid}
+    parameter name: "fleet_inventory_id", in: :path, description: "Fleet inventory id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Fleet inventory item id", schema: {type: :string, format: :uuid}
+
+    get("One fleet inventory item") do
+      operationId "fleetInventoryItem"
+      tags "FleetInventories"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::FleetInventoryItem
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:admin_user, resource_access: [:fleets])
+    @fleet = create(:fleet, created_by: create(:user).id)
+    @inventory = create(:fleet_inventory, fleet: @fleet)
+    @item = create(:fleet_inventory_item, fleet_inventory: @inventory, name: "Titanium")
+  end
+
+  def index_path = "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items"
+
+  def show_path = "/fleets/{fleet_id}/inventories/{fleet_inventory_id}/items/{id}"
+
+  def index_params = {fleet_id: @fleet.id, fleet_inventory_id: @inventory.id}
+
+  test "GET .../items lists the entries in the inventory" do
+    create(:fleet_inventory_item, fleet_inventory: create(:fleet_inventory, fleet: @fleet), name: "Elsewhere")
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: index_params do
+      assert_equal ["Titanium"], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  # `quantity` is a decimal, and a json number would round it. It travels as a
+  # string for the same reason prices do.
+  test "GET .../items sends the quantity as a string" do
+    @item.update!(quantity: 12.5)
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: index_params do
+      assert_equal "12.5", parsed_body["items"].first["quantity"]
+    end
+  end
+
+  test "GET .../items returns 404 for a missing inventory" do
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: index_path,
+      path_params: {fleet_id: @fleet.id, fleet_inventory_id: SecureRandom.uuid}
+  end
+
+  test "GET .../items returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: index_path, path_params: index_params
+  end
+
+  test "GET .../items returns 403 for an admin without fleet access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: index_path, path_params: index_params
+  end
+
+  test "GET .../items/:id returns the entry" do
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: show_path, path_params: index_params.merge(id: @item.id) do
+      assert_equal "Titanium", parsed_body["name"]
+      assert_equal @inventory.id, parsed_body["fleetInventoryId"]
+    end
+  end
+
+  test "GET .../items/:id returns 404 for an entry in another inventory" do
+    other = create(:fleet_inventory_item, fleet_inventory: create(:fleet_inventory, fleet: @fleet))
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: show_path, path_params: index_params.merge(id: other.id)
+  end
+
+  test "GET .../items/:id returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: show_path, path_params: index_params.merge(id: @item.id)
+  end
+
+  test "GET .../items/:id returns 403 for an admin without fleet access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: show_path, path_params: index_params.merge(id: @item.id)
+  end
+end

--- a/test/integration/admin/api/v1/inventories_test.rb
+++ b/test/integration/admin/api/v1/inventories_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::InventoriesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/users/{user_id}/inventories" do
+    parameter name: "user_id", in: :path, description: "User id", schema: {type: :string, format: :uuid}
+
+    get("User Inventories list") do
+      operationId "userInventories"
+      tags "Inventories"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::Inventories
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/users/{user_id}/inventories/{id}" do
+    parameter name: "user_id", in: :path, description: "User id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Inventory id", schema: {type: :string, format: :uuid}
+
+    get("One user inventory") do
+      operationId "userInventory"
+      tags "Inventories"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::Inventory
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:admin_user, resource_access: [:users])
+    @holder = create(:user)
+    @inventory = create(:inventory, holder: @holder, name: "Locker")
+  end
+
+  def index_path = "/users/{user_id}/inventories"
+
+  def show_path = "/users/{user_id}/inventories/{id}"
+
+  test "GET /users/:user_id/inventories lists what the user holds" do
+    create(:inventory, holder: create(:user), name: "Someone Else's")
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: {user_id: @holder.id} do
+      assert_equal ["Locker"], parsed_body["items"].map { |item| item["name"] }
+      assert_equal "User", parsed_body["items"].first["holderType"]
+    end
+  end
+
+  test "GET /users/:user_id/inventories counts the entries in one" do
+    create_list(:inventory_item, 3, inventory: @inventory)
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: {user_id: @holder.id} do
+      assert_equal 3, parsed_body["items"].first["itemsCount"]
+    end
+  end
+
+  test "GET /users/:user_id/inventories returns 404 for a missing user" do
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: index_path, path_params: {user_id: SecureRandom.uuid}
+  end
+
+  test "GET /users/:user_id/inventories returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: index_path, path_params: {user_id: @holder.id}
+  end
+
+  test "GET /users/:user_id/inventories returns 403 for an admin without user access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: index_path, path_params: {user_id: @holder.id}
+  end
+
+  test "GET /users/:user_id/inventories/:id returns the inventory" do
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: show_path, path_params: {user_id: @holder.id, id: @inventory.id} do
+      assert_equal "Locker", parsed_body["name"]
+      assert_nil parsed_body["vehicleId"]
+    end
+  end
+
+  test "GET /users/:user_id/inventories/:id returns 404 for another user's inventory" do
+    other = create(:inventory, holder: create(:user))
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: show_path, path_params: {user_id: @holder.id, id: other.id}
+  end
+
+  test "GET /users/:user_id/inventories/:id returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: show_path, path_params: {user_id: @holder.id, id: @inventory.id}
+  end
+
+  test "GET /users/:user_id/inventories/:id returns 403 for an admin without user access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: show_path, path_params: {user_id: @holder.id, id: @inventory.id}
+  end
+end

--- a/test/integration/admin/api/v1/inventory_items_test.rb
+++ b/test/integration/admin/api/v1/inventory_items_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::InventoryItemsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/users/{user_id}/inventories/{inventory_id}/items" do
+    parameter name: "user_id", in: :path, description: "User id", schema: {type: :string, format: :uuid}
+    parameter name: "inventory_id", in: :path, description: "Inventory id", schema: {type: :string, format: :uuid}
+
+    get("Inventory Items list") do
+      operationId "userInventoryItems"
+      tags "Inventories"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::InventoryItems
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/users/{user_id}/inventories/{inventory_id}/items/{id}" do
+    parameter name: "user_id", in: :path, description: "User id", schema: {type: :string, format: :uuid}
+    parameter name: "inventory_id", in: :path, description: "Inventory id", schema: {type: :string, format: :uuid}
+    parameter name: "id", in: :path, description: "Inventory item id", schema: {type: :string, format: :uuid}
+
+    get("One inventory item") do
+      operationId "userInventoryItem"
+      tags "Inventories"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::InventoryItem
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:admin_user, resource_access: [:users])
+    @holder = create(:user)
+    @inventory = create(:inventory, holder: @holder)
+    @item = create(:inventory_item, inventory: @inventory, name: "Medpen")
+  end
+
+  def index_path = "/users/{user_id}/inventories/{inventory_id}/items"
+
+  def show_path = "/users/{user_id}/inventories/{inventory_id}/items/{id}"
+
+  def index_params = {user_id: @holder.id, inventory_id: @inventory.id}
+
+  test "GET .../items lists the entries in the inventory" do
+    create(:inventory_item, inventory: create(:inventory, holder: @holder), name: "Elsewhere")
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: index_params do
+      assert_equal ["Medpen"], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
+  test "GET .../items sends the quantity as a string" do
+    @item.update!(quantity: 7.25)
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: index_path, path_params: index_params do
+      assert_equal "7.25", parsed_body["items"].first["quantity"]
+    end
+  end
+
+  test "GET .../items returns 404 for a missing inventory" do
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: index_path,
+      path_params: {user_id: @holder.id, inventory_id: SecureRandom.uuid}
+  end
+
+  test "GET .../items returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: index_path, path_params: index_params
+  end
+
+  test "GET .../items returns 403 for an admin without user access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: index_path, path_params: index_params
+  end
+
+  test "GET .../items/:id returns the entry" do
+    sign_in @admin
+
+    assert_api_response :get, 200, api_path: show_path, path_params: index_params.merge(id: @item.id) do
+      assert_equal "Medpen", parsed_body["name"]
+      assert_equal @inventory.id, parsed_body["inventoryId"]
+    end
+  end
+
+  test "GET .../items/:id returns 404 for an entry in another inventory" do
+    other = create(:inventory_item, inventory: create(:inventory, holder: @holder))
+    sign_in @admin
+
+    assert_api_response :get, 404, api_path: show_path, path_params: index_params.merge(id: other.id)
+  end
+
+  test "GET .../items/:id returns 401 when not signed in" do
+    assert_api_response :get, 401, api_path: show_path, path_params: index_params.merge(id: @item.id)
+  end
+
+  test "GET .../items/:id returns 403 for an admin without user access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, api_path: show_path, path_params: index_params.merge(id: @item.id)
+  end
+end

--- a/test/integration/admin/api/v1/versions_test.rb
+++ b/test/integration/admin/api/v1/versions_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::VersionsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  api_path "/versions" do
+    get("Versions list") do
+      operationId "versions"
+      tags "Versions"
+      produces "application/json"
+
+      parameter "$ref": "#/components/parameters/PageParameter"
+      parameter name: "perPage", in: :query, schema: {type: :string}, required: false
+      parameter name: "itemType", in: :query, schema: ::Admin::V1::Schemas::Enums::VersionItemTypeEnum, required: true
+      parameter name: "itemId", in: :query, schema: {type: :string, format: :uuid}, required: true
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::Versions
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/versions/{id}/revert" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id"
+
+    put("Revert one field of a version") do
+      operationId "revertVersion"
+      tags "Versions"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::VersionRevertInput
+
+      response(204, "successful") do
+        schema nil
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @user = create(:admin_user, resource_access: [:models])
+    @model = create(:model, name: "Carrack", cargo: 456)
+    @model.update!(cargo: 400)
+    @version = @model.versions.last
+  end
+
+  def list_params(item = nil)
+    item ||= @model
+
+    {itemType: item.class.name, itemId: item.id}
+  end
+
+  # GET list
+  test "GET /versions lists the history of one item" do
+    sign_in @user
+
+    assert_api_response :get, 200, params: list_params do
+      assert_equal 1, parsed_body["items"].count
+      assert_equal [{"field" => "cargo", "from" => "456.0", "to" => "400.0"}], parsed_body["items"].first["changes"]
+    end
+  end
+
+  test "GET /versions returns 404 for a missing id" do
+    sign_in @user
+
+    assert_api_response :get, 404, params: {itemType: "Model", itemId: "00000000-0000-0000-0000-000000000000"}
+  end
+
+  test "GET /versions returns 401 when not signed in" do
+    assert_api_response :get, 401, params: list_params
+  end
+
+  test "GET /versions returns 403 for an admin without access to the item" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :get, 403, params: list_params
+  end
+
+  # A fleet's roles and inventories have no admin page of their own, so the
+  # fleet's access is what decides.
+  test "GET /versions authorises a fleet role through its fleet" do
+    role = create(:fleet_role, name: "Quartermaster")
+    role.update!(name: "Bosun")
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :get, 200, params: list_params(role) do
+      assert_equal role.versions.count, parsed_body["items"].count
+    end
+  end
+
+  test "GET /versions returns 403 for a fleet role without fleet access" do
+    role = create(:fleet_role, name: "Quartermaster")
+    role.update!(name: "Bosun")
+    sign_in @user
+
+    assert_api_response :get, 403, params: list_params(role)
+  end
+
+  # PUT revert
+  test "PUT /versions/:id/revert puts one field back" do
+    sign_in @user
+
+    assert_api_response :put, 204, path_params: {id: @version.id}, body: {field: "cargo"} do
+      assert_equal 456, @model.reload.cargo
+    end
+  end
+
+  test "PUT /versions/:id/revert records who reverted it and why" do
+    sign_in @user
+
+    assert_api_response :put, 204, path_params: {id: @version.id}, body: {field: "cargo"} do
+      reverting = @model.reload.versions.last
+
+      assert_equal @user.id, reverting.author_id
+      assert_equal "custom", reverting.reason
+      assert_equal "Reverted cargo", reverting.reason_description
+    end
+  end
+
+  test "PUT /versions/:id/revert returns 400 for a field the version never changed" do
+    sign_in @user
+
+    assert_api_response :put, 400, path_params: {id: @version.id}, body: {field: "mass"}
+  end
+
+  test "PUT /versions/:id/revert returns 400 when the value is already back" do
+    @model.update!(cargo: 456)
+    sign_in @user
+
+    assert_api_response :put, 400, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+
+  # Six of the ten track creates too, and a create's changeset is every column
+  # from nothing -- there is no previous value to go back to.
+  test "PUT /versions/:id/revert returns 400 for a create version" do
+    role = create(:fleet_role, name: "Quartermaster")
+    creation = role.versions.find_by(event: "create")
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :put, 400, path_params: {id: creation.id}, body: {field: "name"}
+  end
+
+  test "PUT /versions/:id/revert returns 404 for a missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, path_params: {id: "00000000-0000-0000-0000-000000000000"}, body: {field: "cargo"}
+  end
+
+  test "PUT /versions/:id/revert returns 401 when not signed in" do
+    assert_api_response :put, 401, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+
+  test "PUT /versions/:id/revert returns 403 for an admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, path_params: {id: @version.id}, body: {field: "cargo"}
+  end
+end

--- a/test/integration/admin/api/v1/versions_test.rb
+++ b/test/integration/admin/api/v1/versions_test.rb
@@ -92,6 +92,21 @@ class Admin::Api::V1::VersionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The touch versions paper_trail already filed have no `object_changes` at all,
+  # so there is nothing to show for one -- it rendered as a heading with an empty
+  # body. Fixing the recording does not remove the 572,735 already on disk.
+  test "GET /versions skips a version that recorded no changes" do
+    fleet = create(:fleet, created_by: create(:user).id)
+    fleet.update!(description: "A crew")
+    PaperTrail::Version.create!(item_type: "Fleet", item_id: fleet.id, event: "update", object_changes: nil)
+    sign_in create(:admin_user, resource_access: [:fleets])
+
+    assert_api_response :get, 200, params: list_params(fleet) do
+      assert_equal 2, parsed_body["items"].count
+      assert_empty parsed_body["items"].select { |version| version["changes"].empty? }
+    end
+  end
+
   test "GET /versions returns 404 for a missing id" do
     sign_in @user
 

--- a/test/jobs/loaders/models_job_test.rb
+++ b/test/jobs/loaders/models_job_test.rb
@@ -50,6 +50,62 @@ module Loaders
       assert_includes notification.body, "Spirit C1"
     end
 
+    test "#perform names the models the run updated, and the fields that moved" do
+      model = create(:model, name: "Carrack", cargo: 456)
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(cargo: 400)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Carrack**: cargo"
+    end
+
+    # The matrix writes `rsi_mass` on every run but `mass` only when RSI moved
+    # `time_modified`, so a shadow moving alone is a value we declined.
+    test "#perform separates a matrix value the run did not adopt" do
+      model = create(:model, name: "Idris P", mass: 40_000, rsi_mass: 40_000, cargo: 100)
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(rsi_mass: 52_000, cargo: 120, rsi_cargo: 120)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Idris P**: cargo (matrix only: mass)"
+    end
+
+    # The loader also writes `last_updated_at` and the store image, neither of
+    # which paper_trail watches. Such a run still has a model to name.
+    test "#perform names an updated model paper_trail did not watch" do
+      model = create(:model, name: "Carrack")
+
+      Rsi::ModelsLoader.any_instance.stubs(:all).with do
+        model.update!(last_updated_at: Time.current)
+        true
+      end
+
+      ::Loaders::ModelsJob.new.perform
+
+      notification = AdminNotification.find_by(
+        admin_user: @admin_user, notification_type: "ship_matrix_import"
+      )
+
+      assert_includes notification.body, "- **Carrack**"
+      assert_not_includes notification.body, "- **Carrack**:"
+    end
+
     test "#perform creates an import, runs the loader, and finishes the import" do
       assert_import_wrapping_job_success(
         job_class: ::Loaders::ModelsJob,

--- a/test/lib/versioned_item_test.rb
+++ b/test/lib/versioned_item_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VersionedItemTest < ActiveSupport::TestCase
+  test "#find raises for a type paper_trail does not watch" do
+    admin_user = create(:admin_user)
+
+    assert_raises(ActiveRecord::RecordNotFound) { VersionedItem.find("AdminUser", admin_user.id) }
+  end
+
+  test "#find raises for a blank type" do
+    assert_raises(ActiveRecord::RecordNotFound) { VersionedItem.find(nil, nil) }
+  end
+
+  test "#authorization_root resolves a catalogue to itself" do
+    model = create(:model)
+
+    assert_equal [model, ::Admin::ModelPolicy], VersionedItem.authorization_root(model)
+  end
+
+  test "#authorization_root resolves a fleet role to its fleet" do
+    role = create(:fleet_role, name: "Quartermaster")
+
+    assert_equal [role.fleet, ::Admin::FleetPolicy], VersionedItem.authorization_root(role)
+  end
+
+  test "#authorization_root resolves an inventory item to whoever holds the inventory" do
+    user = create(:user)
+    inventory = create(:inventory, holder: user)
+    item = create(:inventory_item, inventory:)
+
+    assert_equal [user, ::Admin::UserPolicy], VersionedItem.authorization_root(item)
+  end
+
+  # A holder that was deleted leaves nothing to ask, which is a denial rather
+  # than a crash.
+  test "#authorization_root is nil when the chain runs out" do
+    assert_nil VersionedItem.authorization_root(Inventory.new)
+  end
+end

--- a/test/models/fleet_test.rb
+++ b/test/models/fleet_test.rb
@@ -57,6 +57,35 @@ class FleetTest < ActiveSupport::TestCase
     assert_equal 3, fleet.fleet_roles.reload.count
   end
 
+  # A fleet is touched by seven of its children, and rails' `touch` skips
+  # dirty-tracking -- so paper_trail files the version with no `object_changes`
+  # at all. Those are the ones the admin history showed as an empty heading.
+  class VersioningTest < FleetTest
+    setup do
+      @fleet = create(:fleet, created_by: create(:user).id)
+    end
+
+    test "a touch records no version" do
+      assert_no_difference -> { @fleet.versions.count } do
+        @fleet.touch
+      end
+    end
+
+    test "a child write that touches the fleet records no fleet version" do
+      assert_no_difference -> { @fleet.versions.count } do
+        @fleet.fleet_roles.first.update!(name: "Quartermaster")
+      end
+    end
+
+    test "a real edit still records a version with its changes" do
+      assert_difference -> { @fleet.versions.count }, 1 do
+        @fleet.update!(description: "A crew")
+      end
+
+      assert_equal [nil, "A crew"], @fleet.versions.last.changeset["description"]
+    end
+  end
+
   class UrlValidationTest < FleetTest
     setup do
       user = create(:user)

--- a/test/tasks/maintenance/drop_changeless_versions_task_test.rb
+++ b/test/tasks/maintenance/drop_changeless_versions_task_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class DropChangelessVersionsTaskTest < ActiveSupport::TestCase
+    setup do
+      PaperTrail::Version.delete_all
+
+      @fleet = create(:fleet, created_by: create(:user).id)
+      @fleet.update!(description: "A crew")
+      @real = @fleet.versions.last
+      @changeless = changeless_version_for(@fleet)
+    end
+
+    # An accidental run has to report rather than destroy, so the safe mode is
+    # the one you get by not choosing.
+    test "dry_run is on unless it is turned off" do
+      assert_predicate ::Maintenance::DropChangelessVersionsTask.new, :dry_run
+    end
+
+    test "#process leaves every row in place on a dry run" do
+      assert_no_difference -> { PaperTrail::Version.count } do
+        run_task(dry_run: true)
+      end
+    end
+
+    test "#process reports what it would do on a dry run" do
+      output = run_task(dry_run: true)
+
+      assert_includes output, "Fleet: 1 changeless of #{PaperTrail::Version.where(item_type: "Fleet").count}"
+      assert_includes output, "changeless versions: 1 of #{PaperTrail::Version.count}"
+      assert_includes output, "dry run"
+    end
+
+    test "#process drops the changeless version when the dry run is turned off" do
+      assert_difference -> { PaperTrail::Version.count }, -1 do
+        run_task(dry_run: false)
+      end
+
+      assert_nil PaperTrail::Version.find_by(id: @changeless.id)
+    end
+
+    test "#process drops every changeless version, not just the first" do
+      3.times { changeless_version_for(@fleet) }
+
+      assert_difference -> { PaperTrail::Version.count }, -4 do
+        run_task(dry_run: false)
+      end
+
+      assert_empty ::Maintenance::DropChangelessVersionsTask.changeless
+    end
+
+    test "#process keeps a version that recorded changes" do
+      run_task(dry_run: false)
+
+      assert PaperTrail::Version.exists?(@real.id)
+      assert_equal [nil, "A crew"], @real.reload.changeset["description"]
+    end
+
+    # A create or destroy always carries a changeset, so one arriving without is
+    # a row the task does not recognise and must not remove.
+    test "#process keeps a changeless version that is not an update" do
+      creation = @fleet.versions.find_by(event: "create")
+      creation.update_columns(object_changes: nil)
+
+      run_task(dry_run: false)
+
+      assert PaperTrail::Version.exists?(creation.id)
+    end
+
+    # The pre-json column holds history that predates the migration.
+    test "#process keeps a version whose changes are in the legacy column" do
+      @changeless.update_columns(old_object_changes: "---\ndescription:\n- \n- A crew\n")
+
+      assert_no_difference -> { PaperTrail::Version.count } do
+        run_task(dry_run: false)
+      end
+    end
+
+    # What a `touch` leaves behind: the snapshot is written, the changeset is not.
+    private def changeless_version_for(record)
+      PaperTrail::Version.create!(
+        item_type: record.class.name,
+        item_id: record.id,
+        event: "update",
+        object: record.attributes
+      )
+    end
+
+    private def run_task(dry_run:)
+      task = ::Maintenance::DropChangelessVersionsTask.new
+      task.dry_run = dry_run
+
+      capture_io { task.process }.first
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #4597 — review that first, and merge it first.

Five of the ten types paper_trail watches could not be reached in the admin at all, so the version history #4597 adds had nowhere to be shown for them: `FleetRole`, `FleetInventory`, `FleetInventoryItem`, `Inventory`, `InventoryItem`. Read-only throughout; no writes.

## API

Four new read-only resources — index and show — since none of them had an endpoint:

| Endpoint | Authorised through |
|---|---|
| `/fleets/{id}/inventories[/{id}]` | the fleet |
| `/fleets/{id}/inventories/{id}/items[/{id}]` | the fleet |
| `/users/{id}/inventories[/{id}]` | the user |
| `/users/{id}/inventories/{id}/items[/{id}]` | the user |

Each is scoped by the record that authorises it, which is the same walk `VersionedItem` makes to decide who may read one of their versions — so a caller reaches exactly the rows whose history they could already read. `FleetRole` needed no endpoint: the fleet payload already carries `fleetRoles`.

The category, entry-type, unit and visibility enums are declared under `Admin::V1::Schemas::Enums` rather than reused from the public namespace, which would have published them in `swagger/v1/schema.yaml` too. Verified: only the admin schema changed, 138 → 146 paths, none removed.

## UI

Two new tabs on a fleet (Roles, Inventories) and one on a user (Inventories), each with a detail page carrying the record’s fields and its version history. A fleet’s ledger entry and a user’s share one detail component — they differ only in which inventory they name. `DetailList` is new and shared by all five.

## Tests

37 API tests covering payloads, scoping, and 401/403/404 on every endpoint. `lint:ts`, `eslint` and `rubocop` clean.

The pages themselves have no automated coverage — consistent with the admin pages around them (`fleets/[id]/members.vue` has none either), but worth saying out loud.

🤖