### PR TITLE
feat(discord): sync fleet membership to Discord roles

### DIFF
--- a/app/api_components/v1/schemas/fleets/fleet_notification_discord_status.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_notification_discord_status.rb
@@ -15,7 +15,10 @@ module V1
             guildId: {type: :string},
             guildName: {type: :string},
             status: {type: :integer},
-            installUrl: {type: :string}
+            installUrl: {type: :string},
+            rolesOk: {type: :boolean},
+            rolesCode: {type: :string},
+            rolesDetail: {type: :string}
           }
         })
       end

--- a/app/api_components/v1/schemas/fleets/fleet_notification_setting.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_notification_setting.rb
@@ -17,6 +17,7 @@ module V1
             },
             discordGuildId: {type: :string},
             discordChannelId: {type: :string},
+            discordMemberRoleId: {type: :string},
             # discord_webhook_url is encrypted; never returned, only writable.
             discordWebhookConfigured: {type: :boolean}
           },

--- a/app/api_components/v1/schemas/inputs/fleet_notification_setting_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_notification_setting_update_input.rb
@@ -11,6 +11,7 @@ module V1
           properties: {
             discordGuildId: {type: [:string, :null]},
             discordChannelId: {type: [:string, :null]},
+            discordMemberRoleId: {type: [:string, :null]},
             discordWebhookUrl: {type: [:string, :null]},
             enabledInAppEvents: {type: :array, items: {type: :string}}
           }

--- a/app/controllers/api/v1/fleet_notification_settings_controller.rb
+++ b/app/controllers/api/v1/fleet_notification_settings_controller.rb
@@ -38,7 +38,7 @@ module Api
 
         begin
           guild = ::Discord::ApiClient.new.get_guild(@setting.discord_guild_id)
-          {ok: true, guildId: guild["id"], guildName: guild["name"]}
+          {ok: true, guildId: guild["id"], guildName: guild["name"]}.merge(roles_payload)
         rescue ::Discord::ApiClient::Error => e
           code = case e.status
           when 401 then "invalid_token"
@@ -47,6 +47,27 @@ module Api
           else "discord_error"
           end
           {ok: false, code: code, status: e.status, message: e.message}
+        end
+      end
+
+      # Only reported once the fleet has asked for role management, so a fleet
+      # that never mapped a role is not told to re-authorise for a feature it is
+      # not using.
+      #
+      # A fleet that installed the bot before Manage Roles was requested keeps
+      # its original grant -- Discord does not upgrade an existing install -- so
+      # this is the only thing that tells them to re-authorise instead of the
+      # sync failing quietly every time a member's rank changes.
+      private def roles_payload
+        managed = ([@setting.discord_member_role_id] +
+          @setting.fleet.fleet_roles.pluck(:discord_role_id)).compact_blank.uniq
+
+        return {} if managed.empty?
+
+        result = ::Discord::RoleCapability.new(@setting.discord_guild_id).check(managed)
+
+        {rolesOk: result.ok?, rolesCode: result.code.to_s}.tap do |payload|
+          payload[:rolesDetail] = result.detail if result.detail.present?
         end
       end
 
@@ -62,6 +83,7 @@ module Api
 
       private def setting_params
         permitted = params.permit(
+          :discord_member_role_id,
           :discord_guild_id,
           :discord_channel_id,
           :discord_webhook_url,

--- a/app/jobs/discord/backfill_fleet_member_roles_job.rb
+++ b/app/jobs/discord/backfill_fleet_member_roles_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Discord
+  # Applies a fleet's role mapping to the members it already has.
+  #
+  # The per-membership sync is event-driven: it fires when a state or a rank
+  # changes. That is the wrong direction for a rollout -- a fleet maps a role
+  # and nothing happens, because no membership changed. This is what makes
+  # configuring a mapping take effect.
+  class BackfillFleetMemberRolesJob < ::ApplicationJob
+    sidekiq_options retry: 1, queue: "notifications"
+
+    # One membership costs a get_guild_member plus a call per role change, so a
+    # large fleet is spread over time rather than fired at Discord at once.
+    PER_SECOND = 10
+
+    # Positional on purpose: Sidekiq replays arguments positionally. A role id
+    # narrows the backfill to the members holding that rank, which is all a
+    # single rank mapping can affect.
+    def perform(fleet_id, fleet_role_id = nil)
+      return unless ApiClient.configured?
+
+      fleet = Fleet.find_by(id: fleet_id)
+      return if fleet.blank?
+      return if fleet.fleet_notification_setting&.discord_guild_id.blank?
+
+      ids = membership_ids(fleet, fleet_role_id)
+      return if ids.empty?
+
+      Rails.logger.info("[Discord::BackfillFleetMemberRolesJob] fleet=#{fleet_id} members=#{ids.size}")
+
+      ids.each_with_index do |membership_id, index|
+        SyncMemberRolesJob.perform_in((index / PER_SECOND.to_f).seconds, membership_id)
+      end
+    end
+
+    # Only accepted members who actually linked a Discord account: a sync for
+    # anyone else is a job that can only decide to do nothing.
+    private def membership_ids(fleet, fleet_role_id)
+      scope = fleet.fleet_memberships
+        .kept
+        .where(aasm_state: "accepted")
+        .joins(user: :omniauth_connections)
+        .where(omniauth_connections: {provider: OmniauthConnection.providers[:discord]})
+
+      scope = scope.where(fleet_role_id: fleet_role_id) if fleet_role_id.present?
+
+      scope.distinct.pluck(:id)
+    end
+  end
+end

--- a/app/jobs/discord/backfill_user_member_roles_job.rb
+++ b/app/jobs/discord/backfill_user_member_roles_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Discord
+  # Applies every fleet's role mapping to one member, for the case the
+  # per-membership sync cannot see: someone who links their Discord account
+  # *after* being accepted. Nothing about their membership changed, so nothing
+  # would otherwise give them the roles their fleets already mapped.
+  class BackfillUserMemberRolesJob < ::ApplicationJob
+    sidekiq_options retry: 1, queue: "notifications"
+
+    def perform(user_id)
+      return unless ApiClient.configured?
+
+      user = User.find_by(id: user_id)
+      return if user.blank?
+
+      user.fleet_memberships.kept.where(aasm_state: "accepted").find_each do |membership|
+        next if membership.fleet&.fleet_notification_setting&.discord_guild_id.blank?
+
+        SyncMemberRolesJob.perform_async(membership.id)
+      end
+    end
+  end
+end

--- a/app/jobs/discord/sync_member_roles_job.rb
+++ b/app/jobs/discord/sync_member_roles_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "discord/member_role_sync"
+
+module Discord
+  # Applies one member's Discord roles.
+  class SyncMemberRolesJob < ::ApplicationJob
+    sidekiq_options retry: 2, queue: "notifications"
+
+    def perform(membership_id)
+      membership = FleetMembership.find_by(id: membership_id)
+      return if membership.blank?
+
+      sync = MemberRoleSync.new(membership)
+      return unless sync.runnable?
+
+      result = sync.run!
+      return if result.added.blank? && result.removed.blank?
+
+      Rails.logger.info("[Discord::SyncMemberRolesJob] membership=#{membership_id} #{result}")
+    rescue ApiClient::Error => e
+      Rails.logger.error("[Discord::SyncMemberRolesJob] membership=#{membership_id} failed: #{e.message}")
+      raise if e.status == 429 || e.status >= 500
+    end
+  end
+end

--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -107,10 +107,11 @@ class FleetMembership < ApplicationRecord
   after_create_commit :schedule_setup_fleet_vehicles
   after_update_commit :schedule_update_fleet_vehicles
   after_commit :broadcast_update
+  after_commit :sync_discord_roles, on: %i[create update], if: :discord_roles_affected?
   before_destroy :check_if_can_be_destroyed
   before_discard :check_if_can_be_destroyed
-  after_discard :broadcast_destroy, :remove_fleet_vehicles
-  after_undiscard :broadcast_create, :schedule_setup_fleet_vehicles
+  after_discard :broadcast_destroy, :remove_fleet_vehicles, :sync_discord_roles
+  after_undiscard :broadcast_create, :schedule_setup_fleet_vehicles, :sync_discord_roles
 
   def has_access?(privileges)
     return false if fleet_role.blank?
@@ -328,6 +329,22 @@ class FleetMembership < ApplicationRecord
       link: Rails.application.routes.url_helpers.frontend_fleets_invites_path,
       record: self
     )
+  end
+
+  # Only the two things that change which Discord roles a member should hold:
+  # whether they are an accepted member at all, and which rank they hold.
+  # Everything else about a membership -- ship filters, hangar groups, a primary
+  # flag -- has no bearing on it, and enqueuing on every save would put a
+  # Discord round trip behind ordinary edits.
+  def discord_roles_affected?
+    saved_change_to_aasm_state? || saved_change_to_fleet_role_id?
+  end
+
+  def sync_discord_roles
+    return unless ::Discord::ApiClient.configured?
+    return if fleet&.fleet_notification_setting&.discord_guild_id.blank?
+
+    ::Discord::SyncMemberRolesJob.perform_async(id)
   end
 
   def broadcast_update

--- a/app/models/fleet_notification_setting.rb
+++ b/app/models/fleet_notification_setting.rb
@@ -30,6 +30,10 @@ class FleetNotificationSetting < ApplicationRecord
 
   encrypts :discord_webhook_url
 
+  # Mapping a role is a configuration change, not a membership change, so
+  # nothing else would apply it to the members the fleet already has.
+  after_commit :backfill_discord_member_roles, if: :saved_change_to_discord_member_role_id?
+
   DEFAULT_IN_APP_EVENTS = %w[
     fleet_event.published
     fleet_event.locked
@@ -51,5 +55,11 @@ class FleetNotificationSetting < ApplicationRecord
 
   def in_app_enabled?(event_name)
     Array(enabled_in_app_events).include?(event_name)
+  end
+
+  private def backfill_discord_member_roles
+    return if discord_guild_id.blank?
+
+    ::Discord::BackfillFleetMemberRolesJob.perform_async(fleet_id)
   end
 end

--- a/app/models/fleet_notification_setting.rb
+++ b/app/models/fleet_notification_setting.rb
@@ -4,14 +4,15 @@
 #
 # Table name: fleet_notification_settings
 #
-#  id                    :uuid             not null, primary key
-#  discord_webhook_url   :text
-#  enabled_in_app_events :text             default("---\n- fleet_event.published\n- fleet_event.locked\n- fleet_event.starting_soon\n- fleet_event.cancelled\n- fleet_event_signup.created\n- fleet_event_signup.withdrawn")
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  discord_channel_id    :string
-#  discord_guild_id      :string
-#  fleet_id              :uuid             not null
+#  id                     :uuid             not null, primary key
+#  discord_webhook_url    :text
+#  enabled_in_app_events  :text             default("---\n- fleet_event.published\n- fleet_event.locked\n- fleet_event.starting_soon\n- fleet_event.cancelled\n- fleet_event_signup.created\n- fleet_event_signup.withdrawn")
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  discord_channel_id     :string
+#  discord_guild_id       :string
+#  discord_member_role_id :string
+#  fleet_id               :uuid             not null
 #
 # Indexes
 #

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -75,6 +75,9 @@ class FleetRole < ApplicationRecord
   before_save :update_slugs
   before_create :setup_rank
 
+  # Narrowed to this rank: a single mapping cannot affect anyone else.
+  after_commit :backfill_discord_member_roles, if: :saved_change_to_discord_role_id?
+
   DEFAULT_PRIVILEGES = {
     admin: [],
     officer: ["fleet:roles:manage"],
@@ -158,5 +161,9 @@ class FleetRole < ApplicationRecord
 
   private def update_slugs
     self.slug = generate_slug(name)
+  end
+
+  private def backfill_discord_member_roles
+    ::Discord::BackfillFleetMemberRolesJob.perform_async(fleet_id, id)
   end
 end

--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -10,6 +10,7 @@
 #  slug            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  discord_role_id :string
 #  fleet_id        :uuid             not null
 #
 # Indexes

--- a/app/models/omniauth_connection.rb
+++ b/app/models/omniauth_connection.rb
@@ -31,4 +31,13 @@ class OmniauthConnection < ApplicationRecord
   }
 
   validates :provider, presence: true, uniqueness: {scope: :user_id}
+
+  # Linking an account changes no membership, so without this a member who
+  # links Discord after being accepted never receives the roles their fleets
+  # already mapped.
+  after_create_commit :backfill_discord_member_roles, if: :discord?
+
+  private def backfill_discord_member_roles
+    ::Discord::BackfillUserMemberRolesJob.perform_async(user_id)
+  end
 end

--- a/app/views/api/v1/fleet_notification_settings/show.jbuilder
+++ b/app/views/api/v1/fleet_notification_settings/show.jbuilder
@@ -5,4 +5,5 @@ json.fleet_id @setting.fleet_id
 json.enabled_in_app_events Array(@setting.enabled_in_app_events)
 json.discord_guild_id @setting.discord_guild_id
 json.discord_channel_id @setting.discord_channel_id
+json.discord_member_role_id @setting.discord_member_role_id
 json.discord_webhook_configured @setting.discord_webhook_url.present?

--- a/db/migrate/20260831180000_add_discord_role_mapping.rb
+++ b/db/migrate/20260831180000_add_discord_role_mapping.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Maps Fleetyards fleet roles onto Discord roles.
+#
+# Two separate things, deliberately:
+#
+# - `fleet_notification_settings.discord_member_role_id` is the "verified
+#   member" role: one role for anyone who linked their account and is an
+#   accepted member, independent of rank.
+# - `fleet_roles.discord_role_id` maps one rank to one Discord role.
+#
+# Both are nullable and both are opt-in. The sync only ever touches role ids
+# that appear in one of these two columns, so a role the fleet manages by hand
+# in Discord is never removed by us.
+class AddDiscordRoleMapping < ActiveRecord::Migration[8.1]
+  def change
+    add_column :fleet_notification_settings, :discord_member_role_id, :string
+    add_column :fleet_roles, :discord_role_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -647,6 +647,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_160000) do
     t.datetime "created_at", null: false
     t.string "discord_channel_id"
     t.string "discord_guild_id"
+    t.string "discord_member_role_id"
     t.text "discord_webhook_url"
     t.text "enabled_in_app_events", default: "---\n- fleet_event.published\n- fleet_event.locked\n- fleet_event.starting_soon\n- fleet_event.cancelled\n- fleet_event_signup.created\n- fleet_event_signup.withdrawn"
     t.uuid "fleet_id", null: false
@@ -657,6 +658,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_160000) do
 
   create_table "fleet_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "discord_role_id"
     t.uuid "fleet_id", null: false
     t.string "name"
     t.boolean "permanent"

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -183,6 +183,22 @@ What org admins actually ask for. Two tiers: a "verified member" role on account
 
 Also note the role hierarchy: a bot can only assign roles **below its own highest role**. That is a server-configuration problem the app cannot fix, only detect and report.
 
+`Discord::RoleCapability` is what does both detections, and it runs from the existing discord-status endpoint the fleet settings page already polls, so a fleet is told "re-authorise" rather than watching role sync fail quietly. It reports `missing_manage_roles`, `role_above_bot` (naming the role), `unknown_role` for a mapping whose Discord role was deleted, or `ok` — and it reports nothing at all until the fleet has actually mapped a role, so nobody is told to re-authorise for a feature they are not using.
+
+### The invariant
+
+`MemberRoleSync` may only add or remove role ids the fleet itself configured. `managed_role_ids` is that whole universe, so a role handed out by hand in Discord — a colour, a game, a moderator role — is invisible to this code and can never be taken away by it. There is a test named after exactly that.
+
+An accepted member gets the member role plus the role mapped to their rank; anyone invited, requested, declined or discarded gets neither, which is what makes leaving a fleet take the roles off. A member who is not in the Discord server at all is not a failure — plenty never join.
+
+Only two membership changes trigger a sync: the state and the rank. Everything else about a membership — ship filters, hangar groups, the primary flag — has no bearing on roles, and enqueuing on every save would put a Discord round trip behind ordinary edits.
+
+### What is configurable, and what is not
+
+`fleet_notification_settings.discord_member_role_id` has an update endpoint, so the **verified-member role works end to end today**.
+
+`fleet_roles.discord_role_id` does not: `FleetRole` has **no write endpoint anywhere** — the public API exposes `index` only, and even `resource_access` is not writable through it. The sync reads the column and the rank mapping is fully implemented and tested, but until fleet roles become editable it can only be set from a console. Building that endpoint is its own piece of work (policy, schema, tests) and does not belong in a Discord PR.
+
 Hangar-based roles ("owns a Carrack" → role) are the natural extension and deliberately last: they turn a per-link action into a continuous reconcile against every member's hangar, which is a different cost class from everything above.
 
 ## Order and why

--- a/docs/exec-plans/discord-bot.md
+++ b/docs/exec-plans/discord-bot.md
@@ -193,6 +193,22 @@ An accepted member gets the member role plus the role mapped to their rank; anyo
 
 Only two membership changes trigger a sync: the state and the rank. Everything else about a membership — ship filters, hangar groups, the primary flag — has no bearing on roles, and enqueuing on every save would put a Discord round trip behind ordinary edits.
 
+### Why event-driven is not enough on its own
+
+Those triggers cover every *change*, and miss every *rollout*. A fleet maps a role and nothing happens, because no membership changed. Three cases, all of them the first thing anyone will hit:
+
+| The fleet or member does this | Without a backfill |
+| --- | --- |
+| maps the member role for the first time | existing members get nothing |
+| maps a rank to a Discord role | that rank's members get nothing |
+| links their Discord account after being accepted | they get nothing |
+
+So configuration and account-linking enqueue a backfill of their own: `BackfillFleetMemberRolesJob` for the first two — narrowed to one rank when it is a rank mapping, since that is all a single mapping can affect — and `BackfillUserMemberRolesJob` for the third. Both only consider accepted members who actually linked a Discord account: a sync for anyone else is a job that can only decide to do nothing.
+
+A membership costs one `get_guild_member` plus a call per role change, so the fleet backfill spreads its work rather than firing a large fleet at Discord at once.
+
+**Not handled: unlinking.** Removing a Discord connection leaves the roles in place, because the uid the sync needs is gone with the record. Revoking them needs a different operation — "remove every managed role from this uid" — rather than the desired/current diff, since the membership is still accepted and the diff would want to *add* the roles back. Worth doing, and its own change.
+
 ### What is configurable, and what is not
 
 `fleet_notification_settings.discord_member_role_id` has an update endpoint, so the **verified-member role works end to end today**.

--- a/lib/discord/api_client.rb
+++ b/lib/discord/api_client.rb
@@ -32,11 +32,18 @@ module Discord
       Rails.application.config.app.discord[:client_id].presence
     end
 
-    # Manage Events (1 << 33), plus View Channel (1 << 10) and Connect
-    # (1 << 20) — Discord rejects a voice-channel scheduled event without
-    # those two when a fleet sets a discord_channel_id. Must stay in sync
-    # with the app's Default Install Settings in the Discord dev portal.
-    INSTALL_PERMISSIONS = 8_590_984_192
+    # Manage Events (1 << 33), View Channel (1 << 10), Connect (1 << 20) and
+    # Manage Roles (1 << 28).
+    #
+    # Discord rejects a voice-channel scheduled event without View Channel and
+    # Connect when a fleet sets a discord_channel_id, and role assignment needs
+    # Manage Roles. Must stay in sync with the app's Default Install Settings in
+    # the Discord dev portal.
+    #
+    # Raising this does NOT upgrade servers that installed under the old mask --
+    # Discord keeps their original grant. Discord::RoleCapability is what tells
+    # a fleet it has to re-authorise.
+    INSTALL_PERMISSIONS = 8_859_419_648
 
     def self.install_url
       return nil if application_id.blank?
@@ -80,6 +87,22 @@ module Discord
 
     def create_message(channel_id, payload)
       post("channels/#{channel_id}/messages", payload)
+    end
+
+    def get_guild_roles(guild_id)
+      request(:get, "guilds/#{guild_id}/roles")
+    end
+
+    def get_guild_member(guild_id, user_id)
+      request(:get, "guilds/#{guild_id}/members/#{user_id}")
+    end
+
+    def add_guild_member_role(guild_id, user_id, role_id)
+      request(:put, "guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}")
+    end
+
+    def remove_guild_member_role(guild_id, user_id, role_id)
+      request(:delete, "guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}")
     end
 
     def update_guild_scheduled_event(guild_id, event_id, payload)

--- a/lib/discord/member_role_sync.rb
+++ b/lib/discord/member_role_sync.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Discord
+  # Brings one member's Discord roles in line with their Fleetyards membership.
+  #
+  # The invariant that matters: **only role ids the fleet configured are ever
+  # touched.** `managed_role_ids` is the whole universe this class may add or
+  # remove, so a role the fleet hands out by hand in Discord -- a colour, a
+  # game, a moderator role -- is never taken away by us. Anything outside that
+  # set is invisible to this code.
+  class MemberRoleSync
+    Result = Struct.new(:added, :removed, :code) do
+      def ok?
+        code.nil? || code == :ok
+      end
+
+      def to_s
+        "added=#{Array(added).size} removed=#{Array(removed).size} code=#{code}"
+      end
+    end
+
+    def initialize(membership, api: nil)
+      @membership = membership
+      @api = api
+    end
+
+    def runnable?
+      ApiClient.configured? && guild_id.present? && discord_uid.present? && managed_role_ids.any?
+    end
+
+    def run!
+      return Result.new([], [], :not_runnable) unless runnable?
+
+      current = current_role_ids
+      return Result.new([], [], :not_in_guild) if current.nil?
+
+      to_add = desired_role_ids - current
+      to_remove = (managed_role_ids - desired_role_ids) & current
+
+      to_add.each { |role_id| api.add_guild_member_role(guild_id, discord_uid, role_id) }
+      to_remove.each { |role_id| api.remove_guild_member_role(guild_id, discord_uid, role_id) }
+
+      Result.new(to_add, to_remove, :ok)
+    rescue ApiClient::Error => e
+      # 403 here is almost always the old install mask: the bot has no Manage
+      # Roles, or the target role sits above its own highest role. Neither is
+      # fixed by retrying, and RoleCapability is what explains it to the fleet.
+      raise unless [403, 404].include?(e.status)
+
+      Result.new([], [], (e.status == 403) ? :forbidden : :not_found)
+    end
+
+    # Every role this fleet has put under our control, whether or not this
+    # member should have it.
+    def managed_role_ids
+      @managed_role_ids ||= (
+        [setting&.discord_member_role_id] + fleet.fleet_roles.pluck(:discord_role_id)
+      ).compact_blank.uniq
+    end
+
+    # An accepted member gets the member role plus the role mapped to their
+    # rank. Anyone else -- invited, requested, declined, removed -- gets
+    # neither, which is what makes leaving a fleet take the roles away.
+    private def desired_role_ids
+      return [] unless @membership.aasm_state == "accepted"
+      return [] if @membership.discarded_at.present?
+
+      [
+        setting&.discord_member_role_id,
+        @membership.fleet_role&.discord_role_id
+      ].compact_blank.uniq
+    end
+
+    private def current_role_ids
+      member = api.get_guild_member(guild_id, discord_uid)
+
+      Array(member&.dig("roles"))
+    rescue ApiClient::Error => e
+      # The member is not in the Discord server. Nothing to sync, and not a
+      # failure -- plenty of fleet members never join the Discord.
+      raise unless e.status == 404
+
+      nil
+    end
+
+    private def fleet
+      @membership.fleet
+    end
+
+    private def setting
+      fleet&.fleet_notification_setting
+    end
+
+    private def guild_id
+      setting&.discord_guild_id.presence
+    end
+
+    private def discord_uid
+      @discord_uid ||= @membership.user
+        &.omniauth_connections
+        &.find_by(provider: "discord")
+        &.uid
+    end
+
+    private def api
+      @api ||= ApiClient.new
+    end
+  end
+end

--- a/lib/discord/role_capability.rb
+++ b/lib/discord/role_capability.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Discord
+  # Answers "can the bot actually assign these roles in this guild?" before
+  # anything tries to.
+  #
+  # Two separate reasons it might not be able to, and a fleet can only fix one
+  # of them by re-authorising:
+  #
+  # 1. **No Manage Roles.** Raising INSTALL_PERMISSIONS does not upgrade a
+  #    server that installed the bot under the old mask -- Discord keeps the
+  #    original grant. Those fleets have to re-authorise, and something has to
+  #    tell them so rather than letting a job fail silently every hour.
+  # 2. **Role hierarchy.** A bot can only assign roles *below* its own highest
+  #    role. That is a server-configuration problem the app cannot fix, only
+  #    detect and report.
+  class RoleCapability
+    MANAGE_ROLES = 1 << 28
+    ADMINISTRATOR = 1 << 3
+
+    Result = Struct.new(:code, :detail) do
+      def ok?
+        code == :ok
+      end
+    end
+
+    def initialize(guild_id, api: nil)
+      @guild_id = guild_id
+      @api = api
+    end
+
+    # role_ids: the roles the fleet wants managed. Empty means "just tell me
+    # whether the permission is there".
+    def check(role_ids = [])
+      wanted = Array(role_ids).compact_blank.uniq
+
+      roles = api.get_guild_roles(@guild_id)
+      return Result.new(:discord_error, "no roles returned") if roles.blank?
+
+      own = bot_role_ids
+      bot_roles = roles.select { |role| own.include?(role["id"]) }
+
+      return Result.new(:missing_manage_roles) unless manage_roles?(bot_roles)
+
+      unknown = wanted - roles.map { |role| role["id"] }
+      return Result.new(:unknown_role, unknown.join(", ")) if unknown.any?
+
+      above = above_bot(roles, bot_roles, wanted)
+      return Result.new(:role_above_bot, above.join(", ")) if above.any?
+
+      Result.new(:ok)
+    rescue ApiClient::Error => e
+      Result.new(error_code(e.status), e.message)
+    end
+
+    # The bot's own membership carries its role ids. Its user id is the
+    # application id.
+    private def bot_role_ids
+      member = api.get_guild_member(@guild_id, ApiClient.application_id)
+
+      Array(member&.dig("roles"))
+    end
+
+    # Permissions are a decimal string bitfield per role, and a member's
+    # effective permissions are the union of their roles'. Administrator implies
+    # everything, including this.
+    private def manage_roles?(bot_roles)
+      permissions = bot_roles.sum { |role| role["permissions"].to_i }
+
+      permissions.anybits?(ADMINISTRATOR) || permissions.anybits?(MANAGE_ROLES)
+    end
+
+    # A role at or above the bot's highest position cannot be assigned by it,
+    # even with Manage Roles.
+    private def above_bot(roles, bot_roles, wanted)
+      ceiling = bot_roles.map { |role| role["position"].to_i }.max || 0
+
+      roles
+        .select { |role| wanted.include?(role["id"]) && role["position"].to_i >= ceiling }
+        .map { |role| role["name"] }
+    end
+
+    private def error_code(status)
+      case status
+      when 401 then :invalid_token
+      when 403 then :bot_not_in_guild
+      when 404 then :guild_not_found
+      else :discord_error
+      end
+    end
+
+    private def api
+      @api ||= ApiClient.new
+    end
+  end
+end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -14464,6 +14464,12 @@ components:
           type: integer
         installUrl:
           type: string
+        rolesOk:
+          type: boolean
+        rolesCode:
+          type: string
+        rolesDetail:
+          type: string
       title: FleetNotificationDiscordStatus
     FleetNotificationInAppEventEnum:
       type: string
@@ -14499,6 +14505,8 @@ components:
           type: string
         discordChannelId:
           type: string
+        discordMemberRoleId:
+          type: string
         discordWebhookConfigured:
           type: boolean
       required:
@@ -14515,6 +14523,10 @@ components:
           - string
           - 'null'
         discordChannelId:
+          type:
+          - string
+          - 'null'
+        discordMemberRoleId:
           type:
           - string
           - 'null'

--- a/test/factories/fleet_roles.rb
+++ b/test/factories/fleet_roles.rb
@@ -10,6 +10,7 @@
 #  slug            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  discord_role_id :string
 #  fleet_id        :uuid             not null
 #
 # Indexes

--- a/test/integration/api/v1/fleets_notifications_discord_status_behaviour_test.rb
+++ b/test/integration/api/v1/fleets_notifications_discord_status_behaviour_test.rb
@@ -105,4 +105,81 @@ class Api::V1::FleetsNotificationsDiscordStatusBehaviourTest < ActionDispatch::I
     body = JSON.parse(response.body)
     assert_nil body["installUrl"]
   end
+
+  class RoleCapabilityTest < Api::V1::FleetsNotificationsDiscordStatusBehaviourTest
+    setup do
+      @api = mock("Discord::ApiClient")
+      @api.stubs(:get_guild).returns({"id" => "guild-1", "name" => "Test Server"})
+      Discord::ApiClient.stubs(:configured?).returns(true)
+      Discord::ApiClient.stubs(:new).returns(@api)
+    end
+
+    def map_member_role!
+      @fleet.create_fleet_notification_setting!(
+        discord_guild_id: "guild-1",
+        discord_member_role_id: "role-member"
+      )
+    end
+
+    def body
+      get @url, as: :json
+      JSON.parse(response.body)
+    end
+
+    # A fleet that never mapped a role is not told to re-authorise for a
+    # feature it is not using.
+    test "says nothing about roles when the fleet mapped none" do
+      @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+
+      payload = body
+
+      assert_equal true, payload["ok"]
+      assert_nil payload["rolesOk"]
+      assert_nil payload["rolesCode"]
+    end
+
+    test "reports role management as ok once it works" do
+      map_member_role!
+      capability = mock
+      capability.stubs(:check).returns(Discord::RoleCapability::Result.new(:ok))
+      Discord::RoleCapability.stubs(:new).returns(capability)
+
+      payload = body
+
+      assert_equal true, payload["rolesOk"]
+      assert_equal "ok", payload["rolesCode"]
+    end
+
+    # The point of the whole thing: an install from before Manage Roles was
+    # requested keeps its old grant, and Discord never upgrades it.
+    test "tells a fleet installed under the old mask that roles do not work" do
+      map_member_role!
+      capability = mock
+      capability.stubs(:check).returns(Discord::RoleCapability::Result.new(:missing_manage_roles))
+      Discord::RoleCapability.stubs(:new).returns(capability)
+
+      payload = body
+
+      assert_equal false, payload["rolesOk"]
+      assert_equal "missing_manage_roles", payload["rolesCode"]
+    end
+
+    test "passes the offending role name through for a hierarchy problem" do
+      map_member_role!
+      capability = mock
+      capability.stubs(:check).returns(Discord::RoleCapability::Result.new(:role_above_bot, "Officers"))
+      Discord::RoleCapability.stubs(:new).returns(capability)
+
+      payload = body
+
+      assert_equal "role_above_bot", payload["rolesCode"]
+      assert_equal "Officers", payload["rolesDetail"]
+    end
+
+    test "the install url now asks for Manage Roles" do
+      Discord::ApiClient.stubs(:application_id).returns("123456789")
+
+      assert_includes body["installUrl"], "permissions=#{Discord::ApiClient::INSTALL_PERMISSIONS}"
+    end
+  end
 end

--- a/test/jobs/discord/backfill_member_roles_test.rb
+++ b/test/jobs/discord/backfill_member_roles_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Discord
+  # The rollout case the per-membership sync cannot see: a mapping or an account
+  # link is not a membership change, so without a backfill a fleet configures a
+  # role and nothing happens.
+  class BackfillMemberRolesTest < ActiveSupport::TestCase
+    setup do
+      ::Discord::ApiClient.stubs(:configured?).returns(true)
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+      @role = @fleet.fleet_roles.ranked.last
+      clear_jobs
+    end
+
+    def clear_jobs
+      ::Discord::SyncMemberRolesJob.jobs.clear
+      ::Discord::BackfillFleetMemberRolesJob.jobs.clear
+      ::Discord::BackfillUserMemberRolesJob.jobs.clear
+    end
+
+    def accepted_member(linked: true, role: @role)
+      user = create(:user)
+      create(:omniauth_connection, user: user, provider: "discord", uid: "uid-#{user.id}") if linked
+      membership = @fleet.fleet_memberships.create!(user: user, fleet_role: role)
+      membership.update!(aasm_state: "accepted")
+      membership
+    end
+
+    def synced_membership_ids
+      ::Discord::SyncMemberRolesJob.jobs.map { |job| job["args"].first }
+    end
+
+    class FromTheFleetJob < BackfillMemberRolesTest
+      test "syncs the accepted members who linked Discord" do
+        membership = accepted_member
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_equal [membership.id], synced_membership_ids
+      end
+
+      # A sync for someone with no linked account is a job that can only decide
+      # to do nothing.
+      test "skips a member who never linked Discord" do
+        accepted_member(linked: false)
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_empty synced_membership_ids
+      end
+
+      test "skips a member who has not accepted yet" do
+        user = create(:user)
+        create(:omniauth_connection, user: user, provider: "discord", uid: "uid-x")
+        @fleet.fleet_memberships.create!(user: user, fleet_role: @role)
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_empty synced_membership_ids
+      end
+
+      test "skips a discarded membership" do
+        membership = accepted_member
+        membership.discard
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_empty synced_membership_ids
+      end
+
+      test "narrows to one rank when a rank mapping changed" do
+        other_role = @fleet.fleet_roles.ranked.first
+        wanted = accepted_member(role: @role)
+        accepted_member(role: other_role)
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id, @role.id)
+
+        assert_equal [wanted.id], synced_membership_ids
+      end
+
+      test "does nothing for a fleet with no Discord server" do
+        accepted_member
+        @setting.update!(discord_guild_id: nil)
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_empty synced_membership_ids
+      end
+
+      test "does nothing without a bot token" do
+        accepted_member
+        ::Discord::ApiClient.stubs(:configured?).returns(false)
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        assert_empty synced_membership_ids
+      end
+
+      # A large fleet is spread rather than fired at Discord at once.
+      test "spreads the syncs over time" do
+        (::Discord::BackfillFleetMemberRolesJob::PER_SECOND + 2).times { accepted_member }
+        clear_jobs
+
+        ::Discord::BackfillFleetMemberRolesJob.new.perform(@fleet.id)
+
+        scheduled = ::Discord::SyncMemberRolesJob.jobs.filter_map { |job| job["at"] }
+
+        assert scheduled.any?, "expected later members to be scheduled rather than immediate"
+      end
+    end
+
+    class Triggers < BackfillMemberRolesTest
+      test "mapping the member role backfills the fleet" do
+        @setting.update!(discord_member_role_id: "role-member")
+
+        assert_equal [@fleet.id], ::Discord::BackfillFleetMemberRolesJob.jobs.map { |job| job["args"].first }
+      end
+
+      test "an unrelated setting change does not backfill" do
+        @setting.update!(discord_channel_id: "channel-1")
+
+        assert_empty ::Discord::BackfillFleetMemberRolesJob.jobs
+      end
+
+      test "mapping a rank backfills that rank only" do
+        @role.update!(discord_role_id: "role-officer")
+
+        assert_equal [[@fleet.id, @role.id]], ::Discord::BackfillFleetMemberRolesJob.jobs.map { |job| job["args"] }
+      end
+
+      test "linking a Discord account backfills that member" do
+        user = create(:user)
+        clear_jobs
+
+        create(:omniauth_connection, user: user, provider: "discord", uid: "uid-new")
+
+        assert_equal [user.id], ::Discord::BackfillUserMemberRolesJob.jobs.map { |job| job["args"].first }
+      end
+
+      test "linking another provider does not backfill" do
+        user = create(:user)
+        clear_jobs
+
+        create(:omniauth_connection, user: user, provider: "github", uid: "uid-gh")
+
+        assert_empty ::Discord::BackfillUserMemberRolesJob.jobs
+      end
+    end
+
+    class FromTheUserJob < BackfillMemberRolesTest
+      test "syncs every accepted membership the member holds" do
+        membership = accepted_member
+        clear_jobs
+
+        ::Discord::BackfillUserMemberRolesJob.new.perform(membership.user_id)
+
+        assert_equal [membership.id], synced_membership_ids
+      end
+
+      test "skips a fleet that has no Discord server" do
+        membership = accepted_member
+        @setting.update!(discord_guild_id: nil)
+        clear_jobs
+
+        ::Discord::BackfillUserMemberRolesJob.new.perform(membership.user_id)
+
+        assert_empty synced_membership_ids
+      end
+    end
+  end
+end

--- a/test/lib/discord/member_role_sync_test.rb
+++ b/test/lib/discord/member_role_sync_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/member_role_sync"
+
+module Discord
+  class MemberRoleSyncTest < ActiveSupport::TestCase
+    MEMBER_ROLE = "role-member"
+    RANK_ROLE = "role-officer"
+    FOREIGN_ROLE = "role-they-earned-elsewhere"
+
+    setup do
+      @fleet = create(:fleet)
+      @setting = @fleet.create_fleet_notification_setting!(
+        discord_guild_id: "guild-1",
+        discord_member_role_id: MEMBER_ROLE
+      )
+
+      @user = create(:user)
+      create(:omniauth_connection, user: @user, provider: "discord", uid: "discord-uid-1")
+
+      @role = @fleet.fleet_roles.ranked.last
+      @membership = @fleet.fleet_memberships.create!(user: @user, fleet_role: @role)
+      @membership.update!(aasm_state: "accepted")
+
+      @api = mock("Discord::ApiClient")
+      ::Discord::ApiClient.stubs(:configured?).returns(true)
+    end
+
+    def sync
+      ::Discord::MemberRoleSync.new(@membership.reload, api: @api)
+    end
+
+    def member_has(*role_ids)
+      @api.stubs(:get_guild_member).returns({"roles" => role_ids})
+    end
+
+    test "gives an accepted member the member role" do
+      member_has
+      @api.expects(:add_guild_member_role).with("guild-1", "discord-uid-1", MEMBER_ROLE)
+
+      result = sync.run!
+
+      assert result.ok?
+      assert_equal [MEMBER_ROLE], result.added
+    end
+
+    test "adds nothing when the member already has the role" do
+      member_has(MEMBER_ROLE)
+      @api.expects(:add_guild_member_role).never
+      @api.expects(:remove_guild_member_role).never
+
+      assert_empty sync.run!.added
+    end
+
+    test "gives the role mapped to the member's rank" do
+      @role.update!(discord_role_id: RANK_ROLE)
+      member_has(MEMBER_ROLE)
+      @api.expects(:add_guild_member_role).with("guild-1", "discord-uid-1", RANK_ROLE)
+
+      assert_equal [RANK_ROLE], sync.run!.added
+    end
+
+    test "takes the roles away when the member is no longer accepted" do
+      @membership.update!(aasm_state: "declined")
+      member_has(MEMBER_ROLE)
+      @api.expects(:remove_guild_member_role).with("guild-1", "discord-uid-1", MEMBER_ROLE)
+
+      assert_equal [MEMBER_ROLE], sync.run!.removed
+    end
+
+    test "takes the roles away when the membership is discarded" do
+      @membership.update!(discarded_at: Time.current)
+      member_has(MEMBER_ROLE)
+      @api.expects(:remove_guild_member_role).with("guild-1", "discord-uid-1", MEMBER_ROLE)
+
+      assert_equal [MEMBER_ROLE], sync.run!.removed
+    end
+
+    test "swaps the rank role when the member is promoted" do
+      other = @fleet.fleet_roles.ranked.first
+      other.update!(discord_role_id: "role-admin")
+      @role.update!(discord_role_id: RANK_ROLE)
+      @membership.update!(fleet_role: other)
+
+      member_has(MEMBER_ROLE, RANK_ROLE)
+      @api.expects(:add_guild_member_role).with("guild-1", "discord-uid-1", "role-admin")
+      @api.expects(:remove_guild_member_role).with("guild-1", "discord-uid-1", RANK_ROLE)
+
+      sync.run!
+    end
+
+    # The invariant. A colour role, a game role, a moderator role -- none of
+    # them are ours to remove.
+    test "never removes a role the fleet did not put under our control" do
+      @membership.update!(aasm_state: "declined")
+      member_has(MEMBER_ROLE, FOREIGN_ROLE)
+      @api.expects(:remove_guild_member_role).with("guild-1", "discord-uid-1", MEMBER_ROLE)
+
+      result = sync.run!
+
+      assert_equal [MEMBER_ROLE], result.removed
+      assert_not_includes result.removed, FOREIGN_ROLE
+    end
+
+    test "managed roles are exactly what the fleet configured" do
+      @role.update!(discord_role_id: RANK_ROLE)
+
+      assert_equal [MEMBER_ROLE, RANK_ROLE].sort, sync.managed_role_ids.sort
+    end
+
+    test "does nothing when the fleet mapped no roles at all" do
+      @setting.update!(discord_member_role_id: nil)
+      @api.expects(:get_guild_member).never
+
+      refute sync.runnable?
+      assert_equal :not_runnable, sync.run!.code
+    end
+
+    test "does nothing for a member with no linked Discord account" do
+      @user.omniauth_connections.destroy_all
+      @api.expects(:get_guild_member).never
+
+      refute ::Discord::MemberRoleSync.new(@membership.reload, api: @api).runnable?
+    end
+
+    test "does nothing without a bot token" do
+      ::Discord::ApiClient.stubs(:configured?).returns(false)
+
+      refute sync.runnable?
+    end
+
+    # Plenty of fleet members never join the fleet's Discord.
+    test "a member who is not in the guild is not a failure" do
+      @api.stubs(:get_guild_member).raises(::Discord::ApiClient::Error.new(404, "Unknown Member"))
+      @api.expects(:add_guild_member_role).never
+
+      assert_equal :not_in_guild, sync.run!.code
+    end
+
+    # Almost always the pre-Manage-Roles install mask, or a role above the
+    # bot's own. A retry changes neither.
+    test "a forbidden role change is reported rather than retried" do
+      member_has
+      @api.stubs(:add_guild_member_role).raises(::Discord::ApiClient::Error.new(403, "Missing Permissions"))
+
+      assert_nothing_raised do
+        assert_equal :forbidden, sync.run!.code
+      end
+    end
+
+    test "a rate limit is left for the job to retry" do
+      member_has
+      @api.stubs(:add_guild_member_role).raises(::Discord::ApiClient::Error.new(429, "Too Many Requests"))
+
+      assert_raises(::Discord::ApiClient::Error) { sync.run! }
+    end
+  end
+end

--- a/test/lib/discord/role_capability_test.rb
+++ b/test/lib/discord/role_capability_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/role_capability"
+
+module Discord
+  class RoleCapabilityTest < ActiveSupport::TestCase
+    MANAGE_ROLES = ::Discord::RoleCapability::MANAGE_ROLES
+
+    setup do
+      @api = mock("Discord::ApiClient")
+      ::Discord::ApiClient.stubs(:application_id).returns("bot-app-id")
+    end
+
+    def roles(*entries)
+      @api.stubs(:get_guild_roles).returns(entries)
+    end
+
+    def bot_in(*role_ids)
+      @api.stubs(:get_guild_member).with("guild-1", "bot-app-id").returns({"roles" => role_ids})
+    end
+
+    def role(id:, position:, permissions: 0, name: id)
+      {"id" => id, "position" => position, "permissions" => permissions.to_s, "name" => name}
+    end
+
+    def check(*wanted)
+      ::Discord::RoleCapability.new("guild-1", api: @api).check(wanted)
+    end
+
+    test "ok when the bot has Manage Roles and outranks the target" do
+      roles(role(id: "bot", position: 10, permissions: MANAGE_ROLES), role(id: "member", position: 5))
+      bot_in("bot")
+
+      assert check("member").ok?
+    end
+
+    # Raising INSTALL_PERMISSIONS does not upgrade an existing install, so this
+    # is the case that has to be reportable rather than silent.
+    test "reports a missing Manage Roles permission" do
+      roles(role(id: "bot", position: 10, permissions: 0), role(id: "member", position: 5))
+      bot_in("bot")
+
+      assert_equal :missing_manage_roles, check("member").code
+    end
+
+    test "administrator counts as Manage Roles" do
+      roles(role(id: "bot", position: 10, permissions: ::Discord::RoleCapability::ADMINISTRATOR),
+        role(id: "member", position: 5))
+      bot_in("bot")
+
+      assert check("member").ok?
+    end
+
+    test "permissions are the union of the bot's roles" do
+      roles(
+        role(id: "bot-a", position: 10, permissions: 0),
+        role(id: "bot-b", position: 3, permissions: MANAGE_ROLES),
+        role(id: "member", position: 2)
+      )
+      bot_in("bot-a", "bot-b")
+
+      assert check("member").ok?
+    end
+
+    # A server-configuration problem the app cannot fix, only name.
+    test "reports a target role above the bot's highest role" do
+      roles(role(id: "bot", position: 5, permissions: MANAGE_ROLES),
+        role(id: "member", position: 9, name: "Officers"))
+      bot_in("bot")
+
+      result = check("member")
+
+      assert_equal :role_above_bot, result.code
+      assert_includes result.detail, "Officers"
+    end
+
+    test "a role at exactly the bot's position is also out of reach" do
+      roles(role(id: "bot", position: 5, permissions: MANAGE_ROLES), role(id: "member", position: 5))
+      bot_in("bot")
+
+      assert_equal :role_above_bot, check("member").code
+    end
+
+    test "reports a mapped role that no longer exists in the guild" do
+      roles(role(id: "bot", position: 10, permissions: MANAGE_ROLES))
+      bot_in("bot")
+
+      result = check("deleted-role")
+
+      assert_equal :unknown_role, result.code
+      assert_includes result.detail, "deleted-role"
+    end
+
+    test "checks only the permission when nothing is mapped yet" do
+      roles(role(id: "bot", position: 10, permissions: MANAGE_ROLES))
+      bot_in("bot")
+
+      assert check.ok?
+    end
+
+    test "translates a Discord error into a code" do
+      @api.stubs(:get_guild_roles).raises(::Discord::ApiClient::Error.new(403, "Missing Access"))
+
+      assert_equal :bot_not_in_guild, check("member").code
+    end
+
+    test "an invalid token is named as such" do
+      @api.stubs(:get_guild_roles).raises(::Discord::ApiClient::Error.new(401, "Unauthorized"))
+
+      assert_equal :invalid_token, check("member").code
+    end
+  end
+end

--- a/test/models/fleet_membership_discord_roles_test.rb
+++ b/test/models/fleet_membership_discord_roles_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# When a membership change is worth a Discord round trip, and when it is not.
+class FleetMembershipDiscordRolesTest < ActiveSupport::TestCase
+  setup do
+    @fleet = create(:fleet)
+    @fleet.create_fleet_notification_setting!(
+      discord_guild_id: "guild-1",
+      discord_member_role_id: "role-member"
+    )
+    @user = create(:user)
+    ::Discord::ApiClient.stubs(:configured?).returns(true)
+    ::Discord::SyncMemberRolesJob.jobs.clear
+  end
+
+  def create_membership
+    @fleet.fleet_memberships.create!(user: @user, fleet_role: @fleet.fleet_roles.ranked.last)
+  end
+
+  test "accepting a membership syncs the roles" do
+    membership = create_membership
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.update!(aasm_state: "accepted")
+
+    assert_equal [membership.id], ::Discord::SyncMemberRolesJob.jobs.map { |job| job["args"].first }
+  end
+
+  test "a rank change syncs the roles" do
+    membership = create_membership
+    membership.update!(aasm_state: "accepted")
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.update!(fleet_role: @fleet.fleet_roles.ranked.first)
+
+    assert_equal 1, ::Discord::SyncMemberRolesJob.jobs.size
+  end
+
+  test "discarding a membership syncs the roles so they come off" do
+    membership = create_membership
+    membership.update!(aasm_state: "accepted")
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.discard
+
+    assert_equal 1, ::Discord::SyncMemberRolesJob.jobs.size
+  end
+
+  # A Discord round trip has no business behind an ordinary edit.
+  test "an unrelated change does not sync" do
+    membership = create_membership
+    membership.update!(aasm_state: "accepted")
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.update!(ships_filter: "all")
+
+    assert_equal 0, ::Discord::SyncMemberRolesJob.jobs.size
+  end
+
+  test "does not sync for a fleet with no Discord server" do
+    @fleet.fleet_notification_setting.update!(discord_guild_id: nil)
+    membership = create_membership
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.update!(aasm_state: "accepted")
+
+    assert_equal 0, ::Discord::SyncMemberRolesJob.jobs.size
+  end
+
+  test "does not sync without a bot token" do
+    ::Discord::ApiClient.stubs(:configured?).returns(false)
+    membership = create_membership
+    ::Discord::SyncMemberRolesJob.jobs.clear
+
+    membership.update!(aasm_state: "accepted")
+
+    assert_equal 0, ::Discord::SyncMemberRolesJob.jobs.size
+  end
+end

--- a/test/models/fleet_role_test.rb
+++ b/test/models/fleet_role_test.rb
@@ -12,6 +12,7 @@
 #  slug            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  discord_role_id :string
 #  fleet_id        :uuid             not null
 #
 # Indexes


### PR DESCRIPTION
> Stacked on #4631 → #4628 → #4627 → #4625 → #4624 → #4623. The base ref is `feature/discord-wishlist-dms` — review the two commits from `feat(discord): request Manage Roles on install` onwards.

The last phase, and the one org admins actually ask for: an accepted member gets the fleet's verified-member role in Discord and the role mapped to their rank, and loses both when they leave.

## The invariant worth reviewing first

`MemberRoleSync` may only add or remove role ids **the fleet itself configured**. `managed_role_ids` is that entire universe:

```ruby
[setting.discord_member_role_id] + fleet.fleet_roles.pluck(:discord_role_id)
```

A role handed out by hand in Discord — a colour, a game, a moderator role — is invisible to this code and can never be taken away by it. There is a test named after exactly that:

```
never removes a role the fleet did not put under our control
```

An accepted member gets the roles; invited, requested, declined and discarded members get none, which is what makes leaving a fleet take them off. A member who is not in the Discord server at all is not a failure — plenty of fleet members never join it.

## Only two changes trigger a sync

State and rank. Ship filters, hangar groups and the primary flag have no bearing on roles, and enqueuing on every membership save would put a Discord round trip behind ordinary edits. `discord_roles_affected?` is one line and there is a test that an unrelated edit enqueues nothing.

## The permission change, and telling fleets about it

The install mask moves to `8_859_419_648` (adding Manage Roles, `1 << 28`). **Discord does not upgrade a server that installed under the old mask** — it keeps its original grant — so the constant alone changes nothing for existing installs.

`Discord::RoleCapability` is what closes that gap, running from the discord-status endpoint the fleet settings page already polls:

| Code | Meaning | Fixable by |
| --- | --- | --- |
| `missing_manage_roles` | installed before Manage Roles was requested | re-authorising the bot |
| `role_above_bot` | target role at or above the bot's highest role (names the role) | the server admin, not us |
| `unknown_role` | a mapping whose Discord role was deleted | fixing the mapping |
| `ok` | — | — |

It reports **nothing at all** until the fleet has actually mapped a role, so no one is told to re-authorise for a feature they are not using. Permissions are read as the union of the bot's roles, and Administrator counts as Manage Roles.

A 403 on a role change is reported, not retried: neither a missing permission nor a role hierarchy changes by trying again. Rate limits and 5xx still retry.

## What is configurable, and what is not — please read

`fleet_notification_settings.discord_member_role_id` has an update endpoint, an input schema entry and a response field, so **the verified-member role works end to end today**.

`fleet_roles.discord_role_id` does **not**. `FleetRole` has no write endpoint anywhere in the app — the public API exposes `index` only, and not even `resource_access` is writable through it. The rank mapping is fully implemented and tested, but until fleet roles become editable it can only be set from a console.

I did not build that endpoint here: it needs its own policy, schema and tests, and it is a fleet-roles feature rather than a Discord one. Flagging it rather than shipping it quietly, and rather than leaving the rank mapping out and needing a second migration next to it later. **If you would rather nothing inert shipped, say so and I will drop the column and the mapping from this PR.**

Likewise not included: a settings UI for picking which Discord role to use. The API accepts the id; the fleet settings page has no field for it yet.

## Verified

- `bin/rails test` over the Discord, notification, membership and fleet-role suites — **273 runs, 569 assertions, 0 failures** (30 new)
- The existing membership suites still pass with the new `after_commit` in place: `fleet_membership_test`, `fleet_membership_discard_test`, `fleets_members_promote_test`, `fleets_members_demote_test`, `fleets_membership_accept_invitation_test` — 30 runs, 0 failures
- `bundle exec standardrb` on every touched file — clean
- `./bin/generate-schema` — `rolesOk` / `rolesCode` / `rolesDetail` on the status component, `discordMemberRoleId` on both the setting response and `FleetNotificationSettingUpdateInput`

## The stack, for reference

| PR | Phase |
| --- | --- |
| #4623 | install permissions ↔ portal |
| #4624 | interactions endpoint, signature verification, `/ship` |
| #4625 | event RSVPs from Discord |
| #4627 | `/loaner`, `/compare`, `/hangar`, `/fleet` |
| #4628 | event reminders with slot counts |
| #4631 | notifications as Discord DMs |
| this | fleet membership → Discord roles |

🤖
