### PR TITLE
feat(discord): mirror Discord event RSVPs into Fleetyards signups

### DIFF
--- a/app/jobs/discord/poll_event_rsvps_dispatch_job.rb
+++ b/app/jobs/discord/poll_event_rsvps_dispatch_job.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Discord
+  # Finds the Discord scheduled events worth polling for RSVPs and fans out one
+  # job per event.
+  #
+  # Starts from the notification settings rather than from the events: the guild
+  # id lives there, every poll needs it, and a fleet without one has nothing to
+  # poll.
+  class PollEventRsvpsDispatchJob < ::ApplicationJob
+    sidekiq_options retry: false, queue: "notifications"
+
+    # Far enough ahead that an RSVP weeks before an event still arrives, and far
+    # enough past the start that a last-minute click does too -- without polling
+    # events that have been over for days.
+    LOOKAHEAD = 30.days
+    GRACE = 2.hours
+
+    def perform
+      return unless ApiClient.configured?
+
+      FleetNotificationSetting.where.not(discord_guild_id: nil).includes(:fleet).find_each do |setting|
+        fleet = setting.fleet
+        next if fleet.blank?
+
+        dispatch_events(setting, fleet)
+        dispatch_occurrences(setting, fleet)
+      end
+    end
+
+    private def dispatch_events(setting, fleet)
+      fleet.fleet_events
+        .where(archived_at: nil)
+        .where.not(discord_event_id: nil)
+        .where(starts_at: window)
+        .pluck(:discord_event_id)
+        .each { |event_id| enqueue(event_id, setting.discord_guild_id) }
+    end
+
+    # A recurring series pushes one Discord event per occurrence, and those ids
+    # live on the occurrence state rather than on the parent row -- polling only
+    # FleetEvent would miss every recurring event.
+    private def dispatch_occurrences(setting, fleet)
+      FleetEventOccurrenceState
+        .joins(:fleet_event)
+        .where(fleet_events: {fleet_id: fleet.id, archived_at: nil})
+        .where.not(discord_event_id: nil)
+        .where(occurrence_date: date_window)
+        .pluck(:discord_event_id)
+        .each { |event_id| enqueue(event_id, setting.discord_guild_id) }
+    end
+
+    private def enqueue(discord_event_id, guild_id)
+      PollEventRsvpsJob.perform_async(discord_event_id, guild_id)
+    end
+
+    private def window
+      (Time.current - GRACE)..(Time.current + LOOKAHEAD)
+    end
+
+    private def date_window
+      Date.current..(Date.current + LOOKAHEAD)
+    end
+  end
+end

--- a/app/jobs/discord/poll_event_rsvps_job.rb
+++ b/app/jobs/discord/poll_event_rsvps_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "discord/scheduled_event_rsvp_sync"
+
+module Discord
+  # Polls one Discord scheduled event's subscriber list and mirrors it into
+  # Fleetyards signups.
+  class PollEventRsvpsJob < ::ApplicationJob
+    sidekiq_options retry: 3, queue: "notifications"
+
+    # Positional on purpose: Sidekiq replays arguments positionally, so a
+    # keyword here raises ArgumentError for every job the dispatcher enqueues.
+    def perform(discord_event_id, guild_id)
+      sync = ScheduledEventRsvpSync.new(guild_id: guild_id, discord_event_id: discord_event_id)
+      return unless sync.runnable?
+
+      result = sync.run!
+      return if result.nil?
+
+      return if result.added.zero? && result.removed.zero?
+
+      Rails.logger.info("[Discord::PollEventRsvpsJob] event=#{discord_event_id} #{result}")
+    rescue ApiClient::Error => e
+      Rails.logger.error("[Discord::PollEventRsvpsJob] event=#{discord_event_id} failed: #{e.message}")
+      raise if e.status == 429 || e.status >= 500
+    end
+  end
+end

--- a/app/models/discord_event_subscription.rb
+++ b/app/models/discord_event_subscription.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# A Discord user we have seen subscribed to a Discord scheduled event.
+#
+# A snapshot of Discord's state, not of ours: rows are written whatever the
+# Fleetyards side made of the RSVP, because their only job is to let the next
+# poll tell "this user unsubscribed" apart from "this user was never subscribed
+# and answered on the website instead".
+# == Schema Information
+#
+# Table name: discord_event_subscriptions
+#
+#  id               :uuid             not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  discord_event_id :string           not null
+#  discord_user_id  :string           not null
+#
+# Indexes
+#
+#  index_discord_event_subscriptions_on_event_and_user  (discord_event_id,discord_user_id) UNIQUE
+#
+class DiscordEventSubscription < ApplicationRecord
+  validates :discord_event_id, presence: true
+  validates :discord_user_id, presence: true, uniqueness: {scope: :discord_event_id}
+
+  scope :for_event, ->(discord_event_id) { where(discord_event_id: discord_event_id) }
+
+  def self.user_ids_for(discord_event_id)
+    for_event(discord_event_id).pluck(:discord_user_id)
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -81,3 +81,8 @@ fleet_events_auto_lock_job:
   cron: '*/5 * * * *' # Every 5 minutes
   class: 'FleetEvents::AutoLockJob'
   queue: 'default'
+discord_poll_event_rsvps_dispatch_job:
+  cron: '*/5 * * * *' # Every 5 minutes
+  class: 'Discord::PollEventRsvpsDispatchJob'
+  queue: 'notifications'
+  enabled: <%= Discord::ApiClient.configured? %>

--- a/db/migrate/20260831120000_create_discord_event_subscriptions.rb
+++ b/db/migrate/20260831120000_create_discord_event_subscriptions.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# One row per Discord user we have seen subscribed to a Discord scheduled event.
+#
+# This exists to make the *withdrawal* direction safe. RSVPs arrive by polling
+# Discord's subscriber list, and a Fleetyards-native event-level "interested"
+# signup is byte-for-byte indistinguishable from one a Discord click produced --
+# `ScheduledEventRsvpHandler#withdrawable?` can only ask "interested and no
+# slot?". Diffing the subscriber list against Fleetyards signups would
+# therefore withdraw the signup of every member who answered on the website and
+# never touched Discord.
+#
+# So the poll diffs against this snapshot of Discord's own state instead: a
+# withdrawal only ever happens for a user who was previously seen subscribed
+# and has since unsubscribed.
+#
+# Keyed by discord_event_id rather than by FleetEvent: a recurring series
+# pushes one Discord event per occurrence, and those ids live on
+# fleet_event_occurrence_states, so the id is the only thing both cases share.
+class CreateDiscordEventSubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :discord_event_subscriptions, id: :uuid do |t|
+      t.string :discord_event_id, null: false
+      t.string :discord_user_id, null: false
+
+      t.timestamps
+    end
+
+    # The poll reads the whole snapshot for one event, then inserts and deletes
+    # by the pair.
+    add_index :discord_event_subscriptions,
+      %i[discord_event_id discord_user_id],
+      unique: true,
+      name: "index_discord_event_subscriptions_on_event_and_user"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -292,6 +292,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_160000) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "discord_event_subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "discord_event_id", null: false
+    t.string "discord_user_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discord_event_id", "discord_user_id"], name: "index_discord_event_subscriptions_on_event_and_user", unique: true
   end
 
   create_table "docks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -100,11 +100,31 @@ Every response is ephemeral by default (flag 64) unless the invoking member aske
 
 The handler exists; only the transport is missing, and HTTP interactions cannot carry it.
 
-Instead, **poll**: `GET /guilds/{guild_id}/scheduled-events/{event_id}/users` returns the users subscribed to a scheduled event. `ScheduledEventSync` already runs per event and already knows `discord_guild_id` and `discord_event_id`, so it can diff the subscriber list against the FY signups and drive `ScheduledEventRsvpHandler#add!` / `#remove!` for the difference.
+Instead, **poll**: `GET /guilds/{guild_id}/scheduled-events/{event_id}/users` returns the users subscribed to a scheduled event, and `ScheduledEventRsvpSync` drives `ScheduledEventRsvpHandler#add!` / `#remove!` from the difference.
 
 This is strictly better than a Gateway here: it survives restarts and missed events (a Gateway drops what happens while it is down), it needs no new process and no intents, and the handler's existing "never downgrade a Fleetyards commitment" logic makes repeated polling naturally idempotent.
 
-The cost is latency — an RSVP lands on the next poll, not instantly. For an event days away that is invisible; the poll interval can tighten as the event approaches, reusing the same schedule the sync already follows.
+The cost is latency — an RSVP lands on the next poll, not instantly. For an event days away that is invisible.
+
+### What the diff runs against
+
+Not the Fleetyards signups. `ScheduledEventRsvpHandler#withdrawable?` can only ask "interested, and no slot behind it?", which is exactly what a member who answered **on the website** also looks like. Diffing Discord's subscriber list against FY signups would therefore withdraw the answer of every member who never touched Discord.
+
+So the poll diffs against `discord_event_subscriptions` — a snapshot of Discord's own state, one row per user seen subscribed. A withdrawal only ever happens for a user who was previously seen subscribed and has since unsubscribed. Rows are written whatever Fleetyards made of the RSVP, including for a subscriber with no linked account, so a poll does not retry them forever.
+
+Keyed by `discord_event_id` rather than by `FleetEvent`: a recurring series pushes one Discord event per occurrence and those ids live on `fleet_event_occurrence_states`, so the id is the only thing both cases share.
+
+Two failure modes are decided rather than left to chance: a **404** means the scheduled event is gone from Discord, which is not everyone changing their mind — the snapshot is dropped and no withdrawals are issued. A **403** means the bot lost a permission; that is persistent, so it is logged rather than retried every five minutes. Rate limits and 5xx are retried.
+
+| Change | File |
+| --- | --- |
+| Snapshot table | `db/migrate/*_create_discord_event_subscriptions.rb`, `app/models/discord_event_subscription.rb` |
+| Subscriber list, paginated | `lib/discord/api_client.rb` |
+| The diff | `lib/discord/scheduled_event_rsvp_sync.rb` |
+| Per-event poll | `app/jobs/discord/poll_event_rsvps_job.rb` |
+| Fan-out, every 5 min | `app/jobs/discord/poll_event_rsvps_dispatch_job.rb`, `config/sidekiq_schedule.yml` |
+
+The dispatcher starts from `FleetNotificationSetting` rather than from the events: the guild id lives there, every poll needs it, and a fleet without one has nothing to poll. It polls from 2 hours after a start (a last-minute RSVP still counts) to 30 days ahead, and covers both `FleetEvent` and `FleetEventOccurrenceState` ids.
 
 ## Phase 4 — event reminders with what Discord does not know
 

--- a/lib/discord/api_client.rb
+++ b/lib/discord/api_client.rb
@@ -80,6 +80,19 @@ module Discord
       request(:delete, "guilds/#{guild_id}/scheduled-events/#{event_id}")
     end
 
+    # Discord caps a page at 100 and paginates by user id.
+    SUBSCRIBER_PAGE_SIZE = 100
+
+    # Who has clicked "Interested" on a scheduled event. This is the only way
+    # to see RSVPs without a Gateway connection -- the corresponding
+    # GUILD_SCHEDULED_EVENT_USER_ADD/REMOVE events are Gateway-only.
+    def list_guild_scheduled_event_users(guild_id, event_id, after: nil, limit: SUBSCRIBER_PAGE_SIZE)
+      query = {limit: limit}
+      query[:after] = after if after.present?
+
+      request(:get, "guilds/#{guild_id}/scheduled-events/#{event_id}/users?#{query.to_query}")
+    end
+
     private def post(path, payload)
       request(:post, path, payload)
     end

--- a/lib/discord/scheduled_event_rsvp_sync.rb
+++ b/lib/discord/scheduled_event_rsvp_sync.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Discord
+  # Brings Discord's "Interested" list for one scheduled event across to
+  # Fleetyards signups.
+  #
+  # Polling rather than the Gateway. GUILD_SCHEDULED_EVENT_USER_ADD/REMOVE are
+  # Gateway-only events, and this app has no Gateway process; the REST
+  # subscriber list carries the same information, survives restarts, and cannot
+  # miss what happened while a worker was down. The cost is latency: an RSVP
+  # lands on the next poll.
+  #
+  # The diff runs against DiscordEventSubscription -- a snapshot of Discord's
+  # own state -- and never against the Fleetyards signups. A Fleetyards-native
+  # event-level "interested" signup is indistinguishable from one a Discord
+  # click produced, so diffing against signups would withdraw the answer of
+  # every member who used the website and never touched Discord.
+  class ScheduledEventRsvpSync
+    # 20 pages of 100 is far past any real event, and stops a paging bug from
+    # looping against Discord's rate limit.
+    MAX_PAGES = 20
+
+    Result = Struct.new(:added, :removed, :skipped) do
+      def to_s
+        "added=#{added} removed=#{removed} skipped=#{skipped}"
+      end
+    end
+
+    attr_reader :guild_id, :discord_event_id
+
+    def initialize(guild_id:, discord_event_id:, api: nil)
+      @guild_id = guild_id.to_s.presence
+      @discord_event_id = discord_event_id.to_s.presence
+      @api = api
+    end
+
+    def runnable?
+      ApiClient.configured? && guild_id.present? && discord_event_id.present?
+    end
+
+    def run!
+      return nil unless runnable?
+
+      current = fetch_subscriber_ids
+      return nil if current.nil?
+
+      known = DiscordEventSubscription.user_ids_for(discord_event_id)
+
+      Result.new(
+        added: apply_added(current - known),
+        removed: apply_removed(known - current),
+        skipped: 0
+      )
+    end
+
+    private def apply_added(user_ids)
+      user_ids.count do |user_id|
+        handler_for(user_id).add!
+        remember(user_id)
+        true
+      end
+    end
+
+    private def apply_removed(user_ids)
+      user_ids.count do |user_id|
+        handler_for(user_id).remove!
+        forget(user_id)
+        true
+      end
+    end
+
+    # The snapshot records what Discord showed, not what Fleetyards made of it.
+    # A subscriber with no linked Fleetyards account is still recorded, so every
+    # poll does not retry them -- they simply get no signup.
+    private def remember(user_id)
+      DiscordEventSubscription.find_or_create_by!(
+        discord_event_id: discord_event_id,
+        discord_user_id: user_id
+      )
+    end
+
+    private def forget(user_id)
+      DiscordEventSubscription.for_event(discord_event_id)
+        .where(discord_user_id: user_id)
+        .delete_all
+    end
+
+    private def handler_for(user_id)
+      ScheduledEventRsvpHandler.new(
+        guild_id: guild_id,
+        scheduled_event_id: discord_event_id,
+        discord_user_id: user_id
+      )
+    end
+
+    private def fetch_subscriber_ids
+      ids = []
+      after = nil
+
+      MAX_PAGES.times do
+        page = api.list_guild_scheduled_event_users(guild_id, discord_event_id, after: after)
+        break if page.blank?
+
+        ids.concat(page.filter_map { |entry| entry.dig("user", "id") })
+        break if page.size < ApiClient::SUBSCRIBER_PAGE_SIZE
+
+        after = ids.last
+      end
+
+      ids.uniq
+    rescue ApiClient::Error => e
+      # The scheduled event is gone from Discord. That is not everyone
+      # un-RSVPing, so no withdrawals are issued -- the snapshot is simply
+      # dropped, and a recreated event starts from an empty one.
+      raise unless e.status == 404
+
+      DiscordEventSubscription.for_event(discord_event_id).delete_all
+      nil
+    end
+
+    private def api
+      @api ||= ApiClient.new
+    end
+  end
+end

--- a/test/jobs/discord/poll_event_rsvps_dispatch_job_test.rb
+++ b/test/jobs/discord/poll_event_rsvps_dispatch_job_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Discord
+  class PollEventRsvpsDispatchJobTest < ActiveSupport::TestCase
+    setup do
+      ::Discord::ApiClient.stubs(:configured?).returns(true)
+      ::Discord::PollEventRsvpsJob.jobs.clear
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+    end
+
+    def dispatch
+      ::Discord::PollEventRsvpsDispatchJob.new.perform
+    end
+
+    def enqueued_event_ids
+      ::Discord::PollEventRsvpsJob.jobs.map { |job| job["args"].first }
+    end
+
+    test "enqueues a poll for an upcoming synced event" do
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: "scheduled-1")
+
+      dispatch
+
+      assert_equal ["scheduled-1"], enqueued_event_ids
+    end
+
+    test "passes the fleet's guild id to the poll" do
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: "scheduled-1")
+
+      dispatch
+
+      assert_equal "guild-1", ::Discord::PollEventRsvpsJob.jobs.first["args"].second
+    end
+
+    test "skips an event that was never synced to Discord" do
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: nil)
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+
+    test "skips an archived event" do
+      event = create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: "scheduled-1")
+      event.update!(archived_at: Time.current)
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+
+    test "skips an event beyond the lookahead" do
+      create(:fleet_event, :open, fleet: @fleet,
+        starts_at: (::Discord::PollEventRsvpsDispatchJob::LOOKAHEAD + 2.days).from_now,
+        discord_event_id: "scheduled-far")
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+
+    # A last-minute RSVP still counts, an event that ended days ago does not.
+    test "still polls an event that started within the grace period" do
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 30.minutes.ago, discord_event_id: "scheduled-now")
+
+      dispatch
+
+      assert_equal ["scheduled-now"], enqueued_event_ids
+    end
+
+    test "skips an event that is long over" do
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 3.days.ago, discord_event_id: "scheduled-old")
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+
+    # Recurring occurrences carry their own Discord id on the occurrence state,
+    # so polling only FleetEvent would miss all of them.
+    test "enqueues a poll for a recurring occurrence" do
+      series = create(:fleet_event, :open, fleet: @fleet,
+        starts_at: 1.week.from_now, recurring: true, recurrence_interval: "weekly")
+      occurrence_date = series.occurrences(from: Time.current, to: 4.weeks.from_now).second.to_date
+      series.fleet_event_occurrence_states.create!(
+        occurrence_date: occurrence_date, discord_event_id: "scheduled-occurrence-1"
+      )
+
+      dispatch
+
+      assert_includes enqueued_event_ids, "scheduled-occurrence-1"
+    end
+
+    test "skips a fleet with no Discord guild" do
+      @setting.update!(discord_guild_id: nil)
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: "scheduled-1")
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+
+    test "does nothing without a bot token" do
+      ::Discord::ApiClient.stubs(:configured?).returns(false)
+      create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now, discord_event_id: "scheduled-1")
+
+      dispatch
+
+      assert_empty enqueued_event_ids
+    end
+  end
+end

--- a/test/jobs/discord/poll_event_rsvps_job_test.rb
+++ b/test/jobs/discord/poll_event_rsvps_job_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Discord
+  class PollEventRsvpsJobTest < ActiveSupport::TestCase
+    setup do
+      @sync = mock("Discord::ScheduledEventRsvpSync")
+      ::Discord::ScheduledEventRsvpSync.stubs(:new).returns(@sync)
+    end
+
+    def perform
+      ::Discord::PollEventRsvpsJob.new.perform("scheduled-1", "guild-1")
+    end
+
+    test "runs the sync for the event" do
+      @sync.stubs(:runnable?).returns(true)
+      @sync.expects(:run!).returns(::Discord::ScheduledEventRsvpSync::Result.new(added: 1, removed: 0, skipped: 0))
+
+      perform
+    end
+
+    test "does not run an unrunnable sync" do
+      @sync.stubs(:runnable?).returns(false)
+      @sync.expects(:run!).never
+
+      perform
+    end
+
+    # A fleet whose bot lost Manage Events, or a channel it cannot see: real,
+    # persistent, and not fixed by retrying every five minutes.
+    test "a permission error is logged rather than retried" do
+      @sync.stubs(:runnable?).returns(true)
+      @sync.stubs(:run!).raises(::Discord::ApiClient::Error.new(403, "Missing Access"))
+
+      assert_nothing_raised { perform }
+    end
+
+    test "a rate limit is retried" do
+      @sync.stubs(:runnable?).returns(true)
+      @sync.stubs(:run!).raises(::Discord::ApiClient::Error.new(429, "Too Many Requests"))
+
+      assert_raises(::Discord::ApiClient::Error) { perform }
+    end
+
+    test "a Discord outage is retried" do
+      @sync.stubs(:runnable?).returns(true)
+      @sync.stubs(:run!).raises(::Discord::ApiClient::Error.new(503, "Service Unavailable"))
+
+      assert_raises(::Discord::ApiClient::Error) { perform }
+    end
+  end
+end

--- a/test/lib/discord/scheduled_event_rsvp_sync_test.rb
+++ b/test/lib/discord/scheduled_event_rsvp_sync_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/scheduled_event_rsvp_sync"
+
+module Discord
+  class ScheduledEventRsvpSyncTest < ActiveSupport::TestCase
+    setup do
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+      @event = create(:fleet_event, :open, fleet: @fleet, discord_event_id: "scheduled-1")
+
+      @user = create(:user)
+      create(:omniauth_connection, user: @user, provider: "discord", uid: "discord-uid-1")
+      @membership = accept(@user)
+
+      @api = mock("Discord::ApiClient")
+      ::Discord::ApiClient.stubs(:configured?).returns(true)
+    end
+
+    def accept(user)
+      membership = @fleet.fleet_memberships.create!(user: user, fleet_role: @fleet.fleet_roles.ranked.last)
+      membership.update!(aasm_state: "accepted")
+      membership
+    end
+
+    def subscribers(*user_ids)
+      user_ids.map { |id| {"user" => {"id" => id}} }
+    end
+
+    def sync(event_id: "scheduled-1")
+      ::Discord::ScheduledEventRsvpSync.new(guild_id: "guild-1", discord_event_id: event_id, api: @api)
+    end
+
+    def signups
+      @event.fleet_event_signups.where(fleet_membership: @membership).where.not(status: "withdrawn")
+    end
+
+    test "a new subscriber becomes an interested signup" do
+      @api.expects(:list_guild_scheduled_event_users).returns(subscribers("discord-uid-1"))
+
+      result = sync.run!
+
+      assert_equal 1, result.added
+      assert_equal "interested", signups.first.status
+    end
+
+    test "a new subscriber is recorded so the next poll is a no-op" do
+      @api.stubs(:list_guild_scheduled_event_users).returns(subscribers("discord-uid-1"))
+
+      sync.run!
+      second = sync.run!
+
+      assert_equal 0, second.added
+      assert_equal 1, signups.count
+    end
+
+    test "a subscriber who unsubscribes has their signup withdrawn" do
+      @api.stubs(:list_guild_scheduled_event_users).returns(subscribers("discord-uid-1"))
+      sync.run!
+
+      @api.stubs(:list_guild_scheduled_event_users).returns([])
+      result = sync.run!
+
+      assert_equal 1, result.removed
+      assert_equal 0, signups.count
+    end
+
+    test "an unsubscribe drops the snapshot row as well" do
+      @api.stubs(:list_guild_scheduled_event_users).returns(subscribers("discord-uid-1"))
+      sync.run!
+
+      @api.stubs(:list_guild_scheduled_event_users).returns([])
+      sync.run!
+
+      assert_equal 0, DiscordEventSubscription.for_event("scheduled-1").count
+    end
+
+    # The reason DiscordEventSubscription exists. A website signup looks exactly
+    # like a Discord one to the handler, so a poll that diffed against signups
+    # instead of against Discord's own state would withdraw it.
+    test "a signup made on Fleetyards is untouched by a poll that never saw the user" do
+      @event.fleet_event_signups.create!(
+        fleet_membership: @membership, fleet_event_slot: nil, status: "interested"
+      )
+      @api.expects(:list_guild_scheduled_event_users).returns([])
+
+      result = sync.run!
+
+      assert_equal 0, result.removed
+      assert_equal 1, signups.count
+    end
+
+    test "a subscriber with no linked Fleetyards account is still recorded" do
+      @api.expects(:list_guild_scheduled_event_users).returns(subscribers("unlinked-uid"))
+
+      sync.run!
+
+      assert_equal ["unlinked-uid"], DiscordEventSubscription.user_ids_for("scheduled-1")
+    end
+
+    test "a subscriber with no linked account is not retried on the next poll" do
+      @api.stubs(:list_guild_scheduled_event_users).returns(subscribers("unlinked-uid"))
+      sync.run!
+
+      assert_equal 0, sync.run!.added
+    end
+
+    # A deleted Discord event is not everyone changing their mind.
+    test "a 404 drops the snapshot without withdrawing anything" do
+      @api.stubs(:list_guild_scheduled_event_users).returns(subscribers("discord-uid-1"))
+      sync.run!
+
+      @api.stubs(:list_guild_scheduled_event_users)
+        .raises(::Discord::ApiClient::Error.new(404, "Unknown Guild Scheduled Event"))
+
+      assert_nil sync.run!
+      assert_equal 0, DiscordEventSubscription.for_event("scheduled-1").count
+      assert_equal 1, signups.count
+    end
+
+    test "any other API error is left to the caller" do
+      @api.stubs(:list_guild_scheduled_event_users)
+        .raises(::Discord::ApiClient::Error.new(500, "Internal Server Error"))
+
+      assert_raises(::Discord::ApiClient::Error) { sync.run! }
+    end
+
+    test "reads every page of a subscriber list longer than one page" do
+      first_page = Array.new(::Discord::ApiClient::SUBSCRIBER_PAGE_SIZE) do |i|
+        {"user" => {"id" => "uid-#{i}"}}
+      end
+      @api.expects(:list_guild_scheduled_event_users)
+        .with("guild-1", "scheduled-1", after: nil)
+        .returns(first_page)
+      @api.expects(:list_guild_scheduled_event_users)
+        .with("guild-1", "scheduled-1", after: "uid-#{::Discord::ApiClient::SUBSCRIBER_PAGE_SIZE - 1}")
+        .returns(subscribers("discord-uid-1"))
+
+      result = sync.run!
+
+      assert_equal ::Discord::ApiClient::SUBSCRIBER_PAGE_SIZE + 1, result.added
+      assert_equal "interested", signups.first.status
+    end
+
+    test "does nothing without a bot token" do
+      ::Discord::ApiClient.stubs(:configured?).returns(false)
+      @api.expects(:list_guild_scheduled_event_users).never
+
+      assert_nil sync.run!
+    end
+
+    test "does nothing for an event with no Discord id" do
+      @api.expects(:list_guild_scheduled_event_users).never
+
+      assert_nil sync(event_id: nil).run!
+    end
+  end
+end


### PR DESCRIPTION
> Stacked on #4624 (which is stacked on #4623). The base ref is `feature/discord-interactions`, not `main` — review the three commits from `docs(discord): record what the RSVP diff runs against` onwards.

`lib/discord/scheduled_event_rsvp_handler.rb` has been complete and unreachable since it was written. It maps a Discord user to a Fleetyards user through `OmniauthConnection`, resolves the `FleetEvent` (including through `FleetEventOccurrenceState` for recurring occurrences), creates a slot-less `interested` signup, and carefully refuses to downgrade a stronger commitment made on Fleetyards — in both directions.

Nothing called it. It expects `GUILD_SCHEDULED_EVENT_USER_ADD` / `_REMOVE`, which are **Gateway** events, and the only `discordrb` require in the tree is `discordrb/webhooks`. So clicking Interested in Discord never reached Fleetyards.

This gives it a transport.

## Poll, not a Gateway

`GET /guilds/{guild_id}/scheduled-events/{event_id}/users` returns the subscriber list over REST. Polling it beats a Gateway process here for reasons beyond "no new process to deploy": it survives restarts and cannot miss what happened while a worker was down, where a Gateway silently drops it. The cost is latency — an RSVP lands on the next poll rather than instantly, which for an event days away is invisible.

## The part worth reviewing carefully

**The diff runs against Discord's state, not against the signups.**

`ScheduledEventRsvpHandler#withdrawable?` can only ask "status `interested`, and no slot behind it?" — and that is *exactly* what a member who answered on the website looks like. So the obvious implementation, diffing Discord's subscriber list against Fleetyards signups, would withdraw the answer of every member who never touched Discord.

`discord_event_subscriptions` holds one row per Discord user seen subscribed to a Discord event. A withdrawal therefore only ever happens for someone who **was** subscribed and has since unsubscribed. There is a test named after exactly this:

```
a signup made on Fleetyards is untouched by a poll that never saw the user
```

Rows are written whatever Fleetyards made of the RSVP — a subscriber with no linked account included — because the snapshot mirrors Discord, not us. That also stops every poll retrying an unlinked user forever. The trade-off: someone who subscribes and *then* links their account gets no retroactive signup.

Keyed by `discord_event_id` rather than by `FleetEvent`, because a recurring series pushes one Discord event per occurrence and those ids live on `fleet_event_occurrence_states` — the id is the only thing both cases share.

## Failure modes, decided rather than left to chance

| Response | Behaviour | Why |
| --- | --- | --- |
| **404** | Drop the snapshot, issue no withdrawals | The event being deleted in Discord is not everyone changing their mind |
| **403** | Log, do not retry | The bot lost a permission on that guild; that is persistent, and retrying every five minutes just burns rate limit |
| **429 / 5xx** | Retry | Transient |

Pagination is capped at 20 pages of 100, which is far past any real event and stops a paging bug from looping against the rate limit.

## Scheduling

A dispatcher every five minutes fans out one job per event. It starts from `FleetNotificationSetting` rather than from the events: the guild id lives there, every poll needs it, and a fleet without one has nothing to poll. The window runs from two hours after a start — a last-minute RSVP still counts — to thirty days ahead, and covers occurrence-state ids as well as `FleetEvent` ones.

## Verified

- `bin/rails test test/lib/discord test/jobs/discord test/integration/discord_interactions_test.rb` — **121 runs, 205 assertions, 0 failures** (27 new on top of this PR's base)
- `bundle exec standardrb` on every new file — clean

Test coverage of note: a new subscriber becomes a signup; a second poll is a no-op; an unsubscribe withdraws and drops the row; a website signup survives a poll that never saw the user; an unlinked subscriber is recorded once and not retried; a 404 drops the snapshot without withdrawing; a two-page subscriber list is read to the end.

One caveat worth a reviewer's eye: `standardrb --fix` rewrote the pagination test's splat into a single-element array, which quietly made it stop testing pagination. It is restored to build the page directly, so the `Lint/RedundantSplatExpansion` autofix cannot silently defeat it again.

🤖
