### PR TITLE
fix(compare): full-height table, name-ordered columns, and the missing hardpoints

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -55,6 +55,13 @@ const i18nStore = useI18nStore();
 
 const { locale } = storeToRefs(i18nStore);
 
+// `/models` and `/models/` are one page but not one key: route records are declared
+// with a trailing slash, so a link without one lands on the unslashed path and the
+// first `router.replace` a filter makes canonicalises it. Keyed on the raw path, that
+// one navigation throws the page away and rebuilds it mid-session.
+const pageKey = (viewRoute: { path: string }) =>
+  `${locale.value}-${viewRoute.path.replace(/\/$/, "")}`;
+
 const appStore = useAppStore();
 
 const mobile = useMobile();
@@ -193,10 +200,7 @@ const setNoScroll = () => {
                       [route.name || '']: true,
                     }"
                   >
-                    <component
-                      :is="Component"
-                      :key="`${locale}-${viewRoute.path}`"
-                    />
+                    <component :is="Component" :key="pageKey(viewRoute)" />
                   </section>
                 </transition>
               </template>

--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -226,6 +226,14 @@ const activeLocale = (locale: string) => {
   );
 };
 
+// `/compare` and `/compare/` are one page but not one key: route records are
+// declared with a trailing slash, so a link without one lands on `/compare` and the
+// first `router.replace` a filter makes canonicalises the path. Keyed on the raw
+// path, that one navigation threw the page away and rebuilt it — on compare, taking
+// the table's scroll position and its collapsed sections with it.
+const pageKey = (viewRoute: { path: string }) =>
+  `${locale.value}-${viewRoute.path.replace(/\/$/, "")}`;
+
 const setLocale = (locale: string) => {
   i18nStore.locale = locale;
 };
@@ -267,10 +275,7 @@ const setLocale = (locale: string) => {
                   [route.name || '']: true,
                 }"
               >
-                <component
-                  :is="Component"
-                  :key="`${locale}-${viewRoute.path}`"
-                />
+                <component :is="Component" :key="pageKey(viewRoute)" />
               </section>
             </transition>
           </router-view>

--- a/app/frontend/frontend/components/Compare/Models/Form/index.vue
+++ b/app/frontend/frontend/components/Compare/Models/Form/index.vue
@@ -39,9 +39,10 @@ const modelFilterGroup = ref<ComponentExposed<typeof ModelFilterGroup>>();
 
 const handleChange = (model: string) => {
   if (model) {
-    form.value.models = [...(form.value.models || []), model]
-      .filter(uniqArray)
-      .sort();
+    // Appended, not sorted: the query carries slugs and the table orders its
+    // columns by ship name, so sorting here only decided which slug order the URL
+    // happened to carry.
+    form.value.models = [...(form.value.models || []), model].filter(uniqArray);
 
     filter(form.value);
   }

--- a/app/frontend/frontend/components/Compare/Models/Table/index.scss
+++ b/app/frontend/frontend/components/Compare/Models/Table/index.scss
@@ -12,7 +12,9 @@
   --compare-col-max: 400px;
 
   position: relative;
-  max-height: min(76vh, 900px);
+  // Whatever the viewport has left below the pane, measured by the component — see
+  // `--compare-pane-max` there. The fraction is only the pre-measurement fallback.
+  max-height: var(--compare-pane-max, 76dvh);
   overflow: auto;
   // No `overscroll-behavior` here: `stylesheets/shared/scroll.scss` owns that for every
   // inner scroll pane in the app, this one included.

--- a/app/frontend/frontend/components/Compare/Models/Table/index.vue
+++ b/app/frontend/frontend/components/Compare/Models/Table/index.vue
@@ -50,6 +50,39 @@ provide("hardpointStatLimit", 2);
 
 const pane = ref<HTMLElement>();
 
+// Breathing room between the pane's last row and the bottom of the screen, and the
+// height below which filling the viewport stops being worth it.
+const PANE_GUTTER = 24;
+const PANE_MIN = 320;
+
+// A share of the viewport cannot reach the bottom of it: the pane starts a couple of
+// hundred pixels down the page, so `76vh` left that same gap unused at the bottom and
+// the taller the screen the more it wasted. Measured instead, from the document top so
+// that scrolling the page does not resize the table under the cursor.
+const paneMax = ref<string>();
+
+const measurePane = () => {
+  if (!pane.value) {
+    return;
+  }
+
+  const top = Math.round(
+    pane.value.getBoundingClientRect().top + window.scrollY,
+  );
+
+  paneMax.value = `max(${PANE_MIN}px, calc(100dvh - ${top + PANE_GUTTER}px))`;
+};
+
+onMounted(() => {
+  void nextTick(measurePane);
+
+  window.addEventListener("resize", measurePane);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("resize", measurePane);
+});
+
 // Tall store art at rest, collapsing to name and manufacturer once scrolled: the
 // silhouette is half of what identifies a column, but a permanently tall header would
 // cost a third of the pane.
@@ -137,6 +170,7 @@ const deltaLabel = (delta?: CompareDelta) =>
     ref="pane"
     class="compare-table"
     :class="{ 'compare-table--pinned': pinned }"
+    :style="{ '--compare-pane-max': paneMax }"
     @scroll="onScroll"
   >
     <table>

--- a/app/frontend/frontend/composables/useCompareHardpoints.ts
+++ b/app/frontend/frontend/composables/useCompareHardpoints.ts
@@ -13,6 +13,10 @@ import {
 export const useCompareHardpoints = (models: MaybeRefOrGetter<Model[]>) => {
   const cache = ref<Record<string, Hardpoint[]>>({});
   const pendingCount = ref(0);
+  // A request only reaches the cache once it resolves, and the watcher below re-runs
+  // every time a ship arrives from `useCompareModels` -- so without this, each pass
+  // asks again for everything still in flight: four ships cost ten requests.
+  const inFlight = new Set<string>();
 
   const from = async (model: Model, source: HardpointSourceEnum) =>
     (await fetchModelHardpoints(model.slug, { source })) as Hardpoint[];
@@ -38,16 +42,21 @@ export const useCompareHardpoints = (models: MaybeRefOrGetter<Model[]>) => {
       // Left uncached on purpose, so the next change to the compare set retries
       // instead of locking the ship into an empty loadout forever.
       console.info("compare hardpoints failed", model.slug, error);
+    } finally {
+      inFlight.delete(model.slug);
     }
   };
 
   const load = async () => {
-    const missing = toValue(models).filter((model) => !cache.value[model.slug]);
+    const missing = toValue(models).filter(
+      (model) => !cache.value[model.slug] && !inFlight.has(model.slug),
+    );
 
     if (!missing.length) {
       return;
     }
 
+    missing.forEach((model) => inFlight.add(model.slug));
     pendingCount.value += missing.length;
 
     try {

--- a/app/frontend/frontend/composables/useCompareHardpoints.ts
+++ b/app/frontend/frontend/composables/useCompareHardpoints.ts
@@ -14,16 +14,24 @@ export const useCompareHardpoints = (models: MaybeRefOrGetter<Model[]>) => {
   const cache = ref<Record<string, Hardpoint[]>>({});
   const pendingCount = ref(0);
 
-  const sourceFor = (model: Model) =>
-    model.inGame
-      ? HardpointSourceEnum.GAME_FILES
-      : HardpointSourceEnum.SHIP_MATRIX;
+  const from = async (model: Model, source: HardpointSourceEnum) =>
+    (await fetchModelHardpoints(model.slug, { source })) as Hardpoint[];
 
+  // Game files first, whatever `inGame` says. That flag asks whether the build we are
+  // on describes the ship, which is not the same question as whether an export of its
+  // loadout exists -- and the ship-matrix set answers with `component: null` on every
+  // entry, so preferring it leaves Combat, Defense and Loadout with nothing to compare
+  // and all three drop out of the table silently.
+  //
+  // The fallback costs a second request only for a ship the files do not fit, since a
+  // fitted set is recognisable from the first response.
   const fetchFor = async (model: Model) => {
     try {
-      const hardpoints = (await fetchModelHardpoints(model.slug, {
-        source: sourceFor(model),
-      })) as Hardpoint[];
+      const fitted = await from(model, HardpointSourceEnum.GAME_FILES);
+
+      const hardpoints = fitted.some((hardpoint) => hardpoint.component)
+        ? fitted
+        : await from(model, HardpointSourceEnum.SHIP_MATRIX);
 
       cache.value = { ...cache.value, [model.slug]: hardpoints };
     } catch (error) {

--- a/app/frontend/frontend/composables/useCompareModels.ts
+++ b/app/frontend/frontend/composables/useCompareModels.ts
@@ -20,7 +20,12 @@ export const useCompareModels = (slugs: MaybeRefOrGetter<string[]>) => {
 
   const fetchFor = async (slug: string) => {
     try {
-      cache.value = { ...cache.value, [slug]: await fetchModel(slug) };
+      // Awaited into a local first: spreading the cache in the same expression
+      // reads it before the request resolves, so parallel fetches each write back
+      // a snapshot taken before any of them landed and only the last ship survives.
+      const model = await fetchModel(slug);
+
+      cache.value = { ...cache.value, [slug]: model };
     } catch (error) {
       // Left uncached on purpose, so changing the compare set retries instead of
       // leaving the ship missing from the table forever. Reported through

--- a/app/frontend/frontend/composables/useCompareModels.ts
+++ b/app/frontend/frontend/composables/useCompareModels.ts
@@ -60,12 +60,18 @@ export const useCompareModels = (slugs: MaybeRefOrGetter<string[]>) => {
     { immediate: true },
   );
 
-  // In the order the compare set names them, and skipping any whose request
-  // failed, so the table renders what did arrive.
+  // By name, and skipping any whose request failed so the table renders what did
+  // arrive. Not in the order the compare set names them: that is an order of slugs,
+  // which begin with a manufacturer code, so the columns came out grouped by a
+  // prefix that is nowhere on screen and read as no order at all.
   const models = computed(() =>
     toValue(slugs)
       .map((slug) => cache.value[slug])
-      .filter((model): model is ModelExtended => Boolean(model)),
+      .filter((model): model is ModelExtended => Boolean(model))
+      // Numeric so the 100i sorts before the 125a rather than between them.
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { numeric: true }),
+      ),
   );
 
   const loading = computed(() => pendingCount.value > 0);

--- a/app/frontend/frontend/composables/useCompareModels.ts
+++ b/app/frontend/frontend/composables/useCompareModels.ts
@@ -79,16 +79,22 @@ export const useCompareModels = (slugs: MaybeRefOrGetter<string[]>) => {
     await load();
   };
 
-  // Shaped for `AsyncData`, which the page already drives with the query's own
-  // status object. Nothing here refetches in the background, so the fetching and
-  // refetching flags collapse onto the one loading state.
+  // Filling in a ship beside ones already on screen, rather than the first load
+  // with nothing to show yet.
+  const incremental = computed(() => loading.value && models.value.length > 0);
+
+  // Shaped for `AsyncData`, which reads a fetch as a refetch — and so keeps its
+  // resolved slot mounted — only when `isRefetching` says so. Reporting the
+  // incremental fill as a plain load swapped the whole table for a spinner and
+  // remounted it, so adding a fourth ship threw away the scroll position, the
+  // pinned header and every collapsed section.
   const asyncStatus: AsyncStatus = {
     fetchStatus: computed(() => (loading.value ? "fetching" : "idle")),
     isError: computed(() => Boolean(failure.value)),
-    isPending: loading,
-    isLoading: loading,
+    isPending: computed(() => loading.value && !incremental.value),
+    isLoading: computed(() => loading.value && !incremental.value),
     isFetching: loading,
-    isRefetching: computed(() => false),
+    isRefetching: incremental,
     // Wrapped because the slot expects a void return, and handing it a promise
     // leaves a rejection with nobody to catch it.
     refetch: () => {

--- a/app/frontend/frontend/pages/compare.vue
+++ b/app/frontend/frontend/pages/compare.vue
@@ -35,7 +35,11 @@ const items = computed(() => filters.value.models || []);
 //
 // No watcher here: the composable tracks the compare set itself and fetches only
 // what it has not seen, so adding a fourth ship leaves the three on screen alone.
-const { models, asyncStatus } = useCompareModels(() => items.value);
+const {
+  models,
+  loading: modelsLoading,
+  asyncStatus,
+} = useCompareModels(() => items.value);
 
 const { hardpointsFor, loading: hardpointsLoading } = useCompareHardpoints(
   () => models.value,
@@ -174,7 +178,12 @@ const remove = (slug: string) => {
         </template>
       </AsyncData>
 
-      <Loader :loading="hardpointsLoading" fixed />
+      <!-- The one piece of feedback an incremental fetch gets: the table it is
+           filling in stays on screen, so the spinner cannot live in its place. -->
+      <Loader
+        :loading="hardpointsLoading || (modelsLoading && !!models.length)"
+        fixed
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Seven fixes to the compare page, one commit each.

### The table was being thrown away mid-session

Route records are declared with a trailing slash, so a link without one lands on `/compare` and the first `router.replace` a filter makes rewrites the path. The router-view key was the raw path, so that one navigation remounted the page. Both apps key it the same way, so both carried it.

`AsyncData` then compounded it: it keeps its resolved slot mounted only when `isRefetching` says the fetch is a refetch, and the composable reported the incremental fill as a plain load. Adding a ship swapped the whole table for a spinner and rebuilt it — losing the scroll position, the pinned header and every collapsed section, which is the state a comparison is actually read in. The fixed loader carries the feedback now instead.

### Only the last ship survived a parallel fetch

`cache.value = { ...cache.value, [slug]: await fetchModel(slug) }` reads the cache *before* the request it awaits resolves, so every fetch in the `Promise.all` wrote back a snapshot taken before any of them landed.

### The columns were ordered by slug

The picker sorted on the slug, and a slug starts with a manufacturer code — so `anvl-`, `drak-`, `orig-`, `rsi-` decided the order while the header showed F7C Hornet Mk I, Cutlass Blue, 100i, Aurora Mk I MR. Now ordered by the name on screen, numerically aware so the 100i sorts before the 125a.

### The table stopped short of the bottom of the screen

A fraction of the viewport can never reach the bottom of it — the pane starts a couple of hundred pixels down, so `76vh` left that same distance unused, and the taller the screen the more it wasted. It measures where it sits and takes what remains. Verified at 1728x1050 and 1440x800: 24px above the bottom at both.

### No hardpoints, and no explanation

The source was chosen on `model.inGame`, which asks whether the current build describes the ship — not whether an export of its loadout exists. For anything else it fell back to the ship matrix, whose hardpoints carry `component: null` on **every** entry. With no components there is nothing to compute, so Combat, Defense and Loadout by slot all failed `hasRowData` and dropped out without a word: the table just ended at Fuel & Quantum.

The F7C Hornet Mk I has 45 fitted hardpoints in the files and 0 through the matrix. The files are asked first now, with the matrix as a fallback taken only when they come back unfitted — one extra request, only for those ships.

While checking that, the request log showed four ships costing ten hardpoint requests: a request only reaches the cache once it resolves, and the watcher re-runs each time a ship arrives. Tracking the slugs in flight brings it back to one per ship.

### Verified

Against the dev server with Playwright, at 1728x1050 and 1440x800:

- Hornet + 600i Explorer + 100i + 125a → Combat, Defense and **Loadout by slot** all render, 32 hardpoint cells, one request per ship.
- Crucible (nothing fitted in the files) + Hornet → the Crucible probes the files, gets nothing, falls back to `source=ship_matrix`. The fallback path works.
- Columns come out `100i, 125a, 600i Explorer, F7C Hornet Mk I` from a query that names them in a different order.
- Compare unit tests pass (15), eslint clean.

### One thing to decide

The ship page still defaults on `inGame` and offers a source toggle, so a ship no build describes can now show a fitted loadout on compare and an empty one there. I think compare is right — a column with no components compares nothing — but if the two should always agree, the ship page's default should move to this rule rather than compare moving back.

🤖
