### PR TITLE
fix(forms): stop printing the validation error next to the checkbox label

### DIFF
--- a/app/frontend/shared/components/base/FormCheckbox/index.vue
+++ b/app/frontend/shared/components/base/FormCheckbox/index.vue
@@ -145,7 +145,6 @@ const innerPlaceholder = computed(() => {
     <label :for="uuid">
       {{ innerLabel }}
     </label>
-    {{ errorMessage }}
   </div>
 </template>
 

--- a/app/frontend/shared/components/base/FormToggle/index.vue
+++ b/app/frontend/shared/components/base/FormToggle/index.vue
@@ -118,7 +118,6 @@ const innerPlaceholder = computed(() => {
         {{ innerLabel }}
       </span>
     </label>
-    {{ errorMessage }}
   </div>
 </template>
 


### PR DESCRIPTION
`FormCheckbox` and `FormToggle` rendered a bare `{{ errorMessage }}` text node straight after the `</label>`, so an invalid control read as:

> Accept terms**The terms field is required**

— the message unstyled and glued to its own label.

## Why removal rather than restyling

Both components already signal the error the way the rest of the design system does, and all three paths stay in place:

- `v-tooltip.right="errorMessage"` on the input
- `aria-invalid` on the input
- the `--with-error` class that turns the label red

The SCSS in each component implements that red-label state deliberately, with a comment saying it matches `base-input--with-error` on the fields that already did it — and there is no CSS anywhere for the stray text node. `FormInput`, `FormTextarea` and `FormDatePicker` render no such node; they rely on the tooltip alone.

So the red label in the screenshot was the *correct* styling working. The white text after it was the leftover.

## Scope

`FormToggle` had the identical node and is fixed too — it just sits in a later row on the visual-tests page, so it is less obvious.

The node has been there since the Vue 3 migration (#2655) and was never styled. Nothing asserts on it: no unit or e2e test references the rendered message. Prettier and eslint pass on both files.

## Not addressed here

- **Tooltip placement.** On a narrow grid column the `v-tooltip.right` box overlaps the field to its right. Pre-existing and unrelated to this node.
- **Error accessibility.** With the node gone the message lives only in a tooltip plus `aria-invalid`, which is the existing house pattern but is weak for screen readers. Giving every control a real `aria-describedby` error element would be a design-system-wide change, so it is deliberately out of scope for a bug fix.

🤖
