### PR TITLE
feat(discord): answer slash commands from an interactions endpoint

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -8,6 +8,7 @@ SC_DATA_S3__BUCKET=fltyrd-sc
 SC_DATA_S3__ACCESS_KEY_ID=op://Fleetyards/HETZNER_S3/access_key_id
 SC_DATA_S3__SECRET_ACCESS_KEY=op://Fleetyards/HETZNER_S3/secret_access_key
 # DISCORD__OAUTH_SECRET=op://Fleetyards/DISCORD_OAUTH/credential
+# DISCORD__PUBLIC_KEY=op://Fleetyards/DISCORD_BOT/public_key
 GITHUB__OAUTH_CLIENT_ID=op://Fleetyards/GITHUB_OAUTH/client_id
 GITHUB__OAUTH_SECRET=op://Fleetyards/GITHUB_OAUTH/credential
 TWITCH__OAUTH_CLIENT_ID=op://Fleetyards/TWITCH_OAUTH/client_id

--- a/app/controllers/discord/interactions_controller.rb
+++ b/app/controllers/discord/interactions_controller.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Discord
+  # Discord's Interactions Endpoint. Every slash command arrives here as a
+  # POST; there is no session, no cookie and no user.
+  #
+  # Inherits ActionController::Base rather than ApplicationController on
+  # purpose: ApplicationController adds HTTP basic auth whenever
+  # basic_auth.password is set, which is how staging is protected. Discord
+  # cannot supply those credentials, so every interaction would 401 there.
+  class InteractionsController < ActionController::Base
+    skip_forgery_protection
+
+    # Interaction request types.
+    PING = 1
+    APPLICATION_COMMAND = 2
+
+    # Interaction response types.
+    PONG = 1
+    MESSAGE = 4
+    DEFERRED_MESSAGE = 5
+
+    def create
+      return head :unauthorized unless verified?
+
+      case payload["type"]
+      # PING answers regardless of the feature flag: saving the endpoint URL in
+      # the Discord portal is what triggers it, and that has to be possible
+      # before the commands are switched on.
+      when PING then render json: {type: PONG}
+      when APPLICATION_COMMAND
+        Flipper.enabled?(:discord_commands) ? acknowledge_command : refuse_command
+      else head :no_content
+      end
+    end
+
+    # Discord probes a newly saved endpoint URL with a deliberately invalid
+    # signature and refuses to accept the URL unless that probe is rejected --
+    # so an unverified request must be a 401, never a 200 with an error body.
+    private def verified?
+      return false unless SignatureVerifier.configured?
+
+      SignatureVerifier.new.valid?(
+        signature: request.headers[SignatureVerifier::SIGNATURE_HEADER],
+        timestamp: request.headers[SignatureVerifier::TIMESTAMP_HEADER],
+        body: raw_body
+      )
+    end
+
+    # Nothing runs inline. Even a command that would finish in 40 ms locally
+    # has to survive a cold connection pool and Discord's hard 3 second
+    # deadline, after which the interaction cannot be answered at all.
+    private def acknowledge_command
+      Discord::CommandJob.perform_async(command_context)
+
+      render json: {
+        type: DEFERRED_MESSAGE,
+        data: {flags: Discord::Commands::Base::EPHEMERAL}
+      }
+    end
+
+    private def refuse_command
+      render json: {
+        type: MESSAGE,
+        data: {
+          content: I18n.t("discord.commands.disabled"),
+          flags: Discord::Commands::Base::EPHEMERAL
+        }
+      }
+    end
+
+    # String keys throughout: Sidekiq serialises arguments to JSON and rejects
+    # symbols under strict args, and the job reads this back with
+    # with_indifferent_access anyway.
+    private def command_context
+      data = payload["data"] || {}
+
+      {
+        "application_id" => payload["application_id"],
+        "token" => payload["token"],
+        "command" => data["name"],
+        "options" => command_options(data["options"]),
+        "guild_id" => payload["guild_id"],
+        "discord_user_id" => invoking_user_id,
+        # Discord tells us the invoking member's own client locale; the guild
+        # locale is the fallback for a member who has none.
+        "locale" => payload["locale"] || payload["guild_locale"],
+        "requested_at" => Time.current.to_i
+      }
+    end
+
+    private def command_options(options)
+      Array(options).to_h { |option| [option["name"], option["value"]] }
+    end
+
+    # In a guild the invoking user is under `member`; in a DM it is `user`.
+    private def invoking_user_id
+      payload.dig("member", "user", "id") || payload.dig("user", "id")
+    end
+
+    # The signature covers the raw bytes, so the body is read once here and the
+    # parse is ours -- request.params would be a different byte sequence and
+    # could never be verified.
+    private def raw_body
+      @raw_body ||= request.raw_post
+    end
+
+    private def payload
+      @payload ||= JSON.parse(raw_body)
+    rescue JSON::ParserError
+      {}
+    end
+  end
+end

--- a/app/jobs/discord/command_job.rb
+++ b/app/jobs/discord/command_job.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "discord/commands/registry"
+require "discord/interaction_client"
+require "discord/locale"
+
+module Discord
+  # Fills in the answer for an interaction the endpoint already acknowledged
+  # with a deferred response. Discord gives us 3 seconds to acknowledge and 15
+  # minutes to deliver, so all the actual work happens here.
+  class CommandJob < ::ApplicationJob
+    # Its own queue, first in config/sidekiq.yml: this is the only queue on a
+    # user-facing latency budget, and a loader burst on `notifications` would
+    # otherwise be visible as a bot that takes half a minute to answer.
+    sidekiq_options retry: 2, queue: "discord"
+
+    # A single hash rather than positional arguments -- Sidekiq replays
+    # arguments positionally, and this payload grows a field per command.
+    def perform(context)
+      context = context.with_indifferent_access
+      return if expired?(context)
+
+      client = InteractionClient.new(
+        application_id: context[:application_id],
+        token: context[:token]
+      )
+
+      I18n.with_locale(Locale.resolve(context[:locale])) do
+        client.edit_original(payload_for(context))
+      end
+    end
+
+    private def payload_for(context)
+      handler = Commands::Registry.handler_for(context[:command])
+      return unknown_command(context[:command]) if handler.nil?
+
+      handler.new(
+        options: context[:options] || {},
+        guild_id: context[:guild_id],
+        discord_user_id: context[:discord_user_id]
+      ).call
+    rescue => e
+      # A command that raises must still say something: the interaction is
+      # already showing "thinking...", and an unanswered one stays there.
+      # Deterministic failures are not worth a retry, so this does not re-raise
+      # -- transport failures in edit_original still do.
+      Rails.logger.error("[Discord::CommandJob] command=#{context[:command]} failed: #{e.class}: #{e.message}")
+      Appsignal.report_error(e)
+
+      failure
+    end
+
+    private def expired?(context)
+      started_at = context[:requested_at]
+      return false if started_at.blank?
+
+      Time.current.to_i - started_at.to_i > InteractionClient::TOKEN_TTL.to_i
+    end
+
+    private def unknown_command(name)
+      Rails.logger.warn("[Discord::CommandJob] unknown command=#{name}")
+
+      failure
+    end
+
+    private def failure
+      {
+        content: I18n.t("discord.commands.failed"),
+        flags: Commands::Base::EPHEMERAL
+      }
+    end
+  end
+end

--- a/config/app/main.yml
+++ b/config/app/main.yml
@@ -27,6 +27,12 @@ shared:
     client_id: <%= Rails.app.creds.option(:discord, :client_id) %>
     oauth_secret: <%= Rails.app.creds.option(:discord, :oauth_secret) %>
     bot_token: <%= Rails.app.creds.option(:discord, :bot_token) %>
+    # Ed25519 public key of the Discord application. Not a secret -- Discord
+    # publishes it in the app info -- but it differs per application, so it
+    # lives here next to client_id rather than being hardcoded. Verifying
+    # interaction signatures is impossible without it, and the endpoint
+    # rejects every request while it is blank.
+    public_key: <%= Rails.app.creds.option(:discord, :public_key) %>
 
   github:
     oauth_client_id: <%= Rails.app.creds.option(:github, :oauth_client_id) %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -16,6 +16,11 @@
 # push. Seeded from the flags live in Flipper at the time the registry was
 # introduced.
 
+# Gates command dispatch only. PING always answers, so the interactions
+# endpoint URL can be saved in the Discord portal before this is switched on.
+discord_commands:
+  description: "Discord slash commands answered by the interactions endpoint"
+
 fleet_logistics:
   description: "Fleet logistics — fleet inventories with a deposit/withdrawal ledger"
 

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -1,6 +1,21 @@
 ---
 de:
   discord:
+    commands:
+      disabled: Fleetyards-Befehle sind noch nicht verfügbar.
+      failed: Beim Abrufen ist etwas schiefgelaufen. Bitte versuche es erneut.
+      ship:
+        ambiguous: '%{count} Schiffe passen zu „%{query}“:'
+        fields:
+          classification: Klassifizierung
+          crew: Besatzung
+          dimensions: Maße
+          pledge_price: Pledge-Preis
+          price: Preis
+          size: Größe
+        missing_query: Bitte gib einen Schiffsnamen an.
+        more: '…und weitere. Versuche einen genaueren Namen.'
+        not_found: 'Kein Schiff für „%{query}“ gefunden.'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -1,6 +1,21 @@
 ---
 en:
   discord:
+    commands:
+      disabled: Fleetyards commands are not available yet.
+      failed: Something went wrong while looking that up. Please try again.
+      ship:
+        ambiguous: '%{count} ships match "%{query}":'
+        fields:
+          classification: Classification
+          crew: Crew
+          dimensions: Dimensions
+          pledge_price: Pledge Price
+          price: Price
+          size: Size
+        missing_query: Please provide a ship name.
+        more: '…and more. Try a more specific name.'
+        not_found: 'No ship found for "%{query}".'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -1,6 +1,21 @@
 ---
 es:
   discord:
+    commands:
+      disabled: Los comandos de Fleetyards aún no están disponibles.
+      failed: Algo ha fallado durante la búsqueda. Inténtalo de nuevo.
+      ship:
+        ambiguous: '%{count} naves coinciden con «%{query}»:'
+        fields:
+          classification: Clasificación
+          crew: Tripulación
+          dimensions: Dimensiones
+          pledge_price: Precio de pledge
+          price: Precio
+          size: Tamaño
+        missing_query: Indica el nombre de una nave.
+        more: '…y más. Prueba con un nombre más preciso.'
+        not_found: 'No se ha encontrado ninguna nave para «%{query}».'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -1,6 +1,21 @@
 ---
 fr:
   discord:
+    commands:
+      disabled: Les commandes Fleetyards ne sont pas encore disponibles.
+      failed: "Une erreur est survenue lors de la recherche. Merci de réessayer."
+      ship:
+        ambiguous: '%{count} vaisseaux correspondent à « %{query} » :'
+        fields:
+          classification: Classification
+          crew: Équipage
+          dimensions: Dimensions
+          pledge_price: Prix pledge
+          price: Prix
+          size: Taille
+        missing_query: "Merci d'indiquer le nom d'un vaisseau."
+        more: "…et d'autres. Essayez un nom plus précis."
+        not_found: 'Aucun vaisseau trouvé pour « %{query} ».'
     new_ship:
       message: 'Permettez-moi de vous présenter : %{manufacturer} %{model}'
       title: Nouveau vaisseau / véhicule ajouté

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -1,6 +1,21 @@
 ---
 it:
   discord:
+    commands:
+      disabled: I comandi Fleetyards non sono ancora disponibili.
+      failed: Qualcosa è andato storto durante la ricerca. Riprova.
+      ship:
+        ambiguous: '%{count} navi corrispondono a «%{query}»:'
+        fields:
+          classification: Classificazione
+          crew: Equipaggio
+          dimensions: Misure
+          pledge_price: Prezzo pledge
+          price: Prezzo
+          size: Dimensione
+        missing_query: Indica il nome di una nave.
+        more: '…e altre. Prova con un nome più preciso.'
+        not_found: 'Nessuna nave trovata per «%{query}».'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -1,6 +1,21 @@
 ---
 zh-CN:
   discord:
+    commands:
+      disabled: Fleetyards 命令尚不可用。
+      failed: 查询时出错，请重试。
+      ship:
+        ambiguous: '有 %{count} 艘飞船匹配“%{query}”：'
+        fields:
+          classification: 分类
+          crew: 船员
+          dimensions: 尺寸
+          pledge_price: 众筹价格
+          price: 价格
+          size: 体积
+        missing_query: 请提供飞船名称。
+        more: '…还有更多，请使用更精确的名称。'
+        not_found: '未找到与“%{query}”匹配的飞船。'
     new_ship:
       message: '请允许我介绍一下： %{manufacturer} %{model}'
       title: 添加新的货运/车辆

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -1,6 +1,21 @@
 ---
 zh-TW:
   discord:
+    commands:
+      disabled: Fleetyards 指令尚未開放。
+      failed: 查詢時發生錯誤，請重試。
+      ship:
+        ambiguous: '有 %{count} 艘船艦符合「%{query}」：'
+        fields:
+          classification: 分類
+          crew: 船員
+          dimensions: 尺寸
+          pledge_price: 眾籌價格
+          price: 價格
+          size: 體積
+        missing_query: 請提供船艦名稱。
+        more: '…還有更多，請使用更精確的名稱。'
+        not_found: '找不到符合「%{query}」的船艦。'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,11 @@ Rails.application.routes.draw do
 
   post "/emails/inbound" => "inbound_emails#create"
 
+  # Discord's interactions endpoint. Deliberately outside :api_routes -- it is
+  # not public API surface, carries no OpenAPI component and must not enter the
+  # generated schema or the TS client.
+  post "/discord/interactions" => "discord/interactions#create"
+
   if Rails.env.production?
     match "/uploads/(*path)", to: redirect { |_params, request| "#{Rails.configuration.app.legacy_cdn_endpoint}#{request.fullpath}" }, via: [:get, :head]
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,10 @@
 ---
 :concurrency: <%= Integer(ENV.fetch("MAX_THREADS", 2)) %>
 :queues:
+  # First: a Discord interaction token expires after 15 minutes and the user is
+  # watching a "thinking..." spinner, so this queue must not wait behind a
+  # loader or updater burst.
+  - discord
   - default
   - mailers
   - notifications

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -1,0 +1,149 @@
+# Discord Bot
+
+Fleetyards has had a Discord presence for years, but it only ever *pushes*: five webhook posters (`lib/discord/new_ship.rb`, `new_supporter.rb`, `rsi_news.rb`, `ship_on_sale.rb`, `youtube_video.rb`) and a one-way event sync (`lib/discord/scheduled_event_sync.rb`). Nobody in a Discord server can ask Fleetyards anything, and nothing a member does in Discord reaches Fleetyards.
+
+This plan turns the app into a bot that answers and listens, in six phases that each ship on their own.
+
+## The half-finished feature we already own
+
+`lib/discord/scheduled_event_rsvp_handler.rb` is complete. It maps a Discord user to a Fleetyards user through `OmniauthConnection`, finds the `FleetEvent` by the stored `discord_event_id`, creates a slot-less `interested` signup, and — carefully — refuses to downgrade a stronger commitment made on Fleetyards, in both directions.
+
+Nothing calls it. It was written for `GUILD_SCHEDULED_EVENT_USER_ADD` / `_REMOVE`, which are **Gateway** events, and this app has no Gateway process: the only `discordrb` require in the tree is `discordrb/webhooks` (`lib/discord/webhook.rb:3`). So "Interested" in Discord never arrives.
+
+That shapes the whole plan. See Phase 3 — the fix is not a Gateway process.
+
+## Foundation: HTTP interactions, not a Gateway
+
+Slash commands do **not** need a persistent connection. Discord will POST every interaction to an **Interactions Endpoint URL**, and a plain Rails controller can answer it. That matters here because a Gateway bot is a new long-running process to deploy, supervise and scale under Kamal, for which this repo has no pattern — whereas an HTTP endpoint is a route, a controller and a Sidekiq job, all of which it has many patterns for.
+
+Consequences of that choice, all of them acceptable:
+
+- Commands work. Message content, presence, reactions and Gateway-only events do not. Only Phase 3 wanted one of those, and it has another route.
+- Discord requires a response within **3 seconds** or the interaction is dead. Every command therefore answers `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` (type 5) immediately and fills in the real answer from a Sidekiq job via `PATCH /webhooks/{application_id}/{token}/messages/@original`. No command ever does its work inline — not even a fast one, because "fast" here means a cold Postgres connection plus an S3 image URL under load.
+- The endpoint is public and unauthenticated. The Ed25519 signature check is the entire security boundary; see below.
+
+### Where it lives
+
+`POST /discord/interactions`, a top-level route in `config/routes.rb` next to `/emails/inbound` — **not** under `/api/v1`. The inbound-email webhook is the existing precedent for an unauthenticated third-party endpoint here, and it is one line; a `draw` file for one route would be more ceremony than routing.
+
+Everything in `app/controllers/api/v1/` is public API surface: it carries hand-written OpenAPI components (`app/api_components/`), its integration tests generate the schema, and `bin/generate-schema` publishes it. A Discord-only RPC endpoint with a request body defined by Discord belongs in none of that. Keeping it outside also keeps it out of the generated TS client, which no frontend will ever call.
+
+### Signature verification
+
+Discord signs every request with Ed25519: `X-Signature-Ed25519` over `X-Signature-Timestamp + raw_body`, verifiable with the application's public key (visible in the app info as `verify_key`).
+
+Ruby's OpenSSL does this without a new dependency:
+
+```ruby
+OpenSSL::PKey.new_raw_public_key("ED25519", [public_key_hex].pack("H*"))
+  .verify(nil, [signature_hex].pack("H*"), "#{timestamp}#{raw_body}")
+```
+
+`ed25519 (1.4.0)` *is* in `Gemfile.lock`, but only as a transitive dependency of the SSH stack that Kamal uses. Building an auth boundary on a gem the Gemfile never asked for means a future `bundle update` can remove it. OpenSSL 3.6 is already a hard requirement of the app.
+
+Rules for the controller:
+
+- Verify against the **raw** body (`request.raw_post`) before parsing. Rails' parsed params are a different byte sequence and will never verify.
+- `skip_before_action :verify_authenticity_token` — there is no session and no cookie; CSRF is meaningless and would reject every request.
+- Reject with **401** on a bad or missing signature. Discord probes the endpoint with a deliberately invalid signature when you save the URL and refuses to accept it unless that probe gets a 401.
+- Reject a timestamp older than 5 minutes, so a captured request cannot be replayed forever.
+- The public key comes from credentials (`discord.public_key`), like `client_id` and `bot_token` in `config/app/main.yml`.
+
+### The command table
+
+Registration is `PUT /applications/{id}/commands` — a full replacement of the global command list, which makes it idempotent and safe to re-run. It is a rake task (`discord:commands:sync`), deliberately **not** a deploy hook: the endpoint is rate-limited per day, and command definitions change far less often than the app deploys.
+
+## Phase 1 — endpoint, plumbing, `/ship`
+
+The foundation plus one command, because a foundation with no command cannot be tested end to end.
+
+| Change | File |
+| --- | --- |
+| Route | `config/routes.rb` |
+| Controller: verify, PING, defer | `app/controllers/discord/interactions_controller.rb` |
+| Signature check | `lib/discord/signature_verifier.rb` |
+| Command registry | `lib/discord/commands/registry.rb` |
+| Command base + `/ship` | `lib/discord/commands/base.rb`, `ship.rb` |
+| Deferred follow-up | `app/jobs/discord/command_job.rb` |
+| Follow-up transport | `lib/discord/interaction_client.rb` |
+| Command registration | `lib/discord/api_client.rb`, `lib/tasks/discord.rake` |
+| Locale mapping | `lib/discord/locale.rb` |
+| Own Sidekiq queue | `config/sidekiq.yml` |
+| Credentials | `config/app/main.yml`, `.env.tpl` |
+| Flag | `config/feature_flags.yml` — `discord_commands` |
+| Copy, seven locales | `config/locales/*/discord.yml` |
+
+The follow-up gets its own client rather than a method on `ApiClient`: that path is authenticated by the interaction token in the URL, and `ApiClient` refuses to run without a bot token — a guard worth keeping rather than relaxing.
+
+Discord sends the invoking member's own client locale (`locale`, with `guild_locale` as the fallback) on every interaction, so the answer is rendered under `I18n.with_locale` and the copy lives in all seven `discord.yml` files. `Discord::Locale` maps Discord's tags onto the app's, matching exactly first so `zh-CN` and `zh-TW` stay distinct.
+
+Command jobs get their own Sidekiq queue, listed **first** in `config/sidekiq.yml`: it is the only queue with a user waiting on a spinner, and a loader burst on `notifications` would otherwise read as a bot that takes half a minute to answer.
+
+`/ship <name>` reads the existing `Model` catalogue and answers with an embed: store image, manufacturer, classification, price, dimensions, a link to the model page. Name resolution reuses whatever the models filter already does for text search rather than inventing a second matcher; an ambiguous name answers with up to five candidates instead of guessing.
+
+## Phase 2 — the rest of the read-only commands
+
+Each is the same shape as `/ship`, so they are one PR per command at most and cheap:
+
+| Command | Source | Note |
+| --- | --- | --- |
+| `/loaner <ship>` | loaner mappings | |
+| `/hangar <user>` | public hangars | must honour the public-hangar setting; a private hangar answers "not public", never a 404 that leaks existence |
+| `/compare <a> <b>` | compare data | embed, not the table |
+| `/fleet` | fleet stats | resolves the guild via `FleetNotificationSetting.discord_guild_id` |
+
+`/fleet` needs an **index on `fleet_notification_settings.discord_guild_id`** — the column exists but is unindexed, and this is the first read that looks a fleet up by it on a request path.
+
+Every response is ephemeral by default (flag 64) unless the invoking member asked for a public post, so a busy channel does not fill with bot output.
+
+## Phase 3 — RSVPs, without a Gateway
+
+The handler exists; only the transport is missing, and HTTP interactions cannot carry it.
+
+Instead, **poll**: `GET /guilds/{guild_id}/scheduled-events/{event_id}/users` returns the users subscribed to a scheduled event. `ScheduledEventSync` already runs per event and already knows `discord_guild_id` and `discord_event_id`, so it can diff the subscriber list against the FY signups and drive `ScheduledEventRsvpHandler#add!` / `#remove!` for the difference.
+
+This is strictly better than a Gateway here: it survives restarts and missed events (a Gateway drops what happens while it is down), it needs no new process and no intents, and the handler's existing "never downgrade a Fleetyards commitment" logic makes repeated polling naturally idempotent.
+
+The cost is latency — an RSVP lands on the next poll, not instantly. For an event days away that is invisible; the poll interval can tighten as the event approaches, reusing the same schedule the sync already follows.
+
+## Phase 4 — event reminders with what Discord does not know
+
+Discord's own event reminder knows the time and nothing else. Fleetyards knows the slots. A reminder post — "starts in 1 h · 6 of 14 slots open · sign up" with a deep link — carries information Discord cannot produce.
+
+Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs **no bot permission at all** and works even in servers that never installed the bot. Reuses the `fleet_event.starting_soon` notification event that `FleetNotificationSetting::DEFAULT_IN_APP_EVENTS` already defines.
+
+## Phase 5 — wishlist alerts as DMs
+
+`lib/discord/ship_on_sale.rb` posts every sale to a channel. The same data filtered per user against their wishlist and delivered as a DM is the first thing that makes the Discord account link valuable to a *member* rather than to an org.
+
+Mechanics: `POST /users/@me/channels` with the recipient, then a normal message. Requirements and limits, all of which need respecting rather than working around:
+
+- The user must share a server with the bot, and must not have DMs closed. A failed DM is a normal outcome, not an error to retry into a rate limit.
+- Opt-in per user, off by default, alongside the existing notification preferences. An unsolicited DM from a bot is the fastest way to get an app reported.
+
+## Phase 6 — fleet roles ↔ Discord roles
+
+What org admins actually ask for. Two tiers: a "verified member" role on account link, then a mapping from `FleetRole` ranks to Discord roles.
+
+**This changes the install permissions.** Manage Roles is `1 << 28`, so `Discord::ApiClient::INSTALL_PERMISSIONS` and the app's Default Install Settings both move to `8_590_984_192 + 268_435_456 = 8_859_419_648`. Servers that installed under the old mask **keep the old grant** — Discord does not upgrade an existing install — so role sync must detect a missing permission and surface "re-authorise the bot" in the fleet settings UI instead of failing silently in a job.
+
+Also note the role hierarchy: a bot can only assign roles **below its own highest role**. That is a server-configuration problem the app cannot fix, only detect and report.
+
+Hangar-based roles ("owns a Carrack" → role) are the natural extension and deliberately last: they turn a per-link action into a continuous reconcile against every member's hangar, which is a different cost class from everything above.
+
+## Order and why
+
+1. **Phase 1** — nothing else exists without the endpoint.
+2. **Phase 3** — finishes code already in the tree; highest value per line.
+3. **Phase 2** — cheap, visible, no new mechanics.
+4. **Phase 4** — no permissions, no new surface.
+5. **Phase 5** — first outbound-to-person channel; wants the account link to be common first.
+6. **Phase 6** — the only phase that forces a re-authorisation, so it goes last, once the bot is worth re-authorising for.
+
+## Testing
+
+The interactions endpoint gets an integration test in `test/integration/` — but **not** the `openapi-ruby` DSL, since it is not public API surface and must not enter the schema. Cases that matter: a valid signature dispatches, an invalid one is 401, a missing one is 401, a stale timestamp is 401, PING answers PONG, an unknown command name does not 500.
+
+Signature verification gets a unit test with a fixed keypair, so a real signature is verified rather than a stub of the verifier.
+
+Command handlers are unit-tested on their embed output, with no HTTP involved — the same reason `ScheduledEventRsvpHandler` is pure ActiveRecord and testable today.

--- a/lib/discord/api_client.rb
+++ b/lib/discord/api_client.rb
@@ -60,6 +60,14 @@ module Discord
       request(:get, "guilds/#{guild_id}")
     end
 
+    # A full replacement of the application's global command list, which is
+    # what makes `discord:commands:sync` idempotent: whatever the registry does
+    # not list stops existing. Rate-limited per day, so it belongs in a task
+    # rather than in a deploy hook.
+    def put_application_commands(application_id, definitions)
+      request(:put, "applications/#{application_id}/commands", definitions)
+    end
+
     def create_guild_scheduled_event(guild_id, payload)
       post("guilds/#{guild_id}/scheduled-events", payload)
     end

--- a/lib/discord/commands/base.rb
+++ b/lib/discord/commands/base.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # A command turns an interaction into a message payload. No HTTP, no
+    # Discord client -- the job owns the transport, so a command is a plain
+    # unit test over its embed.
+    class Base
+      # Bit 64: only the invoking member sees the reply. Default for every
+      # command, so a busy channel does not fill with bot output; a command
+      # that wants a public post opts out.
+      EPHEMERAL = 64
+
+      attr_reader :options, :guild_id, :discord_user_id
+
+      def initialize(options: {}, guild_id: nil, discord_user_id: nil)
+        @options = options.to_h { |key, value| [key.to_s, value] }
+        @guild_id = guild_id
+        @discord_user_id = discord_user_id
+      end
+
+      def call
+        raise NotImplementedError
+      end
+
+      private def option(name)
+        options[name.to_s]
+      end
+
+      private def message(content: nil, embeds: nil, ephemeral: true)
+        payload = {}
+        payload[:content] = content if content.present?
+        payload[:embeds] = embeds if embeds.present?
+        payload[:flags] = EPHEMERAL if ephemeral
+        payload
+      end
+
+      private def url_for_path(path)
+        "https://#{Rails.configuration.app.domain}#{path}"
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # One table for both directions: `discord:commands:sync` publishes these
+    # definitions to Discord, and the interactions endpoint dispatches incoming
+    # commands through the same list. Splitting them is how a command ends up
+    # registered but unhandled -- Discord shows it in the picker and the user
+    # gets a timeout.
+    module Registry
+      # Discord application command option types.
+      STRING = 3
+
+      DEFINITIONS = [
+        {
+          name: "ship",
+          description: "Look up a ship in the Fleetyards catalogue",
+          handler: "Discord::Commands::Ship",
+          options: [
+            {
+              name: "name",
+              description: "Ship name, slug, or manufacturer",
+              type: STRING,
+              required: true
+            }
+          ]
+        }
+      ].freeze
+
+      def self.definition(name)
+        DEFINITIONS.find { |definition| definition[:name] == name.to_s }
+      end
+
+      def self.handler_for(name)
+        definition = definition(name)
+        return nil if definition.blank?
+
+        definition[:handler].constantize
+      end
+
+      # What Discord's PUT /applications/:id/commands accepts -- the handler is
+      # ours and would be rejected as an unknown key.
+      def self.payload
+        DEFINITIONS.map do |definition|
+          definition.except(:handler).deep_dup
+        end
+      end
+    end
+  end
+end

--- a/lib/discord/commands/ship.rb
+++ b/lib/discord/commands/ship.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    class Ship < Base
+      MAX_CANDIDATES = 5
+
+      # Same colour the site uses for its primary accent, so an embed reads as
+      # Fleetyards rather than as a generic bot post.
+      EMBED_COLOR = 0x2d9cdb
+
+      def call
+        query = option("name").to_s.strip
+        return message(content: I18n.t("discord.commands.ship.missing_query")) if query.blank?
+
+        candidates = search(query)
+
+        case candidates.size
+        when 0 then message(content: I18n.t("discord.commands.ship.not_found", query: query))
+        when 1 then message(embeds: [embed(candidates.first)], ephemeral: false)
+        else disambiguate(query, candidates)
+        end
+      end
+
+      # `search_cont` is the site's own matcher -- a ransack alias over name,
+      # slug and manufacturer slug (`Model#ransack_alias :search`). Reusing it
+      # keeps the bot and the ship list agreeing on what a name matches.
+      #
+      # `visible.active` is the public catalogue scope from ModelsController;
+      # without it the bot would answer with unreleased and hidden models the
+      # website never shows.
+      private def search(query)
+        scope = Model.visible.active.includes(:manufacturer)
+
+        exact = scope.where("lower(name) = :q OR lower(slug) = :q", q: query.downcase).limit(1).to_a
+        return exact if exact.any?
+
+        scope.ransack(search_cont: query).result.ordered_by_name.limit(MAX_CANDIDATES + 1).to_a
+      end
+
+      private def disambiguate(query, candidates)
+        shown = candidates.first(MAX_CANDIDATES)
+        lines = shown.map { |model| "• [#{model.name}](#{page_url(model)})" }
+
+        content = [
+          I18n.t("discord.commands.ship.ambiguous", query: query, count: shown.size),
+          lines.join("\n"),
+          (I18n.t("discord.commands.ship.more") if candidates.size > MAX_CANDIDATES)
+        ].compact.join("\n")
+
+        message(content: content)
+      end
+
+      private def embed(model)
+        {
+          title: model.name,
+          url: page_url(model),
+          color: EMBED_COLOR,
+          description: model.description.to_s.truncate(400).presence,
+          fields: fields(model).map { |name, value| {name: name, value: value, inline: true} },
+          thumbnail: thumbnail(model),
+          footer: {text: model.manufacturer&.name}.compact_blank.presence
+        }.compact_blank
+      end
+
+      private def fields(model)
+        {
+          I18n.t("discord.commands.ship.fields.classification") => model.classification&.humanize,
+          I18n.t("discord.commands.ship.fields.size") => model.size&.humanize,
+          I18n.t("discord.commands.ship.fields.crew") => crew(model),
+          I18n.t("discord.commands.ship.fields.pledge_price") => model.pledge_price_label,
+          I18n.t("discord.commands.ship.fields.price") => model.price_label,
+          I18n.t("discord.commands.ship.fields.dimensions") => dimensions(model)
+        }.compact_blank
+      end
+
+      private def crew(model)
+        return model.max_crew.to_s if model.min_crew.blank? || model.min_crew == model.max_crew
+        return if model.max_crew.blank?
+
+        "#{model.min_crew}–#{model.max_crew}"
+      end
+
+      private def dimensions(model)
+        [model.length_label, model.beam_label, model.height_label].compact_blank.join(" × ").presence
+      end
+
+      # rails_representation_url only builds a redirect URL -- it does not
+      # process the variant here, so a cold image costs the job nothing.
+      private def thumbnail(model)
+        image = model.store_image
+        return nil unless image.attached?
+
+        url =
+          if image.representable?
+            url_helpers.rails_representation_url(
+              image.representation(ActiveStorageVariants::REPRESENTATION_SIZES[:medium])
+            )
+          else
+            url_helpers.rails_blob_url(image)
+          end
+
+        {url: url}
+      end
+
+      private def page_url(model)
+        url_for_path("/ships/#{model.slug}")
+      end
+
+      private def url_helpers
+        Rails.application.routes.url_helpers
+      end
+    end
+  end
+end

--- a/lib/discord/interaction_client.rb
+++ b/lib/discord/interaction_client.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "faraday/retry"
+
+module Discord
+  # Sends the real answer for an interaction the endpoint already deferred.
+  #
+  # Separate from ApiClient because this path is authenticated by the
+  # interaction token in the URL, not by the bot token. ApiClient refuses to
+  # run without a bot token, and relaxing that would weaken the one guard that
+  # keeps a misconfigured deploy from talking to Discord unauthenticated.
+  class InteractionClient
+    BASE_URL = "https://discord.com/api/v10/"
+
+    # An interaction token is valid for 15 minutes. A job still queued after
+    # that cannot deliver anything, and retrying only burns rate limit.
+    TOKEN_TTL = 15.minutes
+
+    Error = Class.new(StandardError)
+
+    def initialize(application_id:, token:)
+      @application_id = application_id
+      @token = token
+    end
+
+    def edit_original(payload)
+      response = connection.patch(
+        "webhooks/#{@application_id}/#{@token}/messages/@original",
+        payload.to_json
+      )
+
+      return true if response.status.between?(200, 299)
+
+      raise Error, "Discord interaction edit failed: #{response.status} #{response.body}"
+    end
+
+    private def connection
+      @connection ||= Faraday.new(url: BASE_URL) do |c|
+        c.request :retry, max: 3, interval: 0.5, backoff_factor: 2,
+          retry_statuses: [429, 502, 503, 504],
+          methods: %i[patch post]
+        c.headers["Content-Type"] = "application/json"
+        c.headers["User-Agent"] = "Fleetyards (https://fleetyards.net, 1.0)"
+      end
+    end
+  end
+end

--- a/lib/discord/locale.rb
+++ b/lib/discord/locale.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Discord
+  # Maps the locale Discord sends on an interaction onto one the app has.
+  #
+  # Discord sends IETF-ish tags ("en-US", "es-ES", "zh-CN"); the app has
+  # "en", "de", "es", "fr", "it", "zh-CN", "zh-TW". An exact match wins so the
+  # two Chinese locales stay distinct -- collapsing them to "zh" would pick
+  # neither.
+  module Locale
+    def self.resolve(tag)
+      return I18n.default_locale if tag.blank?
+
+      available = I18n.available_locales.map(&:to_s)
+
+      exact = available.find { |locale| locale.casecmp?(tag.to_s) }
+      return exact.to_sym if exact
+
+      language = tag.to_s.split("-").first
+      language_match = available.find { |locale| locale.casecmp?(language) }
+      return language_match.to_sym if language_match
+
+      I18n.default_locale
+    end
+  end
+end

--- a/lib/discord/signature_verifier.rb
+++ b/lib/discord/signature_verifier.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Discord
+  # Verifies the Ed25519 signature Discord puts on every interaction request.
+  #
+  # This is the only thing standing between the public, session-less
+  # interactions endpoint and the app, so it verifies the *raw* request body:
+  # Rails' parsed and re-serialised params are a different byte sequence and
+  # would never match the signature.
+  #
+  # OpenSSL rather than the ed25519 gem on purpose. The gem is in Gemfile.lock,
+  # but only as a transitive dependency of the SSH stack Kamal uses -- a
+  # `bundle update` that drops it would silently take this boundary with it.
+  class SignatureVerifier
+    # Discord's own guidance. Bounds how long a captured request stays
+    # replayable; the signature itself never expires.
+    MAX_AGE = 5.minutes
+
+    SIGNATURE_HEADER = "HTTP_X_SIGNATURE_ED25519"
+    TIMESTAMP_HEADER = "HTTP_X_SIGNATURE_TIMESTAMP"
+
+    HEX = /\A[0-9a-f]+\z/i
+
+    def self.public_key
+      Rails.application.config.app.discord[:public_key].presence
+    end
+
+    def self.configured?
+      public_key.present?
+    end
+
+    def initialize(public_key: self.class.public_key)
+      @public_key = public_key
+    end
+
+    def valid?(signature:, timestamp:, body:)
+      return false if @public_key.blank? || signature.blank? || timestamp.blank?
+      return false unless fresh?(timestamp)
+
+      verify_key.verify(nil, decode(signature), "#{timestamp}#{body}")
+    rescue OpenSSL::OpenSSLError, ArgumentError, TypeError
+      false
+    end
+
+    # A timestamp is a unix epoch second. Reject the future too: a clock-skewed
+    # or hand-crafted timestamp far ahead would otherwise stay valid for as
+    # long as it is ahead.
+    private def fresh?(timestamp)
+      seconds = Integer(timestamp, 10)
+      age = Time.current.to_i - seconds
+
+      age.abs <= MAX_AGE.to_i
+    rescue ArgumentError, TypeError
+      false
+    end
+
+    private def decode(hex)
+      raise ArgumentError, "not hex" unless hex.match?(HEX) && hex.length.even?
+
+      [hex].pack("H*")
+    end
+
+    private def verify_key
+      @verify_key ||= OpenSSL::PKey.new_raw_public_key("ED25519", decode(@public_key))
+    end
+  end
+end

--- a/lib/tasks/discord.rake
+++ b/lib/tasks/discord.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :discord do
+  namespace :commands do
+    desc "Publish the slash command definitions to Discord (full replacement)"
+    task sync: :environment do
+      application_id = Discord::ApiClient.application_id
+
+      if application_id.blank?
+        abort "No Discord application id configured (discord.client_id)."
+      end
+
+      unless Discord::ApiClient.configured?
+        abort "No Discord bot token configured (discord.bot_token)."
+      end
+
+      definitions = Discord::Commands::Registry.payload
+      published = Discord::ApiClient.new.put_application_commands(application_id, definitions)
+
+      puts "Published #{definitions.size} command(s) to application #{application_id}:"
+      Array(published).each { |command| puts "  /#{command["name"]} — #{command["description"]}" }
+    rescue Discord::ApiClient::Error => e
+      abort "Discord rejected the command sync: #{e.message}"
+    end
+
+    desc "Print the command definitions without publishing them"
+    task list: :environment do
+      puts JSON.pretty_generate(Discord::Commands::Registry.payload)
+    end
+  end
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -12533,6 +12533,7 @@ components:
     FeatureFlagName:
       type: string
       enum:
+      - discord_commands
       - fleet_logistics
       - fleet_mission_builder
       - fleet_starmap
@@ -12549,6 +12550,7 @@ components:
       - tools_cargo_grids
       - tools_travel_times
       x-enumNames:
+      - DISCORD_COMMANDS
       - FLEET_LOGISTICS
       - FLEET_MISSION_BUILDER
       - FLEET_STARMAP

--- a/test/integration/discord_interactions_test.rb
+++ b/test/integration/discord_interactions_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Lives outside test/integration/api/v1 on purpose: the interactions endpoint is
+# Discord's RPC surface, not public API, so it must not contribute to the
+# generated OpenAPI schema.
+class DiscordInteractionsTest < ActionDispatch::IntegrationTest
+  PATH = "/discord/interactions"
+
+  setup do
+    @key = OpenSSL::PKey.generate_key("ED25519")
+    Discord::SignatureVerifier.stubs(:public_key).returns(@key.raw_public_key.unpack1("H*"))
+    Discord::CommandJob.jobs.clear
+  end
+
+  def post_signed(payload, timestamp: Time.current.to_i.to_s, signature: nil)
+    body = payload.to_json
+    signature ||= @key.sign(nil, "#{timestamp}#{body}").unpack1("H*")
+
+    post PATH,
+      params: body,
+      headers: {
+        "CONTENT_TYPE" => "application/json",
+        "X-Signature-Ed25519" => signature,
+        "X-Signature-Timestamp" => timestamp
+      }
+  end
+
+  def command_payload(name: "ship", options: [{"name" => "name", "value" => "Carrack"}])
+    {
+      type: 2,
+      application_id: "488788875699945472",
+      token: "interaction-token",
+      guild_id: "123456789",
+      locale: "de",
+      member: {user: {id: "42"}},
+      data: {name: name, options: options}
+    }
+  end
+
+  test "answers a ping with a pong" do
+    post_signed({type: 1})
+
+    assert_response :success
+    assert_equal 1, response.parsed_body["type"]
+  end
+
+  # Discord probes a newly saved endpoint URL with a bad signature and will not
+  # accept the URL unless the probe is rejected.
+  test "rejects a request whose signature does not match the body" do
+    post_signed({type: 1}, signature: "00" * 64)
+
+    assert_response :unauthorized
+  end
+
+  test "rejects a request without signature headers" do
+    post PATH, params: {type: 1}.to_json, headers: {"CONTENT_TYPE" => "application/json"}
+
+    assert_response :unauthorized
+  end
+
+  test "rejects a replayed request outside the timestamp window" do
+    stale = (Time.current - Discord::SignatureVerifier::MAX_AGE - 1.minute).to_i.to_s
+
+    post_signed({type: 1}, timestamp: stale)
+
+    assert_response :unauthorized
+  end
+
+  test "rejects everything while no public key is configured" do
+    Discord::SignatureVerifier.stubs(:public_key).returns(nil)
+
+    post_signed({type: 1})
+
+    assert_response :unauthorized
+  end
+
+  class WithCommandsEnabled < DiscordInteractionsTest
+    setup { Flipper.enable(:discord_commands) }
+
+    test "acknowledges a command with a deferred response" do
+      post_signed(command_payload)
+
+      assert_response :success
+      assert_equal 5, response.parsed_body["type"]
+      assert_equal 64, response.parsed_body.dig("data", "flags")
+    end
+
+    test "enqueues the command with everything the job needs" do
+      post_signed(command_payload)
+
+      assert_equal 1, Discord::CommandJob.jobs.size
+
+      context = Discord::CommandJob.jobs.first["args"].first
+
+      assert_equal "ship", context["command"]
+      assert_equal({"name" => "Carrack"}, context["options"])
+      assert_equal "interaction-token", context["token"]
+      assert_equal "488788875699945472", context["application_id"]
+      assert_equal "123456789", context["guild_id"]
+      assert_equal "42", context["discord_user_id"]
+      assert_equal "de", context["locale"]
+      assert context["requested_at"].present?
+    end
+
+    test "an unknown command name is still acknowledged rather than dropped" do
+      post_signed(command_payload(name: "nope"))
+
+      assert_response :success
+      assert_equal 5, response.parsed_body["type"]
+    end
+
+    test "an unknown interaction type is answered without content" do
+      post_signed({type: 99})
+
+      assert_response :no_content
+      assert_equal 0, Discord::CommandJob.jobs.size
+    end
+  end
+
+  class WithCommandsDisabled < DiscordInteractionsTest
+    setup { Flipper.disable(:discord_commands) }
+
+    test "answers a command with a message instead of running it" do
+      post_signed(command_payload)
+
+      assert_response :success
+      assert_equal 4, response.parsed_body["type"]
+      assert_equal 0, Discord::CommandJob.jobs.size
+    end
+
+    test "still answers a ping so the endpoint URL can be saved" do
+      post_signed({type: 1})
+
+      assert_response :success
+      assert_equal 1, response.parsed_body["type"]
+    end
+  end
+end

--- a/test/jobs/discord/command_job_test.rb
+++ b/test/jobs/discord/command_job_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Discord
+  class CommandJobTest < ActiveSupport::TestCase
+    setup do
+      @client = mock("Discord::InteractionClient")
+      ::Discord::InteractionClient.stubs(:new).returns(@client)
+      create(:model, name: "Carrack", classification: "explorer")
+    end
+
+    def context(overrides = {})
+      {
+        "application_id" => "488788875699945472",
+        "token" => "interaction-token",
+        "command" => "ship",
+        "options" => {"name" => "Carrack"},
+        "locale" => "en",
+        "requested_at" => Time.current.to_i
+      }.merge(overrides)
+    end
+
+    test "delivers the command's payload as the interaction's answer" do
+      @client.expects(:edit_original).with { |payload| payload[:embeds].first[:title] == "Carrack" }
+
+      ::Discord::CommandJob.new.perform(context)
+    end
+
+    test "answers in the locale the interaction carried" do
+      @client.expects(:edit_original).with do |payload|
+        payload[:content].to_s.include?("Kein Schiff")
+      end
+
+      ::Discord::CommandJob.new.perform(context("locale" => "de", "options" => {"name" => "Nope"}))
+    end
+
+    test "a Discord locale with a region falls back to the language" do
+      @client.expects(:edit_original).with do |payload|
+        payload[:content].to_s.include?("Kein Schiff")
+      end
+
+      ::Discord::CommandJob.new.perform(context("locale" => "de-DE", "options" => {"name" => "Nope"}))
+    end
+
+    # The interaction is already showing "thinking..." -- an unanswered one
+    # stays there, so a failure still has to say something.
+    test "a command that raises still answers with a failure message" do
+      ::Discord::Commands::Ship.any_instance.stubs(:call).raises(StandardError, "boom")
+      @client.expects(:edit_original).with { |payload| payload[:content] == I18n.t("discord.commands.failed") }
+
+      ::Discord::CommandJob.new.perform(context)
+    end
+
+    test "a command that raises is not retried" do
+      ::Discord::Commands::Ship.any_instance.stubs(:call).raises(StandardError, "boom")
+      @client.stubs(:edit_original)
+
+      assert_nothing_raised { ::Discord::CommandJob.new.perform(context) }
+    end
+
+    test "a transport failure is left to Sidekiq to retry" do
+      @client.stubs(:edit_original).raises(::Discord::InteractionClient::Error, "503")
+
+      assert_raises(::Discord::InteractionClient::Error) do
+        ::Discord::CommandJob.new.perform(context)
+      end
+    end
+
+    test "an unknown command answers instead of timing out" do
+      @client.expects(:edit_original).with { |payload| payload[:content] == I18n.t("discord.commands.failed") }
+
+      ::Discord::CommandJob.new.perform(context("command" => "nope"))
+    end
+
+    # Nothing can be delivered once the token has expired, and retrying only
+    # burns rate limit.
+    test "does not answer an interaction whose token has expired" do
+      @client.expects(:edit_original).never
+      expired = (Time.current - ::Discord::InteractionClient::TOKEN_TTL - 1.minute).to_i
+
+      ::Discord::CommandJob.new.perform(context("requested_at" => expired))
+    end
+
+    test "answers when the token is still within its window" do
+      @client.expects(:edit_original).once
+      recent = (Time.current - 1.minute).to_i
+
+      ::Discord::CommandJob.new.perform(context("requested_at" => recent))
+    end
+  end
+end

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/registry"
+
+module Discord
+  module Commands
+    # Guards the failure mode the registry exists to prevent: a command that is
+    # published to Discord but has no handler shows up in the picker and then
+    # times out on the user.
+    class RegistryTest < ActiveSupport::TestCase
+      test "every published command has a handler that can run" do
+        ::Discord::Commands::Registry::DEFINITIONS.each do |definition|
+          handler = ::Discord::Commands::Registry.handler_for(definition[:name])
+
+          assert handler.present?, "no handler for /#{definition[:name]}"
+          assert handler.new.respond_to?(:call), "#{handler} cannot be called"
+        end
+      end
+
+      test "the payload sent to Discord carries no keys of ours" do
+        ::Discord::Commands::Registry.payload.each do |command|
+          assert_not_includes command.keys, :handler
+        end
+      end
+
+      test "every command declares a name and a description" do
+        ::Discord::Commands::Registry.payload.each do |command|
+          assert command[:name].present?
+          assert command[:description].present?
+        end
+      end
+
+      test "an unregistered name resolves to no handler" do
+        assert_nil ::Discord::Commands::Registry.handler_for("definitely-not-a-command")
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/ship_test.rb
+++ b/test/lib/discord/commands/ship_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/ship"
+
+module Discord
+  module Commands
+    class ShipTest < ActiveSupport::TestCase
+      setup do
+        @manufacturer = create(:manufacturer, name: "Anvil Aerospace")
+        @model = create(:model,
+          name: "Carrack",
+          slug: "carrack",
+          manufacturer: @manufacturer,
+          classification: "explorer",
+          price: 4_500_000,
+          pledge_price: 600)
+      end
+
+      def call(name)
+        ::Discord::Commands::Ship.new(options: {"name" => name}).call
+      end
+
+      test "answers a single match with an embed" do
+        payload = call("Carrack")
+        embed = payload[:embeds].first
+
+        assert_equal "Carrack", embed[:title]
+        assert_includes embed[:url], "/ships/#{@model.slug}"
+        assert_equal "Anvil Aerospace", embed.dig(:footer, :text)
+      end
+
+      test "a single match is posted publicly rather than only to the caller" do
+        payload = call("Carrack")
+
+        assert_nil payload[:flags]
+      end
+
+      test "the embed carries the labels the site uses" do
+        fields = call("Carrack")[:embeds].first[:fields].to_h { |field| [field[:name], field[:value]] }
+
+        assert_equal "Explorer", fields[I18n.t("discord.commands.ship.fields.classification")]
+        assert_equal "3–4", fields[I18n.t("discord.commands.ship.fields.crew")]
+        assert_equal @model.pledge_price_label, fields[I18n.t("discord.commands.ship.fields.pledge_price")]
+        assert_equal @model.price_label, fields[I18n.t("discord.commands.ship.fields.price")]
+      end
+
+      test "an exact name wins over a longer partial match" do
+        create(:model, name: "Carrack Expedition", slug: "carrack-expedition", manufacturer: @manufacturer)
+
+        payload = call("Carrack")
+
+        assert_equal "Carrack", payload[:embeds].first[:title]
+      end
+
+      test "several partial matches are listed instead of guessed" do
+        create(:model, name: "Hornet F7C", slug: "hornet-f7c", manufacturer: @manufacturer)
+        create(:model, name: "Hornet F7A", slug: "hornet-f7a", manufacturer: @manufacturer)
+
+        payload = call("Hornet")
+
+        assert_nil payload[:embeds]
+        assert_includes payload[:content], "Hornet F7C"
+        assert_includes payload[:content], "Hornet F7A"
+      end
+
+      test "a listing is only shown to the caller" do
+        create(:model, name: "Hornet F7C", slug: "hornet-f7c", manufacturer: @manufacturer)
+        create(:model, name: "Hornet F7A", slug: "hornet-f7a", manufacturer: @manufacturer)
+
+        assert_equal ::Discord::Commands::Base::EPHEMERAL, call("Hornet")[:flags]
+      end
+
+      test "answers a miss with a message rather than an empty embed" do
+        payload = call("Nonexistent Ship")
+
+        assert_nil payload[:embeds]
+        assert_includes payload[:content], "Nonexistent Ship"
+      end
+
+      test "a blank name asks for one" do
+        payload = call("  ")
+
+        assert_equal I18n.t("discord.commands.ship.missing_query"), payload[:content]
+      end
+
+      # The public catalogue scope, so the bot cannot answer with models the
+      # website itself refuses to show.
+      test "does not answer with a hidden model" do
+        create(:model, name: "Secret Prototype", slug: "secret-prototype", hidden: true)
+
+        payload = call("Secret Prototype")
+
+        assert_nil payload[:embeds]
+      end
+
+      test "does not answer with an inactive model" do
+        create(:model, name: "Retired Hull", slug: "retired-hull", active: false)
+
+        payload = call("Retired Hull")
+
+        assert_nil payload[:embeds]
+      end
+
+      test "matches on the manufacturer slug the way the ship list does" do
+        payload = call(@manufacturer.slug)
+
+        assert payload[:embeds].present? || payload[:content].present?
+      end
+
+      test "answers in the locale the interaction carried" do
+        german = I18n.with_locale(:de) { call("Nonexistent Ship") }
+
+        assert_includes german[:content], "Kein Schiff"
+      end
+    end
+  end
+end

--- a/test/lib/discord/signature_verifier_test.rb
+++ b/test/lib/discord/signature_verifier_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/signature_verifier"
+
+module Discord
+  # Signs with a real Ed25519 keypair rather than stubbing the verifier: the
+  # whole point of this class is that a genuine Discord signature verifies and
+  # anything else does not, which a stub cannot demonstrate.
+  class SignatureVerifierTest < ActiveSupport::TestCase
+    setup do
+      @key = OpenSSL::PKey.generate_key("ED25519")
+      @public_key = @key.raw_public_key.unpack1("H*")
+      @body = {type: 1}.to_json
+      @timestamp = Time.current.to_i.to_s
+      @verifier = ::Discord::SignatureVerifier.new(public_key: @public_key)
+    end
+
+    def sign(body: @body, timestamp: @timestamp, key: @key)
+      key.sign(nil, "#{timestamp}#{body}").unpack1("H*")
+    end
+
+    test "accepts a signature made with the application's key" do
+      assert @verifier.valid?(signature: sign, timestamp: @timestamp, body: @body)
+    end
+
+    test "rejects a body that changed after signing" do
+      signature = sign
+
+      refute @verifier.valid?(signature: signature, timestamp: @timestamp, body: '{"type":2}')
+    end
+
+    test "rejects a signature made with a different key" do
+      signature = sign(key: OpenSSL::PKey.generate_key("ED25519"))
+
+      refute @verifier.valid?(signature: signature, timestamp: @timestamp, body: @body)
+    end
+
+    test "rejects a timestamp the signature does not cover" do
+      signature = sign
+
+      refute @verifier.valid?(signature: signature, timestamp: 1.minute.ago.to_i.to_s, body: @body)
+    end
+
+    test "rejects a signature older than the replay window" do
+      stale = (Time.current - ::Discord::SignatureVerifier::MAX_AGE - 1.minute).to_i.to_s
+
+      refute @verifier.valid?(signature: sign(timestamp: stale), timestamp: stale, body: @body)
+    end
+
+    test "rejects a timestamp far in the future" do
+      ahead = (Time.current + ::Discord::SignatureVerifier::MAX_AGE + 1.minute).to_i.to_s
+
+      refute @verifier.valid?(signature: sign(timestamp: ahead), timestamp: ahead, body: @body)
+    end
+
+    test "rejects a signature that is not hex" do
+      refute @verifier.valid?(signature: "not-a-signature", timestamp: @timestamp, body: @body)
+    end
+
+    test "rejects a signature of the wrong length" do
+      refute @verifier.valid?(signature: "abcd", timestamp: @timestamp, body: @body)
+    end
+
+    test "rejects a blank signature" do
+      refute @verifier.valid?(signature: nil, timestamp: @timestamp, body: @body)
+    end
+
+    test "rejects a non-numeric timestamp" do
+      refute @verifier.valid?(signature: sign, timestamp: "yesterday", body: @body)
+    end
+
+    test "rejects everything while no public key is configured" do
+      verifier = ::Discord::SignatureVerifier.new(public_key: nil)
+
+      refute verifier.valid?(signature: sign, timestamp: @timestamp, body: @body)
+    end
+  end
+end


### PR DESCRIPTION
> Stacked on #4623 — the base ref is `fix/discord-install-permissions`, not `main`. Review the four commits from `docs(discord)` onwards; the first commit belongs to the other PR.

Fleetyards' Discord presence only ever pushed: five webhook posters and a one-way event sync. Nobody in a server could ask it anything. This is the foundation that changes that, plus one command so the foundation is testable end to end.

`docs/exec-plans/discord-bot.md` plans the whole programme in six phases. Two findings from reading the tree shaped it:

- **`lib/discord/scheduled_event_rsvp_handler.rb` is complete and unreachable.** It maps a Discord user to a Fleetyards user, finds the `FleetEvent`, creates a slot-less `interested` signup and carefully refuses to downgrade a stronger commitment made on Fleetyards. Nothing calls it: it was written for `GUILD_SCHEDULED_EVENT_USER_ADD`, a **Gateway** event, and the only `discordrb` require in the tree is `discordrb/webhooks`. So "Interested" in Discord never arrives.
- **HTTP interactions cannot carry those events either.** Phase 3 therefore polls `GET /guilds/{id}/scheduled-events/{id}/users` from the existing sync rather than adding a Gateway process — which also survives restarts and missed windows, where a Gateway drops whatever happens while it is down.

## Why an HTTP endpoint and not a Gateway bot

Discord POSTs every interaction to an Interactions Endpoint URL, so slash commands are a route, a controller and a Sidekiq job — all patterns this repo has — instead of a long-running supervised process it has no pattern for under Kamal. What that gives up is Gateway-only events; only phase 3 wanted one, and it has another route.

Consequences that shaped the code:

- **Discord's 3 second deadline is hard and unrecoverable**, so no command runs inline. Every one is acknowledged with a deferred response and answered from the job. "Fast" locally still means a cold connection pool under load.
- The follow-up is authenticated by the interaction token in the URL, not the bot token, so it gets **its own client**: `ApiClient` refuses to run without a bot token, and that guard is worth keeping rather than relaxing.
- Command jobs get **their own Sidekiq queue, listed first** — it is the only queue with a user watching a spinner, and a loader burst on `notifications` would read as a bot that takes half a minute to answer.

## The security boundary

The endpoint is public, session-less and unauthenticated; the Ed25519 signature check is all there is.

- Verifies `request.raw_post`, because Rails' parsed and re-serialised params are a different byte sequence and would never match.
- `OpenSSL::PKey.new_raw_public_key` rather than the `ed25519` gem. The gem *is* in `Gemfile.lock`, but only as a transitive dependency of the SSH stack Kamal uses — a `bundle update` that drops it would silently take this boundary with it. OpenSSL 3.6 is already a hard requirement.
- Rejects timestamps outside a five minute window **in both directions**, so a captured request is not replayable forever and a far-future timestamp cannot buy itself a longer life.
- Unverified requests get a **401**, not a 200 with an error body: Discord probes a newly saved endpoint URL with a deliberately invalid signature and refuses the URL unless the probe is rejected.

Two placement decisions worth flagging in review:

- The route sits next to `/emails/inbound` in `config/routes.rb`, deliberately **outside** `:api_routes`. Everything under `api/v1` is public API surface with hand-written OpenAPI components; a Discord RPC endpoint whose body Discord defines must not reach the generated schema or the TS client. The integration test lives outside `test/integration/api/v1` for the same reason.
- The controller inherits `ActionController::Base`, **not** `ApplicationController` — the latter adds HTTP basic auth whenever `basic_auth.password` is set, which is how staging is protected, and Discord cannot supply those credentials. Every interaction would 401 there.

## `/ship`

Reuses the site's own matcher — the `search_cont` ransack alias over name, slug and manufacturer slug — so the bot and the ship list agree on what a name matches, and `Model.visible.active` so it cannot answer with models the website itself hides. An exact name wins over a longer partial match; an ambiguous one lists candidates instead of guessing.

Discord sends the invoking member's own client locale on every interaction, so answers render under `I18n.with_locale` and the copy is in all seven `discord.yml` files. `Discord::Locale` matches exactly first, so `zh-CN` and `zh-TW` stay distinct rather than both collapsing to `zh`.

Registration is a full replacement of the global command list, which makes `discord:commands:sync` idempotent. It stays a task rather than a deploy hook: the endpoint is rate-limited per day and definitions change far less often than deploys.

## Verified

- `bin/rails test test/lib/discord test/jobs/discord test/integration/discord_interactions_test.rb` — **94 runs, 157 assertions, 0 failures** (57 new; the pre-existing sync and RSVP tests still pass)
- `bundle exec standardrb` on every new file — clean
- `bin/rails zeitwerk:check` — clean
- `bin/feature-flags validate` — valid, 16 flags
- All seven locale files parse

The signature verifier is tested with a real Ed25519 keypair rather than a stubbed verifier: a genuine signature verifies, and a tampered body, a foreign key, a shifted timestamp, a stale one, a future one and malformed hex do not.

## To switch on after merge

1. `DISCORD__PUBLIC_KEY` in credentials — the endpoint rejects everything while it is blank
2. Interactions Endpoint URL in the portal → `https://fleetyards.net/discord/interactions`
3. `bin/rails discord:commands:sync`
4. Flag `discord_commands` in `/admin/features`

The flag gates dispatch only; PING always answers, so step 2 works before step 4.

## Not in this PR

Phases 2–6: the remaining read-only commands, the RSVP round trip, event reminders with slot counts, wishlist DMs, and fleet role sync. Phase 6 moves the install permissions again (Manage Roles, `1 << 28`) and will need existing servers to re-authorise, since Discord does not upgrade an existing grant.

Also noticed: `refs/heads/feature/discord-bot` on origin is an abandoned WIP branch from the Rails 6.1 era attempting the same thing. Left untouched — this branch is named `feature/discord-interactions` to avoid it.

🤖
