### PR TITLE
feat(discord): add /loaner, /compare, /hangar and /fleet

### DIFF
--- a/app/models/fleet_notification_setting.rb
+++ b/app/models/fleet_notification_setting.rb
@@ -15,7 +15,8 @@
 #
 # Indexes
 #
-#  index_fleet_notification_settings_on_fleet_id  (fleet_id) UNIQUE
+#  index_fleet_notification_settings_on_discord_guild_id  (discord_guild_id)
+#  index_fleet_notification_settings_on_fleet_id          (fleet_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -4,10 +4,33 @@ de:
     commands:
       disabled: Fleetyards-Befehle sind noch nicht verfügbar.
       failed: Beim Abrufen ist etwas schiefgelaufen. Bitte versuche es erneut.
+      compare:
+        missing_query: Bitte nenne zwei Schiffe.
+        same_ship: 'Das ist zweimal dasselbe Schiff: %{ship}.'
+        title: '%{first} vs. %{second}'
+      fleet:
+        fields:
+          members: Mitglieder
+          models: Schiffstypen
+          ships: Schiffe
+          upcoming_events: Kommende Events
+        not_allowed: '%{fleet} hat seine Seite nicht öffentlich gemacht.'
+        not_bound: Dieser Server ist mit keiner Flotte auf Fleetyards verknüpft.
+      hangar:
+        empty: '%{username} hat keine Schiffe im öffentlichen Hangar.'
+        heading: '[Hangar von %{username}](%{url}) — %{count} Schiffe, %{models} Typen'
+        missing_query: Bitte gib einen Benutzernamen an.
+        more: '…und %{count} weitere.'
+        not_available: 'Kein öffentlicher Hangar für „%{username}“.'
+      loaner:
+        heading: '[%{ship}](%{url}) kommt mit %{count} Leihschiff(en):'
+        missing_query: Bitte gib einen Schiffsnamen an.
+        none: 'Für %{ship} gibt es keine Leihschiffe.'
       ship:
         ambiguous: '%{count} Schiffe passen zu „%{query}“:'
         fields:
           classification: Klassifizierung
+          cargo: Frachtraum
           crew: Besatzung
           dimensions: Maße
           pledge_price: Pledge-Preis

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -4,10 +4,33 @@ en:
     commands:
       disabled: Fleetyards commands are not available yet.
       failed: Something went wrong while looking that up. Please try again.
+      compare:
+        missing_query: Please name two ships.
+        same_ship: 'That is the same ship twice: %{ship}.'
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: Members
+          models: Ship types
+          ships: Ships
+          upcoming_events: Upcoming events
+        not_allowed: '%{fleet} has not made its page public.'
+        not_bound: This server is not linked to a fleet on Fleetyards.
+      hangar:
+        empty: '%{username} has no ships in their public hangar.'
+        heading: '[%{username}''s hangar](%{url}) — %{count} ships, %{models} types'
+        missing_query: Please provide a username.
+        more: '…and %{count} more.'
+        not_available: 'No public hangar for "%{username}".'
+      loaner:
+        heading: '[%{ship}](%{url}) comes with %{count} loaner(s):'
+        missing_query: Please provide a ship name.
+        none: '%{ship} has no loaners.'
       ship:
         ambiguous: '%{count} ships match "%{query}":'
         fields:
           classification: Classification
+          cargo: Cargo
           crew: Crew
           dimensions: Dimensions
           pledge_price: Pledge Price

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -4,10 +4,33 @@ es:
     commands:
       disabled: Los comandos de Fleetyards aún no están disponibles.
       failed: Algo ha fallado durante la búsqueda. Inténtalo de nuevo.
+      compare:
+        missing_query: Indica dos naves.
+        same_ship: 'Es la misma nave dos veces: %{ship}.'
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: Miembros
+          models: Tipos de nave
+          ships: Naves
+          upcoming_events: Próximos eventos
+        not_allowed: '%{fleet} no ha hecho pública su página.'
+        not_bound: Este servidor no está vinculado a ninguna flota en Fleetyards.
+      hangar:
+        empty: '%{username} no tiene naves en su hangar público.'
+        heading: '[Hangar de %{username}](%{url}) — %{count} naves, %{models} tipos'
+        missing_query: Indica un nombre de usuario.
+        more: '…y %{count} más.'
+        not_available: 'No hay hangar público para «%{username}».'
+      loaner:
+        heading: '[%{ship}](%{url}) incluye %{count} nave(s) de préstamo:'
+        missing_query: Indica el nombre de una nave.
+        none: '%{ship} no tiene naves de préstamo.'
       ship:
         ambiguous: '%{count} naves coinciden con «%{query}»:'
         fields:
           classification: Clasificación
+          cargo: Carga
           crew: Tripulación
           dimensions: Dimensiones
           pledge_price: Precio de pledge

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -4,10 +4,33 @@ fr:
     commands:
       disabled: Les commandes Fleetyards ne sont pas encore disponibles.
       failed: "Une erreur est survenue lors de la recherche. Merci de réessayer."
+      compare:
+        missing_query: Merci d'indiquer deux vaisseaux.
+        same_ship: "C'est deux fois le même vaisseau : %{ship}."
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: Membres
+          models: Types de vaisseau
+          ships: Vaisseaux
+          upcoming_events: Événements à venir
+        not_allowed: "%{fleet} n'a pas rendu sa page publique."
+        not_bound: "Ce serveur n'est lié à aucune flotte sur Fleetyards."
+      hangar:
+        empty: "%{username} n'a aucun vaisseau dans son hangar public."
+        heading: '[Hangar de %{username}](%{url}) — %{count} vaisseaux, %{models} types'
+        missing_query: Merci d'indiquer un nom d'utilisateur.
+        more: '…et %{count} de plus.'
+        not_available: 'Aucun hangar public pour « %{username} ».'
+      loaner:
+        heading: '[%{ship}](%{url}) donne accès à %{count} vaisseau(x) de prêt :'
+        missing_query: Merci d'indiquer le nom d'un vaisseau.
+        none: '%{ship} ne donne accès à aucun vaisseau de prêt.'
       ship:
         ambiguous: '%{count} vaisseaux correspondent à « %{query} » :'
         fields:
           classification: Classification
+          cargo: Fret
           crew: Équipage
           dimensions: Dimensions
           pledge_price: Prix pledge

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -4,10 +4,33 @@ it:
     commands:
       disabled: I comandi Fleetyards non sono ancora disponibili.
       failed: Qualcosa è andato storto durante la ricerca. Riprova.
+      compare:
+        missing_query: Indica due navi.
+        same_ship: 'È la stessa nave due volte: %{ship}.'
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: Membri
+          models: Tipi di nave
+          ships: Navi
+          upcoming_events: Prossimi eventi
+        not_allowed: '%{fleet} non ha reso pubblica la propria pagina.'
+        not_bound: Questo server non è collegato a nessuna flotta su Fleetyards.
+      hangar:
+        empty: '%{username} non ha navi nell''hangar pubblico.'
+        heading: '[Hangar di %{username}](%{url}) — %{count} navi, %{models} tipi'
+        missing_query: Indica un nome utente.
+        more: '…e altre %{count}.'
+        not_available: 'Nessun hangar pubblico per «%{username}».'
+      loaner:
+        heading: '[%{ship}](%{url}) include %{count} nave(i) in prestito:'
+        missing_query: Indica il nome di una nave.
+        none: '%{ship} non ha navi in prestito.'
       ship:
         ambiguous: '%{count} navi corrispondono a «%{query}»:'
         fields:
           classification: Classificazione
+          cargo: Carico
           crew: Equipaggio
           dimensions: Misure
           pledge_price: Prezzo pledge

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -4,10 +4,33 @@ zh-CN:
     commands:
       disabled: Fleetyards 命令尚不可用。
       failed: 查询时出错，请重试。
+      compare:
+        missing_query: 请提供两艘飞船。
+        same_ship: '这是同一艘飞船：%{ship}。'
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: 成员
+          models: 飞船类型
+          ships: 飞船
+          upcoming_events: 即将开始的活动
+        not_allowed: '%{fleet} 未公开其页面。'
+        not_bound: 此服务器尚未与 Fleetyards 上的舰队关联。
+      hangar:
+        empty: '%{username} 的公开机库中没有飞船。'
+        heading: '[%{username} 的机库](%{url}) — %{count} 艘飞船，%{models} 种类型'
+        missing_query: 请提供用户名。
+        more: '…还有 %{count} 艘。'
+        not_available: '未找到“%{username}”的公开机库。'
+      loaner:
+        heading: '[%{ship}](%{url}) 附带 %{count} 艘替代飞船：'
+        missing_query: 请提供飞船名称。
+        none: '%{ship} 没有替代飞船。'
       ship:
         ambiguous: '有 %{count} 艘飞船匹配“%{query}”：'
         fields:
           classification: 分类
+          cargo: 货舱
           crew: 船员
           dimensions: 尺寸
           pledge_price: 众筹价格

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -4,10 +4,33 @@ zh-TW:
     commands:
       disabled: Fleetyards 指令尚未開放。
       failed: 查詢時發生錯誤，請重試。
+      compare:
+        missing_query: 請提供兩艘船艦。
+        same_ship: '這是同一艘船艦：%{ship}。'
+        title: '%{first} vs %{second}'
+      fleet:
+        fields:
+          members: 成員
+          models: 船艦類型
+          ships: 船艦
+          upcoming_events: 即將開始的活動
+        not_allowed: '%{fleet} 未公開其頁面。'
+        not_bound: 此伺服器尚未與 Fleetyards 上的艦隊連結。
+      hangar:
+        empty: '%{username} 的公開機庫中沒有船艦。'
+        heading: '[%{username} 的機庫](%{url}) — %{count} 艘船艦，%{models} 種類型'
+        missing_query: 請提供使用者名稱。
+        more: '…還有 %{count} 艘。'
+        not_available: '找不到「%{username}」的公開機庫。'
+      loaner:
+        heading: '[%{ship}](%{url}) 附帶 %{count} 艘替代船艦：'
+        missing_query: 請提供船艦名稱。
+        none: '%{ship} 沒有替代船艦。'
       ship:
         ambiguous: '有 %{count} 艘船艦符合「%{query}」：'
         fields:
           classification: 分類
+          cargo: 貨艙
           crew: 船員
           dimensions: 尺寸
           pledge_price: 眾籌價格

--- a/db/migrate/20260831140000_add_index_to_fleet_notification_settings_discord_guild_id.rb
+++ b/db/migrate/20260831140000_add_index_to_fleet_notification_settings_discord_guild_id.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# /fleet resolves the fleet from the guild the command came from, which is the
+# first read that looks a fleet up by this column on a request path. The column
+# has existed unindexed since the Discord binding was added.
+#
+# Not unique: nothing stops two fleets from being pointed at the same guild
+# today, and turning that into a constraint is a separate decision from making
+# the lookup fast.
+class AddIndexToFleetNotificationSettingsDiscordGuildId < ActiveRecord::Migration[8.1]
+  def change
+    add_index :fleet_notification_settings, :discord_guild_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -651,6 +651,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_120000) do
     t.text "enabled_in_app_events", default: "---\n- fleet_event.published\n- fleet_event.locked\n- fleet_event.starting_soon\n- fleet_event.cancelled\n- fleet_event_signup.created\n- fleet_event_signup.withdrawn"
     t.uuid "fleet_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["discord_guild_id"], name: "index_fleet_notification_settings_on_discord_guild_id"
     t.index ["fleet_id"], name: "index_fleet_notification_settings_on_fleet_id", unique: true
   end
 

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -83,18 +83,27 @@ Command jobs get their own Sidekiq queue, listed **first** in `config/sidekiq.ym
 
 ## Phase 2 — the rest of the read-only commands
 
-Each is the same shape as `/ship`, so they are one PR per command at most and cheap:
+Each is the same shape as `/ship`:
 
 | Command | Source | Note |
 | --- | --- | --- |
-| `/loaner <ship>` | loaner mappings | |
-| `/hangar <user>` | public hangars | must honour the public-hangar setting; a private hangar answers "not public", never a 404 that leaks existence |
-| `/compare <a> <b>` | compare data | embed, not the table |
-| `/fleet` | fleet stats | resolves the guild via `FleetNotificationSetting.discord_guild_id` |
+| `/loaner <ship>` | `Model#loaners` | scoped `visible.active`, so a hidden loaner is not listed |
+| `/hangar <user>` | public hangars | mirrors `Public::UserPolicy#show?` |
+| `/compare <a> <b>` | the `Model` catalogue | one field per stat holding both values |
+| `/fleet` | the guild's fleet | resolves via `FleetNotificationSetting.discord_guild_id` |
 
-`/fleet` needs an **index on `fleet_notification_settings.discord_guild_id`** — the column exists but is unindexed, and this is the first read that looks a fleet up by it on a request path.
+Resolving a ship name moves into `Discord::Commands::ModelLookup`, shared by `/ship`, `/loaner` and `/compare`. All three must resolve a name the *same* way as the ship list — a bot that finds a different ship than the website for the same words is a bug report nobody can reproduce.
 
-Every response is ephemeral by default (flag 64) unless the invoking member asked for a public post, so a busy channel does not fill with bot output.
+`/fleet` needs an **index on `fleet_notification_settings.discord_guild_id`** — the column exists but is unindexed, and this is the first read that looks a fleet up by it on a request path. Not unique: nothing stops two fleets pointing at one guild today, and making that a constraint is a separate decision from making the lookup fast.
+
+Two privacy rules that are easy to get wrong:
+
+- **`/hangar` answers a private hangar and an unknown username identically.** Distinguishing them turns the command into a probe for which accounts exist. There is a test asserting the two answers are the same.
+- **`/fleet` treats sharing a Discord server as no evidence of membership.** A guild can have guests. A member (resolved through `OmniauthConnection` → an accepted `FleetMembership`) may always see the fleet; anyone else only if `public_fleet?`. A pending invite is not membership.
+
+`/compare` links the real comparison: the compare page keeps its selection in the query string through `useFilters`, as repeated `models[]` entries, so `/compare/?models[]=a&models[]=b` opens it populated. The embed carries only six stats — the site's table has dozens across ten sections, and an embed caps out long before that, so the link is what carries the full picture.
+
+Every refusal is ephemeral (flag 64); a real answer is posted to the channel, since that is the point of asking in company.
 
 ## Phase 3 — RSVPs, without a Gateway
 

--- a/lib/discord/commands/compare.rb
+++ b/lib/discord/commands/compare.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "discord/commands/model_lookup"
+
+module Discord
+  module Commands
+    class Compare < Base
+      include ModelLookup
+
+      EMBED_COLOR = 0x2d9cdb
+
+      def call
+        first_query = option("first").to_s.strip
+        second_query = option("second").to_s.strip
+
+        if first_query.blank? || second_query.blank?
+          return message(content: I18n.t("discord.commands.compare.missing_query"))
+        end
+
+        first, answer = resolve_model(first_query)
+        return answer if first.nil?
+
+        second, answer = resolve_model(second_query)
+        return answer if second.nil?
+
+        if first.id == second.id
+          return message(content: I18n.t("discord.commands.compare.same_ship", ship: first.name))
+        end
+
+        message(embeds: [embed(first, second)], ephemeral: false)
+      end
+
+      # A Discord embed has no table, so each stat becomes one field holding
+      # both values. Deliberately not the website's comparison table: that has
+      # dozens of rows across ten sections, and an embed caps out long before it
+      # -- the link is there for the full picture.
+      private def embed(first, second)
+        {
+          title: I18n.t("discord.commands.compare.title", first: first.name, second: second.name),
+          url: compare_url(first, second),
+          color: EMBED_COLOR,
+          description: [
+            "[#{first.name}](#{model_page_url(first)})",
+            "[#{second.name}](#{model_page_url(second)})"
+          ].join(" · "),
+          fields: rows(first, second).map { |name, values| {name: name, value: values, inline: true} }
+        }.compact_blank
+      end
+
+      # The compare page keeps its selection in the query string through
+      # useFilters, as repeated `models[]` entries.
+      private def compare_url(first, second)
+        url_for_path("/compare/?#{{models: [first.slug, second.slug]}.to_query}")
+      end
+
+      private def rows(first, second)
+        stats(first).keys.each_with_object({}) do |key, rows|
+          left = stats(first)[key]
+          right = stats(second)[key]
+          next if left.blank? && right.blank?
+
+          rows[key] = "#{first.name}: #{left.presence || "—"}\n#{second.name}: #{right.presence || "—"}"
+        end
+      end
+
+      private def stats(model)
+        @stats ||= {}
+        @stats[model.id] ||= {
+          I18n.t("discord.commands.ship.fields.classification") => model.classification&.humanize,
+          I18n.t("discord.commands.ship.fields.size") => model.size&.humanize,
+          I18n.t("discord.commands.ship.fields.crew") => crew(model),
+          I18n.t("discord.commands.ship.fields.cargo") => cargo(model),
+          I18n.t("discord.commands.ship.fields.pledge_price") => model.pledge_price_label,
+          I18n.t("discord.commands.ship.fields.dimensions") => dimensions(model)
+        }
+      end
+
+      private def crew(model)
+        return model.max_crew.to_s if model.min_crew.blank? || model.min_crew == model.max_crew
+        return if model.max_crew.blank?
+
+        "#{model.min_crew}–#{model.max_crew}"
+      end
+
+      private def cargo(model)
+        return if model.cargo.blank? || model.cargo.zero?
+
+        "#{model.cargo.to_i} SCU"
+      end
+
+      private def dimensions(model)
+        [model.length_label, model.beam_label, model.height_label].compact_blank.join(" × ").presence
+      end
+    end
+  end
+end

--- a/lib/discord/commands/fleet.rb
+++ b/lib/discord/commands/fleet.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    class Fleet < Base
+      EMBED_COLOR = 0x2d9cdb
+
+      def call
+        fleet = resolve_fleet
+        return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
+        return message(content: I18n.t("discord.commands.fleet.not_allowed", fleet: fleet.name)) unless allowed?(fleet)
+
+        message(embeds: [embed(fleet)], ephemeral: false)
+      end
+
+      # The guild the command came from decides which fleet is meant, through
+      # the binding the fleet's own notification settings already carry.
+      private def resolve_fleet
+        return nil if guild_id.blank?
+
+        ::FleetNotificationSetting.find_by(discord_guild_id: guild_id)&.fleet
+      end
+
+      # A member of the fleet may always see it; anyone else only if the fleet
+      # chose to be public. Sharing a Discord server is not membership -- a
+      # server can have guests, and the fleet's own privacy setting is the only
+      # thing that speaks for it.
+      private def allowed?(fleet)
+        fleet.public_fleet? || member?(fleet)
+      end
+
+      private def member?(fleet)
+        user = ::OmniauthConnection.find_by(provider: "discord", uid: discord_user_id)&.user
+        return false if user.blank?
+
+        user.fleet_memberships.exists?(fleet_id: fleet.id, aasm_state: "accepted")
+      end
+
+      private def embed(fleet)
+        {
+          title: fleet.name,
+          url: url_for_path("/fleets/#{fleet.slug}"),
+          color: EMBED_COLOR,
+          description: fleet.description.to_s.truncate(300).presence,
+          fields: fields(fleet).map { |name, value| {name: name, value: value, inline: true} }
+        }.compact_blank
+      end
+
+      private def fields(fleet)
+        {
+          I18n.t("discord.commands.fleet.fields.members") => member_count(fleet).to_s,
+          I18n.t("discord.commands.fleet.fields.ships") => fleet.vehicles.count.to_s,
+          I18n.t("discord.commands.fleet.fields.models") => fleet.models.distinct.count.to_s,
+          I18n.t("discord.commands.fleet.fields.upcoming_events") => upcoming_events(fleet).to_s
+        }.compact_blank
+      end
+
+      private def member_count(fleet)
+        fleet.fleet_memberships.where(aasm_state: "accepted").count
+      end
+
+      private def upcoming_events(fleet)
+        fleet.fleet_events.where(archived_at: nil).where(starts_at: Time.current..).count
+      end
+    end
+  end
+end

--- a/lib/discord/commands/hangar.rb
+++ b/lib/discord/commands/hangar.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    class Hangar < Base
+      MAX_SHIPS = 10
+
+      def call
+        username = option("username").to_s.strip
+        return message(content: I18n.t("discord.commands.hangar.missing_query")) if username.blank?
+
+        user = User.find_by(normalized_username: username.downcase)
+
+        # A private hangar and a username that does not exist get the *same*
+        # answer on purpose. Distinguishing them turns the command into a probe
+        # for whether an account exists.
+        return message(content: I18n.t("discord.commands.hangar.not_available", username: username)) unless visible?(user)
+
+        vehicles = user.vehicles.purchased.public
+        counts = vehicles.joins(:model).group("models.name").order("count_all desc, models.name asc").count
+
+        return message(content: I18n.t("discord.commands.hangar.empty", username: user.username)) if counts.empty?
+
+        message(content: content_for(user, counts), ephemeral: false)
+      end
+
+      # Mirrors Public::UserPolicy#show? -- the same rule the public hangar
+      # endpoint enforces, rather than a second interpretation of it.
+      private def visible?(user)
+        user.present? && user.public_hangar?
+      end
+
+      private def content_for(user, counts)
+        shown = counts.first(MAX_SHIPS)
+        lines = shown.map { |name, count| (count > 1) ? "• #{count}× #{name}" : "• #{name}" }
+
+        [
+          I18n.t("discord.commands.hangar.heading",
+            username: user.username,
+            url: user.public_hangar_url,
+            count: counts.values.sum,
+            models: counts.size),
+          lines.join("\n"),
+          (I18n.t("discord.commands.hangar.more", count: counts.size - shown.size) if counts.size > shown.size)
+        ].compact.join("\n")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/loaner.rb
+++ b/lib/discord/commands/loaner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "discord/commands/model_lookup"
+
+module Discord
+  module Commands
+    class Loaner < Base
+      include ModelLookup
+
+      def call
+        query = option("name").to_s.strip
+        return message(content: I18n.t("discord.commands.loaner.missing_query")) if query.blank?
+
+        model, answer = resolve_model(query)
+        return answer if model.nil?
+
+        loaners = model.loaners.visible.active.ordered_by_name.to_a
+        return message(content: I18n.t("discord.commands.loaner.none", ship: model.name)) if loaners.empty?
+
+        message(content: content_for(model, loaners), ephemeral: false)
+      end
+
+      private def content_for(model, loaners)
+        lines = loaners.map { |loaner| "• [#{loaner.name}](#{model_page_url(loaner)})" }
+
+        [
+          I18n.t("discord.commands.loaner.heading",
+            ship: model.name,
+            url: model_page_url(model),
+            count: loaners.size),
+          lines.join("\n")
+        ].join("\n")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/model_lookup.rb
+++ b/lib/discord/commands/model_lookup.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # Resolving a ship name is shared by /ship, /loaner and /compare, and all
+    # three have to resolve it the *same* way as the website -- a bot that finds
+    # a different ship than the ship list for the same words is a bug report
+    # nobody can reproduce.
+    module ModelLookup
+      MAX_CANDIDATES = 5
+
+      # `search_cont` is the site's own matcher: a ransack alias over name, slug
+      # and manufacturer slug (`Model#ransack_alias :search`).
+      #
+      # `visible.active` is the public catalogue scope from ModelsController --
+      # without it the bot answers with unreleased and hidden models the website
+      # never shows.
+      private def find_models(query)
+        scope = Model.visible.active.includes(:manufacturer)
+
+        exact = scope.where("lower(name) = :q OR lower(slug) = :q", q: query.downcase).limit(1).to_a
+        return exact if exact.any?
+
+        scope.ransack(search_cont: query).result.ordered_by_name.limit(MAX_CANDIDATES + 1).to_a
+      end
+
+      # One match answers; several list rather than guess.
+      private def resolve_model(query)
+        candidates = find_models(query)
+
+        return [nil, message(content: I18n.t("discord.commands.ship.not_found", query: query))] if candidates.empty?
+        return [candidates.first, nil] if candidates.one?
+
+        [nil, candidate_list(query, candidates)]
+      end
+
+      private def candidate_list(query, candidates)
+        shown = candidates.first(MAX_CANDIDATES)
+        lines = shown.map { |model| "• [#{model.name}](#{model_page_url(model)})" }
+
+        content = [
+          I18n.t("discord.commands.ship.ambiguous", query: query, count: shown.size),
+          lines.join("\n"),
+          (I18n.t("discord.commands.ship.more") if candidates.size > MAX_CANDIDATES)
+        ].compact.join("\n")
+
+        message(content: content)
+      end
+
+      private def model_page_url(model)
+        url_for_path("/ships/#{model.slug}")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -24,6 +24,57 @@ module Discord
               required: true
             }
           ]
+        },
+        {
+          name: "loaner",
+          description: "Show the loaners a ship comes with",
+          handler: "Discord::Commands::Loaner",
+          options: [
+            {
+              name: "name",
+              description: "Ship name, slug, or manufacturer",
+              type: STRING,
+              required: true
+            }
+          ]
+        },
+        {
+          name: "compare",
+          description: "Compare two ships side by side",
+          handler: "Discord::Commands::Compare",
+          options: [
+            {
+              name: "first",
+              description: "First ship",
+              type: STRING,
+              required: true
+            },
+            {
+              name: "second",
+              description: "Second ship",
+              type: STRING,
+              required: true
+            }
+          ]
+        },
+        {
+          name: "hangar",
+          description: "Show a member's public hangar",
+          handler: "Discord::Commands::Hangar",
+          options: [
+            {
+              name: "username",
+              description: "Fleetyards username",
+              type: STRING,
+              required: true
+            }
+          ]
+        },
+        {
+          name: "fleet",
+          description: "Show this server's fleet on Fleetyards",
+          handler: "Discord::Commands::Fleet",
+          options: []
         }
       ].freeze
 

--- a/lib/discord/commands/ship.rb
+++ b/lib/discord/commands/ship.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "discord/commands/model_lookup"
+
 module Discord
   module Commands
     class Ship < Base
-      MAX_CANDIDATES = 5
+      include ModelLookup
 
       # Same colour the site uses for its primary accent, so an embed reads as
       # Fleetyards rather than as a generic bot post.
@@ -13,48 +15,16 @@ module Discord
         query = option("name").to_s.strip
         return message(content: I18n.t("discord.commands.ship.missing_query")) if query.blank?
 
-        candidates = search(query)
+        model, answer = resolve_model(query)
+        return answer if model.nil?
 
-        case candidates.size
-        when 0 then message(content: I18n.t("discord.commands.ship.not_found", query: query))
-        when 1 then message(embeds: [embed(candidates.first)], ephemeral: false)
-        else disambiguate(query, candidates)
-        end
-      end
-
-      # `search_cont` is the site's own matcher -- a ransack alias over name,
-      # slug and manufacturer slug (`Model#ransack_alias :search`). Reusing it
-      # keeps the bot and the ship list agreeing on what a name matches.
-      #
-      # `visible.active` is the public catalogue scope from ModelsController;
-      # without it the bot would answer with unreleased and hidden models the
-      # website never shows.
-      private def search(query)
-        scope = Model.visible.active.includes(:manufacturer)
-
-        exact = scope.where("lower(name) = :q OR lower(slug) = :q", q: query.downcase).limit(1).to_a
-        return exact if exact.any?
-
-        scope.ransack(search_cont: query).result.ordered_by_name.limit(MAX_CANDIDATES + 1).to_a
-      end
-
-      private def disambiguate(query, candidates)
-        shown = candidates.first(MAX_CANDIDATES)
-        lines = shown.map { |model| "• [#{model.name}](#{page_url(model)})" }
-
-        content = [
-          I18n.t("discord.commands.ship.ambiguous", query: query, count: shown.size),
-          lines.join("\n"),
-          (I18n.t("discord.commands.ship.more") if candidates.size > MAX_CANDIDATES)
-        ].compact.join("\n")
-
-        message(content: content)
+        message(embeds: [embed(model)], ephemeral: false)
       end
 
       private def embed(model)
         {
           title: model.name,
-          url: page_url(model),
+          url: model_page_url(model),
           color: EMBED_COLOR,
           description: model.description.to_s.truncate(400).presence,
           fields: fields(model).map { |name, value| {name: name, value: value, inline: true} },
@@ -101,10 +71,6 @@ module Discord
           end
 
         {url: url}
-      end
-
-      private def page_url(model)
-        url_for_path("/ships/#{model.slug}")
       end
 
       private def url_helpers

--- a/test/lib/discord/commands/compare_test.rb
+++ b/test/lib/discord/commands/compare_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/compare"
+
+module Discord
+  module Commands
+    class CompareTest < ActiveSupport::TestCase
+      setup do
+        @first = create(:model, name: "Origin 100i", slug: "orig-100i", cargo: 2, max_crew: 1, min_crew: 1)
+        @second = create(:model, name: "Origin 300i", slug: "orig-300i", cargo: 4, max_crew: 1, min_crew: 1)
+      end
+
+      def call(first, second)
+        ::Discord::Commands::Compare.new(options: {"first" => first, "second" => second}).call
+      end
+
+      test "puts both ships' values in one field per stat" do
+        fields = call("Origin 100i", "Origin 300i")[:embeds].first[:fields]
+        cargo = fields.find { |field| field[:name] == I18n.t("discord.commands.ship.fields.cargo") }
+
+        assert_includes cargo[:value], "Origin 100i: 2 SCU"
+        assert_includes cargo[:value], "Origin 300i: 4 SCU"
+      end
+
+      test "titles the embed with both names" do
+        embed = call("Origin 100i", "Origin 300i")[:embeds].first
+
+        assert_equal I18n.t("discord.commands.compare.title", first: "Origin 100i", second: "Origin 300i"), embed[:title]
+      end
+
+      # The compare page reads its selection from the query string, so this link
+      # opens the real comparison rather than an empty page.
+      test "links the comparison on the site" do
+        embed = call("Origin 100i", "Origin 300i")[:embeds].first
+
+        assert_includes embed[:url], "/compare/?"
+        assert_includes embed[:url], "models%5B%5D=#{@first.slug}"
+        assert_includes embed[:url], "models%5B%5D=#{@second.slug}"
+      end
+
+      test "links both ships in the description" do
+        embed = call("Origin 100i", "Origin 300i")[:embeds].first
+
+        assert_includes embed[:description], "/ships/#{@first.slug}"
+        assert_includes embed[:description], "/ships/#{@second.slug}"
+      end
+
+      test "a stat neither ship has is left out" do
+        fields = call("Origin 100i", "Origin 300i")[:embeds].first[:fields]
+
+        assert_not_includes fields.map { |field| field[:name] }, I18n.t("discord.commands.ship.fields.price")
+      end
+
+      test "a stat only one ship has still shows, with a dash for the other" do
+        @second.update!(cargo: nil)
+
+        fields = call("Origin 100i", "Origin 300i")[:embeds].first[:fields]
+        cargo = fields.find { |field| field[:name] == I18n.t("discord.commands.ship.fields.cargo") }
+
+        assert_includes cargo[:value], "Origin 100i: 2 SCU"
+        assert_includes cargo[:value], "Origin 300i: —"
+      end
+
+      test "refuses to compare a ship with itself" do
+        payload = call("Origin 100i", "Origin 100i")
+
+        assert_nil payload[:embeds]
+        assert_includes payload[:content], "Origin 100i"
+      end
+
+      test "a missing second ship asks for both" do
+        assert_equal I18n.t("discord.commands.compare.missing_query"), call("Origin 100i", "")[:content]
+      end
+
+      test "an unknown first ship is reported before the second is looked up" do
+        assert_includes call("Nonexistent", "Origin 300i")[:content], "Nonexistent"
+      end
+
+      test "an unknown second ship is reported too" do
+        assert_includes call("Origin 100i", "Nonexistent")[:content], "Nonexistent"
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/fleet_test.rb
+++ b/test/lib/discord/commands/fleet_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/fleet"
+
+module Discord
+  module Commands
+    class FleetTest < ActiveSupport::TestCase
+      setup do
+        # The factory defaults to a public fleet; most of what matters here is
+        # what a *private* one exposes.
+        @fleet = create(:fleet, :private, name: "Test Wing")
+        @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+
+        @user = create(:user)
+        create(:omniauth_connection, user: @user, provider: "discord", uid: "discord-uid-1")
+        @membership = @fleet.fleet_memberships.create!(user: @user, fleet_role: @fleet.fleet_roles.ranked.last)
+        @membership.update!(aasm_state: "accepted")
+      end
+
+      def call(guild_id: "guild-1", discord_user_id: "discord-uid-1")
+        ::Discord::Commands::Fleet.new(guild_id: guild_id, discord_user_id: discord_user_id).call
+      end
+
+      test "shows the fleet bound to the guild" do
+        embed = call[:embeds].first
+
+        assert_equal "Test Wing", embed[:title]
+        assert_includes embed[:url], "/fleets/#{@fleet.slug}"
+      end
+
+      test "says so when the server is not bound to a fleet" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: "guild-nope")[:content]
+      end
+
+      test "says so when the command arrives without a guild" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: nil)[:content]
+      end
+
+      # Sharing a server is not membership: a guild can have guests, and only
+      # the fleet's own privacy setting speaks for it.
+      test "a non-member cannot see a fleet that is not public" do
+        create(:omniauth_connection, user: create(:user), provider: "discord", uid: "guest-uid")
+
+        payload = call(discord_user_id: "guest-uid")
+
+        assert_nil payload[:embeds]
+        assert_includes payload[:content], "Test Wing"
+      end
+
+      test "a non-member can see a public fleet" do
+        # update_column, not update!: Fleet accepts nested attributes for
+        # fleet_memberships, so a normal save re-validates the loaded membership
+        # and fails on something this test is not about.
+        @fleet.update_column(:public_fleet, true)
+        create(:omniauth_connection, user: create(:user), provider: "discord", uid: "guest-uid")
+
+        assert_equal "Test Wing", call(discord_user_id: "guest-uid")[:embeds].first[:title]
+      end
+
+      test "a Discord user with no linked account is treated as a guest" do
+        payload = call(discord_user_id: "unlinked-uid")
+
+        assert_nil payload[:embeds]
+      end
+
+      test "a pending membership does not count as membership" do
+        @membership.update!(aasm_state: "invited")
+
+        assert_nil call[:embeds]
+      end
+
+      test "counts the accepted members" do
+        fields = call[:embeds].first[:fields].to_h { |field| [field[:name], field[:value]] }
+
+        assert_equal "1", fields[I18n.t("discord.commands.fleet.fields.members")]
+      end
+
+      test "counts only upcoming events" do
+        create(:fleet_event, :open, fleet: @fleet, starts_at: 2.days.from_now)
+        create(:fleet_event, :open, fleet: @fleet, starts_at: 3.days.ago)
+
+        fields = call[:embeds].first[:fields].to_h { |field| [field[:name], field[:value]] }
+
+        assert_equal "1", fields[I18n.t("discord.commands.fleet.fields.upcoming_events")]
+      end
+
+      test "a refusal is only shown to the caller" do
+        assert_equal ::Discord::Commands::Base::EPHEMERAL, call(guild_id: "guild-nope")[:flags]
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/hangar_test.rb
+++ b/test/lib/discord/commands/hangar_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/hangar"
+
+module Discord
+  module Commands
+    class HangarTest < ActiveSupport::TestCase
+      setup do
+        @user = create(:user, username: "Aendrax", public_hangar: true)
+        @carrack = create(:model, name: "Carrack")
+      end
+
+      def call(username)
+        ::Discord::Commands::Hangar.new(options: {"username" => username}).call
+      end
+
+      def add_ship(model, count: 1, public: true, wanted: false)
+        count.times { create(:vehicle, user: @user, model: model, public: public, wanted: wanted) }
+      end
+
+      test "lists the ships in a public hangar" do
+        add_ship(@carrack)
+
+        assert_includes call("Aendrax")[:content], "Carrack"
+      end
+
+      test "counts duplicates rather than repeating them" do
+        add_ship(@carrack, count: 3)
+
+        assert_includes call("Aendrax")[:content], "3× Carrack"
+      end
+
+      test "links the public hangar" do
+        add_ship(@carrack)
+
+        assert_includes call("Aendrax")[:content], @user.public_hangar_url
+      end
+
+      test "finds a user regardless of case" do
+        add_ship(@carrack)
+
+        assert_includes call("aendrax")[:content], "Carrack"
+      end
+
+      test "a hangar with only private ships reads as empty" do
+        add_ship(@carrack, public: false)
+
+        assert_includes call("Aendrax")[:content], I18n.t("discord.commands.hangar.empty", username: "Aendrax")
+      end
+
+      test "a wanted ship is not in the hangar" do
+        add_ship(@carrack, wanted: true)
+
+        assert_includes call("Aendrax")[:content], I18n.t("discord.commands.hangar.empty", username: "Aendrax")
+      end
+
+      # Mirrors Public::UserPolicy#show?.
+      test "a private hangar is not shown" do
+        @user.update!(public_hangar: false)
+        add_ship(@carrack)
+
+        assert_includes call("Aendrax")[:content], "Aendrax"
+        assert_not_includes call("Aendrax")[:content], "Carrack"
+      end
+
+      # Otherwise the command becomes a probe for which accounts exist.
+      test "a private hangar and an unknown user give the same answer" do
+        @user.update!(public_hangar: false)
+
+        assert_equal call("Nobody")[:content].sub("Nobody", "X"), call("Aendrax")[:content].sub("Aendrax", "X")
+      end
+
+      test "a listing is only shown to the caller when it is a refusal" do
+        @user.update!(public_hangar: false)
+
+        assert_equal ::Discord::Commands::Base::EPHEMERAL, call("Aendrax")[:flags]
+      end
+
+      test "a blank username asks for one" do
+        assert_equal I18n.t("discord.commands.hangar.missing_query"), call(" ")[:content]
+      end
+
+      test "caps a long hangar and says how many were left out" do
+        (::Discord::Commands::Hangar::MAX_SHIPS + 3).times do |i|
+          add_ship(create(:model, name: "Ship #{i.to_s.rjust(2, "0")}"))
+        end
+
+        content = call("Aendrax")[:content]
+
+        assert_includes content, I18n.t("discord.commands.hangar.more", count: 3)
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/loaner_test.rb
+++ b/test/lib/discord/commands/loaner_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/loaner"
+
+module Discord
+  module Commands
+    class LoanerTest < ActiveSupport::TestCase
+      setup do
+        @model = create(:model, name: "Carrack")
+        @loaner = create(:model, name: "Constellation Andromeda")
+      end
+
+      def call(name)
+        ::Discord::Commands::Loaner.new(options: {"name" => name}).call
+      end
+
+      def add_loaner(model, loaner)
+        model.model_loaners.create!(loaner_model: loaner)
+      end
+
+      test "lists the loaners a ship comes with" do
+        add_loaner(@model, @loaner)
+
+        content = call("Carrack")[:content]
+
+        assert_includes content, "Constellation Andromeda"
+        assert_includes content, "/ships/#{@loaner.slug}"
+      end
+
+      test "says so when a ship has no loaners" do
+        assert_equal I18n.t("discord.commands.loaner.none", ship: "Carrack"), call("Carrack")[:content]
+      end
+
+      test "a hidden loaner is not listed" do
+        @loaner.update!(hidden: true)
+        add_loaner(@model, @loaner)
+
+        assert_equal I18n.t("discord.commands.loaner.none", ship: "Carrack"), call("Carrack")[:content]
+      end
+
+      test "an unknown ship is reported rather than answered empty" do
+        assert_includes call("Nonexistent")[:content], "Nonexistent"
+      end
+
+      test "a blank name asks for one" do
+        assert_equal I18n.t("discord.commands.loaner.missing_query"), call(" ")[:content]
+      end
+
+      test "an ambiguous name lists candidates" do
+        create(:model, name: "Hornet F7C")
+        create(:model, name: "Hornet F7A")
+
+        assert_includes call("Hornet")[:content], "Hornet F7C"
+      end
+
+      test "a real answer is posted publicly" do
+        add_loaner(@model, @loaner)
+
+        assert_nil call("Carrack")[:flags]
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Stacked on #4625 → #4624 → #4623. The base ref is `feature/discord-event-rsvps` — review the two commits from `refactor(discord)` onwards.

Four read-only commands over data the site already publishes, all the same shape as `/ship`.

| Command | Answers with |
| --- | --- |
| `/loaner <ship>` | the loaners a ship comes with, each linked |
| `/compare <a> <b>` | six stats side by side, plus a link to the real comparison |
| `/hangar <user>` | a public hangar's ships, deduplicated with counts |
| `/fleet` | the fleet bound to this Discord server |

## Two privacy rules that are easy to get wrong

**`/hangar` answers a private hangar and an unknown username identically.** Telling them apart turns the command into a probe for which accounts exist — ask for a name, and the difference in wording tells you whether someone by that name is registered. There is a test asserting the two answers are the same string:

```ruby
test "a private hangar and an unknown user give the same answer"
```

Visibility mirrors `Public::UserPolicy#show?` rather than reinterpreting it, and the ship list comes from `user.vehicles.purchased.public` — the same scope the public hangar endpoint uses, so a private ship or a wishlist entry never appears.

**`/fleet` treats sharing a Discord server as no evidence of membership.** A guild can have guests, so the fleet's own privacy setting is the only thing that speaks for it: a member — resolved through `OmniauthConnection` to an **accepted** `FleetMembership` — may always see the fleet, anyone else only if `public_fleet?`. A pending invite is not membership, and there are tests for the guest, the unlinked Discord account and the invited-but-not-accepted cases.

## Shared name resolution

`/ship`, `/loaner` and `/compare` all resolve a ship name, and all three must resolve it the *same* way as the ship list — a bot that finds a different ship than the website for the same words is a bug report nobody can reproduce. That logic moves into `Discord::Commands::ModelLookup`: the `visible.active` public catalogue scope, the `search_cont` ransack alias over name/slug/manufacturer-slug, exact-match-wins, and the candidate listing for an ambiguous name.

The first commit is that extraction with no behaviour change — the existing `/ship` tests carry over untouched.

## `/compare` links a populated comparison

I initially thought the compare page took its selection from local state and deliberately left the link out. That was wrong: `useFilters` keeps it in the query string as repeated `models[]` entries, so

```
/compare/?models%5B%5D=orig-100i&models%5B%5D=orig-300i
```

opens the real thing. The embed carries six stats and the link carries the rest — the site's table has dozens of rows across ten sections, and a Discord embed caps out long before that. There is a test asserting the query-string shape so a future change to `useFilters` breaks it loudly rather than silently producing an empty comparison.

## Schema and index

`/fleet` is the first read that looks a fleet up by `fleet_notification_settings.discord_guild_id` on a request path, so the column gets an index. **Not unique** — nothing stops two fleets from pointing at the same guild today, and turning that into a constraint is a separate decision from making the lookup fast.

No new feature flag, so no `swagger/` change this time (see #4624 for why a flag would have meant one).

## Verified

- `bin/rails test test/lib/discord test/jobs/discord test/integration/discord_interactions_test.rb` — **159 runs, 305 assertions, 0 failures** (38 new)
- `bundle exec standardrb` on every new file — clean
- All seven `discord.yml` files parse and carry **identical key sets** (30 keys each), checked explicitly — nothing in CI validates locale parity, and `enableFallback` would hide a gap

One test-only wrinkle worth knowing about: `Fleet` has `accepts_nested_attributes_for :fleet_memberships`, which makes the association autosave, so a plain `fleet.update!` in a test re-validates the loaded membership and fails on something unrelated. The public-fleet test uses `update_column` with a comment saying why.

🤖
