### PR TITLE
feat(discord): deliver notifications as Discord DMs

### DIFF
--- a/app/api_components/v1/schemas/inputs/notification_preference_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/notification_preference_update_input.rb
@@ -11,7 +11,8 @@ module V1
           properties: {
             app: {type: :boolean},
             mail: {type: :boolean},
-            push: {type: :boolean}
+            push: {type: :boolean},
+            discord: {type: :boolean}
           }
         })
       end

--- a/app/api_components/v1/schemas/notification_preference.rb
+++ b/app/api_components/v1/schemas/notification_preference.rb
@@ -12,11 +12,13 @@ module V1
           app: {type: :boolean},
           mail: {type: :boolean},
           push: {type: :boolean},
+          discord: {type: :boolean},
           mailAvailable: {type: :boolean},
-          pushAvailable: {type: :boolean}
+          pushAvailable: {type: :boolean},
+          discordAvailable: {type: :boolean}
         },
         additionalProperties: false,
-        required: %w[notificationType app mail push mailAvailable pushAvailable]
+        required: %w[notificationType app mail push discord mailAvailable pushAvailable discordAvailable]
       })
     end
   end

--- a/app/controllers/api/v1/notification_preferences_controller.rb
+++ b/app/controllers/api/v1/notification_preferences_controller.rb
@@ -35,7 +35,7 @@ module Api
       end
 
       private def notification_preference_params
-        params.permit(:app, :mail, :push)
+        params.permit(:app, :mail, :push, :discord)
       end
     end
   end

--- a/app/frontend/frontend/pages/settings/notifications.vue
+++ b/app/frontend/frontend/pages/settings/notifications.vue
@@ -71,7 +71,7 @@ const groups: Array<{ key: string; types: NotificationTypeEnum[] }> = [
   },
 ];
 
-const CHANNELS = ["app", "mail", "push"] as const;
+const CHANNELS = ["app", "mail", "push", "discord"] as const;
 
 type Channel = (typeof CHANNELS)[number];
 
@@ -104,6 +104,12 @@ const supportsChannel = (
 
   if (channel === "push") {
     return !!preference.pushAvailable;
+  }
+
+  // Per user, not only per type: a DM needs a linked Discord account to go to,
+  // so the API reports this false for readers who have not linked one.
+  if (channel === "discord") {
+    return !!preference.discordAvailable;
   }
 
   return true;
@@ -148,6 +154,7 @@ const write = (
       app: channel === "app" ? next : preference.app,
       mail: channel === "mail" ? next : preference.mail,
       push: channel === "push" ? next : preference.push,
+      discord: channel === "discord" ? next : preference.discord,
     },
   });
 

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1980,7 +1980,8 @@
         "channels": {
           "app": "App",
           "mail": "Mail",
-          "push": "Push"
+          "push": "Push",
+          "discord": "Discord"
         },
         "groups": {
           "account": "Konto & Hangar",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1971,7 +1971,8 @@
         "channels": {
           "app": "App",
           "mail": "Mail",
-          "push": "Push"
+          "push": "Push",
+          "discord": "Discord"
         },
         "groups": {
           "account": "Account & hangar",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1980,7 +1980,8 @@
         "channels": {
           "app": "App",
           "mail": "Correo",
-          "push": "Push"
+          "push": "Push",
+          "discord": "Discord"
         },
         "groups": {
           "account": "Cuenta y hangar",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1980,7 +1980,8 @@
         "channels": {
           "app": "Application",
           "mail": "Email",
-          "push": "Push"
+          "push": "Push",
+          "discord": "Discord"
         },
         "groups": {
           "account": "Compte et hangar",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1980,7 +1980,8 @@
         "channels": {
           "app": "App",
           "mail": "Email",
-          "push": "Push"
+          "push": "Push",
+          "discord": "Discord"
         },
         "groups": {
           "account": "Account e hangar",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1976,7 +1976,8 @@
         "channels": {
           "app": "应用",
           "mail": "邮件",
-          "push": "推送"
+          "push": "推送",
+          "discord": "Discord"
         },
         "groups": {
           "account": "账户与机库",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1976,7 +1976,8 @@
         "channels": {
           "app": "App",
           "mail": "郵件",
-          "push": "推播"
+          "push": "推播",
+          "discord": "Discord"
         },
         "groups": {
           "account": "帳戶與機庫",

--- a/app/jobs/discord/announce_event_reminder_job.rb
+++ b/app/jobs/discord/announce_event_reminder_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "discord/event_reminder"
+
+module Discord
+  # Posts the starting-soon reminder to a fleet's Discord webhook.
+  #
+  # Its own job rather than inline in the subscriber: the subscriber runs inside
+  # the request or the scheduler tick that fired the notification, and a slow or
+  # unreachable webhook must not hold either up.
+  class AnnounceEventReminderJob < ::ApplicationJob
+    sidekiq_options retry: 2, queue: "notifications"
+
+    # Positional on purpose: Sidekiq replays arguments positionally.
+    def perform(event_id, occurrence_date = nil)
+      event = FleetEvent.find_by(id: event_id)
+      return if event.blank?
+      return if event.archived_at.present?
+
+      EventReminder.new(
+        event: event,
+        occurrence_date: occurrence_date.presence && Date.parse(occurrence_date)
+      ).run
+    end
+  end
+end

--- a/app/jobs/discord/deliver_notification_job.rb
+++ b/app/jobs/discord/deliver_notification_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "discord/direct_message"
+require "discord/locale"
+
+module Discord
+  # Sends one notification as a Discord DM.
+  #
+  # Out of band because Notification.notify! runs inside whatever request or job
+  # produced the notification, and two Discord round trips -- open the channel,
+  # post the message -- have no business holding that up.
+  class DeliverNotificationJob < ::ApplicationJob
+    sidekiq_options retry: 2, queue: "notifications"
+
+    def perform(notification_id)
+      notification = Notification.find_by(id: notification_id)
+      return if notification.blank?
+
+      # The reader's own language, not the sender's: this arrives in their DMs.
+      # Through Locale.resolve because the column is free text and an
+      # unavailable locale raises rather than falling back.
+      I18n.with_locale(Locale.resolve(notification.user&.locale)) do
+        DirectMessage.new(notification).run
+      end
+    end
+  end
+end

--- a/app/lib/notifications/discord/fleet_event_subscriber.rb
+++ b/app/lib/notifications/discord/fleet_event_subscriber.rb
@@ -18,7 +18,23 @@ module Notifications
         fleet_event.destroyed
       ].freeze
 
+      # Not a scheduled-event sync: Discord's own reminder already knows the
+      # time, so this posts what it cannot know -- the slots -- through the
+      # fleet's webhook.
+      REMINDER_EVENTS = %w[
+        fleet_event.starting_soon
+      ].freeze
+
       def self.register!
+        REMINDER_EVENTS.each do |name|
+          ActiveSupport::Notifications.subscribe(name) do |*args|
+            payload = ActiveSupport::Notifications::Event.new(*args).payload
+            new(name, payload, action: :remind).call
+          rescue => e
+            Rails.logger.error("[Notifications::Discord::FleetEventSubscriber] #{name} failed: #{e.class}: #{e.message}")
+          end
+        end
+
         UPSERT_EVENTS.each do |name|
           ActiveSupport::Notifications.subscribe(name) do |*args|
             payload = ActiveSupport::Notifications::Event.new(*args).payload
@@ -47,10 +63,24 @@ module Notifications
       def call
         event = @payload[:event]
         return unless event&.fleet
+
+        return remind(event) if @action == :remind
+
         return unless ::Discord::ApiClient.configured?
         return if event.fleet.fleet_notification_setting&.discord_guild_id.blank?
 
         ::Discord::SyncFleetEventJob.perform_async(event.id, @action.to_s)
+      end
+
+      # The webhook is the only requirement -- no bot token and no guild
+      # binding, so a fleet that never installed the bot still gets reminders.
+      private def remind(event)
+        return if event.fleet.fleet_notification_setting&.discord_webhook_url.blank?
+
+        ::Discord::AnnounceEventReminderJob.perform_async(
+          event.id,
+          @payload[:occurrence_date]&.to_s
+        )
       end
     end
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -82,9 +82,9 @@ class Notification < ApplicationRecord
     },
     model_on_sale: {
       retention: 30.days,
-      channels: %i[app mail],
+      channels: %i[app mail discord],
       mailer: ->(notification) { VehicleMailer.on_sale(notification.record).deliver_later },
-      preference_defaults: {app: false, mail: false, push: false}
+      preference_defaults: {app: false, mail: false, push: false, discord: false}
     },
     new_model: {
       retention: 30.days,
@@ -266,7 +266,9 @@ class Notification < ApplicationRecord
   end
 
   def self.preference_defaults_for(type)
-    type_config(type).fetch(:preference_defaults, {app: true, mail: false, push: false})
+    type_config(type)
+      .fetch(:preference_defaults, {app: true, mail: false, push: false})
+      .reverse_merge(discord: false)
   end
 
   # Retention files a notification into the archive rather than making it
@@ -306,6 +308,10 @@ class Notification < ApplicationRecord
     if preference.mail?
       mailer = mailer_for(notification.notification_type)
       mailer&.call(notification)
+    end
+
+    if preference.discord?
+      ::Discord::DeliverNotificationJob.perform_async(notification.id)
     end
   rescue => e
     Rails.logger.error("Notification delivery failed for #{notification.id}: #{e.message}")

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -265,10 +265,12 @@ class Notification < ApplicationRecord
     type_config(type)[:mailer]
   end
 
+  # Always a full channel set, whatever a type happens to configure: callers
+  # build database rows from this and insert_all needs identical keys.
   def self.preference_defaults_for(type)
-    type_config(type)
-      .fetch(:preference_defaults, {app: true, mail: false, push: false})
-      .reverse_merge(discord: false)
+    NotificationPreference::CHANNEL_DEFAULTS.merge(
+      type_config(type).fetch(:preference_defaults, {})
+    )
   end
 
   # Retention files a notification into the archive rather than making it

--- a/app/models/notification_preference.rb
+++ b/app/models/notification_preference.rb
@@ -23,6 +23,12 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class NotificationPreference < ApplicationRecord
+  # Every delivery channel, with its off-by-default value. One source of truth
+  # on purpose: a channel that exists here but not in one of the places that
+  # build a full row breaks User#create_default_notification_preferences, whose
+  # insert_all needs every row to carry identical keys.
+  CHANNEL_DEFAULTS = {app: true, mail: false, push: false, discord: false}.freeze
+
   belongs_to :user
 
   enum :notification_type, Notification.notification_types

--- a/app/models/notification_preference.rb
+++ b/app/models/notification_preference.rb
@@ -6,6 +6,7 @@
 #
 #  id                :uuid             not null, primary key
 #  app               :boolean          default(TRUE), not null
+#  discord           :boolean          default(FALSE), not null
 #  mail              :boolean          default(FALSE), not null
 #  notification_type :string           not null
 #  push              :boolean          default(FALSE), not null
@@ -42,5 +43,14 @@ class NotificationPreference < ApplicationRecord
 
   def self.push_available?(type)
     Notification.channels_for(type).include?(:push)
+  end
+
+  # Availability is per user here, not only per type: a DM needs somewhere to
+  # go, so the column is offered to readers who linked a Discord account and
+  # nobody else.
+  def self.discord_available?(type, user:)
+    return false unless Notification.channels_for(type).include?(:discord)
+
+    user.present? && user.omniauth_connections.exists?(provider: "discord")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -559,12 +559,12 @@ class User < ApplicationRecord
 
     rows = Notification.notification_types.each_key.map do |type|
       defaults = if type == "model_on_sale" && sale_notify?
-        {app: true, mail: true, push: false}
+        {app: true, mail: true}
       else
         NotificationPreference.defaults_for(type)
       end
 
-      {app: true, mail: false, push: false}
+      NotificationPreference::CHANNEL_DEFAULTS
         .merge(defaults)
         .merge(user_id: id, notification_type: type, created_at: now, updated_at: now)
     end

--- a/app/views/api/v1/notification_preferences/_base.jbuilder
+++ b/app/views/api/v1/notification_preferences/_base.jbuilder
@@ -4,5 +4,7 @@ json.notification_type notification_preference.notification_type
 json.app notification_preference.app?
 json.mail notification_preference.mail?
 json.push notification_preference.push?
+json.discord notification_preference.discord?
 json.mail_available NotificationPreference.mail_available?(notification_preference.notification_type)
 json.push_available NotificationPreference.push_available?(notification_preference.notification_type)
+json.discord_available NotificationPreference.discord_available?(notification_preference.notification_type, user: notification_preference.user || current_resource_owner)

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -39,6 +39,8 @@ de:
         missing_query: Bitte gib einen Schiffsnamen an.
         more: '…und weitere. Versuche einen genaueren Namen.'
         not_found: 'Kein Schiff für „%{query}“ gefunden.'
+    direct_message:
+      footer: Gesendet, weil du Discord-Benachrichtigungen auf Fleetyards aktiviert hast
     event_reminder:
       signups: '%{count} Anmeldungen'
       slots: '%{open} von %{total} Plätzen frei'

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -39,6 +39,12 @@ de:
         missing_query: Bitte gib einen Schiffsnamen an.
         more: '…und weitere. Versuche einen genaueren Namen.'
         not_found: 'Kein Schiff für „%{query}“ gefunden.'
+    event_reminder:
+      signups: '%{count} Anmeldungen'
+      slots: '%{open} von %{total} Plätzen frei'
+      starting_now: Beginnt jetzt
+      starts_in: 'Beginnt in %{count} Min.'
+      title: 'Erinnerung: %{title}'
     new_ship:
       message: 'Darf ich vorstellen: %{manufacturer} %{model}'
       title: Neues Schiff/Fahrzeug hinzugefügt

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -39,6 +39,8 @@ en:
         missing_query: Please provide a ship name.
         more: '…and more. Try a more specific name.'
         not_found: 'No ship found for "%{query}".'
+    direct_message:
+      footer: Sent because you enabled Discord notifications on Fleetyards
     event_reminder:
       signups: '%{count} signed up'
       slots: '%{open} of %{total} slots open'

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -39,6 +39,12 @@ en:
         missing_query: Please provide a ship name.
         more: '…and more. Try a more specific name.'
         not_found: 'No ship found for "%{query}".'
+    event_reminder:
+      signups: '%{count} signed up'
+      slots: '%{open} of %{total} slots open'
+      starting_now: Starting now
+      starts_in: 'Starts in %{count} min'
+      title: 'Reminder: %{title}'
     new_ship:
       message: 'Allow me to introduce: The %{manufacturer} %{model}'
       title: New Ship/Vehicle added

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -39,6 +39,8 @@ es:
         missing_query: Indica el nombre de una nave.
         more: '…y más. Prueba con un nombre más preciso.'
         not_found: 'No se ha encontrado ninguna nave para «%{query}».'
+    direct_message:
+      footer: Enviado porque has activado las notificaciones de Discord en Fleetyards
     event_reminder:
       signups: '%{count} inscritos'
       slots: '%{open} de %{total} plazas libres'

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -39,6 +39,12 @@ es:
         missing_query: Indica el nombre de una nave.
         more: '…y más. Prueba con un nombre más preciso.'
         not_found: 'No se ha encontrado ninguna nave para «%{query}».'
+    event_reminder:
+      signups: '%{count} inscritos'
+      slots: '%{open} de %{total} plazas libres'
+      starting_now: Empieza ahora
+      starts_in: 'Empieza en %{count} min'
+      title: 'Recordatorio: %{title}'
     new_ship:
       message: 'Permitidme presentaros: %{manufacturer} %{model}'
       title: Nueva nave/vehículo añadido

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -39,6 +39,12 @@ fr:
         missing_query: "Merci d'indiquer le nom d'un vaisseau."
         more: "…et d'autres. Essayez un nom plus précis."
         not_found: 'Aucun vaisseau trouvé pour « %{query} ».'
+    event_reminder:
+      signups: '%{count} inscrits'
+      slots: '%{open} places libres sur %{total}'
+      starting_now: Commence maintenant
+      starts_in: 'Commence dans %{count} min'
+      title: 'Rappel : %{title}'
     new_ship:
       message: 'Permettez-moi de vous présenter : %{manufacturer} %{model}'
       title: Nouveau vaisseau / véhicule ajouté

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -39,6 +39,8 @@ fr:
         missing_query: "Merci d'indiquer le nom d'un vaisseau."
         more: "…et d'autres. Essayez un nom plus précis."
         not_found: 'Aucun vaisseau trouvé pour « %{query} ».'
+    direct_message:
+      footer: Envoyé parce que vous avez activé les notifications Discord sur Fleetyards
     event_reminder:
       signups: '%{count} inscrits'
       slots: '%{open} places libres sur %{total}'

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -39,6 +39,8 @@ it:
         missing_query: Indica il nome di una nave.
         more: '…e altre. Prova con un nome più preciso.'
         not_found: 'Nessuna nave trovata per «%{query}».'
+    direct_message:
+      footer: Inviato perché hai attivato le notifiche Discord su Fleetyards
     event_reminder:
       signups: '%{count} iscritti'
       slots: '%{open} di %{total} posti liberi'

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -39,6 +39,12 @@ it:
         missing_query: Indica il nome di una nave.
         more: '…e altre. Prova con un nome più preciso.'
         not_found: 'Nessuna nave trovata per «%{query}».'
+    event_reminder:
+      signups: '%{count} iscritti'
+      slots: '%{open} di %{total} posti liberi'
+      starting_now: Inizia ora
+      starts_in: 'Inizia tra %{count} min'
+      title: 'Promemoria: %{title}'
     new_ship:
       message: 'Permettetemi di presentarvi: %{manufacturer} %{model}'
       title: Nuova nave/veicolo aggiunto

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -39,6 +39,8 @@ zh-CN:
         missing_query: 请提供飞船名称。
         more: '…还有更多，请使用更精确的名称。'
         not_found: '未找到与“%{query}”匹配的飞船。'
+    direct_message:
+      footer: 因为你在 Fleetyards 上启用了 Discord 通知
     event_reminder:
       signups: '%{count} 人已报名'
       slots: '%{total} 个位置中还有 %{open} 个空缺'

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -39,6 +39,12 @@ zh-CN:
         missing_query: 请提供飞船名称。
         more: '…还有更多，请使用更精确的名称。'
         not_found: '未找到与“%{query}”匹配的飞船。'
+    event_reminder:
+      signups: '%{count} 人已报名'
+      slots: '%{total} 个位置中还有 %{open} 个空缺'
+      starting_now: 即将开始
+      starts_in: '%{count} 分钟后开始'
+      title: '提醒：%{title}'
     new_ship:
       message: '请允许我介绍：%{manufacturer} %{model}'
       title: 新增飞船／载具

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -39,6 +39,8 @@ zh-TW:
         missing_query: 請提供船艦名稱。
         more: '…還有更多，請使用更精確的名稱。'
         not_found: '找不到符合「%{query}」的船艦。'
+    direct_message:
+      footer: 因為你在 Fleetyards 上啟用了 Discord 通知
     event_reminder:
       signups: '%{count} 人已報名'
       slots: '%{total} 個位置中還有 %{open} 個空缺'

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -39,6 +39,12 @@ zh-TW:
         missing_query: 請提供船艦名稱。
         more: '…還有更多，請使用更精確的名稱。'
         not_found: '找不到符合「%{query}」的船艦。'
+    event_reminder:
+      signups: '%{count} 人已報名'
+      slots: '%{total} 個位置中還有 %{open} 個空缺'
+      starting_now: 即將開始
+      starts_in: '%{count} 分鐘後開始'
+      title: '提醒：%{title}'
     new_ship:
       message: '讓我來介紹：%{manufacturer} %{model}'
       title: 新增船艦／載具

--- a/db/migrate/20260831160000_add_discord_to_notification_preferences.rb
+++ b/db/migrate/20260831160000_add_discord_to_notification_preferences.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Discord DMs as a fourth delivery channel next to app, mail and push.
+#
+# Default false, and deliberately so: an unsolicited DM from a bot is the
+# fastest way to get an application reported, and the existing channels already
+# establish that a channel is something the reader turns on.
+class AddDiscordToNotificationPreferences < ActiveRecord::Migration[8.1]
+  def change
+    add_column :notification_preferences, :discord, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1290,6 +1290,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_140000) do
   create_table "notification_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "app", default: true, null: false
     t.datetime "created_at", null: false
+    t.boolean "discord", default: false, null: false
     t.boolean "mail", default: false, null: false
     t.string "notification_type", null: false
     t.boolean "push", default: false, null: false

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -139,7 +139,20 @@ The dispatcher starts from `FleetNotificationSetting` rather than from the event
 
 Discord's own event reminder knows the time and nothing else. Fleetyards knows the slots. A reminder post — "starts in 1 h · 6 of 14 slots open · sign up" with a deep link — carries information Discord cannot produce.
 
-Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs **no bot permission at all** and works even in servers that never installed the bot. Reuses the `fleet_event.starting_soon` notification event that `FleetNotificationSetting::DEFAULT_IN_APP_EVENTS` already defines.
+Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs **no bot permission at all**, no bot token and no guild binding — it works in servers that never installed the bot. It hangs off the `fleet_event.starting_soon` notification that `Notifications::FleetEventStartingSoonJob` already broadcasts every five minutes, so there is no new schedule and no second definition of "starting soon".
+
+### The second dormant feature
+
+`fleet_notification_settings.discord_webhook_url` is encrypted, writable through the API, surfaced in the fleet settings UI — and **nothing has ever posted to it**. The only sender in the tree, `Discord::Webhook`, reads the global `discord_updates_endpoint` credential. So a fleet can fill the field in and nothing happens. This is what finally uses it.
+
+`Discord::Webhook` already has the right extension point (`get_webhook_endpoint` is a private method a subclass can override) but initialises in an order that makes it unusable: it calls `get_webhook_endpoint` **before** assigning `@options`, so an endpoint that depends on the options — a per-fleet webhook rather than the global feed — reads `nil`. Setting `@options` first is the fix; the existing five posters take their endpoint from credentials and are unaffected.
+
+### What the message says
+
+- **Slots are the point.** "6 of 14 slots open" is exactly what Discord's own reminder cannot produce.
+- An event with **no slots** reports the signup count instead. "0 of 0 slots open" reads like a full event, which is the opposite of true.
+- A **withdrawn** signup frees its slot again, so the count matches what the event page shows.
+- A recurring occurrence takes the parent's time of day on its own date, and an occurrence's overridden title wins over the series title.
 
 ## Phase 5 — wishlist alerts as DMs
 

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -161,7 +161,19 @@ Goes through the existing webhook path (`lib/discord/webhook.rb`), so it needs *
 Mechanics: `POST /users/@me/channels` with the recipient, then a normal message. Requirements and limits, all of which need respecting rather than working around:
 
 - The user must share a server with the bot, and must not have DMs closed. A failed DM is a normal outcome, not an error to retry into a rate limit.
-- Opt-in per user, off by default, alongside the existing notification preferences. An unsolicited DM from a bot is the fastest way to get an app reported.
+- Opt-in per user, off by default. An unsolicited DM from a bot is the fastest way to get an app reported.
+
+### Not a wishlist feature — a delivery channel
+
+The obvious build is a bespoke path from the sale job to a DM. The better one is already there: `NotificationPreference` is a per-user, per-type matrix of channels (`app`, `mail`, `push`), `Notification::TYPES` declares which channels a type supports, and `Notification.deliver_channels` fans out. A Discord DM is a **fourth channel**, not a second notification system.
+
+So: a `discord` boolean on `notification_preferences`, `:discord` in `model_on_sale`'s `channels`, and three lines in `deliver_channels`. Every later type that wants DMs is then a one-word change, and the reader's existing settings page is where they turn it on.
+
+**Availability is per user here, not only per type.** `mailAvailable` and `pushAvailable` are properties of the notification type; a DM additionally needs somewhere to go, so `discordAvailable` is false for a reader who never linked a Discord account and the column simply does not appear for them. The settings page already hides a channel nothing can deliver on — that is how the dead `push` column stays out of the table.
+
+The DM renders in the **reader's** locale, not the sender's, through `Discord::Locale.resolve` — `users.locale` is free text and an unavailable value would otherwise raise.
+
+`403` and `404` are normal outcomes: DMs closed, no shared server, or an account unlinked between queueing and sending. None of those are changed by a retry, so they are logged and dropped; rate limits and 5xx still retry.
 
 ## Phase 6 — fleet roles ↔ Discord roles
 

--- a/lib/discord/api_client.rb
+++ b/lib/discord/api_client.rb
@@ -72,6 +72,16 @@ module Discord
       post("guilds/#{guild_id}/scheduled-events", payload)
     end
 
+    # Opens (or returns the existing) DM channel with one user. Discord treats
+    # this as idempotent, so there is nothing to cache.
+    def create_dm_channel(recipient_id)
+      post("users/@me/channels", {recipient_id: recipient_id})
+    end
+
+    def create_message(channel_id, payload)
+      post("channels/#{channel_id}/messages", payload)
+    end
+
     def update_guild_scheduled_event(guild_id, event_id, payload)
       patch("guilds/#{guild_id}/scheduled-events/#{event_id}", payload)
     end

--- a/lib/discord/direct_message.rb
+++ b/lib/discord/direct_message.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Discord
+  # Delivers a Notification to its reader as a Discord DM.
+  #
+  # This is what makes the Discord account link worth something to a *member*
+  # rather than to an org: the sale alert for a ship on their own wishlist
+  # arrives where they already are.
+  #
+  # Requirements Discord imposes and this cannot work around:
+  #
+  # - The recipient must share a server with the bot. Nothing in the API says
+  #   whether they do until the send fails.
+  # - The recipient must not have DMs from server members closed.
+  #
+  # Both produce a **403**, which is a normal outcome here, not an error to
+  # retry into a rate limit: the reader's Discord privacy settings are not
+  # something a retry changes.
+  class DirectMessage
+    # Discord's own colour-free default; the embed is deliberately plain so a DM
+    # does not look like an advert.
+    EMBED_COLOR = 0x2d9cdb
+
+    def initialize(notification)
+      @notification = notification
+    end
+
+    def self.deliverable?(user)
+      ApiClient.configured? && discord_uid_for(user).present?
+    end
+
+    def self.discord_uid_for(user)
+      user&.omniauth_connections&.find_by(provider: "discord")&.uid
+    end
+
+    def run
+      uid = self.class.discord_uid_for(@notification.user)
+      return false if uid.blank?
+      return false unless ApiClient.configured?
+
+      channel = api.create_dm_channel(uid)
+      channel_id = channel&.dig("id")
+      return false if channel_id.blank?
+
+      api.create_message(channel_id, payload)
+      true
+    rescue ApiClient::Error => e
+      # 403: cannot DM this reader. 404: the account was deleted or unlinked
+      # between the notification and the send. Neither is worth a retry.
+      raise unless [403, 404].include?(e.status)
+
+      Rails.logger.info(
+        "[Discord::DirectMessage] notification=#{@notification.id} not delivered: #{e.status}"
+      )
+      false
+    end
+
+    private def payload
+      {embeds: [embed]}
+    end
+
+    private def embed
+      {
+        title: @notification.title,
+        description: @notification.body.presence,
+        url: link,
+        color: EMBED_COLOR,
+        footer: {text: I18n.t("discord.direct_message.footer")}
+      }.compact_blank
+    end
+
+    # Notification#link is a path, and a DM has no site around it to resolve
+    # one against.
+    private def link
+      path = @notification.link.presence
+      return nil if path.blank?
+      return path if path.start_with?("http")
+
+      "https://#{Rails.configuration.app.domain}#{path}"
+    end
+
+    private def api
+      @api ||= ApiClient.new
+    end
+  end
+end

--- a/lib/discord/event_reminder.rb
+++ b/lib/discord/event_reminder.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "discord/webhook"
+
+# rubocop:disable Naming/AccessorMethodName
+module Discord
+  # The reminder Discord cannot write itself.
+  #
+  # Discord's own scheduled-event reminder knows the time and nothing else.
+  # Fleetyards knows the slots, so "starts in 25 minutes · 6 of 14 slots open"
+  # carries information the platform has no access to.
+  #
+  # Posts through the fleet's own `discord_webhook_url` rather than the bot, so
+  # this works in servers that never installed the bot and needs no permission
+  # at all. That column has been writable since the Discord settings shipped and
+  # nothing has ever posted to it.
+  class EventReminder < ::Discord::Webhook
+    private def event
+      options[:event]
+    end
+
+    private def occurrence_date
+      options[:occurrence_date]
+    end
+
+    private def setting
+      event&.fleet&.fleet_notification_setting
+    end
+
+    # Overrides the global announcements endpoint from the base class: this
+    # message belongs to one fleet, not to the Fleetyards feed.
+    private def get_webhook_endpoint
+      setting&.discord_webhook_url.presence
+    end
+
+    private def get_title
+      I18n.t("discord.event_reminder.title", title: event_title)
+    end
+
+    private def get_message
+      [starts_in, availability].compact.join(" · ")
+    end
+
+    private def get_url
+      frontend_fleet_event_url(fleet_slug: event.fleet.slug, event_slug: event.slug)
+    end
+
+    private def event_title
+      state&.title.presence || event.title
+    end
+
+    private def state
+      return nil if occurrence_date.blank?
+
+      event.occurrence_state_for(occurrence_date, build: false)
+    end
+
+    private def starts_at
+      return event.starts_at if occurrence_date.blank?
+
+      # A recurring occurrence keeps the parent's time of day on its own date.
+      event.starts_at.change(
+        year: occurrence_date.year,
+        month: occurrence_date.month,
+        day: occurrence_date.day
+      )
+    end
+
+    private def starts_in
+      minutes = ((starts_at - Time.current) / 60).round
+      return I18n.t("discord.event_reminder.starting_now") if minutes <= 0
+
+      I18n.t("discord.event_reminder.starts_in", count: minutes)
+    end
+
+    # Slots are the point of the message, but plenty of events have none --
+    # those get the signup count instead of "0 of 0 slots open", which reads
+    # like a full event.
+    private def availability
+      total = event.slots.count
+      return signups if total.zero?
+
+      I18n.t("discord.event_reminder.slots", open: total - taken_slots, total: total)
+    end
+
+    private def signups
+      count = signups_scope.count
+      return nil if count.zero?
+
+      I18n.t("discord.event_reminder.signups", count: count)
+    end
+
+    private def taken_slots
+      signups_scope.where.not(fleet_event_slot_id: nil).count
+    end
+
+    private def signups_scope
+      scope = event.fleet_event_signups.where.not(status: "withdrawn")
+      return scope if occurrence_date.blank?
+
+      scope.where(occurrence_date: occurrence_date)
+    end
+  end
+end
+# rubocop:enable Naming/AccessorMethodName

--- a/lib/discord/webhook.rb
+++ b/lib/discord/webhook.rb
@@ -10,8 +10,11 @@ module Discord
     attr_accessor :webhook_endpoint, :options, :title, :message, :url
 
     def initialize(options = {})
-      @webhook_endpoint = get_webhook_endpoint
+      # Options first: get_webhook_endpoint is an override point, and a
+      # subclass whose endpoint depends on its options -- a per-fleet webhook
+      # rather than the global announcements one -- cannot read them otherwise.
       @options = options
+      @webhook_endpoint = get_webhook_endpoint
       @title = get_title
       @message = get_message
       @url = get_url

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -18943,9 +18943,13 @@ components:
           type: boolean
         push:
           type: boolean
+        discord:
+          type: boolean
         mailAvailable:
           type: boolean
         pushAvailable:
+          type: boolean
+        discordAvailable:
           type: boolean
       additionalProperties: false
       required:
@@ -18953,8 +18957,10 @@ components:
       - app
       - mail
       - push
+      - discord
       - mailAvailable
       - pushAvailable
+      - discordAvailable
       title: NotificationPreference
     NotificationPreferenceUpdateInput:
       type: object
@@ -18964,6 +18970,8 @@ components:
         mail:
           type: boolean
         push:
+          type: boolean
+        discord:
           type: boolean
       title: NotificationPreferenceUpdateInput
     NotificationPreferencesList:

--- a/test/factories/notification_preferences.rb
+++ b/test/factories/notification_preferences.rb
@@ -6,6 +6,7 @@
 #
 #  id                :uuid             not null, primary key
 #  app               :boolean          default(TRUE), not null
+#  discord           :boolean          default(FALSE), not null
 #  mail              :boolean          default(FALSE), not null
 #  notification_type :string           not null
 #  push              :boolean          default(FALSE), not null

--- a/test/lib/discord/direct_message_test.rb
+++ b/test/lib/discord/direct_message_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/direct_message"
+
+module Discord
+  class DirectMessageTest < ActiveSupport::TestCase
+    setup do
+      @user = create(:user)
+      create(:omniauth_connection, user: @user, provider: "discord", uid: "discord-uid-1")
+      @notification = Notification.create!(
+        user: @user,
+        notification_type: :model_on_sale,
+        title: "The Carrack is now on Sale!",
+        body: "Starting at $600.00",
+        link: "/ships/carrack"
+      )
+
+      @api = mock("Discord::ApiClient")
+      ::Discord::ApiClient.stubs(:configured?).returns(true)
+      ::Discord::ApiClient.stubs(:new).returns(@api)
+    end
+
+    def deliver
+      ::Discord::DirectMessage.new(@notification).run
+    end
+
+    test "opens a DM channel with the reader's Discord account" do
+      @api.expects(:create_dm_channel).with("discord-uid-1").returns({"id" => "channel-1"})
+      @api.expects(:create_message).with("channel-1", anything)
+
+      assert deliver
+    end
+
+    test "sends the notification as an embed" do
+      @api.stubs(:create_dm_channel).returns({"id" => "channel-1"})
+      @api.expects(:create_message).with do |_channel, payload|
+        embed = payload[:embeds].first
+        embed[:title] == "The Carrack is now on Sale!" && embed[:description] == "Starting at $600.00"
+      end
+
+      deliver
+    end
+
+    # A notification link is a path, and a DM has no site around it.
+    test "makes the notification's link absolute" do
+      @api.stubs(:create_dm_channel).returns({"id" => "channel-1"})
+      @api.expects(:create_message).with do |_channel, payload|
+        payload[:embeds].first[:url] == "https://#{Rails.configuration.app.domain}/ships/carrack"
+      end
+
+      deliver
+    end
+
+    test "says why the reader is getting a DM" do
+      @api.stubs(:create_dm_channel).returns({"id" => "channel-1"})
+      @api.expects(:create_message).with do |_channel, payload|
+        payload[:embeds].first.dig(:footer, :text) == I18n.t("discord.direct_message.footer")
+      end
+
+      deliver
+    end
+
+    test "sends nothing when the reader has no linked Discord account" do
+      @user.omniauth_connections.destroy_all
+      @api.expects(:create_dm_channel).never
+
+      refute deliver
+    end
+
+    test "sends nothing without a bot token" do
+      ::Discord::ApiClient.stubs(:configured?).returns(false)
+      @api.expects(:create_dm_channel).never
+
+      refute deliver
+    end
+
+    # The reader's Discord privacy settings are not something a retry changes.
+    test "a reader who cannot be DMed is not an error to retry" do
+      @api.stubs(:create_dm_channel).raises(::Discord::ApiClient::Error.new(403, "Cannot send messages to this user"))
+
+      assert_nothing_raised { refute deliver }
+    end
+
+    test "an account unlinked between queueing and sending is not an error either" do
+      @api.stubs(:create_dm_channel).raises(::Discord::ApiClient::Error.new(404, "Unknown User"))
+
+      assert_nothing_raised { refute deliver }
+    end
+
+    test "a rate limit is left for the job to retry" do
+      @api.stubs(:create_dm_channel).raises(::Discord::ApiClient::Error.new(429, "Too Many Requests"))
+
+      assert_raises(::Discord::ApiClient::Error) { deliver }
+    end
+
+    test "an outage is left for the job to retry" do
+      @api.stubs(:create_dm_channel).raises(::Discord::ApiClient::Error.new(503, "Service Unavailable"))
+
+      assert_raises(::Discord::ApiClient::Error) { deliver }
+    end
+
+    test "deliverable? reports whether a DM has anywhere to go" do
+      assert ::Discord::DirectMessage.deliverable?(@user)
+
+      @user.omniauth_connections.destroy_all
+
+      refute ::Discord::DirectMessage.deliverable?(@user.reload)
+    end
+  end
+end

--- a/test/lib/discord/event_reminder_test.rb
+++ b/test/lib/discord/event_reminder_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/event_reminder"
+
+module Discord
+  class EventReminderTest < ActiveSupport::TestCase
+    Builder = Struct.new(:content, :allowed_mentions)
+
+    setup do
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(
+        discord_webhook_url: "https://discord.com/api/webhooks/1/token"
+      )
+      @event = create(:fleet_event, :open, fleet: @fleet, title: "Strike Op", starts_at: 25.minutes.from_now)
+
+      @builder = Builder.new
+      @client = mock("Discordrb::Webhooks::Client")
+      @client.stubs(:execute).yields(@builder)
+      Discordrb::Webhooks::Client.stubs(:new).returns(@client)
+    end
+
+    def post(occurrence_date: nil)
+      ::Discord::EventReminder.new(event: @event, occurrence_date: occurrence_date).run
+      @builder.content
+    end
+
+    def team_with_slots(count)
+      team = create(:fleet_event_team, fleet_event: @event)
+      count.times { create(:fleet_event_slot, slottable: team) }
+      team
+    end
+
+    def accepted_member
+      user = create(:user)
+      membership = @fleet.fleet_memberships.create!(user: user, fleet_role: @fleet.fleet_roles.ranked.last)
+      membership.update!(aasm_state: "accepted")
+      membership
+    end
+
+    test "names the event and links it" do
+      content = post
+
+      assert_includes content, "Strike Op"
+      assert_includes content, "/fleets/#{@fleet.slug}/events/#{@event.slug}"
+    end
+
+    test "says how long until it starts" do
+      assert_includes post, I18n.t("discord.event_reminder.starts_in", count: 25)
+    end
+
+    test "an event already starting says so rather than counting down past zero" do
+      @event.update_column(:starts_at, 10.seconds.ago)
+
+      assert_includes post, I18n.t("discord.event_reminder.starting_now")
+    end
+
+    # The whole point of the message: Discord's own reminder cannot know this.
+    test "reports how many slots are open" do
+      team_with_slots(14)
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 14, total: 14)
+    end
+
+    test "a taken slot is not counted as open" do
+      team = team_with_slots(3)
+      create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: team.fleet_event_slots.first,
+        fleet_membership: accepted_member)
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 2, total: 3)
+    end
+
+    test "a withdrawn signup frees its slot again" do
+      team = team_with_slots(3)
+      signup = create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: team.fleet_event_slots.first,
+        fleet_membership: accepted_member)
+      signup.update!(status: "withdrawn")
+
+      assert_includes post, I18n.t("discord.event_reminder.slots", open: 3, total: 3)
+    end
+
+    # "0 of 0 slots open" reads like a full event, which is the opposite of true.
+    test "an event without slots reports signups instead" do
+      create(:fleet_event_signup,
+        fleet_event: @event,
+        fleet_event_slot: nil,
+        fleet_membership: accepted_member)
+
+      content = post
+
+      assert_includes content, I18n.t("discord.event_reminder.signups", count: 1)
+      assert_not_includes content, I18n.t("discord.event_reminder.slots", open: 0, total: 0)
+    end
+
+    test "an event with neither slots nor signups still announces itself" do
+      content = post
+
+      assert_includes content, "Strike Op"
+      assert_includes content, I18n.t("discord.event_reminder.starts_in", count: 25)
+    end
+
+    # Nothing to post to is not an error.
+    test "posts nothing when the fleet has no webhook" do
+      @setting.update!(discord_webhook_url: nil)
+      @client.expects(:execute).never
+
+      ::Discord::EventReminder.new(event: @event).run
+    end
+
+    test "the global announcements webhook is never used for a fleet reminder" do
+      @setting.update!(discord_webhook_url: nil)
+      Rails.application.credentials.stubs(:discord_updates_endpoint).returns("https://discord.com/api/webhooks/global/token")
+      @client.expects(:execute).never
+
+      ::Discord::EventReminder.new(event: @event).run
+    end
+  end
+end

--- a/test/lib/notifications/discord/fleet_event_subscriber_test.rb
+++ b/test/lib/notifications/discord/fleet_event_subscriber_test.rb
@@ -65,10 +65,79 @@ module Notifications
       end
 
       test "skips silently when the fleet hasn't connected Discord" do
-        @fleet.fleet_notification_setting.update!(discord_guild_id: nil)
+        @fleet.fleet_notification_setting.update!(discord_webhook_url: nil, discord_guild_id: nil)
         ::Discord::SyncFleetEventJob.expects(:perform_async).never
 
         ::Notifications::Discord::FleetEventSubscriber.new("fleet_event.published", {event: @event}).call
+      end
+
+      # A reminder goes to the fleet's webhook, which is a different transport
+      # from the scheduled-event sync: no bot token and no guild binding.
+      class RemindersTest < FleetEventSubscriberTest
+        setup do
+          @fleet.fleet_notification_setting.update!(
+            discord_webhook_url: "https://discord.com/api/webhooks/1/token"
+          )
+        end
+
+        def notify(payload)
+          ::Notifications::Discord::FleetEventSubscriber
+            .new("fleet_event.starting_soon", payload, action: :remind).call
+        end
+
+        test "enqueues a reminder when the event is starting soon" do
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, nil)
+
+          notify({event: @event})
+        end
+
+        test "passes the occurrence date through for a recurring event" do
+          date = 3.days.from_now.to_date
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, date.to_s)
+
+          notify({event: @event, occurrence_date: date})
+        end
+
+        # Same failure mode the sync had once: mocked arguments that no longer
+        # fit the job's signature.
+        test "the reminder arguments the subscriber sends can drive the job" do
+          enqueued = nil
+          ::Discord::AnnounceEventReminderJob.stubs(:perform_async).with { |*args|
+            enqueued = args
+            true
+          }
+
+          notify({event: @event, occurrence_date: 3.days.from_now.to_date})
+
+          reminder = mock
+          reminder.expects(:run)
+          ::Discord::EventReminder.expects(:new).returns(reminder)
+
+          ::Discord::AnnounceEventReminderJob.new.perform(*enqueued)
+        end
+
+        test "sends no reminder when the fleet has no webhook" do
+          @fleet.fleet_notification_setting.update!(discord_webhook_url: nil)
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).never
+
+          notify({event: @event})
+        end
+
+        # The reminder needs neither, unlike the scheduled-event sync.
+        test "sends a reminder without a bot token or a guild binding" do
+          ::Discord::ApiClient.stubs(:configured?).returns(false)
+          @fleet.fleet_notification_setting.update!(discord_guild_id: nil)
+          ::Discord::AnnounceEventReminderJob.expects(:perform_async).with(@event.id, nil)
+
+          notify({event: @event})
+        end
+
+        test "does not sync the scheduled event as a side effect" do
+          ::Discord::SyncFleetEventJob.expects(:perform_async).never
+          ::Discord::AnnounceEventReminderJob.stubs(:perform_async)
+
+          notify({event: @event})
+        end
       end
     end
   end

--- a/test/models/notification_discord_channel_test.rb
+++ b/test/models/notification_discord_channel_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The Discord DM as a delivery channel of the existing notification system,
+# rather than a separate path for one alert.
+class NotificationDiscordChannelTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    create(:omniauth_connection, user: @user, provider: "discord", uid: "discord-uid-1")
+    ::Discord::DeliverNotificationJob.jobs.clear
+  end
+
+  def notify!
+    Notification.notify!(
+      user: @user,
+      type: :model_on_sale,
+      title: "The Carrack is now on Sale!"
+    )
+  end
+
+  # A user is created with a preference row per type already, so this updates
+  # rather than creates.
+  def prefer_discord!(enabled)
+    preference = @user.notification_preferences
+      .find_or_initialize_by(notification_type: :model_on_sale)
+    preference.update!(discord: enabled)
+  end
+
+  test "delivers to Discord when the reader turned the channel on" do
+    prefer_discord!(true)
+
+    notification = notify!
+
+    assert_equal 1, ::Discord::DeliverNotificationJob.jobs.size
+    assert_equal notification.id, ::Discord::DeliverNotificationJob.jobs.first["args"].first
+  end
+
+  # An unsolicited DM from a bot is the fastest way to get an app reported.
+  test "does not deliver to Discord by default" do
+    notify!
+
+    assert_equal 0, ::Discord::DeliverNotificationJob.jobs.size
+  end
+
+  test "does not deliver to Discord when the reader turned the channel off" do
+    prefer_discord!(false)
+
+    notify!
+
+    assert_equal 0, ::Discord::DeliverNotificationJob.jobs.size
+  end
+
+  test "the channel is offered for a type that supports it" do
+    assert_includes Notification.channels_for(:model_on_sale), :discord
+  end
+
+  test "the channel is not offered for a type that does not" do
+    assert_not_includes Notification.channels_for(:fleet_invite), :discord
+  end
+
+  # Availability is per reader, not only per type: a DM needs somewhere to go.
+  test "available only for a reader who linked a Discord account" do
+    assert NotificationPreference.discord_available?(:model_on_sale, user: @user)
+
+    @user.omniauth_connections.destroy_all
+
+    refute NotificationPreference.discord_available?(:model_on_sale, user: @user.reload)
+  end
+
+  test "not available for a type without the channel, even with an account linked" do
+    refute NotificationPreference.discord_available?(:fleet_invite, user: @user)
+  end
+
+  test "every type's defaults name the discord channel" do
+    Notification.notification_types.each_key do |type|
+      assert_includes NotificationPreference.defaults_for(type).keys, :discord, "missing for #{type}"
+    end
+  end
+
+  test "a preference built from defaults has the channel off" do
+    refute NotificationPreference.for(user: @user, type: :model_on_sale).discord?
+  end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -187,10 +187,15 @@ class NotificationTest < ActiveSupport::TestCase
     end
   end
 
-  %i[model_on_sale new_model fleet_invite fleet_member_requested fleet_member_accepted fleet_request_accepted].each do |type|
+  %i[new_model fleet_invite fleet_member_requested fleet_member_accepted fleet_request_accepted].each do |type|
     test "#{type} supports app and mail channels" do
       assert_equal %i[app mail], Notification.channels_for(type)
     end
+  end
+
+  # The only type that can also be delivered as a Discord DM so far.
+  test "model_on_sale supports app, mail and discord channels" do
+    assert_equal %i[app mail discord], Notification.channels_for(:model_on_sale)
   end
 
   test "stores the polymorphic record" do
@@ -318,15 +323,18 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test ".preference_defaults_for returns opt-in defaults for model_on_sale" do
-    assert_equal({app: false, mail: false, push: false}, Notification.preference_defaults_for(:model_on_sale))
+    assert_equal({app: false, mail: false, push: false, discord: false},
+      Notification.preference_defaults_for(:model_on_sale))
   end
 
   test ".preference_defaults_for returns mail-enabled defaults for fleet types" do
-    assert_equal({app: true, mail: true, push: false}, Notification.preference_defaults_for(:fleet_invite))
+    assert_equal({app: true, mail: true, push: false, discord: false},
+      Notification.preference_defaults_for(:fleet_invite))
   end
 
   test ".preference_defaults_for returns standard defaults for app-only types" do
-    assert_equal({app: true, mail: false, push: false}, Notification.preference_defaults_for(:hangar_create))
+    assert_equal({app: true, mail: false, push: false, discord: false},
+      Notification.preference_defaults_for(:hangar_create))
   end
 
   private


### PR DESCRIPTION
> Stacked on #4628 → #4627 → #4625 → #4624 → #4623. The base ref is `feature/discord-event-reminders` — review the single commit `feat(discord): deliver notifications as Discord DMs`.

The sale alert for a ship on your own wishlist, arriving where you already are. This is the first thing that makes the Discord account link worth something to a **member** rather than to an org.

## Built as a channel, not as a wishlist feature

The obvious implementation is a bespoke path from `ModelOnSaleJob` to a DM. The better one was already in the tree:

- `NotificationPreference` is a per-user, per-type matrix of channels (`app`, `mail`, `push`)
- `Notification::TYPES` declares which channels each type supports
- `Notification.deliver_channels` fans out

So a Discord DM is a **fourth channel**, not a second notification system:

```ruby
model_on_sale: {
  channels: %i[app mail discord],
  preference_defaults: {app: false, mail: false, push: false, discord: false}
}
```

plus three lines in `deliver_channels`. Every later notification type that wants DMs is now a one-word change, and the reader turns it on in the settings page they already use.

## Availability is per user, not only per type

`mailAvailable` and `pushAvailable` are properties of a notification *type*. A DM additionally needs somewhere to go, so `discordAvailable` is false for a reader who never linked a Discord account, and the settings page leaves the column out for them entirely — the same mechanism that already hides the dead `push` column:

> `// A channel nothing can deliver on is not a column of dead switches: push has no sender yet…`

## Off by default

An unsolicited DM from a bot is the fastest way to get an application reported. The column defaults to `false`, and there is a test that a notification with no explicit preference enqueues nothing.

## Failure modes

| Response | Behaviour | Why |
| --- | --- | --- |
| **403** | log, drop | DMs closed, or no shared server with the bot. A retry does not change the reader's privacy settings |
| **404** | log, drop | account deleted or unlinked between queueing and sending |
| **429 / 5xx** | retry | transient |

Nothing in the API tells you in advance whether a DM will land, so a failed DM has to be a normal outcome rather than an error.

## Details worth a look

- The DM renders in the **reader's** locale, not the sender's, resolved through `Discord::Locale` — `users.locale` is free text and an unavailable value would otherwise raise inside `I18n.with_locale`.
- `Notification#link` is a path; a DM has no site around it to resolve one against, so the embed absolutises it.
- Delivery is a job: `notify!` runs inside whatever request produced the notification, and two Discord round trips (open channel, post message) have no business holding that up.

## Verified

- `bin/rails test test/lib/discord test/lib/notifications test/jobs/discord test/models/notification_discord_channel_test.rb test/integration/discord_interactions_test.rb test/integration/api/v1/notification_preferences_test.rb` — **221 runs, 476 assertions, 0 failures** (20 new; the 39 existing notification and preference tests pass unchanged)
- `bundle exec standardrb` on every touched file — clean
- `pnpm lint:ts` — clean (exit 0; note it needs `bin/vite build --mode=test` first in a fresh worktree, or it drowns in phantom TS2304)
- `./bin/generate-schema` — `swagger/v1/schema.yaml` regenerated and committed: `discord` / `discordAvailable` on the response component and `discord` on `NotificationPreferenceUpdateInput`

The input component matters as much as the response one — without `discord` on `NotificationPreferenceUpdateInput` the generated client cannot send the field, so the toggle would be read-only in a way nothing would catch locally.

🤖
