### PR TITLE
feat(ui): make FilterGroup operable, and give its popover a surface

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/forms.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms.vue
@@ -73,14 +73,6 @@ const toggleLoading = ref(false);
 
 const filterSingle = ref<string | null>("medium");
 
-const filterAttached = ref<string | null>(null);
-
-const filterDetached = ref<string | null>(null);
-
-const filterAttachedMultiple = ref<string[]>(["medium"]);
-
-const filterDetachedMultiple = ref<string[]>(["medium"]);
-
 const filterMultiple = ref<string[]>(["small", "large"]);
 
 const sizes = [
@@ -544,73 +536,6 @@ const powerMarks = (value: number) => ({ label: String(value) });
         label="Ship Size (disabled)"
         :options="sizeOptions"
         disabled
-      />
-    </div>
-  </div>
-
-  <Heading :level="HeadingLevelEnum.H2">
-    FilterGroup — how the dropdown meets the trigger
-  </Heading>
-  <p>
-    A decision, not a finished state: see D7 in
-    <code>docs/exec-plans/filter-group-redesign.md</code>. The trigger is
-    untouched in both. What differs is what hangs off it. Top row is single
-    select, the bottom row the same three with <code>multiple</code>.
-  </p>
-  <ul>
-    <li>
-      <strong>today</strong> — the segment continues the trigger's own frame.
-    </li>
-    <li>
-      <strong>capped</strong> — its own surface in the new language, standing
-      off the trigger with a gap, rounded all round, an end-cap top and bottom.
-    </li>
-  </ul>
-  <div class="row">
-    <div class="col-12 col-md-6 col-lg-4">
-      <p class="text-muted">today</p>
-      <FilterGroup
-        v-model="filterAttached"
-        name="filter-single-today"
-        label="Ship Size"
-        :options="sizeOptions"
-        search-label="Find a size…"
-        searchable
-      />
-    </div>
-    <div class="col-12 col-md-6 col-lg-4">
-      <p class="text-muted">capped — chosen, see D7</p>
-      <FilterGroup
-        v-model="filterDetached"
-        name="filter-single-capped"
-        label="Ship Size"
-        :options="sizeOptions"
-        search-label="Find a size…"
-        searchable
-        class="filter-group--capped"
-      />
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12 col-md-6 col-lg-4">
-      <p class="text-muted">today</p>
-      <FilterGroup
-        v-model="filterAttachedMultiple"
-        name="filter-multi-today"
-        label="Ship Sizes"
-        :options="sizeOptions"
-        multiple
-      />
-    </div>
-    <div class="col-12 col-md-6 col-lg-4">
-      <p class="text-muted">capped — chosen, see D7</p>
-      <FilterGroup
-        v-model="filterDetachedMultiple"
-        name="filter-multi-capped"
-        label="Ship Sizes"
-        :options="sizeOptions"
-        multiple
-        class="filter-group--capped"
       />
     </div>
   </div>

--- a/app/frontend/frontend/pages/visual-tests/forms.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms.vue
@@ -72,6 +72,15 @@ const toggleActive = ref(true);
 const toggleLoading = ref(false);
 
 const filterSingle = ref<string | null>("medium");
+
+const filterAttached = ref<string | null>(null);
+
+const filterDetached = ref<string | null>(null);
+
+const filterAttachedMultiple = ref<string[]>(["medium"]);
+
+const filterDetachedMultiple = ref<string[]>(["medium"]);
+
 const filterMultiple = ref<string[]>(["small", "large"]);
 
 const sizes = [
@@ -535,6 +544,73 @@ const powerMarks = (value: number) => ({ label: String(value) });
         label="Ship Size (disabled)"
         :options="sizeOptions"
         disabled
+      />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">
+    FilterGroup — how the dropdown meets the trigger
+  </Heading>
+  <p>
+    A decision, not a finished state: see D7 in
+    <code>docs/exec-plans/filter-group-redesign.md</code>. The trigger is
+    untouched in both. What differs is what hangs off it. Top row is single
+    select, the bottom row the same three with <code>multiple</code>.
+  </p>
+  <ul>
+    <li>
+      <strong>today</strong> — the segment continues the trigger's own frame.
+    </li>
+    <li>
+      <strong>capped</strong> — its own surface in the new language, standing
+      off the trigger with a gap, rounded all round, an end-cap top and bottom.
+    </li>
+  </ul>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-4">
+      <p class="text-muted">today</p>
+      <FilterGroup
+        v-model="filterAttached"
+        name="filter-single-today"
+        label="Ship Size"
+        :options="sizeOptions"
+        search-label="Find a size…"
+        searchable
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+      <p class="text-muted">capped — chosen, see D7</p>
+      <FilterGroup
+        v-model="filterDetached"
+        name="filter-single-capped"
+        label="Ship Size"
+        :options="sizeOptions"
+        search-label="Find a size…"
+        searchable
+        class="filter-group--capped"
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-4">
+      <p class="text-muted">today</p>
+      <FilterGroup
+        v-model="filterAttachedMultiple"
+        name="filter-multi-today"
+        label="Ship Sizes"
+        :options="sizeOptions"
+        multiple
+      />
+    </div>
+    <div class="col-12 col-md-6 col-lg-4">
+      <p class="text-muted">capped — chosen, see D7</p>
+      <FilterGroup
+        v-model="filterDetachedMultiple"
+        name="filter-multi-capped"
+        label="Ship Sizes"
+        :options="sizeOptions"
+        multiple
+        class="filter-group--capped"
       />
     </div>
   </div>

--- a/app/frontend/shared/components/base/FilterGroup/Option/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/Option/index.scss
@@ -59,7 +59,10 @@
     right: -4px;
   }
 
-  &:hover {
+  /* Keyboard and pointer mark the same thing -- "this row" -- so they draw the
+     same cue. Phase 3 changes both at once when the glow rail goes. */
+  &:hover,
+  &--focused {
     &::before,
     &::after {
       background: $primary;

--- a/app/frontend/shared/components/base/FilterGroup/Option/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/Option/index.scss
@@ -6,7 +6,7 @@
   padding: 10px 6px;
   color: $input-color;
   border-right: 4px solid transparent;
-  border-bottom: 1px solid $input-border;
+  border-bottom: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
   border-left: 4px solid transparent;
   cursor: pointer;
 
@@ -59,24 +59,36 @@
     transition: all 0.5s ease;
   }
 
+  /*
+   * The row rail, flat. It used to be a $primary bar under three 10px shadows
+   * at 0.9 alpha -- the same bloom PR #4595 took out of the table -- and it sat
+   * at -4px, outside the row, which now lands it on the surface's own frame.
+   *
+   * Same tokens the table rail uses, so the two say "this row" the same way.
+   */
   &::before,
   &::after {
     position: absolute;
     top: 50%;
-    width: 3px;
+    width: var(--cap-h-row, 3px);
     height: 26px;
     margin-top: -13px;
+    background-color: var(--color-primary, #428bca);
     opacity: 0;
-    transition: all ease 0.3s;
+    transition: opacity 0.3s ease;
     content: "";
   }
 
   &::before {
-    left: -4px;
+    left: 0;
+    border-top-right-radius: var(--cap-r-row, 1.5px);
+    border-bottom-right-radius: var(--cap-r-row, 1.5px);
   }
 
   &::after {
-    right: -4px;
+    right: 0;
+    border-top-left-radius: var(--cap-r-row, 1.5px);
+    border-bottom-left-radius: var(--cap-r-row, 1.5px);
   }
 
   /* Keyboard and pointer mark the same thing -- "this row" -- so they draw the
@@ -85,38 +97,21 @@
   &--focused {
     &::before,
     &::after {
-      background: $primary;
       opacity: 1;
-    }
-
-    &::before {
-      border-top-right-radius: 2px;
-      border-bottom-right-radius: 2px;
-      box-shadow:
-        3px 0 10px rgba(darken($primary, 20%), 0.9),
-        0 3px 10px rgba(darken($primary, 20%), 0.9),
-        0 -3px 10px rgba(darken($primary, 20%), 0.9);
-    }
-
-    &::after {
-      border-top-left-radius: 2px;
-      border-bottom-left-radius: 2px;
-      box-shadow:
-        -3px 0 10px rgba(darken($primary, 20%), 0.9),
-        0 3px 10px rgba(darken($primary, 20%), 0.9),
-        0 -3px 10px rgba(darken($primary, 20%), 0.9);
     }
   }
 
   &.active {
     color: $primary;
-    animation-name: flash;
-    animation-duration: 0.5s;
+  }
 
-    i,
-    svg {
-      transform: rotate(45deg);
-    }
+  /*
+   * The rows outside the popover are all selected by definition, so saying so
+   * in primary tells the reader nothing and turns a list of choices into a list
+   * of links.
+   */
+  &:is(button).active {
+    color: $input-color;
   }
 
   &:last-child {
@@ -127,18 +122,5 @@
     .filter-group-item-icon {
       width: 60px;
     }
-  }
-}
-
-@keyframes flash {
-  from,
-  50%,
-  to {
-    opacity: 1;
-  }
-
-  25%,
-  75% {
-    opacity: 0.5;
   }
 }

--- a/app/frontend/shared/components/base/FilterGroup/Option/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/Option/index.scss
@@ -10,6 +10,26 @@
   border-left: 4px solid transparent;
   cursor: pointer;
 
+  /*
+   * The rows that render outside the popover are <button> -- they remove a
+   * selection, they are not options of anything -- so the browser's control
+   * styling has to be undone here the way it is on the trigger.
+   *
+   * `width: 100%` is the load-bearing one: a button has intrinsic width and does
+   * not stretch to its container even with `display: flex`, unlike the anchor
+   * this replaced. Left alone it collapsed to its label, which put the hover
+   * rail (`::after`, `right: -4px`) in the middle of the row instead of at its
+   * edge. Measured: 75px against the anchor's 278px in the same container.
+   */
+  &:is(button) {
+    width: 100%;
+    appearance: none;
+    font: inherit;
+    text-align: left;
+    background: none;
+    border-top: none;
+  }
+
   .filter-group-item-label {
     padding-right: 14px;
     flex-grow: 1;

--- a/app/frontend/shared/components/base/FilterGroup/Option/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/Option/index.vue
@@ -14,6 +14,16 @@ type Props = {
   multiple?: boolean;
   bigIcon?: boolean;
   nullable?: boolean;
+  /*
+   * A row inside the popover is an `option` in the listbox sense: it is not
+   * focusable itself, the trigger keeps focus and points at it with
+   * aria-activedescendant. The same component also renders the selected rows
+   * that sit *outside* the popover, and those are not options of anything --
+   * they are remove buttons, so they get to be real buttons.
+   */
+  inListbox?: boolean;
+  optionId?: string;
+  active?: boolean;
 };
 
 withDefaults(defineProps<Props>(), {
@@ -21,6 +31,9 @@ withDefaults(defineProps<Props>(), {
   multiple: false,
   bigIcon: false,
   nullable: false,
+  inListbox: false,
+  optionId: undefined,
+  active: false,
 });
 
 const { t } = useI18n();
@@ -33,10 +46,17 @@ const select = (option: FilterOption) => {
 </script>
 
 <template>
-  <a
+  <component
+    :is="inListbox ? 'div' : 'button'"
+    :id="inListbox ? optionId : undefined"
+    :role="inListbox ? 'option' : undefined"
+    :aria-selected="inListbox ? selected : undefined"
+    :tabindex="inListbox ? -1 : undefined"
+    :type="inListbox ? undefined : 'button'"
     :class="{
       active: selected,
       bigIcon,
+      'filter-group-item--focused': active,
     }"
     class="filter-group-item fade-list-item"
     @click="select(option)"
@@ -53,7 +73,7 @@ const select = (option: FilterOption) => {
     >
       <i class="fa-light fa-plus" />
     </span>
-  </a>
+  </component>
 </template>
 
 <style lang="scss" scoped>

--- a/app/frontend/shared/components/base/FilterGroup/Option/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/Option/index.vue
@@ -71,7 +71,8 @@ const select = (option: FilterOption) => {
       v-if="multiple || (selected && nullable)"
       v-tooltip="t('filterGroup.labels.removeTooltip')"
     >
-      <i class="fa-light fa-plus" />
+      <!-- The glyph it means, rather than a plus rotated 45 degrees into one. -->
+      <i :class="selected ? 'fa-light fa-xmark' : 'fa-light fa-plus'" />
     </span>
   </component>
 </template>

--- a/app/frontend/shared/components/base/FilterGroup/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/index.scss
@@ -31,6 +31,19 @@
   }
 
   .filter-group-title {
+    /*
+     * This is a <button> now, not a div, so the browser's own control styling
+     * has to be undone: a button does not inherit the page's font or colour --
+     * it renders in the platform UI font at ~13px in `buttontext`, which on this
+     * surface is near-black on near-black -- and it centres its own text.
+     *
+     * `font: inherit` resets weight too, so the `font-weight: bold` below has to
+     * stay after it.
+     */
+    appearance: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
     position: relative;
     display: flex;
     align-items: center;

--- a/app/frontend/shared/components/base/FilterGroup/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/index.scss
@@ -24,10 +24,10 @@
     }
   }
 
+  // Inside the surface now, so it divides rather than frames.
   .filter-group-search {
-    border: 1px solid $input-border;
-    border-top: none;
-    border-bottom: none;
+    border: none;
+    border-bottom: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
   }
 
   .filter-group-title {
@@ -78,13 +78,14 @@
       background: $input-bg;
     }
 
+    /*
+     * No bottom-corner squaring any more: both segments stand off the trigger
+     * with a gap of their own, so nothing meets its lower edge.
+     */
     &.active {
-      border-bottom-right-radius: 0;
-      border-bottom-left-radius: 0;
-
       i,
       svg {
-        transform: rotate(90deg);
+        transform: rotate(180deg);
       }
     }
 
@@ -101,132 +102,69 @@
     &.selected {
       color: white;
       font-weight: bold;
-      border-bottom-right-radius: 0;
-      border-bottom-left-radius: 0;
     }
   }
 
+  // Only the scrolling. The frame belongs to the surface around it, which
+  // cannot clip, because the end-caps sit outside its box.
   .filter-group-items {
     max-height: 300px;
     overflow-x: hidden;
     overflow-y: auto;
-    background-color: rgba($gray-darker, 0.95);
-    border: 1px solid $input-border;
-    border-top: none;
-    border-bottom-right-radius: $border-radius-base;
-    border-bottom-left-radius: $border-radius-base;
+  }
+
+  /*
+   * Both things that hang off the trigger -- the popover, and for a
+   * multi-select the list of chosen options -- are the same surface, and each
+   * stands off it rather than continuing its frame.
+   *
+   * That this element is inside the one Collapsed animates is load-bearing:
+   * Collapsed reads inline styles, so its keyframes resolve border, padding and
+   * margin to 0 for the full 500ms and snap them in at the end. A frame on the
+   * animated element stays collapsed and then jumps in.
+   */
+  .filter-group-surface {
+    position: relative;
+    margin-top: 6px;
+    background-color: var(--color-gray-darker, #272b30);
+    border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
+    border-radius: var(--radius-control, 8px);
+
+    &::before,
+    &::after {
+      position: absolute;
+      right: max(10px, var(--cap-inset, 12%));
+      left: max(10px, var(--cap-inset, 12%));
+      height: var(--cap-h, 4px);
+      background-color: var(--color-endcap, #7a8288);
+      content: "";
+    }
+
+    &::before {
+      top: -1px;
+      border-radius: 0 0 var(--cap-r, 3px) var(--cap-r, 3px);
+    }
+
+    &::after {
+      bottom: -1px;
+      border-radius: var(--cap-r, 3px) var(--cap-r, 3px) 0 0;
+    }
   }
 
   .filter-group-items-wrapper {
     position: absolute;
     right: 0;
     left: 0;
-    z-index: 1000;
-    box-shadow: 0 1px 3px rgba(black, 0.9);
-    border-bottom-right-radius: $border-radius-base;
-    border-bottom-left-radius: $border-radius-base;
+    z-index: 2100;
   }
 
   .filter-group-fetch-more {
     width: 100%;
-    border-bottom-right-radius: $border-radius-base;
-    border-bottom-left-radius: $border-radius-base;
+    border-radius: 0 0 var(--radius-control-inner, 7px)
+      var(--radius-control-inner, 7px);
 
     > * {
       color: darken($input-color, 15%);
-    }
-  }
-
-  /*
-   * PREVIEW ONLY -- see F13 in docs/exec-plans/filter-group-redesign.md.
-   *
-   * Draws the popover the way BtnDropdown/Menu draws its own: a detached
-   * surface floating over the page, fully bordered and capped, rather than a
-   * continuation of the trigger. It exists so the two forms can be compared on
-   * the visual-tests page before the decision is made, and it goes away either
-   * way -- the real version is authored with @apply once the component leaves
-   * SCSS, which is why this uses var() on the same tokens instead.
-   *
-   * The trigger keeps its own radius here. Restyling it is Phase 3 and is
-   * deliberately not previewed, so that what is being compared is the popover's
-   * form and nothing else.
-   */
-  /*
-   * PREVIEW -- variant C, see the plan's D7/D8.
-   *
-   * The attached form, but read as one Panel rather than as a stack of framed
-   * boxes: a single surface with an end-cap at each outer edge and
-   * --color-edge-soft where the segments meet. That is the call Panel already
-   * makes -- caps signature the surface, soft rules divide inside it.
-   *
-   * Only one thing is ever attached below the trigger: the selected block hides
-   * itself while the popover is open. So the bottom cap belongs to whichever
-   * segment is last, which is expressible without knowing which that is.
-   */
-  /*
-   * PREVIEW -- variant D, see the plan's D7/D8.
-   *
-   * The trigger keeps exactly the look it has today. Only the two things that
-   * hang off it change: the popover and the selected list each become their own
-   * capped surface, and the selected items stay a list of full-width rows
-   * rather than turning into pills.
-   *
-   * The trigger's corners come back for the one reason that nothing meets it
-   * any more -- both segments now stand off it with a gap of their own.
-   */
-  &.filter-group--capped {
-    .filter-group-title.active,
-    .filter-group-title.selected {
-      border-bottom-right-radius: $border-radius-base;
-      border-bottom-left-radius: $border-radius-base;
-    }
-
-    .filter-group-surface {
-      position: relative;
-      margin-top: 6px;
-      background-color: var(--color-gray-darker, #272b30);
-      border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
-      border-radius: var(--radius-control, 8px);
-
-      &::before,
-      &::after {
-        position: absolute;
-        right: max(10px, var(--cap-inset, 12%));
-        left: max(10px, var(--cap-inset, 12%));
-        height: var(--cap-h, 4px);
-        background-color: var(--color-endcap, #7a8288);
-        content: "";
-      }
-
-      &::before {
-        top: -1px;
-        border-radius: 0 0 var(--cap-r, 3px) var(--cap-r, 3px);
-      }
-
-      &::after {
-        bottom: -1px;
-        border-radius: var(--cap-r, 3px) var(--cap-r, 3px) 0 0;
-      }
-    }
-
-    .filter-group-surface .filter-group-items {
-      background-color: transparent;
-      border: none;
-      border-radius: 0;
-    }
-
-    // Rows stay rows; only the division between them joins the new language.
-    .filter-group-item {
-      border-bottom-color: var(--color-edge-soft, rgb(122 130 136 / 0.28));
-    }
-
-    .filter-group-search {
-      border: none;
-      border-bottom: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
-
-      :deep(input) {
-        background-color: transparent;
-      }
     }
   }
 

--- a/app/frontend/shared/components/base/FilterGroup/index.scss
+++ b/app/frontend/shared/components/base/FilterGroup/index.scss
@@ -137,6 +137,99 @@
     }
   }
 
+  /*
+   * PREVIEW ONLY -- see F13 in docs/exec-plans/filter-group-redesign.md.
+   *
+   * Draws the popover the way BtnDropdown/Menu draws its own: a detached
+   * surface floating over the page, fully bordered and capped, rather than a
+   * continuation of the trigger. It exists so the two forms can be compared on
+   * the visual-tests page before the decision is made, and it goes away either
+   * way -- the real version is authored with @apply once the component leaves
+   * SCSS, which is why this uses var() on the same tokens instead.
+   *
+   * The trigger keeps its own radius here. Restyling it is Phase 3 and is
+   * deliberately not previewed, so that what is being compared is the popover's
+   * form and nothing else.
+   */
+  /*
+   * PREVIEW -- variant C, see the plan's D7/D8.
+   *
+   * The attached form, but read as one Panel rather than as a stack of framed
+   * boxes: a single surface with an end-cap at each outer edge and
+   * --color-edge-soft where the segments meet. That is the call Panel already
+   * makes -- caps signature the surface, soft rules divide inside it.
+   *
+   * Only one thing is ever attached below the trigger: the selected block hides
+   * itself while the popover is open. So the bottom cap belongs to whichever
+   * segment is last, which is expressible without knowing which that is.
+   */
+  /*
+   * PREVIEW -- variant D, see the plan's D7/D8.
+   *
+   * The trigger keeps exactly the look it has today. Only the two things that
+   * hang off it change: the popover and the selected list each become their own
+   * capped surface, and the selected items stay a list of full-width rows
+   * rather than turning into pills.
+   *
+   * The trigger's corners come back for the one reason that nothing meets it
+   * any more -- both segments now stand off it with a gap of their own.
+   */
+  &.filter-group--capped {
+    .filter-group-title.active,
+    .filter-group-title.selected {
+      border-bottom-right-radius: $border-radius-base;
+      border-bottom-left-radius: $border-radius-base;
+    }
+
+    .filter-group-surface {
+      position: relative;
+      margin-top: 6px;
+      background-color: var(--color-gray-darker, #272b30);
+      border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
+      border-radius: var(--radius-control, 8px);
+
+      &::before,
+      &::after {
+        position: absolute;
+        right: max(10px, var(--cap-inset, 12%));
+        left: max(10px, var(--cap-inset, 12%));
+        height: var(--cap-h, 4px);
+        background-color: var(--color-endcap, #7a8288);
+        content: "";
+      }
+
+      &::before {
+        top: -1px;
+        border-radius: 0 0 var(--cap-r, 3px) var(--cap-r, 3px);
+      }
+
+      &::after {
+        bottom: -1px;
+        border-radius: var(--cap-r, 3px) var(--cap-r, 3px) 0 0;
+      }
+    }
+
+    .filter-group-surface .filter-group-items {
+      background-color: transparent;
+      border: none;
+      border-radius: 0;
+    }
+
+    // Rows stay rows; only the division between them joins the new language.
+    .filter-group-item {
+      border-bottom-color: var(--color-edge-soft, rgb(122 130 136 / 0.28));
+    }
+
+    .filter-group-search {
+      border: none;
+      border-bottom: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
+
+      :deep(input) {
+        background-color: transparent;
+      }
+    }
+  }
+
   &.inline {
     margin-bottom: 0;
   }

--- a/app/frontend/shared/components/base/FilterGroup/index.spec.ts
+++ b/app/frontend/shared/components/base/FilterGroup/index.spec.ts
@@ -7,7 +7,7 @@
  * against rather than being verified by eye.
  */
 import { mountWithDefaults } from "@/shared/utils/TestUtils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import Component from "./index.vue";
 
 const options = [
@@ -16,17 +16,40 @@ const options = [
   { value: "b", label: "Banu Merchantman" },
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mount = (props: Record<string, any> = {}) =>
-  mountWithDefaults<typeof Component>(Component, {
+/*
+ * FilterGroup is declared `<script setup generic="T">`, so its type is a
+ * generic function component rather than a constructor, and mountWithDefaults
+ * constrains to `new (...args: any) => any`. Casting to the shape the helper
+ * asks for is contained to this file; widening the helper would reach the 40-odd
+ * other specs that rely on its inference.
+ *
+ * The exposed methods are spelled out because four call sites reach them through
+ * template refs -- see the plan's F5.
+ */
+const FilterGroup = Component as unknown as new (...args: never[]) => {
+  $props: Record<string, unknown>;
+  reset: () => void;
+  clear: () => void;
+  clearSearch: () => void;
+};
+
+const mount = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults<typeof FilterGroup>(FilterGroup, {
     props: { name: "ships", options, ...props },
   });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const labelsIn = (wrapper: any, root = "") =>
+type Wrapper = Awaited<ReturnType<typeof mount>>;
+
+const labelsIn = (wrapper: Wrapper, root = "") =>
   wrapper
     .findAll(`${root} .filter-group-item-label`)
     .map((node: { text: () => string }) => node.text());
+
+// jsdom has no layout, so it does not implement scrollIntoView. Stubbed here
+// rather than guarded in the component: it exists in every browser.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -198,6 +221,168 @@ describe("FilterGroup", () => {
       });
 
       expect(wrapper.find(".filter-group-fetch-more").exists()).toBe(false);
+    });
+  });
+  describe("combobox semantics", () => {
+    it("makes the trigger a button that announces itself as a combobox", async () => {
+      const wrapper = await mount();
+      const trigger = wrapper.find('[data-test="filter-group-title"]');
+
+      expect(trigger.element.tagName).toBe("BUTTON");
+      expect(trigger.attributes("role")).toBe("combobox");
+      expect(trigger.attributes("aria-haspopup")).toBe("listbox");
+      expect(trigger.attributes("aria-expanded")).toBe("false");
+    });
+
+    it("flips aria-expanded when it opens", async () => {
+      const wrapper = await mount();
+
+      await wrapper.find('[data-test="filter-group-title"]').trigger("click");
+
+      expect(
+        wrapper
+          .find('[data-test="filter-group-title"]')
+          .attributes("aria-expanded"),
+      ).toBe("true");
+    });
+
+    it("points the label at the trigger when there is no search box", async () => {
+      const wrapper = await mount();
+
+      expect(wrapper.find("label").attributes("for")).toBe(
+        wrapper.find('[data-test="filter-group-title"]').attributes("id"),
+      );
+    });
+
+    it("still points the label at the search box when there is one", async () => {
+      const wrapper = await mount({ searchable: true, label: "Ships" });
+
+      expect(wrapper.find("label").attributes("for")).toContain("searchInput");
+    });
+
+    it("gives every row an option role and its selected state", async () => {
+      const wrapper = await mount({ modelValue: "a" });
+      const rows = wrapper.findAll('[role="option"]');
+
+      expect(rows).toHaveLength(3);
+      expect(rows.map((r) => r.attributes("aria-selected"))).toEqual([
+        "false",
+        "true",
+        "false",
+      ]);
+    });
+
+    it("marks the listbox multi-selectable only when it is", async () => {
+      const single = await mount();
+      const many = await mount({ multiple: true });
+
+      expect(
+        single.find('[role="listbox"]').attributes("aria-multiselectable"),
+      ).toBe("false");
+      expect(
+        many.find('[role="listbox"]').attributes("aria-multiselectable"),
+      ).toBe("true");
+    });
+  });
+
+  describe("keyboard", () => {
+    const open = async () => {
+      const wrapper = await mount();
+      await wrapper.trigger("keydown", { key: "ArrowDown" });
+      return wrapper;
+    };
+
+    const activeLabel = (wrapper: {
+      find: (s: string) => { exists: () => boolean; text: () => string };
+    }) => wrapper.find(".filter-group-item--focused").text();
+
+    it("opens on ArrowDown and points at the first row", async () => {
+      const wrapper = await open();
+
+      expect(
+        wrapper
+          .find('[data-test="filter-group-title"]')
+          .attributes("aria-expanded"),
+      ).toBe("true");
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
+    });
+
+    it("opens on ArrowUp and points at the last row", async () => {
+      const wrapper = await mount();
+
+      await wrapper.trigger("keydown", { key: "ArrowUp" });
+
+      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+    });
+
+    it("wraps around both ends", async () => {
+      const wrapper = await open();
+
+      await wrapper.trigger("keydown", { key: "ArrowUp" });
+      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+
+      await wrapper.trigger("keydown", { key: "ArrowDown" });
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
+    });
+
+    it("jumps to the ends with Home and End", async () => {
+      const wrapper = await open();
+
+      await wrapper.trigger("keydown", { key: "End" });
+      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+
+      await wrapper.trigger("keydown", { key: "Home" });
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
+    });
+
+    it("publishes the pointed-at row through aria-activedescendant", async () => {
+      const wrapper = await open();
+
+      expect(
+        wrapper
+          .find('[data-test="filter-group-title"]')
+          .attributes("aria-activedescendant"),
+      ).toBe(wrapper.find(".filter-group-item--focused").attributes("id"));
+    });
+
+    it("selects the pointed-at row on Enter", async () => {
+      const wrapper = await open();
+
+      await wrapper.trigger("keydown", { key: "ArrowDown" });
+      await wrapper.trigger("keydown", { key: "Enter" });
+
+      expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["a"]);
+    });
+
+    it("closes on Escape without selecting", async () => {
+      const wrapper = await open();
+
+      await wrapper.trigger("keydown", { key: "Escape" });
+
+      expect(
+        wrapper
+          .find('[data-test="filter-group-title"]')
+          .attributes("aria-expanded"),
+      ).toBe("false");
+      expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+    });
+
+    it("jumps to a row by typing its first letters", async () => {
+      const wrapper = await mount();
+
+      await wrapper.trigger("keydown", { key: "b" });
+      await wrapper.trigger("keydown", { key: "a" });
+
+      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+    });
+
+    it("leaves typing to the search box when the group is searchable", async () => {
+      const wrapper = await mount({ searchable: true });
+
+      await wrapper.find('[data-test="filter-group-title"]').trigger("click");
+      await wrapper.trigger("keydown", { key: "b" });
+
+      expect(wrapper.find(".filter-group-item--focused").exists()).toBe(false);
     });
   });
 });

--- a/app/frontend/shared/components/base/FilterGroup/index.spec.ts
+++ b/app/frontend/shared/components/base/FilterGroup/index.spec.ts
@@ -76,21 +76,18 @@ describe("FilterGroup", () => {
 
   describe("options", () => {
     /*
-     * Pins a defect, not an intention. `sort()` exists and `availableOptions`
-     * applies it, but the popover renders `filteredOptions`, which returns
-     * `internalOptions` untouched -- so the list a user reads is in arrival
-     * order and only the selected rows come out sorted (see the test below).
-     *
-     * The rebuild should make this list sorted and flip this assertion. Until
-     * it does, the current behaviour is written down rather than assumed.
+     * The flip side of the defect this spec used to pin: `sort()` ran in
+     * `availableOptions` while the popover rendered `filteredOptions`, so the
+     * selected rows came out alphabetical and the options a user picks from
+     * stayed in whatever order the API returned them.
      */
-    it("renders the popover list in arrival order, because the sort never reaches it", async () => {
+    it("sorts the popover list by label, whatever order the options arrive in", async () => {
       const wrapper = await mount();
 
       expect(labelsIn(wrapper, '[id^="ships-options-"]')).toEqual([
-        "Caterpillar",
         "Aurora",
         "Banu Merchantman",
+        "Caterpillar",
       ]);
     });
 
@@ -131,10 +128,9 @@ describe("FilterGroup", () => {
       const wrapper = await mount({ multiple: true, modelValue: ["a"] });
 
       await wrapper
-        .find('[id^="ships-options-"] .filter-group-item')
+        .findAll('[id^="ships-options-"] .filter-group-item')[2]
         .trigger("click");
 
-      // The first row is Caterpillar, not Aurora -- arrival order, per above.
       expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([
         ["a", "c"],
       ]);
@@ -266,8 +262,8 @@ describe("FilterGroup", () => {
 
       expect(rows).toHaveLength(3);
       expect(rows.map((r) => r.attributes("aria-selected"))).toEqual([
-        "false",
         "true",
+        "false",
         "false",
       ]);
     });
@@ -304,7 +300,7 @@ describe("FilterGroup", () => {
           .find('[data-test="filter-group-title"]')
           .attributes("aria-expanded"),
       ).toBe("true");
-      expect(activeLabel(wrapper)).toContain("Caterpillar");
+      expect(activeLabel(wrapper)).toContain("Aurora");
     });
 
     it("opens on ArrowUp and points at the last row", async () => {
@@ -312,27 +308,27 @@ describe("FilterGroup", () => {
 
       await wrapper.trigger("keydown", { key: "ArrowUp" });
 
-      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
     });
 
     it("wraps around both ends", async () => {
       const wrapper = await open();
 
       await wrapper.trigger("keydown", { key: "ArrowUp" });
-      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
 
       await wrapper.trigger("keydown", { key: "ArrowDown" });
-      expect(activeLabel(wrapper)).toContain("Caterpillar");
+      expect(activeLabel(wrapper)).toContain("Aurora");
     });
 
     it("jumps to the ends with Home and End", async () => {
       const wrapper = await open();
 
       await wrapper.trigger("keydown", { key: "End" });
-      expect(activeLabel(wrapper)).toContain("Banu Merchantman");
+      expect(activeLabel(wrapper)).toContain("Caterpillar");
 
       await wrapper.trigger("keydown", { key: "Home" });
-      expect(activeLabel(wrapper)).toContain("Caterpillar");
+      expect(activeLabel(wrapper)).toContain("Aurora");
     });
 
     it("publishes the pointed-at row through aria-activedescendant", async () => {
@@ -351,7 +347,7 @@ describe("FilterGroup", () => {
       await wrapper.trigger("keydown", { key: "ArrowDown" });
       await wrapper.trigger("keydown", { key: "Enter" });
 
-      expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["a"]);
+      expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["b"]);
     });
 
     it("closes on Escape without selecting", async () => {

--- a/app/frontend/shared/components/base/FilterGroup/index.spec.ts
+++ b/app/frontend/shared/components/base/FilterGroup/index.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Phase 0 of the FilterGroup redesign (docs/exec-plans/filter-group-redesign.md).
+ *
+ * These pin the behaviour the rebuild must not regress. They are deliberately
+ * written against the component as it is today -- including the DOM contract
+ * CargoGrids.spec.ts depends on -- so that the rebuild has something to fail
+ * against rather than being verified by eye.
+ */
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Component from "./index.vue";
+
+const options = [
+  { value: "c", label: "Caterpillar" },
+  { value: "a", label: "Aurora" },
+  { value: "b", label: "Banu Merchantman" },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mount = (props: Record<string, any> = {}) =>
+  mountWithDefaults<typeof Component>(Component, {
+    props: { name: "ships", options, ...props },
+  });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const labelsIn = (wrapper: any, root = "") =>
+  wrapper
+    .findAll(`${root} .filter-group-item-label`)
+    .map((node: { text: () => string }) => node.text());
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("FilterGroup", () => {
+  describe("the DOM contract CargoGrids.spec.ts drives it through", () => {
+    it("names the trigger filter-group-title", async () => {
+      const wrapper = await mount();
+
+      expect(wrapper.find('[data-test="filter-group-title"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it("keeps the search box as the first input in the subtree", async () => {
+      const wrapper = await mount({ searchable: true });
+
+      const first = wrapper.findAll("input")[0];
+
+      expect(first.attributes("name")).toContain("searchInput");
+    });
+  });
+
+  describe("options", () => {
+    /*
+     * Pins a defect, not an intention. `sort()` exists and `availableOptions`
+     * applies it, but the popover renders `filteredOptions`, which returns
+     * `internalOptions` untouched -- so the list a user reads is in arrival
+     * order and only the selected rows come out sorted (see the test below).
+     *
+     * The rebuild should make this list sorted and flip this assertion. Until
+     * it does, the current behaviour is written down rather than assumed.
+     */
+    it("renders the popover list in arrival order, because the sort never reaches it", async () => {
+      const wrapper = await mount();
+
+      expect(labelsIn(wrapper, '[id^="ships-options-"]')).toEqual([
+        "Caterpillar",
+        "Aurora",
+        "Banu Merchantman",
+      ]);
+    });
+
+    it("shows the selected label on the trigger rather than the raw value", async () => {
+      const wrapper = await mount({ modelValue: "b" });
+
+      expect(wrapper.find('[data-test="filter-group-title"]').text()).toContain(
+        "Banu Merchantman",
+      );
+    });
+  });
+
+  describe("multiple", () => {
+    it("renders the selected rows outside the popover while it is closed", async () => {
+      const wrapper = await mount({ multiple: true, modelValue: ["a", "c"] });
+
+      const selected = wrapper.find('[id^="ships-selected-"]');
+
+      expect(selected.exists()).toBe(true);
+      expect(
+        selected
+          .findAll(".filter-group-item-label")
+          .map((n: { text: () => string }) => n.text()),
+      ).toEqual(["Aurora", "Caterpillar"]);
+    });
+
+    it("does not render that second list when hideSelected is set", async () => {
+      const wrapper = await mount({
+        multiple: true,
+        hideSelected: true,
+        modelValue: ["a"],
+      });
+
+      expect(wrapper.find('[id^="ships-selected-"]').exists()).toBe(false);
+    });
+
+    it("adds to the selection rather than replacing it", async () => {
+      const wrapper = await mount({ multiple: true, modelValue: ["a"] });
+
+      await wrapper
+        .find('[id^="ships-options-"] .filter-group-item')
+        .trigger("click");
+
+      // The first row is Caterpillar, not Aurora -- arrival order, per above.
+      expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([
+        ["a", "c"],
+      ]);
+    });
+  });
+
+  describe("the imperative API four call sites depend on", () => {
+    it("exposes reset, clear and clearSearch", async () => {
+      const wrapper = await mount();
+
+      expect(typeof wrapper.vm.reset).toBe("function");
+      expect(typeof wrapper.vm.clear).toBe("function");
+      expect(typeof wrapper.vm.clearSearch).toBe("function");
+    });
+  });
+
+  describe("querying", () => {
+    it("fetches an option that is selected but absent from the loaded page", async () => {
+      const queryFn = vi
+        .fn()
+        .mockResolvedValue([{ value: "x", label: "Idris" }]);
+
+      await mount({ options: undefined, queryFn, modelValue: "zeus" });
+
+      expect(queryFn).toHaveBeenCalled();
+      expect(
+        queryFn.mock.calls.some(([params]) => params.missing === "zeus"),
+      ).toBe(true);
+    });
+
+    it("debounces the search and resets to the first page", async () => {
+      const queryFn = vi.fn().mockResolvedValue([]);
+      const wrapper = await mount({
+        options: undefined,
+        queryFn,
+        searchable: true,
+      });
+
+      queryFn.mockClear();
+      vi.useFakeTimers();
+
+      await wrapper.find("input").setValue("cat");
+      await wrapper.find("input").trigger("input");
+
+      expect(queryFn).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(queryFn).toHaveBeenCalledTimes(1);
+      expect(queryFn.mock.calls[0][0]).toMatchObject({
+        page: 1,
+        search: "cat",
+      });
+    });
+
+    it("offers more only while the response says there are more pages", async () => {
+      const paged = (currentPage: number, totalPages: number) => ({
+        data: [],
+        meta: { pagination: { currentPage, totalPages } },
+      });
+      const queryFn = vi.fn().mockResolvedValue(paged(1, 3));
+
+      const wrapper = await mount({
+        options: undefined,
+        queryFn,
+        queryResponseFormatter: (r: { data: unknown[] }) => r.data,
+        paginated: true,
+      });
+
+      expect(wrapper.find(".filter-group-fetch-more").exists()).toBe(true);
+    });
+
+    it("hides the fetch-more row on the last page", async () => {
+      const queryFn = vi.fn().mockResolvedValue({
+        data: [],
+        meta: { pagination: { currentPage: 3, totalPages: 3 } },
+      });
+
+      const wrapper = await mount({
+        options: undefined,
+        queryFn,
+        queryResponseFormatter: (r: { data: unknown[] }) => r.data,
+        paginated: true,
+      });
+
+      expect(wrapper.find(".filter-group-fetch-more").exists()).toBe(false);
+    });
+  });
+});

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -735,52 +735,21 @@ defineExpose({
       v-if="multiple && !hideSelected"
       :id="`${name}-selected-${id}`"
       :visible="selectedOptions.length > 0 && !visible"
-      class="filter-group-items"
+      class="filter-group-selected"
     >
-      <Option
-        v-for="(option, index) in selectedOptions"
-        :key="`${name}-selected-${id}-${option.value}-${index}`"
-        :option="option"
-        :selected="selected(option.value)"
-        :big-icon="bigIcon"
-        :multiple="multiple"
-        :nullable="nullable"
-        @select="select(option.value)"
-      />
-    </Collapsed>
-    <Collapsed
-      :id="`${name}-options-${id}`"
-      :visible="visible"
-      class="filter-group-items-wrapper"
-    >
-      <FormInput
-        v-if="searchable"
-        ref="searchInput"
-        :id="labelFor"
-        v-model="search"
-        :name="`${name}-searchInput-${id}`"
-        :placeholder="searchPlaceholder"
-        :label="searchLabelFallback"
-        class="filter-group-search"
-        :variant="InputVariantsEnum.CLEAN"
-        :no-label="true"
-        :clearable="true"
-        @input="onSearch"
-      />
-      <div class="filter-group-items">
-        <div
-          :id="listboxId"
-          role="listbox"
-          :aria-multiselectable="multiple"
-          :aria-labelledby="triggerId"
-        >
+      <!--
+        Same shape as the popover below, and for the same reason: Collapsed
+        animates this element's height and drives its margin, padding and border
+        to zero for the duration, so anything framing the segment -- including
+        the gap that stands it off the trigger -- has to sit inside it or it
+        snaps in at the end.
+      -->
+      <div class="filter-group-surface">
+        <div class="filter-group-items">
           <Option
-            v-for="(option, index) in filteredOptions"
-            :key="`${name}-options-${id}-${option.value}-${index}`"
+            v-for="(option, index) in selectedOptions"
+            :key="`${name}-selected-${id}-${option.value}-${index}`"
             :option="option"
-            :option-id="optionId(index)"
-            :in-listbox="true"
-            :active="index === activeIndex"
             :selected="selected(option.value)"
             :big-icon="bigIcon"
             :multiple="multiple"
@@ -788,15 +757,67 @@ defineExpose({
             @select="select(option.value)"
           />
         </div>
+      </div>
+    </Collapsed>
+    <Collapsed
+      :id="`${name}-options-${id}`"
+      :visible="visible"
+      class="filter-group-items-wrapper"
+    >
+      <!--
+        Collapsed animates this wrapper's height, and its keyframes drive
+        padding, border and margin to zero for the duration (it reads inline
+        styles, which a stylesheet never sets, so the end keyframe resolves to
+        0). Anything framing the popover therefore has to sit *inside* the
+        animated element, or it stays collapsed for 500ms and snaps in at the
+        end.
+      -->
+      <div class="filter-group-surface">
+        <FormInput
+          v-if="searchable"
+          ref="searchInput"
+          :id="labelFor"
+          v-model="search"
+          :name="`${name}-searchInput-${id}`"
+          :placeholder="searchPlaceholder"
+          :label="searchLabelFallback"
+          class="filter-group-search"
+          :variant="InputVariantsEnum.CLEAN"
+          :no-label="true"
+          :clearable="true"
+          @input="onSearch"
+        />
+        <div class="filter-group-items">
+          <div
+            :id="listboxId"
+            role="listbox"
+            :aria-multiselectable="multiple"
+            :aria-labelledby="triggerId"
+          >
+            <Option
+              v-for="(option, index) in filteredOptions"
+              :key="`${name}-options-${id}-${option.value}-${index}`"
+              :option="option"
+              :option-id="optionId(index)"
+              :in-listbox="true"
+              :active="index === activeIndex"
+              :selected="selected(option.value)"
+              :big-icon="bigIcon"
+              :multiple="multiple"
+              :nullable="nullable"
+              @select="select(option.value)"
+            />
+          </div>
 
-        <Btn
-          v-if="fetchMoreVisible && paginated"
-          :disabled="loading"
-          class="fade-list-item filter-group-fetch-more"
-          @click="fetchMore"
-          :variant="BtnVariantsEnum.BARE"
-          >{{ t("filterGroup.actions.fetchMore") }}</Btn
-        >
+          <Btn
+            v-if="fetchMoreVisible && paginated"
+            :disabled="loading"
+            class="fade-list-item filter-group-fetch-more"
+            @click="fetchMore"
+            :variant="BtnVariantsEnum.BARE"
+            >{{ t("filterGroup.actions.fetchMore") }}</Btn
+          >
+        </div>
       </div>
     </Collapsed>
   </div>

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -271,6 +271,25 @@ const searchLabelFallback = computed(() => {
   return t("filterGroup.labels.search");
 });
 
+/*
+ * Declared above availableOptions on purpose: a const is in its temporal dead
+ * zone until the line that defines it runs, and the watcher on filteredOptions
+ * evaluates that chain during setup. Defined below, this threw
+ * "Cannot access 'sort' before initialization" and nothing mounted.
+ */
+const sort = (options: FilterOption[]) => {
+  const sortedOptions = JSON.parse(JSON.stringify(options));
+  return sortedOptions.sort((a: FilterOption, b: FilterOption) => {
+    if (a.label < b.label) {
+      return -1;
+    }
+    if (a.label > b.label) {
+      return 1;
+    }
+    return 0;
+  });
+};
+
 const availableOptions = computed<FilterOption[]>(() =>
   sort(internalOptions.value),
 );
@@ -291,14 +310,20 @@ const selectedOptions = computed(() => {
   return selectedOption ? [selectedOption] : [];
 });
 
+/*
+ * Sorted, which it was not. `sort()` ran in availableOptions, but the popover
+ * renders this -- so the selected rows came out alphabetical and the options a
+ * user picks from stayed in whatever order the API returned them. Two lists in
+ * one popover, ordered differently, from one sort that only half-ran.
+ */
 const filteredOptions = computed(() => {
   if (search.value) {
-    return internalOptions.value.filter((item) =>
+    return availableOptions.value.filter((item) =>
       item.label.toLowerCase().includes(String(search.value?.toLowerCase())),
     );
   }
 
-  return internalOptions.value;
+  return availableOptions.value;
 });
 
 const cssClasses = computed(() => ({
@@ -567,19 +592,6 @@ const fetchMore = async () => {
   page.value += 1;
 
   await refetch();
-};
-
-const sort = (options: FilterOption[]) => {
-  const sortedOptions = JSON.parse(JSON.stringify(options));
-  return sortedOptions.sort((a: FilterOption, b: FilterOption) => {
-    if (a.label < b.label) {
-      return -1;
-    }
-    if (a.label > b.label) {
-      return 1;
-    }
-    return 0;
-  });
 };
 
 const addOptions = (newOptions: FilterOption[]) => {

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -231,12 +231,24 @@ const innerLabel = computed(() => {
   return t(`filterGroup.${props.name}.label`);
 });
 
+const triggerId = computed(() => `${props.name}-trigger-${id.value}`);
+
+const listboxId = computed(() => `${props.name}-listbox-${id.value}`);
+
+const optionId = (index: number) => `${listboxId.value}-option-${index}`;
+
+/*
+ * The label points at a real control now. It used to point at the collapsed
+ * container's id -- a div -- for every group that is not searchable, which is
+ * 68 of the component's 135 call sites: clicking the label did nothing and a
+ * screen reader announced nothing.
+ */
 const labelFor = computed(() => {
   if (props.searchable) {
     return `${props.name}-searchInput-${id.value}`;
   }
 
-  return `${props.name}-options-${id.value}`;
+  return triggerId.value;
 });
 
 const searchPlaceholder = computed(() => {
@@ -283,6 +295,205 @@ const cssClasses = computed(() => ({
   "filter-group--medium": props.size === FilterGroupSizesEnum.MEDIUM,
 }));
 
+/*
+ * The visually pointed-at row. Focus itself never leaves the trigger (or the
+ * search box), so this is carried as an index and published through
+ * aria-activedescendant rather than by moving focus into the list.
+ */
+const activeIndex = ref(-1);
+
+const activeOption = computed(() => filteredOptions.value[activeIndex.value]);
+
+const activeDescendant = computed(() =>
+  visible.value && activeIndex.value >= 0
+    ? optionId(activeIndex.value)
+    : undefined,
+);
+
+// A list that shrank under the cursor -- by a search, or a page of results
+// arriving -- must not leave the pointer past its end.
+watch(filteredOptions, () => {
+  if (activeIndex.value >= filteredOptions.value.length) {
+    activeIndex.value = filteredOptions.value.length - 1;
+  }
+});
+
+const moveActive = (delta: number) => {
+  const count = filteredOptions.value.length;
+
+  if (count === 0) {
+    activeIndex.value = -1;
+    return;
+  }
+
+  activeIndex.value =
+    activeIndex.value < 0
+      ? delta > 0
+        ? 0
+        : count - 1
+      : (activeIndex.value + delta + count) % count;
+
+  void scrollActiveIntoView();
+};
+
+const scrollActiveIntoView = async () => {
+  await nextTick();
+
+  if (activeIndex.value < 0 || !filterGroup.value) {
+    return;
+  }
+
+  filterGroup.value
+    .querySelector(`#${CSS.escape(optionId(activeIndex.value))}`)
+    ?.scrollIntoView({ block: "nearest" });
+};
+
+/*
+ * Type-ahead, for the groups that are not searchable. A native select gives
+ * this for free; a custom combobox has to pay it back, and without it the only
+ * way through the longer lists -- manufacturers, star systems -- is fifty
+ * arrow presses.
+ */
+const typeAheadBuffer = ref("");
+
+let typeAheadTimer: ReturnType<typeof setTimeout> | undefined;
+
+const typeAhead = (character: string) => {
+  clearTimeout(typeAheadTimer);
+  typeAheadBuffer.value += character.toLowerCase();
+  typeAheadTimer = setTimeout(() => {
+    typeAheadBuffer.value = "";
+  }, 500);
+
+  const match = filteredOptions.value.findIndex((option) =>
+    option.label.toLowerCase().startsWith(typeAheadBuffer.value),
+  );
+
+  if (match >= 0) {
+    activeIndex.value = match;
+    void scrollActiveIntoView();
+  }
+};
+
+const focusTrigger = async () => {
+  await nextTick();
+  trigger.value?.focus();
+};
+
+const close = (returnFocus = false) => {
+  visible.value = false;
+  activeIndex.value = -1;
+
+  if (returnFocus) {
+    void focusTrigger();
+  }
+};
+
+const onKeydown = async (event: KeyboardEvent) => {
+  if (props.disabled) {
+    return;
+  }
+
+  switch (event.key) {
+    case "ArrowDown":
+    case "ArrowUp": {
+      event.preventDefault();
+
+      if (!visible.value) {
+        await toggle();
+        activeIndex.value = event.key === "ArrowDown" ? 0 : -1;
+        if (event.key === "ArrowUp") moveActive(-1);
+        return;
+      }
+
+      moveActive(event.key === "ArrowDown" ? 1 : -1);
+      return;
+    }
+    case "Home":
+    case "End": {
+      if (!visible.value) {
+        return;
+      }
+
+      event.preventDefault();
+      activeIndex.value =
+        event.key === "Home" ? 0 : filteredOptions.value.length - 1;
+      void scrollActiveIntoView();
+      return;
+    }
+    case "Enter": {
+      event.preventDefault();
+
+      if (!visible.value) {
+        await toggle();
+        return;
+      }
+
+      if (activeOption.value) {
+        await select(activeOption.value.value);
+      }
+      return;
+    }
+    case " ": {
+      // In a searchable group a space is a character, not a command.
+      if (props.searchable) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (!visible.value) {
+        await toggle();
+        return;
+      }
+
+      if (activeOption.value) {
+        await select(activeOption.value.value);
+      }
+      return;
+    }
+    case "Escape": {
+      if (!visible.value) {
+        return;
+      }
+
+      event.preventDefault();
+      close(true);
+      return;
+    }
+    case "Tab": {
+      close();
+      return;
+    }
+    default: {
+      if (
+        !props.searchable &&
+        event.key.length === 1 &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        if (!visible.value) {
+          await toggle();
+        }
+        typeAhead(event.key);
+      }
+    }
+  }
+};
+
+// A pointer click outside already closes the group; this is the same rule for
+// focus, so tabbing out of an open group does not leave the popover hanging.
+const onFocusout = (event: FocusEvent) => {
+  const next = event.relatedTarget as Node | null;
+
+  if (next && filterGroup.value?.contains(next)) {
+    return;
+  }
+
+  close();
+};
+
 onMounted(() => {
   document.addEventListener("click", documentClick);
 
@@ -298,6 +509,8 @@ onUnmounted(() => {
 });
 
 const filterGroup = ref<HTMLElement | null>(null);
+
+const trigger = ref<HTMLButtonElement | null>(null);
 
 const documentClick = (event: Event) => {
   if (!filterGroup.value) {
@@ -456,6 +669,8 @@ defineExpose({
     class="filter-group"
     :class="cssClasses"
     :data-test="`filter-group-${name}`"
+    @keydown="onKeydown"
+    @focusout="onFocusout"
   >
     <transition name="fade">
       <label
@@ -466,8 +681,17 @@ defineExpose({
         {{ innerLabel }}
       </label>
     </transition>
-    <div
+    <button
+      :id="triggerId"
+      ref="trigger"
       v-tooltip.right="error"
+      type="button"
+      role="combobox"
+      aria-haspopup="listbox"
+      :aria-expanded="visible"
+      :aria-controls="listboxId"
+      :aria-activedescendant="activeDescendant"
+      :disabled="disabled"
       :class="{
         active: visible,
         disabled,
@@ -483,7 +707,7 @@ defineExpose({
       </span>
       <SmallLoader v-if="props.queryFn" :loading="loading" />
       <i class="fa fa-chevron-right" />
-    </div>
+    </button>
     <Collapsed
       v-if="multiple && !hideSelected"
       :id="`${name}-selected-${id}`"
@@ -521,16 +745,26 @@ defineExpose({
         @input="onSearch"
       />
       <div class="filter-group-items">
-        <Option
-          v-for="(option, index) in filteredOptions"
-          :key="`${name}-options-${id}-${option.value}-${index}`"
-          :option="option"
-          :selected="selected(option.value)"
-          :big-icon="bigIcon"
-          :multiple="multiple"
-          :nullable="nullable"
-          @select="select(option.value)"
-        />
+        <div
+          :id="listboxId"
+          role="listbox"
+          :aria-multiselectable="multiple"
+          :aria-labelledby="triggerId"
+        >
+          <Option
+            v-for="(option, index) in filteredOptions"
+            :key="`${name}-options-${id}-${option.value}-${index}`"
+            :option="option"
+            :option-id="optionId(index)"
+            :in-listbox="true"
+            :active="index === activeIndex"
+            :selected="selected(option.value)"
+            :big-icon="bigIcon"
+            :multiple="multiple"
+            :nullable="nullable"
+            @select="select(option.value)"
+          />
+        </div>
 
         <Btn
           v-if="fetchMoreVisible && paginated"

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -126,6 +126,18 @@ const prompt = computed(() => {
     return selectedOptions.value[0].label;
   }
 
+  /*
+   * A multi-select used to fall straight through to the generic prompt, so a
+   * group with two things chosen still read "No Option selected" and the only
+   * place the selection appeared was the list below. That is wrong in any
+   * layout and plainly wrong once the popover detaches.
+   */
+  if (props.multiple && selectedOptions.value.length > 0) {
+    return t("filterGroup.labels.selectedCount", {
+      count: selectedOptions.value.length,
+    });
+  }
+
   if (props.translationKey) {
     if (props.nullable) {
       if (tExists(`filterGroup.${props.translationKey}.nullablePrompt`)) {

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -729,7 +729,7 @@ defineExpose({
         {{ prompt }}
       </span>
       <SmallLoader v-if="props.queryFn" :loading="loading" />
-      <i class="fa fa-chevron-right" />
+      <i class="fa fa-chevron-down" />
     </button>
     <Collapsed
       v-if="multiple && !hideSelected"

--- a/app/frontend/shared/components/base/FilterGroup/index.vue
+++ b/app/frontend/shared/components/base/FilterGroup/index.vue
@@ -641,7 +641,18 @@ const focusSearch = async () => {
   if (props.searchable && visible.value) {
     await nextTick(() => {
       if (searchInput.value) {
-        searchInput.value.setFocus();
+        /*
+         * preventScroll matters here. The popover is still collapsed when this
+         * runs -- Collapsed animates its height from 0 under overflow: hidden --
+         * and an overflow: hidden box is still programmatically scrollable, so
+         * focusing the field made the browser scroll it into view inside a box
+         * of almost no height. That pushed the whole popover's content up behind
+         * the trigger, and it unwound over the next 500ms as the box grew, which
+         * read as the popover starting halfway under the control.
+         *
+         * Measured: scrollTop 21, content at -21px, against 0 and 0 with this.
+         */
+        searchInput.value.setFocus({ preventScroll: true });
       }
     });
   }

--- a/app/frontend/shared/components/base/FormInput/index.scss
+++ b/app/frontend/shared/components/base/FormInput/index.scss
@@ -148,10 +148,17 @@
     }
   }
 
+  /*
+   * For a field that sits inside another surface rather than on the page: no
+   * frame of its own, and no fill either. Keeping $input-bg made it read as a
+   * lighter slab inset into whatever contains it, with square corners cutting
+   * across that surface's rounded ones.
+   */
   &--clean {
     margin-bottom: 0;
 
     input {
+      background-color: transparent;
       border: none;
       border-radius: 0;
     }

--- a/app/frontend/shared/components/base/FormInput/index.vue
+++ b/app/frontend/shared/components/base/FormInput/index.vue
@@ -185,8 +185,14 @@ const onChange = (event: Event) => {
   emit("update:modelValue", inputValue.value);
 };
 
-const setFocus = () => {
-  inputElement.value?.focus();
+/*
+ * Options are passed through rather than fixed here. Focusing normally scrolls
+ * the field into view, which is what a caller focusing a failed field further
+ * down the page wants; a caller focusing into a container that is still
+ * animating open does not, and passes { preventScroll: true }.
+ */
+const setFocus = (options?: FocusOptions) => {
+  inputElement.value?.focus(options);
 };
 
 const slots = useSlots();

--- a/app/frontend/translations/en/filterGroup.json
+++ b/app/frontend/translations/en/filterGroup.json
@@ -8,7 +8,11 @@
         "search": "Type to search",
         "nullablePrompt": "No Option selected",
         "prompt": "Please select an Option",
-        "removeTooltip": "Click to remove Option"
+        "removeTooltip": "Click to remove Option",
+        "selectedCount": {
+          "one": "%{count} selected",
+          "other": "%{count} selected"
+        }
       },
       "model": {
         "baseModel": {

--- a/docs/exec-plans/filter-group-redesign.md
+++ b/docs/exec-plans/filter-group-redesign.md
@@ -200,6 +200,25 @@ than a surprise.
 
 Found by writing the Phase 0 tests, which is the argument for the gate.
 
+### F13 — The popover is attached, and the shared surface would detach it
+
+Not drift, and not obviously wrong: FilterGroup's popover is drawn as a
+continuation of its trigger. `.filter-group-items` carries `border-top: none`
+and only bottom radii, and the trigger's `.active` and `.selected` states drop
+their own bottom radii to meet it (`index.scss:69-72`, `:88-95`). The two read
+as one object.
+
+`BtnDropdown/Menu` is the opposite: a detached surface floating over the page,
+fully bordered, `rounded-control` all round, with end-caps top and bottom.
+
+Moving FilterGroup onto that surface is therefore not a like-for-like swap —
+it changes what the control _is_ on screen. It also strands the search box,
+which today sits **outside** the bordered area as a sibling of
+`.filter-group-items`, above it.
+
+This is a design decision, not a refactor, and it belongs to whoever owns the
+look rather than to the phase that happens to touch the CSS.
+
 ## Decisions
 
 ### D1 — A custom combobox, not a native `<select>`
@@ -291,14 +310,31 @@ arrow keys, Home/End, Enter/Space, Escape, focus-out, type-ahead (D5);
 `aria-activedescendant`.
 No visual change in this phase beyond what the element swap forces.
 
-### Phase 2 — The shared popover surface
+### Phase 2 — Move the component off SCSS
+
+**Corrected after Phase 1; the original split of this phase from the next one
+was wrong.** See F13.
+
+`btn-redesign`'s D3 verified empirically that `@reference` and `@apply` inside
+`<style lang="scss">` pass through sass untouched, reach the minifier as
+unknown at-rules and are **silently dropped**. `BtnDropdown/Menu`'s surface is
+authored with `@apply`, and FilterGroup is SCSS, so the surface cannot be
+shared until the component moves to a plain `<style scoped>` block with
+`@reference`.
+
+That migration also has to replace every injected SCSS variable the component
+reads — `$input-bg`, `$input-border`, `$primary`, `$gray-darker`,
+`$border-radius-base`, `$input-color` — with theme tokens, which is the same
+work the restyle was going to do. So the two are one phase, not two.
+
+The failure mode is silent, which is the reason to write this down: a popover
+that lost its styling renders as unstyled content over the page rather than as
+an error.
+
+### Phase 3 — The shared surface, the trigger and the rows
 
 Extract the surface primitive from `BtnDropdown/Menu` (D3) and move both onto
-it.
-
-### Phase 3 — Restyle trigger and rows
-
-Trigger onto `--color-control` / `--color-edge` / `--radius-control` with
+it; trigger onto `--color-control` / `--color-edge` / `--radius-control` with
 end-caps; rows onto `--color-edge-soft` divisions; drop the glow rail and the
 `flash` keyframe (F8); real chevron and × glyphs (F10).
 

--- a/docs/exec-plans/filter-group-redesign.md
+++ b/docs/exec-plans/filter-group-redesign.md
@@ -200,7 +200,10 @@ than a surprise.
 
 Found by writing the Phase 0 tests, which is the argument for the gate.
 
-### F13 — The popover is attached, and the shared surface would detach it
+### F13 — The popover is attached, and the shared surface would detach it — **RESOLVED, see D7**
+
+> Resolved against the shared surface: detaching every piece turns a multi-select
+> into three stacked framed boxes. D7 records what was chosen instead.
 
 Not drift, and not obviously wrong: FilterGroup's popover is drawn as a
 continuation of its trigger. `.filter-group-items` carries `border-top: none`
@@ -218,6 +221,26 @@ which today sits **outside** the bordered area as a sibling of
 
 This is a design decision, not a refactor, and it belongs to whoever owns the
 look rather than to the phase that happens to touch the CSS.
+
+### F14 — Collapsed animates the element the frame wants to live on
+
+`Collapsed.getElementStyle` reads **inline** styles, which a stylesheet never
+sets, so the enter keyframes resolve `border`, `padding` and `margin` to `0` for
+the whole 500ms and let them snap to their real values at the end. Anything
+framing a segment -- including the gap that stands it off the trigger -- has to
+sit on an element _inside_ the animated one.
+
+Both segments now do: the popover through `.filter-group-surface`, and the
+selected list through the same element after it was restructured to match. The
+element `Collapsed` animates carries no rules at all.
+
+A second trap in the same component: focusing into a still-collapsed one scrolls
+its content out of sight, because an `overflow: hidden` box is still
+programmatically scrollable. Fixed with `focus({ preventScroll: true })`, passed
+through a `setFocus` that now takes `FocusOptions` — not fixed inside
+`FormInput`, where scrolling a focused field into view is usually right.
+
+Measured: `scrollTop 21`, content at `-21px`, against `0` and `0`.
 
 ## Decisions
 
@@ -273,6 +296,48 @@ entries — manufacturers, star systems, model classifications. Without
 type-ahead the only way through them is fifty arrow presses. A native `<select>`
 does this for free, which is exactly the expectation D1 opts out of and has to
 pay back by hand.
+
+### D7 — The trigger stays; what hangs off it becomes a capped surface — **DECIDED**
+
+Reached by building the alternatives on the visual-tests page and looking at
+them, single and multiple, rather than from descriptions. Three rounds, and the
+first two answers were wrong in ways only the pictures showed.
+
+**The decision.** The trigger keeps exactly the look it has today. The popover
+and the selected list each become their own surface in the new language:
+`--color-gray-darker`, a `--color-edge` border, `--radius-control` all round, an
+end-cap top and bottom, standing off the trigger by 6px. The selected items stay
+a list of full-width rows.
+
+**Why not the shared `BtnDropdown/Menu` surface, which is what #4371 asked for.**
+It was tried and chosen first. It works for single select and fails for
+multiple: the selected list renders _outside_ the popover, so the control
+becomes three separately framed boxes stacked down the page. That is a property
+of "every piece is its own detached surface", not a defect of the styling.
+
+The capped form keeps the surfaces distinct but subordinates them to a trigger
+that never changes, so the control still reads as one thing with something
+attached to it.
+
+**Consequences.**
+
+- D3 no longer binds. The surface is not shared with `BtnDropdown/Menu`, so
+  extracting a common primitive is no longer a prerequisite, and the SCSS
+  migration loses its blocking reason. It stays worth doing to get rid of
+  `$input-bg` and friends, but it does not gate anything.
+- The trigger's `.active` / `.selected` rules that square its bottom corners
+  become wrong -- nothing meets it any more -- and have to be undone.
+- `FormInput` needs a treatment for sitting inside a surface; its clean variant
+  keeps `$input-bg` and reads as a lighter slab inset into one. The preview
+  faked this with `:deep()`; the real version styles the control for the context.
+- Both segments must carry their frame on an inner element, never on the one
+  `Collapsed` animates. See F14.
+
+**Rejected along the way:** chips inside the trigger (the trigger is a
+`<button>`, so a chip cannot carry its own remove control); the whole control as
+a single Panel with caps outside and soft seams within (a misreading of the
+brief); and the flap, which docks the surface to the trigger with square top
+corners.
 
 ### D6 — One PR
 

--- a/docs/exec-plans/filter-group-redesign.md
+++ b/docs/exec-plans/filter-group-redesign.md
@@ -149,7 +149,8 @@ by a test:
 - Search is debounced at 500ms and resets pagination to page 1.
 - `paginated` tracks `currentPage < totalPages` off the response meta and
   renders a fetch-more button inside the popover.
-- Options are sorted client-side, alphabetically by label.
+- Options are sorted client-side, alphabetically by label — **except they are
+  not**, see F12.
 - `keepPreviousData` keeps the list stable while refetching.
 - With `multiple` and not `hideSelected`, the selected rows render in a second
   `Collapsed` _outside_ the popover while it is closed.
@@ -181,6 +182,23 @@ listbox filter or a native control for the combobox.
 
 It is also the only automated coverage the component has anywhere: there is no
 unit spec, no colocated test, and nothing else asserts on a `filter-group` id.
+
+### F12 — The sort never reaches the list — found in Phase 0
+
+`sort()` exists and `availableOptions` applies it, but the popover renders
+`filteredOptions` (`index.vue:266-276`), which returns `internalOptions`
+untouched.
+
+The consequence is split: `selectedOptions` derives from `availableOptions`, so
+the **selected** rows come out alphabetical, while the **options** a user picks
+from are in whatever order the API returned them. Two lists in the same popover,
+ordered differently, from one sort function that only half-runs.
+
+The rebuild should sort the rendered list. The Phase 0 spec pins the current
+behaviour with that noted, so flipping the assertion is a deliberate act rather
+than a surprise.
+
+Found by writing the Phase 0 tests, which is the argument for the gate.
 
 ## Decisions
 

--- a/docs/exec-plans/filter-group-redesign.md
+++ b/docs/exec-plans/filter-group-redesign.md
@@ -1,0 +1,299 @@
+# FilterGroup redesign
+
+## Goal
+
+Rebuild `base/FilterGroup` on the control language `btn-redesign` (#4338)
+established and the surface language `panel-redesign` (#4362) established, and
+give it the combobox semantics it has never had — without changing its public
+API.
+
+Issue: #4371.
+
+## Context
+
+`FilterGroup` is the app's select: **135 `<FilterGroup>` tags across 68 files**.
+It sits directly beside redesigned buttons in every filter bar, and its trigger,
+its popover and its rows each disagree with them in a different way.
+
+It predates both redesigns. Unlike `Btn`, it was never rebuilt — it was styled
+once from the Bootstrap 3 base and has been extended since.
+
+## Findings that drive the design
+
+### F1 — The API survives, so this is a five-file change, not a codemod
+
+Scanning all 135 tags for the props they actually pass:
+
+| Prop                       | Tags |
+| -------------------------- | ---- |
+| `name`                     | 134  |
+| `v-model`                  | 132  |
+| `label`                    | 116  |
+| `options`                  | 96   |
+| `searchable`               | 67   |
+| `nullable`                 | 50   |
+| `multiple`                 | 43   |
+| `no-label`                 | 41   |
+| `query-fn`                 | 38   |
+| `query-response-formatter` | 24   |
+| `paginated`                | 21   |
+| `translation-key`          | 19   |
+| `inline`                   | 9    |
+| `search-label`             | 6    |
+| `disabled`                 | 3    |
+| `size`                     | 2    |
+| `hide-selected`            | 1    |
+| `big-icon`                 | 1    |
+
+This is the single most important fact about the work: every one of these keeps
+working unchanged, so the rebuild touches `FilterGroup/index.vue`, `index.scss`,
+`Option/index.vue`, `Option/index.scss` and `types.ts` — and no call site.
+
+`btn-redesign` needed a 468-site codemod. This needs none.
+
+### F2 — Three props are dead at every call site
+
+`query` (the `UseQueryReturnType` variant, distinct from `queryFn`), `error`,
+and `hideLabelOnEmpty` are passed by **zero** of the 135 tags. `hideLabelOnEmpty`
+looks used only because `FormInput` has a prop of the same name, which the login,
+signup and password pages do use.
+
+`error` is worth a second look rather than a straight delete: it is the only
+validation affordance the component has, and a select that cannot show an error
+is a gap, not a saving. The other two are dead weight.
+
+### F3 — Nothing in the component is a control
+
+- The trigger is a `div` with `@click` (`index.vue:465-482`).
+- Each option is an `<a>` with no `href` and `@click` (`Option/index.vue:36-56`).
+- No `tabindex`, no `combobox`/`listbox`/`option` roles, no `aria-expanded`,
+  no `aria-activedescendant`.
+- No arrow-key navigation, no Home/End, no type-ahead, no Escape.
+- When the group is not `searchable` — **68 of the 135 tags** — the label's
+  `for` points at the collapsed container's id (`index.vue:231-237`), which is
+  a `div`. Clicking the label does nothing and screen readers announce nothing.
+
+The component is completely keyboard-inoperable. That is the substance of the
+redesign; the styling is the visible half.
+
+### F4 — Closing is document-click only
+
+`documentClick` is bound on `document` at mount (`index.vue:298-309`). There is
+no Escape handler and no focus-out handling, so a keyboard user who could reach
+the popover would have no way out of it.
+
+### F5 — The imperative API is real and must survive
+
+`defineExpose({ reset, clear, clearSearch })` is called through template refs at
+four places:
+
+- `frontend/components/base/ModelFilterGroup/index.vue:93,97,103`
+- `admin/components/base/ModelFilterGroup/index.vue:104,108,114`
+- `frontend/components/Compare/Models/Form/index.vue:49`
+- `frontend/pages/tools/cargo-grids.vue:259,264`
+
+A rebuild that quietly drops these breaks the compare tool and both model
+pickers, and TypeScript will not catch it — the calls are all `?.`-guarded.
+
+### F6 — The trigger borrows the form-input treatment
+
+`index.scss:33-48` — `rgba($input-bg, 0.9)` inside a `1px solid $input-border`
+edge that is _darker_ than its own fill, at `$border-radius-base` (4px) against
+`--radius-control`'s 8px, with no end-caps. The redesign's controls are a dark
+fill inside a _lighter_ edge. Hover is a hand-picked `color: white; background:
+$input-bg` rather than `--color-control-hover`.
+
+This is the same inverted fill/edge relationship the forms issue (#4372)
+describes, inherited through `$input-bg` / `$input-border`.
+
+### F7 — The popover is a second dropdown menu
+
+`btn-redesign` ships `BtnDropdown/Menu`: `bg-gray-darker`, `border-edge`,
+`rounded-control`, `role="menu"`, its own end-caps and an `--color-edge-soft`
+separator, at `z-index: 2100`. It also documents _why_ it is opaque where a
+button is translucent — a popover floats over arbitrary content, so anything
+showing through competes with its labels.
+
+`FilterGroup`'s popover (`index.scss:96-115`) is the same object built from
+different values: `rgba($gray-darker, 0.95)`, `1px solid $input-border`,
+`border-top: none`, and a `0 1px 3px rgba(black, 0.9)` shadow on the wrapper.
+
+After #4338 the two are open on the same screen — the ships filter bar.
+
+### F8 — The glow rail, and a keyframe that should die with it
+
+`Option/index.scss:62-86` carries the table row rail byte-for-byte, on every
+option row on hover. PR #4595 removed that rail from the table and introduced
+`--cap-h-row` / `--cap-r-row` for it, so the replacement already exists.
+
+`Option/index.scss:88-97` animates `.active` with `animation-name: flash`, and
+the last surviving `@keyframes flash` in the frontend is declared at the bottom
+of that same scoped block (`:110`). It resolves only because the reference and
+the declaration share a scope. It should go with the rail, not be preserved.
+
+Each row also carries `border-bottom: 1px solid $input-border` where internal
+divisions in the new language are `--color-edge-soft`, and a `transition: all
+0.5s ease` on its icon.
+
+`RadioList` aside, this is the last of the three glow copies `btn-redesign`
+set out to remove. Two more live in `TabNavView` and the `flex-list` partial —
+tracked separately in #4596.
+
+### F9 — Behaviour that must not regress
+
+The component does more than it looks like it does, and none of it is covered
+by a test:
+
+- `fetchMissingOption` — a value selected but absent from the loaded page is
+  fetched on its own so the trigger can show its label rather than a raw id.
+- Search is debounced at 500ms and resets pagination to page 1.
+- `paginated` tracks `currentPage < totalPages` off the response meta and
+  renders a fetch-more button inside the popover.
+- Options are sorted client-side, alphabetically by label.
+- `keepPreviousData` keeps the list stable while refetching.
+- With `multiple` and not `hideSelected`, the selected rows render in a second
+  `Collapsed` _outside_ the popover while it is closed.
+
+### F10 — The chevron and the remove affordance are rotated glyphs
+
+The chevron is `fa-chevron-right` rotated 90° (`index.scss:70-75`); the per-row
+remove control is a `fa-plus` rotated 45° into an × (`Option/index.scss:93-96`).
+Both should become the glyph they are trying to be.
+
+### F11 — Test coupling is not zero
+
+`btn-redesign` could rebuild freely because nothing asserted on the button's
+DOM. That is not the case here.
+
+`test/playwright/e2e/CargoGrids.spec.ts:34,125` drives the component through
+its internals:
+
+```ts
+await filterGroup.getByTestId("filter-group-title").click();
+await filterGroup.locator("input").first().fill("Caterpillar");
+```
+
+Two constraints follow. `data-test="filter-group-title"` has to survive onto
+the new trigger even though the element under it changes from `div` to
+`button`. And the search input has to stay the first `input` in the subtree —
+which the popover rebuild could easily break by adding a hidden input, a
+listbox filter or a native control for the combobox.
+
+It is also the only automated coverage the component has anywhere: there is no
+unit spec, no colocated test, and nothing else asserts on a `filter-group` id.
+
+## Decisions
+
+### D1 — A custom combobox, not a native `<select>`
+
+Native `<select>` cannot express per-option icons, the multi-select chip
+behaviour, in-popover search, async pagination, or the fetch-more row. The
+feature set decides this; there is no trade to weigh.
+
+The consequence is that the ARIA has to be written by hand and is the risk
+surface of this work, not the CSS.
+
+### D2 — The trigger becomes a real `<button>`
+
+`role="combobox"`, `aria-expanded`, `aria-controls`, `aria-haspopup="listbox"`.
+This also fixes F3's label problem for the 68 non-searchable tags: `for` points
+at the button, and clicking the label opens the group.
+
+When `searchable`, the search input keeps the `for` — the pattern stays as it
+is today, only with a real control on the other end of it.
+
+### D3 — The popover reuses `BtnDropdown/Menu` through a shared descendant
+
+Not `BtnDropdown/Menu` directly: it hard-codes `role="menu"` and provides
+`BTN_CONTAINER` to style its children as menu buttons, and a listbox of options
+is neither. The shared part is the _surface_ — opaque `bg-gray-darker`,
+`border-edge`, `rounded-control`, end-caps, `z-index: 2100`.
+
+Extract that surface into a primitive both compose, so the two popovers cannot
+drift again. This is the one piece of the work that reaches outside FilterGroup.
+
+### D4 — Keep the props API frozen; drop only `query` and `hideLabelOnEmpty` — **DECIDED**
+
+Both are dead at all 135 tags and neither has a story.
+
+`error` **stays**, carrying today's tooltip behaviour unchanged. It is unused,
+but it is the only validation affordance a select has, and #4372 has to set an
+error pattern for every form control anyway. Building one here first would mean
+#4372 either follows a pattern set by the odd control out, or overrides it.
+FilterGroup inherits instead.
+
+`bigIcon`, `hideSelected` and `size` stay despite one or two uses each — they
+carry behaviour, and removing them means changing call sites, which is exactly
+what this redesign is trying not to do.
+
+### D5 — Type-ahead is in scope — **DECIDED**
+
+Typing on a closed or open group jumps to the first option whose label starts
+with what was typed, with the usual buffer-and-timeout behaviour.
+
+68 of the 135 tags are not `searchable`, and several of those lists run past 50
+entries — manufacturers, star systems, model classifications. Without
+type-ahead the only way through them is fifty arrow presses. A native `<select>`
+does this for free, which is exactly the expectation D1 opts out of and has to
+pay back by hand.
+
+### D6 — One PR
+
+The component is five files and no call site changes. Splitting the visual half
+from the semantic half would be artificial: the trigger changing from `div` to
+`button` is simultaneously both, and the two halves would conflict in the same
+lines.
+
+Worth noting against #4362's experience: that PR was bounced twice by the review
+bot's file limit at 118 files. This one is nowhere near that.
+
+## Prop API: before → after
+
+| Prop               | Before                 | After                              |
+| ------------------ | ---------------------- | ---------------------------------- |
+| `query`            | `UseQueryReturnType`   | **removed** — 0 uses               |
+| `hideLabelOnEmpty` | `boolean`              | **removed** — 0 uses               |
+| `error`            | `string`, tooltip-only | kept, given a real error treatment |
+| everything else    | —                      | unchanged                          |
+
+## Phases
+
+### Phase 0 — Cover the behaviour before touching it
+
+F9 lists six behaviours with no test. Land tests against the _current_
+component first, so the rebuild has something to fail against. The visual-tests
+page (`pages/visual-tests/forms`) already exists as the render surface.
+
+This is the gate: no rebuild before the async behaviour is pinned.
+
+### Phase 1 — Semantics and keyboard
+
+Trigger to `<button>` with combobox roles; options to real `option` roles;
+arrow keys, Home/End, Enter/Space, Escape, focus-out, type-ahead (D5);
+`aria-activedescendant`.
+No visual change in this phase beyond what the element swap forces.
+
+### Phase 2 — The shared popover surface
+
+Extract the surface primitive from `BtnDropdown/Menu` (D3) and move both onto
+it.
+
+### Phase 3 — Restyle trigger and rows
+
+Trigger onto `--color-control` / `--color-edge` / `--radius-control` with
+end-caps; rows onto `--color-edge-soft` divisions; drop the glow rail and the
+`flash` keyframe (F8); real chevron and × glyphs (F10).
+
+### Phase 4 — Verify
+
+Visual-tests page across all prop combinations; keyboard walkthrough; the four
+imperative call sites from F5 exercised by hand.
+
+## Open questions
+
+1. **`size`** — `types.ts` documents the separate per-control enum as
+   deliberate: `MEDIUM` is already 48px, matching `Btn`'s `md` and
+   `FormInput`'s `medium`, and each control keeps its own copy so one can gain
+   a size without dragging the others in. There is no drift to fix, so the
+   default is to leave it alone. Merging the three enums into one scale is a
+   separate change that reaches `FormInput` and reverses a documented decision.

--- a/docs/exec-plans/filter-group-redesign.md
+++ b/docs/exec-plans/filter-group-redesign.md
@@ -396,12 +396,22 @@ The failure mode is silent, which is the reason to write this down: a popover
 that lost its styling renders as unstyled content over the page rather than as
 an error.
 
-### Phase 3 — The shared surface, the trigger and the rows
+### Phase 3 — The surface and the rows — **DONE**
 
-Extract the surface primitive from `BtnDropdown/Menu` (D3) and move both onto
-it; trigger onto `--color-control` / `--color-edge` / `--radius-control` with
-end-caps; rows onto `--color-edge-soft` divisions; drop the glow rail and the
-`flash` keyframe (F8); real chevron and × glyphs (F10).
+Not what this phase was originally written as, because D7 changed what it is
+for. No surface primitive is extracted -- D3 no longer binds -- and the trigger
+is deliberately untouched, which is the whole point of the chosen shape.
+
+Landed: the capped surface becomes the treatment and the preview modifier goes;
+the trigger stops squaring its bottom corners, which was right only while
+something met them; the frame moves onto `.filter-group-surface` inside the
+element `Collapsed` animates; the glow rail is flat and on the table's own
+`--cap-h-row` / `--cap-r-row`; the last `@keyframes flash` in the frontend is
+gone; rows divide with `--color-edge-soft`; the chosen rows outside the popover
+stop being primary blue; chevron and × are the glyphs they meant rather than
+rotations of other ones; `FormInput`'s clean variant drops its fill so a field
+can sit inside a surface without reading as a slab inset into it; and F12's
+half-run sort now reaches the list it was written for.
 
 ### Phase 4 — Verify
 
@@ -410,7 +420,22 @@ imperative call sites from F5 exercised by hand.
 
 ## Open questions
 
-1. **`size`** — `types.ts` documents the separate per-control enum as
+1. **The trigger still speaks the old language, by decision.** #4371's first
+   complaint is that the trigger borrows the form-input treatment: a lighter
+   `$input-bg` fill inside a _darker_ `$input-border` edge, where the redesign's
+   controls are a dark fill inside a lighter one, at `$border-radius-base`'s 4px
+   against `--radius-control`'s 8px, with no end-caps.
+
+   D7 keeps the trigger exactly as it is, so that complaint is **not addressed
+   by this work**. It was the right call for the shape -- the alternatives that
+   restyled the trigger were the ones that fell apart on a multi-select -- but it
+   leaves the control itself in the old vocabulary while everything hanging off
+   it speaks the new one. Worth deciding deliberately rather than discovering
+   later: either #4371 stays open for it, or it moves to the forms redesign
+   (#4372), which owns `$input-bg` and `$input-border` for every other control
+   that shares them.
+
+2. **`size`** — `types.ts` documents the separate per-control enum as
    deliberate: `MEDIUM` is already 48px, matching `Btn`'s `md` and
    `FormInput`'s `medium`, and each control keeps its own copy so one can gain
    a size without dragging the others in. There is no drift to fix, so the


### PR DESCRIPTION
Refs #4371. Phases 0 through 3 of [the plan](docs/exec-plans/filter-group-redesign.md).

`FilterGroup` is the app's select — **135 tags across 68 files** — and it predates both the control language `btn-redesign` established and the surface language `panel-redesign` established.

## The finding that framed the work

Every prop the 135 tags actually pass can stay. So this is five files and **no call site**; `btn-redesign` needed a 468-site codemod, this needs none.

## The substance is not the styling

Nothing in the component was a control. The trigger was a `div` with `@click`, the options were anchors with no `href`, there were no combobox roles, no `aria-expanded`, no arrow keys and no Escape. For the 68 tags that are not `searchable`, the label's `for` pointed at a `div`. It was completely keyboard-inoperable.

It now has a real `<button>` carrying `role="combobox"`, options in a listbox, arrow keys with wrap, Home/End, Enter/Space, Escape returning focus, Tab and focus-out closing, and type-ahead for the groups that are not searchable — where the alternative on a list of manufacturers is fifty arrow presses. Focus never enters the list; the pointed-at row travels by `aria-activedescendant`.

## Phase 0 was a gate, and it earned it

The component had **no unit spec**, and its only automated coverage anywhere — `CargoGrids.spec.ts` — drives it through the two internals the rebuild moves: `data-test="filter-group-title"` and `locator("input").first()`. Both are asserted now, so breaking the e2e test fails in the unit suite first.

Writing those tests turned up a defect nobody had noticed: `sort()` runs in `availableOptions`, but the popover renders `filteredOptions`, which returns `internalOptions` untouched. The **selected** rows come out alphabetical and the options you pick from stay in API order — two lists in one popover, ordered differently, from one sort that only half-runs. The spec pins the current behaviour and says so, so phase 3 flips that assertion deliberately.

## Three fixes that stand on their own

Split out ahead of the feature commit because none of them depends on the visual decision:

- **A row no longer collapses to its label.** Phase 1 made the selected rows buttons; a button has intrinsic width and does not stretch like the anchor it replaced, so the hover rail ended up mid-list. Measured against the compiled CSS: 75px where the anchor was 278px.
- **The search box no longer scrolls the popover out of sight.** Focusing it while the popover is still collapsed made the browser scroll it into view inside an `overflow: hidden` box of almost no height — content went behind the trigger and unwound over 500ms. `scrollTop 21` and `-21px` against `0` and `0`. Fixed at the call site; `FormInput.setFocus` now takes `FocusOptions` rather than deciding for its 308 callers.
- **A multi-select says what is selected.** It used to read "No Option selected" with two things chosen.

## The surface, and the two answers that were wrong first

Chosen by building the alternatives on the visual-tests page and looking at them. The trigger is untouched; the popover and the selected list each become their own capped surface standing off it.

**Not** the shared `BtnDropdown/Menu` surface this issue asked for. That was tried and chosen first, and it works for single select — but the selected list renders *outside* the popover, so a multi-select becomes three separately framed boxes stacked down the page. That follows from "every piece is its own detached surface", not from the styling. So **D3 no longer binds**: the surface is not shared, extracting a common primitive is not a prerequisite, and the SCSS migration stops gating anything.

Both segments carry their frame on an inner element, never on the one `Collapsed` animates — it reads inline styles, so its keyframes drive border, padding and margin to `0` for the full 500ms and snap them in at the end. The 6px gap put there directly appeared only after the animation finished.

## Phase 3 landed too

The modifier is gone; the capped surface is the treatment. With it: the trigger stops squaring its bottom corners (right only while something met them); the glow rail is flat and on the table's own `--cap-h-row` / `--cap-r-row`; the **last `@keyframes flash` in the frontend** is gone; rows divide with `--color-edge-soft`; the chosen rows outside the popover stop being primary blue, because they are all selected by definition and saying so turned a list of choices into a list of links; chevron and × are the glyphs they meant rather than rotations of other ones; and `FormInput`'s clean variant drops its fill, replacing the `:deep()` override that was reaching into it from outside.

Two of those had to be fixed before they could be seen: the sort that only half-ran (F12 — the flip its Phase 0 test was written to invite), which also had to move above `availableOptions`, because a `const` in its temporal dead zone made the whole component fail to mount.

## What this deliberately leaves

**The trigger still speaks the old language.** This issue's first complaint is its inverted fill/edge relationship — a lighter `$input-bg` inside a darker `$input-border`, 4px against `--radius-control`'s 8px, no end-caps. D7 keeps the trigger exactly as it is, because every alternative that restyled it fell apart on a multi-select. So the control itself stays in the old vocabulary while everything hanging off it speaks the new one.

That is a real gap, not an oversight, and it needs a decision: either #4371 stays open for it, or it moves to #4372, which owns `$input-bg` and `$input-border` for every other control that shares them.

Also outstanding and no longer blocking anything: the SCSS → plain-CSS migration. D3 stopped binding when the surface stopped being shared, so it is now only worth doing to get rid of the injected variables — a separate change, not this one.

## Verification

325 tests across 43 files, 27 of them FilterGroup's; `eslint`, `vue-tsc` and Prettier clean; `bin/vite build` clean. The measurements above come from a static harness against the real compiled CSS — the dev server needs an interactive 1Password unlock, so nothing here was verified by eye in the running app except through screen recordings.

🤖
