### PR TITLE
fix(i18n): title the fleet features settings tab

### DIFF
--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -86,7 +86,8 @@
           "roles": "%{fleet} Roles",
           "notifications": "%{fleet} Notification Settings",
           "discord": "%{fleet} Discord Settings",
-          "calendar": "%{fleet} Calendar Settings"
+          "calendar": "%{fleet} Calendar Settings",
+          "features": "%{fleet} Features"
         }
       },
       "roadmap": {


### PR DESCRIPTION
The `fleet-settings-features` route sets `meta.title: "fleets.settings.features"`, which `useFleetMeta` resolves as `title.fleets.settings.features`. That key was the only one of the seven fleet settings tabs missing from `en/title.json`, so the browser tab on `/fleets/:slug/settings/features/` read:

```
[missing "en.title.fleets.settings.features" translation] | FleetYards.net
```

Only the document-title namespace was affected — `nav.fleets.settings.features` ("Features") and `headlines.fleets.settings.features` ("Fleet Features") both already existed, which is why the sidebar tab and the page heading looked correct.

The new string follows the `%{fleet} Roles` / `%{fleet} Membership` shape rather than `%{fleet} … Settings`, since the section already says "Settings".

The other locales stop at `roles` for this subtree, so `enableFallback` sends them all to `en` — this one key covers every language.

🤖
