### PR TITLE
fix(discord): match the bot install permissions to the portal

### DIFF
--- a/lib/discord/api_client.rb
+++ b/lib/discord/api_client.rb
@@ -32,8 +32,11 @@ module Discord
       Rails.application.config.app.discord[:client_id].presence
     end
 
-    # Manage Events permission bit (1 << 33).
-    INSTALL_PERMISSIONS = 8_589_934_592
+    # Manage Events (1 << 33), plus View Channel (1 << 10) and Connect
+    # (1 << 20) — Discord rejects a voice-channel scheduled event without
+    # those two when a fleet sets a discord_channel_id. Must stay in sync
+    # with the app's Default Install Settings in the Discord dev portal.
+    INSTALL_PERMISSIONS = 8_590_984_192
 
     def self.install_url
       return nil if application_id.blank?


### PR DESCRIPTION
`Discord::ApiClient.install_url` asked for `8_589_934_592` — Manage Events (`1 << 33`) and nothing else. The application's Default Install Settings in the Discord developer portal now carry three bits, so the two installation paths handed out different permissions:

| Path | Permissions granted |
| --- | --- |
| Portal / "Add App" link | Manage Events + View Channel + Connect |
| Fleet settings link (`install_url`) | Manage Events only |

That matters because `ScheduledEventSync#build_payload` switches to a **voice** scheduled event as soon as a fleet fills in the Channel ID field, and Discord rejects a voice-channel event unless the bot also has View Channel and Connect on the target channel. A bot installed through the fleet settings link therefore works fine until the first event with a channel id, then returns a 403 that surfaces as `discord_error` / `bad_gateway` from `FleetEventsController` — long after the install that caused it.

This aligns the constant with the portal:

```
Manage Events  1 << 33  =  8589934592
View Channel   1 << 10  =        1024
Connect        1 << 20  =     1048576
                          -----------
                            8590984192
```

The comment now names all three bits and the fact that the value has to stay in sync with the portal, since nothing enforces that automatically.

No test asserted the old number, and none asserts the new one — `installUrl` is covered by `fleets_notifications_discord_status_behaviour_test.rb`, which checks the scopes and the client_id prefix rather than the permission mask.

### Verified

- `bundle exec rubocop lib/discord/api_client.rb` — clean
- `bin/rails test test/integration/api/v1/fleets_notifications_discord_status_behaviour_test.rb` — 8 runs, 15 assertions, 0 failures
- The live application's `install_params` read back from Discord as `{"scopes": ["bot", "applications.commands"], "permissions": "8590984192"}`, so this matches what the portal already serves

### Note for existing installs

Discord does not upgrade the grant of a server that already installed the bot. Servers installed before this keep Manage Events only and have to re-authorise before a channel-bound event works. That is worth remembering for anything later that adds another permission bit.

🤖
