### PR TITLE
fix(layout): give the primary action the space below it as space above

### DIFF
--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -247,7 +247,12 @@ const setLocale = (locale: string) => {
         <FrontendNavigation />
       </transition>
       <div class="main-wrapper">
-        <div class="main-inner">
+        <div
+          class="main-inner"
+          :class="{
+            'main-inner--with-primary-action': route.meta.primaryAction,
+          }"
+        >
           <AppNavigationHeader />
 
           <ScDataSourceBar />

--- a/app/frontend/shared/components/PrimaryAction/index.scss
+++ b/app/frontend/shared/components/PrimaryAction/index.scss
@@ -11,13 +11,14 @@
   // Last in a `.main` that is stretched to fill the page and has given up its
   // bottom margin - see `.main-inner--with-primary-action` in
   // shared/layout.scss. `auto` sends the button to the end of that section,
-  // since sticky cannot push it down there itself, and the padding carries the
-  // margin the section dropped. Above rather than below, because below is the
-  // side the button already cannot reach: it is what left the button flush
-  // against the last row of the page with the gap beneath it.
+  // since sticky cannot push it down there itself.
+  //
+  // The inset is the same both ends, though the two are seen at different
+  // times: the bottom is the gap the button floats on all the way down the
+  // page, the top only shows once it comes to rest. Matching them is what
+  // stops it reading as flush against the last row with a gap beneath it.
   margin-top: auto;
-  padding-top: $main-bottom-spacing;
-  padding-bottom: 1rem;
+  padding-block: 1rem;
   // The floated element used to sit outside the flow; a flex row that ignores
   // pointer events keeps the page clickable around the button.
   pointer-events: none;

--- a/app/frontend/shared/components/PrimaryAction/index.scss
+++ b/app/frontend/shared/components/PrimaryAction/index.scss
@@ -8,11 +8,15 @@
   z-index: 1025;
   display: flex;
   justify-content: flex-end;
-  // Last in a `.main` that is stretched to fill the page - see
-  // `.main-inner--with-primary-action` in shared/layout.scss. Without this the
-  // button rests where the content ends rather than at the bottom of the page,
-  // and sticky cannot push it down from there.
+  // Last in a `.main` that is stretched to fill the page and has given up its
+  // bottom margin - see `.main-inner--with-primary-action` in
+  // shared/layout.scss. `auto` sends the button to the end of that section,
+  // since sticky cannot push it down there itself, and the padding carries the
+  // margin the section dropped. Above rather than below, because below is the
+  // side the button already cannot reach: it is what left the button flush
+  // against the last row of the page with the gap beneath it.
   margin-top: auto;
+  padding-top: $main-bottom-spacing;
   padding-bottom: 1rem;
   // The floated element used to sit outside the flow; a flex row that ignores
   // pointer events keeps the page clickable around the button.

--- a/app/frontend/shared/components/PrimaryAction/index.scss
+++ b/app/frontend/shared/components/PrimaryAction/index.scss
@@ -8,6 +8,11 @@
   z-index: 1025;
   display: flex;
   justify-content: flex-end;
+  // Last in a `.main` that is stretched to fill the page - see
+  // `.main-inner--with-primary-action` in shared/layout.scss. Without this the
+  // button rests where the content ends rather than at the bottom of the page,
+  // and sticky cannot push it down from there.
+  margin-top: auto;
   padding-bottom: 1rem;
   // The floated element used to sit outside the flow; a flex row that ignores
   // pointer events keeps the page clickable around the button.

--- a/app/frontend/stylesheets/shared/layout.scss
+++ b/app/frontend/stylesheets/shared/layout.scss
@@ -113,11 +113,15 @@ body {
   }
 
   // A sticky element can only be pulled up, never pushed down, so
-  // PrimaryAction - the last thing in `.main` - parks wherever the page content
-  // happens to end. On a short page that is hundreds of pixels above the footer,
-  // with the min-height above as dead space beneath it. Stretching `.main` over
-  // that space and sending the button to the end of it puts its resting place
-  // just above the footer, which is where it also lands on a long page.
+  // PrimaryAction - the last thing in `.main` - rests wherever the page content
+  // happens to end, and everything below it is space it cannot reach. That is
+  // the section's bottom margin on a full page, and the min-height above as
+  // dead space too on a short one: the button ends up flush against the
+  // paginator with the whole gap underneath it.
+  //
+  // So the section stretches over the dead space, and hands its bottom margin
+  // to the button, which carries the same distance as padding on the side it
+  // can use - above itself. See PrimaryAction/index.scss.
   .main-inner--with-primary-action {
     display: flex;
     flex-direction: column;
@@ -126,6 +130,7 @@ body {
       display: flex;
       flex: 1;
       flex-direction: column;
+      margin-bottom: 0;
     }
   }
 
@@ -134,7 +139,7 @@ body {
     left: 0;
     width: 100%;
     max-width: 100%;
-    margin-bottom: 50px;
+    margin-bottom: $main-bottom-spacing;
     padding-inline: 15px;
     margin-inline: auto;
   }

--- a/app/frontend/stylesheets/shared/layout.scss
+++ b/app/frontend/stylesheets/shared/layout.scss
@@ -119,9 +119,10 @@ body {
   // dead space too on a short one: the button ends up flush against the
   // paginator with the whole gap underneath it.
   //
-  // So the section stretches over the dead space, and hands its bottom margin
-  // to the button, which carries the same distance as padding on the side it
-  // can use - above itself. See PrimaryAction/index.scss.
+  // So the section stretches over the dead space and drops the margin, and
+  // PrimaryAction insets itself on the side it can use. The button row is
+  // 90px of its own, so the page still clears the footer by more than the
+  // margin gave it. See PrimaryAction/index.scss.
   .main-inner--with-primary-action {
     display: flex;
     flex-direction: column;
@@ -139,7 +140,7 @@ body {
     left: 0;
     width: 100%;
     max-width: 100%;
-    margin-bottom: $main-bottom-spacing;
+    margin-bottom: 50px;
     padding-inline: 15px;
     margin-inline: auto;
   }

--- a/app/frontend/stylesheets/shared/layout.scss
+++ b/app/frontend/stylesheets/shared/layout.scss
@@ -112,6 +112,23 @@ body {
     min-height: 100vh;
   }
 
+  // A sticky element can only be pulled up, never pushed down, so
+  // PrimaryAction - the last thing in `.main` - parks wherever the page content
+  // happens to end. On a short page that is hundreds of pixels above the footer,
+  // with the min-height above as dead space beneath it. Stretching `.main` over
+  // that space and sending the button to the end of it puts its resting place
+  // just above the footer, which is where it also lands on a long page.
+  .main-inner--with-primary-action {
+    display: flex;
+    flex-direction: column;
+
+    .main {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+    }
+  }
+
   .main {
     position: relative;
     left: 0;

--- a/app/frontend/stylesheets/variables.scss
+++ b/app/frontend/stylesheets/variables.scss
@@ -53,6 +53,10 @@ $panelContentBorderRadius: var(--radius-surface-inner, 14px);
 $navigation-mobile-height: 60px;
 $navigation-mobile-bottom-offset: 20px;
 
+// The gap `.main` keeps between a page and the footer. Named because
+// PrimaryAction takes it over: see shared/layout.scss.
+$main-bottom-spacing: 50px;
+
 $transition-base-speed: 0.5s;
 
 // bootstrap overrides

--- a/app/frontend/stylesheets/variables.scss
+++ b/app/frontend/stylesheets/variables.scss
@@ -53,10 +53,6 @@ $panelContentBorderRadius: var(--radius-surface-inner, 14px);
 $navigation-mobile-height: 60px;
 $navigation-mobile-bottom-offset: 20px;
 
-// The gap `.main` keeps between a page and the footer. Named because
-// PrimaryAction takes it over: see shared/layout.scss.
-$main-bottom-spacing: 50px;
-
 $transition-base-speed: 0.5s;
 
 // bootstrap overrides


### PR DESCRIPTION
## What

The floating **+** button on the hangar pages rested flush against the paginator, with a visible gap between it and the footer that it never used.

## Why

`PrimaryAction` is `position: sticky; bottom: 0` and is the last child of `section.container.main`. Sticky can only pull an element *up* toward its offset — it never pushes one down past where the document flow puts it. So while you scroll it floats at the viewport bottom, but the moment `.main`'s bottom edge rises above that line the pin releases and the button drops back to its flow position: directly under the last row of the page.

Everything below that point is out of its reach — `.main`'s `margin-bottom: 50px` on a full page, and on a short page the leftover of `.main-inner { min-height: 100vh }` as well. Measured on the real page, at rest: **0px above the button, 66px below it**.

## How

On routes that declare `meta.primaryAction`, `.main` stretches over the short-page dead space and drops its bottom margin, an auto top margin sends the button to the end of the stretched section — sticky cannot get there on its own — and the button insets itself equally at both ends.

- `App.vue` — a `main-inner--with-primary-action` modifier when the route declares one
- `layout.scss` — the modifier stretches `.main` and zeroes its bottom margin
- `PrimaryAction/index.scss` — `margin-top: auto` and `padding-block: 1rem`

The two ends of that inset are seen at different times: the bottom is the gap the button floats on the whole way down the page, the top only shows once it comes to rest. Matching them is what stops it reading as flush against the paginator with a gap beneath it. The row is 90px of its own, so the last content row still clears the footer by 91px — more than the 50px margin every other page gets.

Scoped to the modifier rather than applied globally because it makes `.main` a flex container, which stops margins collapsing through it. Only `hangar/index` and `hangar/wishlist` declare a primary action, and they are also the only two pages that render the component.

## Measurements

Page scrolled to the end:

| page | gap above button | gap to footer |
| --- | --- | --- |
| long content, before | 0px | 66px |
| long content, after | **16px** | **16px** |
| short content, before | 0px | 461px |
| short content, after | **16px** | **16px** |

The float during scroll is unchanged: 16px above the viewport bottom on desktop, 96px on mobile to clear the tab bar.

## Risk

- `.row` — the root of `FilteredList` and of the hangar page's own grid — is already `display: flex` and carries no vertical margins, and `Heading` sets `margin-top: 0`, so no sibling margin-collapsing changes when `.main` becomes a flex container.
- The added top padding sits on a `pointer-events: none` flex row, so it blocks nothing.
- `/visual-tests/buttons/` has no `primaryAction` meta, so `.main` keeps its margin there and `margin-top: auto` is inert; `Buttons.spec.ts` asserts on the button element itself and is unaffected.
- Verified against a running dev server that the rules compute as intended, plus Prettier, ESLint and a sass compile.

🤖