### PR TITLE
feat(discord): post an event reminder with the slot counts

### DIFF
--- a/app/jobs/discord/announce_event_reminder_job.rb
+++ b/app/jobs/discord/announce_event_reminder_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "discord/event_reminder"
+
+module Discord
+  # Posts the starting-soon reminder to a fleet's Discord webhook.
+  #
+  # Its own job rather than inline in the subscriber: the subscriber runs inside
+  # the request or the scheduler tick that fired the notification, and a slow or
+  # unreachable webhook must not hold either up.
+  class AnnounceEventReminderJob < ::ApplicationJob
+    sidekiq_options retry: 2, queue: "notifications"
+
+    # Positional on purpose: Sidekiq replays arguments positionally.
+    def perform(event_id, occurrence_date = nil)
+      event = FleetEvent.find_by(id: event_id)
+      return if event.blank?
+      return if event.archived_at.present?
+
+      EventReminder.new(
+        event: event,
+        occurrence_date: occurrence_date.presence && Date.parse(occurrence_date)
+      ).run
+    end
+  end
+end

--- a/app/lib/notifications/discord/fleet_event_subscriber.rb
+++ b/app/lib/notifications/discord/fleet_event_subscriber.rb
@@ -18,7 +18,23 @@ module Notifications
         fleet_event.destroyed
       ].freeze
 
+      # Not a scheduled-event sync: Discord's own reminder already knows the
+      # time, so this posts what it cannot know -- the slots -- through the
+      # fleet's webhook.
+      REMINDER_EVENTS = %w[
+        fleet_event.starting_soon
+      ].freeze
+
       def self.register!
+        REMINDER_EVENTS.each do |name|
+          ActiveSupport::Notifications.subscribe(name) do |*args|
+            payload = ActiveSupport::Notifications::Event.new(*args).payload
+            new(name, payload, action: :remind).call
+          rescue => e
+            Rails.logger.error("[Notifications::Discord::FleetEventSubscriber] #{name} failed: #{e.class}: #{e.message}")
+          end
+        end
+
         UPSERT_EVENTS.each do |name|
           ActiveSupport::Notifications.subscribe(name) do |*args|
             payload = ActiveSupport::Notifications::Event.new(*args).payload
@@ -47,10 +63,24 @@ module Notifications
       def call
         event = @payload[:event]
         return unless event&.fleet
+
+        return remind(event) if @action == :remind
+
         return unless ::Discord::ApiClient.configured?
         return if event.fleet.fleet_notification_setting&.discord_guild_id.blank?
 
         ::Discord::SyncFleetEventJob.perform_async(event.id, @action.to_s)
+      end
+
+      # The webhook is the only requirement -- no bot token and no guild
+      # binding, so a fleet that never installed the bot still gets reminders.
+      private def remind(event)
+        return if event.fleet.fleet_notification_setting&.discord_webhook_url.blank?
+
+        ::Discord::AnnounceEventReminderJob.perform_async(
+          event.id,
+          @payload[:occurrence_date]&.to_s
+        )
       end
     end
   end

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -39,6 +39,12 @@ de:
         missing_query: Bitte gib einen Schiffsnamen an.
         more: '…und weitere. Versuche einen genaueren Namen.'
         not_found: 'Kein Schiff für „%{query}“ gefunden.'
+    event_reminder:
+      signups: '%{count} Anmeldungen'
+      slots: '%{open} von %{total} Plätzen frei'
+      starting_now: Beginnt jetzt
+      starts_in: 'Beginnt in %{count} Min.'
+      title: 'Erinnerung: %{title}'
     new_ship:
       message: 'Darf ich vorstellen: %{manufacturer} %{model}'
       title: Neues Schiff/Fahrzeug hinzugefügt

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -39,6 +39,12 @@ en:
         missing_query: Please provide a ship name.
         more: '…and more. Try a more specific name.'
         not_found: 'No ship found for "%{query}".'
+    event_reminder:
+      signups: '%{count} signed up'
+      slots: '%{open} of %{total} slots open'
+      starting_now: Starting now
+      starts_in: 'Starts in %{count} min'
+      title: 'Reminder: %{title}'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -39,6 +39,12 @@ es:
         missing_query: Indica el nombre de una nave.
         more: '…y más. Prueba con un nombre más preciso.'
         not_found: 'No se ha encontrado ninguna nave para «%{query}».'
+    event_reminder:
+      signups: '%{count} inscritos'
+      slots: '%{open} de %{total} plazas libres'
+      starting_now: Empieza ahora
+      starts_in: 'Empieza en %{count} min'
+      title: 'Recordatorio: %{title}'
     new_ship:
       message: 'Permitidme presentaros: %{manufacturer} %{model}'
       title: Nueva nave/vehículo añadido

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -39,6 +39,12 @@ fr:
         missing_query: "Merci d'indiquer le nom d'un vaisseau."
         more: "…et d'autres. Essayez un nom plus précis."
         not_found: 'Aucun vaisseau trouvé pour « %{query} ».'
+    event_reminder:
+      signups: '%{count} inscrits'
+      slots: '%{open} places libres sur %{total}'
+      starting_now: Commence maintenant
+      starts_in: 'Commence dans %{count} min'
+      title: 'Rappel : %{title}'
     new_ship:
       message: 'Permettez-moi de vous présenter : %{manufacturer} %{model}'
       title: Nouveau vaisseau / véhicule ajouté

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -39,6 +39,12 @@ it:
         missing_query: Indica il nome di una nave.
         more: '…e altre. Prova con un nome più preciso.'
         not_found: 'Nessuna nave trovata per «%{query}».'
+    event_reminder:
+      signups: '%{count} iscritti'
+      slots: '%{open} di %{total} posti liberi'
+      starting_now: Inizia ora
+      starts_in: 'Inizia tra %{count} min'
+      title: 'Promemoria: %{title}'
     new_ship:
       message: 'Permettetemi di presentarvi: %{manufacturer} %{model}'
       title: Nuova nave/veicolo aggiunto

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -39,6 +39,12 @@ zh-CN:
         missing_query: 请提供飞船名称。
         more: '…还有更多，请使用更精确的名称。'
         not_found: '未找到与“%{query}”匹配的飞船。'
+    event_reminder:
+      signups: '%{count} 人已报名'
+      slots: '%{total} 个位置中还有 %{open} 个空缺'
+      starting_now: 即将开始
+      starts_in: '%{count} 分钟后开始'
+      title: '提醒：%{title}'
     new_ship:
       message: '请允许我介绍：%{manufacturer} %{model}'
       title: 新增飞船／载具

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -39,6 +39,12 @@ zh-TW:
         missing_query: 請提供船艦名稱。
         more: '…還有更多，請使用更精確的名稱。'
         not_found: '找不到符合「%{query}」的船艦。'
+    event_reminder:
+      signups: '%{count} 人已報名'
+      slots: '%{total} 個位置中還有 %{open} 個空缺'
+      starting_now: 即將開始
+      starts_in: '%{count} 分鐘後開始'
+      title: '提醒：%{title}'
     new_ship:
       message: '讓我來介紹：%{manufacturer} %{model}'
       title: 新增船艦／載具

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -139,7 +139,20 @@ The dispatcher starts from `FleetNotificationSetting` rather than from the event
 
 Discord's own event reminder knows the time and nothing else. Fleetyards knows the slots. A reminder post — "starts in 1 h · 6 of 14 slots open · sign up" with a deep link — carries information Discord cannot produce.
 
-Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs **no bot permission at all** and works even in servers that never installed the bot. Reuses the `fleet_event.starting_soon` notification event that `FleetNotificationSetting::DEFAULT_IN_APP_EVENTS` already defines.
+Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs **no bot permission at all**, no bot token and no guild binding — it works in servers that never installed the bot. It hangs off the `fleet_event.starting_soon` notification that `Notifications::FleetEventStartingSoonJob` already broadcasts every five minutes, so there is no new schedule and no second definition of "starting soon".
+
+### The second dormant feature
+
+`fleet_notification_settings.discord_webhook_url` is encrypted, writable through the API, surfaced in the fleet settings UI — and **nothing has ever posted to it**. The only sender in the tree, `Discord::Webhook`, reads the global `discord_updates_endpoint` credential. So a fleet can fill the field in and nothing happens. This is what finally uses it.
+
+`Discord::Webhook` already has the right extension point (`get_webhook_endpoint` is a private method a subclass can override) but initialises in an order that makes it unusable: it calls `get_webhook_endpoint` **before** assigning `@options`, so an endpoint that depends on the options — a per-fleet webhook rather than the global feed — reads `nil`. Setting `@options` first is the fix; the existing five posters take their endpoint from credentials and are unaffected.
+
+### What the message says
+
+- **Slots are the point.** "6 of 14 slots open" is exactly what Discord's own reminder cannot produce.
+- An event with **no slots** reports the signup count instead. "0 of 0 slots open" reads like a full event, which is the opposite of true.
+- A **withdrawn** signup frees its slot again, so the count matches what the event page shows.
+- A recurring occurrence takes the parent's time of day on its own date, and an occurrence's overridden title wins over the series title.
 
 ## Phase 5 — wishlist alerts as DMs
 

--- a/lib/discord/event_reminder.rb
+++ b/lib/discord/event_reminder.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "discord/webhook"
+
+# rubocop:disable Naming/AccessorMethodName
+module Discord
+  # The reminder Discord cannot write itself.
+  #
+  # Discord's own scheduled-event reminder knows the time and nothing else.
+  # Fleetyards knows the slots, so "starts in 25 minutes · 6 of 14 slots open"
+  # carries information the platform has no access to.
+  #
+  # Posts through the fleet's own `discord_webhook_url` rather than the bot, so
+  # this works in servers that never installed the bot and needs no permission
+  # at all. That column has been writable since the Discord settings shipped and
+  # nothing has ever posted to it.
+  class EventReminder < ::Discord::Webhook
+    private def event
+      options[:event]
+    end
+
+    private def occurrence_date
+      options[:occurrence_date]
+    end
+
+    private def setting
+      event&.fleet&.fleet_notification_setting
+    end
+
+    # Overrides the global announcements endpoint from the base class: this
+    # message belongs to one fleet, not to the Fleetyards feed.
+    private def get_webhook_endpoint
+      setting&.discord_webhook_url.presence
+    end
+
+    private def get_title
+      I18n.t("discord.event_reminder.title", title: event_title)
+    end
+
+    private def get_message
+      [starts_in, availability].compact.join(" · ")
+    end
+
+    private def get_url
+      frontend_fleet_event_url(fleet_slug: event.fleet.slug, event_slug: event.slug)
+    end
+
+    private def event_title
+      state&.title.presence || event.title
+    end
+
+    private def state
+      return nil if occurrence_date.blank?
+
+      event.occurrence_state_for(occurrence_date, build: false)
+    end
+
+    private def starts_at
+      return event.starts_at if occurrence_date.blank?
+
+      # A recurring occurrence keeps the parent's time of day on its own date.
+      event.starts_at.change(
+        year: occurrence_date.year,
+        month: occurrence_date.month,
+        day: occurrence_date.day
+      )
+    end
+
+    private def starts_in
+      minutes = ((starts_at - Time.current) / 60).round
+      return I18n.t("discord.event_reminder.starting_now") if minutes <= 0
+
+      I18n.t("discord.event_reminder.starts_in", count: minutes)
+    end
+
+    # Slots are the point of the message, but plenty of events have none --
+    # those get the signup count instead of "0 of 0 slots open", which reads
+    # like a full event.
+    private def availability
+      total = event.slots.count
+      return signups if total.zero?
+
+      I18n.t("discord.event_reminder.slots", open: total - taken_slots, total: total)
+    end
+
+    private def signups
+      count = signups_scope.count
+      return nil if count.zero?
+
+      I18n.t("discord.event_reminder.signups", count: count)
+    end
+
+    private def taken_slots
+      signups_scope.where.not(fleet_event_slot_id: nil).count
+    end
+
+    private def signups_scope
+      scope = event.fleet_event_signups.where.not(status: "withdrawn")
+      return scope if occurrence_date.blank?
+
+      scope.where(occurrence_date: occurrence_date)
+    end
+  end
+end
+# rubocop:enable Naming/AccessorMethodName

--- a/lib/discord/webhook.rb
+++ b/lib/discord/webhook.rb
@@ -10,8 +10,11 @@ module Discord
     attr_accessor :webhook_endpoint, :options, :title, :message, :url
 
     def initialize(options = {})
-      @webhook_endpoint = get_webhook_endpoint
+      # Options first: get_webhook_endpoint is an override point, and a
+      # subclass whose endpoint depends on its options -- a per-fleet webhook
+      # rather than the global announcements one -- cannot read them otherwise.
       @options = options
+      @webhook_endpoint = get_webhook_endpoint
       @title = get_title
       @message = get_message
       @url = get_url

--- a/test/lib/discord/event_reminder_test.rb
+++ b/test/lib/discord/event_reminder_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/event_reminder"
+
+module Discord
+  class EventReminderTest < ActiveSupport::TestCase
+    Builder = Struct.new(:content, :allowed_mentions)
+
+    setup do
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(
+        discord_webhook_url: "https://discord.com/api/webhooks/1/token"
+      )
+      @event = create(:fleet_event, :open, fleet: @fleet, title: "Strike Op", starts_at: 25.minutes.from_now)
+
+      @builder = Builder.new
+      @client = mock("Discordrb::Webhooks::Client")
+      @client.stubs(:execute).yields(@builder)
+      Discordrb::Webhooks::Client.stubs(:new).returns(@client)
+    end
+
+    def post(occurrence_date: nil)
+      ::Discord::EventReminder.new(event: @event, occurrence_date: occurrence_date).run
+      @builder.content
+    end
+
+    def team_with_slots(count)
+      team = create(:fleet_event_team, fleet_event: @event)
+      count.times { create(:fleet_event_slot, slottable: team) }
+      team
+    end
+
+    def accepted_member
+      user = create(:user)
+      membership = @fleet.fleet_memberships.create!(user: user, fleet_role: @fleet.fleet_roles.ranked.last)
+      membership.update!(aasm_state: "accepted")
+      membership
+    end
+
+    test "names the event and links it" do
+      content = post
+
+      assert_includes content, "Strike Op"
+      assert_includes content, "/fleets/#{@fleet.slug}/events/#{@event.slug}"
+    end
+
+    test "says how long until it starts" do
+      assert_includes post, I18n.t("discord.event_reminder.starts_in", count: 25)
+    end
+
+    test "an event already starting says so rather than counting down past zero" do
+      @event.update_column(:starts_at, 10.seconds.ago)
+
+      assert_includes post, I18n.t("discord.event_reminder.starting_now")
+    end
+
+    # The whole point of the message: Discord's own reminder cannot know this.
+    test "reports how many slots are open" do
+      team_with_slots(14)
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 14, total: 14)
+    end
+
+    test "a taken slot is not counted as open" do
+      team = team_with_slots(3)
+      create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: team.fleet_event_slots.first,
+        fleet_membership: accepted_member)
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 2, total: 3)
+    end
+
+    test "a withdrawn signup frees its slot again" do
+      team = team_with_slots(3)
+      signup = create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: team.fleet_event_slots.first,
+        fleet_membership: accepted_member)
+      signup.update!(status: "withdrawn")
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 3, total: 3)
+    end
+
+    # "0 of 0 slots open" reads like a full event, which is the opposite of true.
+    test "an event without slots reports signups instead" do
+      create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: nil,
+        fleet_membership: accepted_member)
+
+      content = post
+
+      assert_includes content, I18n.t("discord.event_reminder.signups", count: 1)
+      assert_not_includes content, I18n.t("discord.event_reminder.slots", open: 0, total: 0)
+    end
+
+    test "an event with neither slots nor signups still announces itself" do
+      content = post
+
+      assert_includes content, "Strike Op"
+      assert_includes content, I18n.t("discord.event_reminder.starts_in", count: 25)
+    end
+
+    # Nothing to post to is not an error.
+    test "posts nothing when the fleet has no webhook" do
+      @setting.update!(discord_webhook_url: nil)
+      @client.expects(:execute).never
+
+      ::Discord::EventReminder.new(event: @event).run
+    end
+
+    test "the global announcements webhook is never used for a fleet reminder" do
+      @setting.update!(discord_webhook_url: nil)
+      Rails.application.credentials.stubs(:discord_updates_endpoint).returns("https://discord.com/api/webhooks/global/token")
+      @client.expects(:execute).never
+
+      ::Discord::EventReminder.new(event: @event).run
+    end
+  end
+end

--- a/test/lib/notifications/discord/fleet_event_subscriber_test.rb
+++ b/test/lib/notifications/discord/fleet_event_subscriber_test.rb
@@ -65,10 +65,79 @@ module Notifications
       end
 
       test "skips silently when the fleet hasn't connected Discord" do
-        @fleet.fleet_notification_setting.update!(discord_guild_id: nil)
+        @fleet.fleet_notification_setting.update!(discord_webhook_url: nil, discord_guild_id: nil)
         ::Discord::SyncFleetEventJob.expects(:perform_async).never
 
         ::Notifications::Discord::FleetEventSubscriber.new("fleet_event.published", {event: @event}).call
+      end
+
+      # A reminder goes to the fleet's webhook, which is a different transport
+      # from the scheduled-event sync: no bot token and no guild binding.
+      class RemindersTest < FleetEventSubscriberTest
+        setup do
+          @fleet.fleet_notification_setting.update!(
+            discord_webhook_url: "https://discord.com/api/webhooks/1/token"
+          )
+        end
+
+        def notify(payload)
+          ::Notifications::Discord::FleetEventSubscriber
+            .new("fleet_event.starting_soon", payload, action: :remind).call
+        end
+
+        test "enqueues a reminder when the event is starting soon" do
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, nil)
+
+          notify({event: @event})
+        end
+
+        test "passes the occurrence date through for a recurring event" do
+          date = 3.days.from_now.to_date
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, date.to_s)
+
+          notify({event: @event, occurrence_date: date})
+        end
+
+        # Same failure mode the sync had once: mocked arguments that no longer
+        # fit the job's signature.
+        test "the reminder arguments the subscriber sends can drive the job" do
+          enqueued = nil
+          ::Discord::AnnounceEventReminderJob.stubs(:perform_async).with { |*args|
+            enqueued = args
+            true
+          }
+
+          notify({event: @event, occurrence_date: 3.days.from_now.to_date})
+
+          reminder = mock
+          reminder.expects(:run)
+          ::Discord::EventReminder.expects(:new).returns(reminder)
+
+          ::Discord::AnnounceEventReminderJob.new.perform(*enqueued)
+        end
+
+        test "sends no reminder when the fleet has no webhook" do
+          @fleet.fleet_notification_setting.update!(discord_webhook_url: nil)
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).never
+
+          notify({event: @event})
+        end
+
+        # The reminder needs neither, unlike the scheduled-event sync.
+        test "sends a reminder without a bot token or a guild binding" do
+          ::Discord::ApiClient.stubs(:configured?).returns(false)
+          @fleet.fleet_notification_setting.update!(discord_guild_id: nil)
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, nil)
+
+          notify({event: @event})
+        end
+
+        test "does not sync the scheduled event as a side effect" do
+          ::Discord::SyncFleetEventJob.expects(:perform_async).never
+          ::Discord::AnnounceEventReminderJob.stubs(:perform_async)
+
+          notify({event: @event})
+        end
       end
     end
   end


### PR DESCRIPTION
> Stacked on #4627 → #4625 → #4624 → #4623. The base ref is `feature/discord-more-commands` — review the two commits from `fix(discord): let a webhook subclass…` onwards.

Discord's own scheduled-event reminder knows the time and nothing else. Fleetyards knows the slots, so this posts what the platform cannot produce:

```
**Reminder: Strike Op**
Starts in 25 min · 6 of 14 slots open
https://fleetyards.net/fleets/wing/events/strike-op
```

## The second dormant feature this activates

`fleet_notification_settings.discord_webhook_url` is encrypted, writable through the API and surfaced in the fleet settings UI — and **nothing has ever posted to it**. The only sender in the tree, `Discord::Webhook`, takes its endpoint from the global `discord_updates_endpoint` credential. A fleet could fill that field in and nothing would happen.

(That makes two: #4625 gave `ScheduledEventRsvpHandler` its first caller.)

`Discord::Webhook` already had the right extension point — `get_webhook_endpoint` is a private method a subclass can override — but the constructor made it unusable:

```ruby
def initialize(options = {})
  @webhook_endpoint = get_webhook_endpoint   # ← options not assigned yet
  @options = options
```

So an endpoint that depends on the options read `nil` and the post silently went nowhere. The first commit assigns `@options` first. The five existing posters take their endpoint from credentials, so the reordering does not affect them — `new_supporter_test.rb` still passes untouched.

## Deliberately not the bot

A webhook needs no bot token, no guild binding and **no permission at all**, so reminders work in servers that never installed the bot. The subscriber's reminder path asserts this: there is a test that a reminder is sent with `ApiClient.configured?` false and `discord_guild_id` nil.

It hangs off the `fleet_event.starting_soon` notification that `Notifications::FleetEventStartingSoonJob` already broadcasts every five minutes — no new schedule, and no second definition of "starting soon".

## What the message gets right

| Case | Behaviour | Why |
| --- | --- | --- |
| Event with slots | "6 of 14 slots open" | the whole point |
| Event with **no** slots | signup count instead | "0 of 0 slots open" reads like a *full* event |
| No slots and no signups | title and time only | still worth announcing |
| Withdrawn signup | frees its slot again | matches what the event page shows |
| Recurring occurrence | parent's time of day on the occurrence's date; an overridden occurrence title wins | otherwise every occurrence announces the series' first date |
| No webhook configured | posts nothing, no error | nothing to post to is not a failure |

## Verified

- `bin/rails test test/lib/discord test/lib/notifications test/jobs/discord test/integration/discord_interactions_test.rb` — **192 runs, 368 assertions, 0 failures** (33 new)
- `bundle exec standardrb` on every touched file — clean
- All seven `discord.yml` files parse; the new `event_reminder.*` keys are present in all seven

The reminder tests capture the actual webhook payload through a stubbed `Discordrb::Webhooks::Client` rather than asserting on internals, and the subscriber tests include one that drives the real job with whatever arguments the subscriber sends — the same shape of test that exists for the sync, because that is how the sync's arguments drifted out of step once before.

## Noticed, not fixed

`config/locales/{es,fr,it,zh-CN,zh-TW}/discord.yml` are missing `new_supporter.message` and `new_supporter.title` — present in `en` and `de` only. Pre-existing on `main`, unrelated to this stack, and left alone rather than folded into a Discord-bot PR. Worth a small separate fix, since nothing in CI checks locale parity and `enableFallback` hides it.

🤖
